### PR TITLE
Implements the alch command to highalch items

### DIFF
--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -27,7 +27,7 @@ export default class extends BotCommand {
 		if (!msg.author.hasMinion) {
 			throw `You dont have a minion. Use the command \`${msg.guild?.settings.get(
 				GuildSettings.Prefix
-				)}minion buy\` to get one.`;
+			)}minion buy\` to get one.`;
 		}
 
 		if (msg.author.minionIsBusy) {
@@ -41,7 +41,7 @@ export default class extends BotCommand {
 
 		itemName = itemName.toLowerCase();
 		const osItem = Items.get(cleanItemName(itemName)) as Item;
-		if (!osItem) throw "That is not a valid item.";
+		if (!osItem) throw 'That is not a valid item.';
 		const highAlchValue = osItem.highalch;
 
 		const natureRune = Items.get(cleanItemName('Nature rune'))!;
@@ -54,7 +54,7 @@ export default class extends BotCommand {
 		const numNatureRunes = userBank[natureRune.id];
 
 		// Alching is a 5-tick/3 second action
-		const timePerAlch = Time.Second * 3;	
+		const timePerAlch = Time.Second * 3;
 
 		// Calculates the max number of alchs based on the max duration, runes, and number of items to be alched
 		let maxCasts = Math.min(Math.min(numFireRunes / 5, numNatureRunes), numAlchables);
@@ -65,7 +65,7 @@ export default class extends BotCommand {
 			quantity = maxCasts;
 		}
 
-		if (!highAlchValue && highAlchValue == 0) throw `That's not a valid item you can alch.`;
+		if (!highAlchValue && highAlchValue === 0) throw `That's not a valid item you can alch.`;
 
 		const duration = quantity * timePerAlch;
 

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -80,10 +80,10 @@ export default class extends BotCommand {
 		if (!hasItem) {
 			throw `You dont have ${quantity}x ${osItem.name}.`;
 		}
-		if(!hasFireRune) {
+		if (!hasFireRune) {
 			throw `You don't have ${quantity * 5}x ${fireRune.name}`;
 		}
-		if(!hasNatureRune) {
+		if (!hasNatureRune) {
 			throw `You don't have ${quantity}x ${natureRune.name}`;
 		}
 
@@ -92,14 +92,17 @@ export default class extends BotCommand {
 		// Confirm the user wants to alch the item(s)
 		if (!msg.flagArgs.confirm && !msg.flagArgs.cf) {
 			const alchMsg = await msg.channel.send(
-				`${msg.author}, say \`confirm\` to confirm that you want to High Alch ${quantity}x ${osItem.name} for ${totalValue}gp (${toKMB(
-					totalValue
-				)}).`
+				`${
+					msg.author
+				}, say \`confirm\` to confirm that you want to High Alch ${quantity}x ${
+					osItem.name
+				} for ${totalValue}gp (${toKMB(totalValue)}).`
 			);
 			try {
 				await msg.channel.awaitMessages(
 					_msg =>
-						_msg.author.id === msg.author.id && _msg.content.toLowerCase() === 'confirm',
+						_msg.author.id === msg.author.id &&
+						_msg.content.toLowerCase() === 'confirm',
 					{
 						max: 1,
 						time: Time.Second * 15,
@@ -115,9 +118,9 @@ export default class extends BotCommand {
 			itemName: osItem.name,
 			userID: msg.author.id,
 			channelID: msg.channel.id,
-			quantity: quantity,
-			duration: duration,
-			totalValue: totalValue,
+			quantity,
+			duration,
+			totalValue,
 			type: Activity.Alching,
 			id: rand(1, 10_000_000),
 			finishDate: Date.now() + duration
@@ -125,13 +128,13 @@ export default class extends BotCommand {
 
 		// Remove alched items, as well as runes from bank
 		await msg.author.removeItemFromBank(osItem.id, quantity);
-		await msg.author.removeItemFromBank(fireRune.id, quantity*5);
+		await msg.author.removeItemFromBank(fireRune.id, quantity * 5);
 		await msg.author.removeItemFromBank(natureRune.id, quantity);
 
 		await addSubTaskToActivityTask(this.client, Tasks.SkillingTicker, data);
 		msg.author.incrementMinionDailyDuration(duration);
 
-		let response = `${msg.author.minionName} is now alching ${quantity}x ${
+		const response = `${msg.author.minionName} is now alching ${quantity}x ${
 			osItem.name
 		}, it'll take around ${formatDuration(duration)} to finish.`;
 

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -1,0 +1,143 @@
+import { CommandStore, KlasaMessage } from 'klasa';
+
+import { Items } from 'oldschooljs';
+import { BotCommand } from '../../lib/BotCommand';
+import cleanItemName from '../../lib/util/cleanItemName';
+import { Time } from '../../lib/constants';
+import { toKMB } from 'oldschooljs/dist/util/util';
+import { formatDuration, rand } from '../../lib/util';
+import { AlchingActivityTaskOptions } from '../../lib/types/minions';
+import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
+import { Activity, Tasks } from '../../lib/constants';
+import { UserSettings } from '../../lib/UserSettings';
+import { Item } from 'oldschooljs/dist/meta/types';
+import { GuildSettings } from '../../lib/GuildSettings';
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			usage: '<quantity:int{1}|name:...string> [name:...string]',
+			usageDelim: ' ',
+			oneAtTime: true,
+			cooldown: 5,
+			altProtection: true
+		});
+	}
+
+	async run(msg: KlasaMessage, [quantity, itemName = '']: [null | number | string, string]) {
+
+		if (!msg.author.hasMinion) {
+			throw `You dont have a minion. Use the command \`${msg.guild?.settings.get(GuildSettings.Prefix)}minion buy\` to get one.`;
+		}
+
+		if (msg.author.minionIsBusy) {
+			return msg.send(msg.author.minionStatus);
+        }
+
+        if (typeof quantity === 'string') {
+			itemName = quantity;
+			quantity = null;
+        }
+
+        itemName = itemName.toLowerCase();
+        const osItem = Items.get(cleanItemName(itemName)) as Item;
+        if(!osItem) throw "That is not a valid item.";
+        const highAlchValue = osItem.highalch;
+
+
+        const natureRune = Items.get(cleanItemName("Nature rune"))!;
+        const fireRune = Items.get(cleanItemName("Fire rune"))!;
+        
+
+        // Gets the amount of each item the minion has in it's bank
+        const userBank = msg.author.settings.get(UserSettings.Bank);
+        const numAlchables = userBank[osItem.id];
+        const numFireRunes = userBank[fireRune.id];
+        const numNatureRunes = userBank[natureRune.id];
+
+        // Alching is a 5-tick/3 second action
+        const timePerAlch = Time.Second * 3;	
+
+        // Calculates the max number of alchs based on the max duration, runes, and number of items to be alched
+        let maxCasts = Math.min(Math.min(numFireRunes/5, numNatureRunes), numAlchables)
+        maxCasts = Math.min(Math.floor(msg.author.maxTripLength / timePerAlch), maxCasts)
+        
+        // If no quantity provided, set it to the max.
+		if (quantity === null) {
+			quantity = maxCasts;
+        }
+        
+        if (!highAlchValue && highAlchValue == 0) throw `That's not a valid item you can alch.`;
+
+        const duration = quantity * timePerAlch;
+
+        if (duration > msg.author.maxTripLength || quantity > maxCasts) {
+			throw `The max number of alchs you can do for this item is ${maxCasts}.`;
+        }
+        
+        // Ensures the minion has all of the required items for the number of alchs
+        const hasItem = await msg.author.hasItem(osItem.id, quantity);
+        const hasFireRune = await msg.author.hasItem(fireRune.id, quantity*5);
+        const hasNatureRune = await msg.author.hasItem(natureRune.id, quantity);
+		if (!hasItem) {
+			throw `You dont have ${quantity}x ${osItem.name}.`;
+        }
+        if(!hasFireRune) {
+            throw `You don't have ${quantity*5}x ${fireRune.name}`;
+        }
+        if(!hasNatureRune) {
+            throw `You don't have ${quantity}x ${natureRune.name}`;
+        }
+        
+
+        const totalValue = highAlchValue * quantity;
+
+        // Confirm the user wants to alch the item(s)
+        if (!msg.flagArgs.confirm && !msg.flagArgs.cf) {
+            const alchMsg = await msg.channel.send(
+                `${msg.author}, say \`confirm\` to confirm that you want to High Alch ${quantity}x ${osItem.name} for ${totalValue}gp (${toKMB(
+                    totalValue
+                )}).`
+            );
+            try {
+                await msg.channel.awaitMessages(
+                    _msg =>
+                        _msg.author.id === msg.author.id && _msg.content.toLowerCase() === 'confirm',
+                    {
+                        max: 1,
+                        time: Time.Second * 15,
+                        errors: ['time']
+                    }
+                );
+            } catch (err) {
+                return alchMsg.edit(`Cancelling alching item.`);
+            }
+        }
+
+        const data: AlchingActivityTaskOptions = {
+			itemName: osItem.name,
+			userID: msg.author.id,
+			channelID: msg.channel.id,
+			quantity: quantity,
+            duration: duration,
+            totalValue: totalValue,
+            type: Activity.Alching,
+            id: rand(1, 10_000_000),
+			finishDate: Date.now() + duration
+		};
+        
+        // Remove alched items, as well as runes from bank
+        await msg.author.removeItemFromBank(osItem.id, quantity);
+        await msg.author.removeItemFromBank(fireRune.id, quantity*5);
+        await msg.author.removeItemFromBank(natureRune.id, quantity);
+
+		await addSubTaskToActivityTask(this.client, Tasks.SkillingTicker, data);
+		msg.author.incrementMinionDailyDuration(duration);
+
+		let response = `${msg.author.minionName} is now alching ${quantity}x ${
+			osItem.name
+		}, it'll take around ${formatDuration(duration)} to finish.`;
+
+        return msg.send(response);
+	}
+}

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -8,9 +8,9 @@ import { formatDuration, rand } from '../../lib/util';
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { Activity, Tasks, Time } from '../../lib/constants';
-import { UserSettings } from '../../lib/UserSettings';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { Item } from 'oldschooljs/dist/meta/types';
-import { GuildSettings } from '../../lib/GuildSettings';
+import { GuildSettings } from '../../lib/settings/types/GuildSettings';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -3,12 +3,11 @@ import { CommandStore, KlasaMessage } from 'klasa';
 import { Items } from 'oldschooljs';
 import { BotCommand } from '../../lib/BotCommand';
 import cleanItemName from '../../lib/util/cleanItemName';
-import { Time } from '../../lib/constants';
 import { toKMB } from 'oldschooljs/dist/util/util';
 import { formatDuration, rand } from '../../lib/util';
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
-import { Activity, Tasks } from '../../lib/constants';
+import { Activity, Tasks, Time } from '../../lib/constants';
 import { UserSettings } from '../../lib/UserSettings';
 import { Item } from 'oldschooljs/dist/meta/types';
 import { GuildSettings } from '../../lib/GuildSettings';
@@ -25,111 +24,110 @@ export default class extends BotCommand {
 	}
 
 	async run(msg: KlasaMessage, [quantity, itemName = '']: [null | number | string, string]) {
-
 		if (!msg.author.hasMinion) {
 			throw `You dont have a minion. Use the command \`${msg.guild?.settings.get(GuildSettings.Prefix)}minion buy\` to get one.`;
 		}
-
+		
 		if (msg.author.minionIsBusy) {
 			return msg.send(msg.author.minionStatus);
-        }
+		}
 
-        if (typeof quantity === 'string') {
+		if (typeof quantity === 'string') {
 			itemName = quantity;
 			quantity = null;
-        }
+		}
 
-        itemName = itemName.toLowerCase();
-        const osItem = Items.get(cleanItemName(itemName)) as Item;
-        if(!osItem) throw "That is not a valid item.";
-        const highAlchValue = osItem.highalch;
+		itemName = itemName.toLowerCase();
+		const osItem = Items.get(cleanItemName(itemName)) as Item;
+		if(!osItem) throw "That is not a valid item.";
+		const highAlchValue = osItem.highalch;
 
 
-        const natureRune = Items.get(cleanItemName("Nature rune"))!;
-        const fireRune = Items.get(cleanItemName("Fire rune"))!;
-        
+		const natureRune = Items.get(cleanItemName("Nature rune"))!;
+		const fireRune = Items.get(cleanItemName("Fire rune"))!;
+		
 
-        // Gets the amount of each item the minion has in it's bank
-        const userBank = msg.author.settings.get(UserSettings.Bank);
-        const numAlchables = userBank[osItem.id];
-        const numFireRunes = userBank[fireRune.id];
-        const numNatureRunes = userBank[natureRune.id];
+		// Gets the amount of each item the minion has in it's bank
+		const userBank = msg.author.settings.get(UserSettings.Bank);
+		const numAlchables = userBank[osItem.id];
+		const numFireRunes = userBank[fireRune.id];
+		const numNatureRunes = userBank[natureRune.id];
 
-        // Alching is a 5-tick/3 second action
-        const timePerAlch = Time.Second * 3;	
+		// Alching is a 5-tick/3 second action
+		const timePerAlch = Time.Second * 3;	
 
-        // Calculates the max number of alchs based on the max duration, runes, and number of items to be alched
-        let maxCasts = Math.min(Math.min(numFireRunes/5, numNatureRunes), numAlchables)
-        maxCasts = Math.min(Math.floor(msg.author.maxTripLength / timePerAlch), maxCasts)
-        
-        // If no quantity provided, set it to the max.
+		// Calculates the max number of alchs based on the max duration, runes, and number of items to be alched
+		let maxCasts = Math.min(Math.min(numFireRunes/5, numNatureRunes), numAlchables)
+		maxCasts = Math.min(Math.floor(msg.author.maxTripLength / timePerAlch), maxCasts)
+		
+		// If no quantity provided, set it to the max.
 		if (quantity === null) {
 			quantity = maxCasts;
-        }
-        
-        if (!highAlchValue && highAlchValue == 0) throw `That's not a valid item you can alch.`;
+		}
+		
+		if (!highAlchValue && highAlchValue == 0) throw `That's not a valid item you can alch.`;
 
-        const duration = quantity * timePerAlch;
+		const duration = quantity * timePerAlch;
 
-        if (duration > msg.author.maxTripLength || quantity > maxCasts) {
+		if (duration > msg.author.maxTripLength || quantity > maxCasts) {
 			throw `The max number of alchs you can do for this item is ${maxCasts}.`;
-        }
-        
-        // Ensures the minion has all of the required items for the number of alchs
-        const hasItem = await msg.author.hasItem(osItem.id, quantity);
-        const hasFireRune = await msg.author.hasItem(fireRune.id, quantity*5);
-        const hasNatureRune = await msg.author.hasItem(natureRune.id, quantity);
+		}
+		
+		// Ensures the minion has all of the required items for the number of alchs
+		const hasItem = await msg.author.hasItem(osItem.id, quantity);
+		const hasFireRune = await msg.author.hasItem(fireRune.id, quantity*5);
+		const hasNatureRune = await msg.author.hasItem(natureRune.id, quantity);
 		if (!hasItem) {
 			throw `You dont have ${quantity}x ${osItem.name}.`;
-        }
-        if(!hasFireRune) {
-            throw `You don't have ${quantity*5}x ${fireRune.name}`;
-        }
-        if(!hasNatureRune) {
-            throw `You don't have ${quantity}x ${natureRune.name}`;
-        }
-        
+		}
+		if(!hasFireRune) {
+			throw `You don't have ${quantity*5}x ${fireRune.name}`;
+		}
+		if(!hasNatureRune) {
+			throw `You don't have ${quantity}x ${natureRune.name}`;
+		}
+		
 
-        const totalValue = highAlchValue * quantity;
+		const totalValue = highAlchValue * quantity;
 
-        // Confirm the user wants to alch the item(s)
-        if (!msg.flagArgs.confirm && !msg.flagArgs.cf) {
-            const alchMsg = await msg.channel.send(
-                `${msg.author}, say \`confirm\` to confirm that you want to High Alch ${quantity}x ${osItem.name} for ${totalValue}gp (${toKMB(
-                    totalValue
-                )}).`
-            );
-            try {
-                await msg.channel.awaitMessages(
-                    _msg =>
-                        _msg.author.id === msg.author.id && _msg.content.toLowerCase() === 'confirm',
-                    {
-                        max: 1,
-                        time: Time.Second * 15,
-                        errors: ['time']
-                    }
-                );
-            } catch (err) {
-                return alchMsg.edit(`Cancelling alching item.`);
-            }
-        }
+		// Confirm the user wants to alch the item(s)
+		if (!msg.flagArgs.confirm && !msg.flagArgs.cf) {
+			const alchMsg = await msg.channel.send(
+				`${msg.author}, say \`confirm\` to confirm that you want to High Alch ${quantity}x ${osItem.name} for ${totalValue}gp (${toKMB(
+					totalValue
+				)}).`
+			);
+			try {
+				await msg.channel.awaitMessages(
+					_msg =>
+						_msg.author.id === msg.author.id && _msg.content.toLowerCase() === 'confirm',
+					{
+						max: 1,
+						time: Time.Second * 15,
+						errors: ['time']
+					}
+				);
+			} catch (err) {
+				return alchMsg.edit(`Cancelling alching item.`);
+			}
+		}
 
-        const data: AlchingActivityTaskOptions = {
+		const data: AlchingActivityTaskOptions = {
 			itemName: osItem.name,
 			userID: msg.author.id,
 			channelID: msg.channel.id,
 			quantity: quantity,
-            duration: duration,
-            totalValue: totalValue,
-            type: Activity.Alching,
-            id: rand(1, 10_000_000),
+			duration: duration,
+			totalValue: totalValue,
+			type: Activity.Alching,
+			id: rand(1, 10_000_000),
 			finishDate: Date.now() + duration
 		};
-        
-        // Remove alched items, as well as runes from bank
-        await msg.author.removeItemFromBank(osItem.id, quantity);
-        await msg.author.removeItemFromBank(fireRune.id, quantity*5);
-        await msg.author.removeItemFromBank(natureRune.id, quantity);
+		
+		// Remove alched items, as well as runes from bank
+		await msg.author.removeItemFromBank(osItem.id, quantity);
+		await msg.author.removeItemFromBank(fireRune.id, quantity*5);
+		await msg.author.removeItemFromBank(natureRune.id, quantity);
 
 		await addSubTaskToActivityTask(this.client, Tasks.SkillingTicker, data);
 		msg.author.incrementMinionDailyDuration(duration);
@@ -138,6 +136,6 @@ export default class extends BotCommand {
 			osItem.name
 		}, it'll take around ${formatDuration(duration)} to finish.`;
 
-        return msg.send(response);
+		return msg.send(response);
 	}
 }

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -25,9 +25,11 @@ export default class extends BotCommand {
 
 	async run(msg: KlasaMessage, [quantity, itemName = '']: [null | number | string, string]) {
 		if (!msg.author.hasMinion) {
-			throw `You dont have a minion. Use the command \`${msg.guild?.settings.get(GuildSettings.Prefix)}minion buy\` to get one.`;
+			throw `You dont have a minion. Use the command \`${msg.guild?.settings.get(
+				GuildSettings.Prefix
+				)}minion buy\` to get one.`;
 		}
-		
+
 		if (msg.author.minionIsBusy) {
 			return msg.send(msg.author.minionStatus);
 		}
@@ -39,13 +41,11 @@ export default class extends BotCommand {
 
 		itemName = itemName.toLowerCase();
 		const osItem = Items.get(cleanItemName(itemName)) as Item;
-		if(!osItem) throw "That is not a valid item.";
+		if (!osItem) throw "That is not a valid item.";
 		const highAlchValue = osItem.highalch;
 
-
-		const natureRune = Items.get(cleanItemName("Nature rune"))!;
-		const fireRune = Items.get(cleanItemName("Fire rune"))!;
-		
+		const natureRune = Items.get(cleanItemName('Nature rune'))!;
+		const fireRune = Items.get(cleanItemName('Fire rune'))!;
 
 		// Gets the amount of each item the minion has in it's bank
 		const userBank = msg.author.settings.get(UserSettings.Bank);
@@ -57,14 +57,14 @@ export default class extends BotCommand {
 		const timePerAlch = Time.Second * 3;	
 
 		// Calculates the max number of alchs based on the max duration, runes, and number of items to be alched
-		let maxCasts = Math.min(Math.min(numFireRunes/5, numNatureRunes), numAlchables)
-		maxCasts = Math.min(Math.floor(msg.author.maxTripLength / timePerAlch), maxCasts)
-		
+		let maxCasts = Math.min(Math.min(numFireRunes / 5, numNatureRunes), numAlchables);
+		maxCasts = Math.min(Math.floor(msg.author.maxTripLength / timePerAlch), maxCasts);
+
 		// If no quantity provided, set it to the max.
 		if (quantity === null) {
 			quantity = maxCasts;
 		}
-		
+
 		if (!highAlchValue && highAlchValue == 0) throw `That's not a valid item you can alch.`;
 
 		const duration = quantity * timePerAlch;
@@ -72,21 +72,20 @@ export default class extends BotCommand {
 		if (duration > msg.author.maxTripLength || quantity > maxCasts) {
 			throw `The max number of alchs you can do for this item is ${maxCasts}.`;
 		}
-		
+
 		// Ensures the minion has all of the required items for the number of alchs
 		const hasItem = await msg.author.hasItem(osItem.id, quantity);
-		const hasFireRune = await msg.author.hasItem(fireRune.id, quantity*5);
+		const hasFireRune = await msg.author.hasItem(fireRune.id, quantity * 5);
 		const hasNatureRune = await msg.author.hasItem(natureRune.id, quantity);
 		if (!hasItem) {
 			throw `You dont have ${quantity}x ${osItem.name}.`;
 		}
 		if(!hasFireRune) {
-			throw `You don't have ${quantity*5}x ${fireRune.name}`;
+			throw `You don't have ${quantity * 5}x ${fireRune.name}`;
 		}
 		if(!hasNatureRune) {
 			throw `You don't have ${quantity}x ${natureRune.name}`;
 		}
-		
 
 		const totalValue = highAlchValue * quantity;
 
@@ -123,7 +122,7 @@ export default class extends BotCommand {
 			id: rand(1, 10_000_000),
 			finishDate: Date.now() + duration
 		};
-		
+
 		// Remove alched items, as well as runes from bank
 		await msg.author.removeItemFromBank(osItem.id, quantity);
 		await msg.author.removeItemFromBank(fireRune.id, quantity*5);

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -380,7 +380,7 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 			.catch(err => {
 				throw err;
 			});
-		}
+	}
 
 	async mine(msg: KlasaMessage, [quantity, oreName]: [number, string]) {
 		await this.client.commands

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -395,7 +395,7 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 			.catch(err => {
 				throw err;
 			});
-		}
+	}
 
 	async mine(msg: KlasaMessage, [quantity, oreName]: [number, string]) {
 		await this.client.commands

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -364,10 +364,23 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 			});
 	}
 
+<<<<<<< HEAD
+=======
+	async laps(msg: KlasaMessage, [quantity, courseName]: [number, string]) {
+		await this.client.commands
+			.get('laps')!
+			.run(msg, [quantity, courseName])
+			.catch(err => {
+				throw err;
+			});
+	}
+
+>>>>>>> Should fix remaining conflicts
 	async alch(msg: KlasaMessage, [quantity, itemName]: [number, string]) {
 		await this.client.commands
 			.get('alch')!
 			.run(msg, [quantity, itemName])
+<<<<<<< HEAD
 			.catch(err => {
 				throw err;
 			});
@@ -377,10 +390,12 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 		await this.client.commands
 			.get('laps')!
 			.run(msg, [quantity, courseName])
+=======
+>>>>>>> Should fix remaining conflicts
 			.catch(err => {
 				throw err;
 			});
-	}
+		}
 
 	async mine(msg: KlasaMessage, [quantity, oreName]: [number, string]) {
 		await this.client.commands

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -58,7 +58,7 @@ export default class MinionCommand extends BotCommand {
 			cooldown: 1,
 			aliases: ['m'],
 			usage:
-				'[clues|k|kill|setname|buy|clue|kc|pat|stats|mine|smith|quest|qp|chop|ironman|light|fish|laps|cook] [quantity:int{1}|name:...string] [name:...string]',
+				'[clues|k|kill|setname|buy|clue|kc|pat|stats|mine|smith|quest|qp|chop|ironman|light|fish|laps|cook|alch] [quantity:int{1}|name:...string] [name:...string]',
 
 			usageDelim: ' ',
 			subcommands: true
@@ -359,6 +359,15 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 		await this.client.commands
 			.get('fish')!
 			.run(msg, [quantity, fishName])
+			.catch(err => {
+				throw err;
+			});
+	}
+
+	async alch(msg: KlasaMessage, [quantity, itemName]: [number, string]) {
+		await this.client.commands
+			.get('alch')!
+			.run(msg, [quantity, itemName])
 			.catch(err => {
 				throw err;
 			});

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -364,23 +364,10 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 			});
 	}
 
-<<<<<<< HEAD
-=======
-	async laps(msg: KlasaMessage, [quantity, courseName]: [number, string]) {
-		await this.client.commands
-			.get('laps')!
-			.run(msg, [quantity, courseName])
-			.catch(err => {
-				throw err;
-			});
-	}
-
->>>>>>> Should fix remaining conflicts
 	async alch(msg: KlasaMessage, [quantity, itemName]: [number, string]) {
 		await this.client.commands
 			.get('alch')!
 			.run(msg, [quantity, itemName])
-<<<<<<< HEAD
 			.catch(err => {
 				throw err;
 			});
@@ -390,12 +377,10 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 		await this.client.commands
 			.get('laps')!
 			.run(msg, [quantity, courseName])
-=======
->>>>>>> Should fix remaining conflicts
 			.catch(err => {
 				throw err;
 			});
-	}
+		}
 
 	async mine(msg: KlasaMessage, [quantity, oreName]: [number, string]) {
 		await this.client.commands

--- a/src/extendables/UserExtendables.ts
+++ b/src/extendables/UserExtendables.ts
@@ -452,7 +452,7 @@ export default class extends Extendable {
 			case Activity.Alching: {
 				const data = currentTask as AlchingActivityTaskOptions;
 
-				return `${this.minionName} is currently alching ${data.quantity}x ${data.itemName}, for a value of ${data.totalValue}. Approximately ${formattedDuration} remaining.`
+				return `${this.minionName} is currently alching ${data.quantity}x ${data.itemName}, for a value of ${data.totalValue}. Approximately ${formattedDuration} remaining.`;
 			}
 		}
 	}

--- a/src/extendables/UserExtendables.ts
+++ b/src/extendables/UserExtendables.ts
@@ -27,7 +27,8 @@ import {
 	WoodcuttingActivityTaskOptions,
 	FiremakingActivityTaskOptions,
 	FishingActivityTaskOptions,
-	AgilityActivityTaskOptions
+	AgilityActivityTaskOptions,
+	AlchingActivityTaskOptions
 } from '../lib/types/minions';
 import getActivityOfUser from '../lib/util/getActivityOfUser';
 import Smithing from '../lib/skilling/skills/smithing';
@@ -447,6 +448,12 @@ export default class extends Extendable {
 				}x Essence into ${rune!.name}. Approximately ${formattedDuration} remaining. Your ${
 					Emoji.Runecraft
 				} Runecraft level is ${this.skillLevel(SkillsEnum.Runecraft)}`;
+			}
+			case Activity.Alching: {
+				const data = currentTask as AlchingActivityTaskOptions;
+
+
+				return `${this.minionName} is currently alching ${data.quantity}x ${data.itemName}, for a value of ${data.totalValue}. Approximately ${formattedDuration} remaining.`
 			}
 		}
 	}

--- a/src/extendables/UserExtendables.ts
+++ b/src/extendables/UserExtendables.ts
@@ -452,7 +452,6 @@ export default class extends Extendable {
 			case Activity.Alching: {
 				const data = currentTask as AlchingActivityTaskOptions;
 
-
 				return `${this.minionName} is currently alching ${data.quantity}x ${data.itemName}, for a value of ${data.totalValue}. Approximately ${formattedDuration} remaining.`
 			}
 		}

--- a/src/extendables/UserExtendables.ts
+++ b/src/extendables/UserExtendables.ts
@@ -452,7 +452,8 @@ export default class extends Extendable {
 			case Activity.Alching: {
 				const data = currentTask as AlchingActivityTaskOptions;
 
-				return `${this.minionName} is currently alching ${data.quantity}x ${data.itemName}, for a value of ${data.totalValue}. Approximately ${formattedDuration} remaining.`;
+
+				return `${this.minionName} is currently alching ${data.quantity}x ${data.itemName}, for a value of ${data.totalValue}. Approximately ${formattedDuration} remaining.`
 			}
 		}
 	}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -94,7 +94,8 @@ export const enum Tasks {
 	QuestingActivity = 'questingActivity',
 	MonsterKillingTicker = 'monsterKillingTicker',
 	ClueTicker = 'clueTicker',
-	SkillingTicker = 'skillingTicker'
+	SkillingTicker = 'skillingTicker',
+	AlchingActivity = 'alchingActivity'
 }
 
 export const enum Activity {
@@ -108,7 +109,8 @@ export const enum Activity {
 	Woodcutting = 'Woodcutting',
 	Questing = 'Questing',
 	Firemaking = 'Firemaking',
-	Runecraft = 'Runecraft'
+	Runecraft = 'Runecraft',
+	Alching = 'Alching'
 }
 
 export const enum Events {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -65,6 +65,13 @@ export interface QuestingActivityTaskOptions extends ActivityTaskOptions {
 	channelID: string;
 }
 
+export interface AlchingActivityTaskOptions extends ActivityTaskOptions {
+	itemName: string;
+	channelID: string;
+	quantity: number;
+	totalValue: number;
+}
+
 export interface MonsterKillingTickerTaskData {
 	subTasks: MonsterActivityTaskOptions[];
 }
@@ -93,4 +100,5 @@ export type MinionActivityTask =
 	| Tasks.WoodcuttingActivity
 	| Tasks.RunecraftActivity
 	| Tasks.FiremakingActivity
-	| Tasks.QuestingActivity;
+	| Tasks.QuestingActivity
+	| Tasks.AlchingActivity;

--- a/src/lib/util/taskNameFromType.ts
+++ b/src/lib/util/taskNameFromType.ts
@@ -24,5 +24,7 @@ export function taskNameFromType(activityType: Activity) {
 			return Tasks.QuestingActivity;
 		case Activity.Runecraft:
 			return Tasks.RunecraftActivity;
+		case Activity.Alching:
+			return Tasks.AlchingActivity;
 	}
 }

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -1,0 +1,28 @@
+import { Task } from 'klasa';
+
+import { AlchingActivityTaskOptions } from "../../lib/types/minions";
+import { UserSettings } from '../../lib/UserSettings';
+import { channelIsSendable } from '../../lib/util/channelIsSendable';
+import { toKMB } from 'oldschooljs/dist/util/util';
+
+export default class extends Task{
+    async run({itemName, totalValue, quantity, channelID, userID}: AlchingActivityTaskOptions) {
+        const user = await this.client.users.fetch(userID);
+
+        await user.settings.update(
+			UserSettings.GP,
+			user.settings.get(UserSettings.GP) + totalValue
+        );
+        
+        const channel = this.client.channels.get(channelID);
+        if(!channelIsSendable(channel)) return;
+        
+        const str = `${user}, ${user.minionName} has finished alching ${quantity}x ${itemName}! ${totalValue.toLocaleString()}gp (${toKMB(
+            totalValue
+        )}) has been added to your bank.`;
+
+        this.client.queuePromise(() => {
+            channel.send(str);
+        })
+    }
+}

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -6,23 +6,23 @@ import { channelIsSendable } from '../../lib/util/channelIsSendable';
 import { toKMB } from 'oldschooljs/dist/util/util';
 
 export default class extends Task{
-    async run({itemName, totalValue, quantity, channelID, userID}: AlchingActivityTaskOptions) {
-        const user = await this.client.users.fetch(userID);
+	async run({itemName, totalValue, quantity, channelID, userID}: AlchingActivityTaskOptions) {
+		const user = await this.client.users.fetch(userID);
 
-        await user.settings.update(
+		await user.settings.update(
 			UserSettings.GP,
 			user.settings.get(UserSettings.GP) + totalValue
-        );
-        
-        const channel = this.client.channels.get(channelID);
-        if(!channelIsSendable(channel)) return;
-        
-        const str = `${user}, ${user.minionName} has finished alching ${quantity}x ${itemName}! ${totalValue.toLocaleString()}gp (${toKMB(
-            totalValue
-        )}) has been added to your bank.`;
+		);
+		
+		const channel = this.client.channels.get(channelID);
+		if(!channelIsSendable(channel)) return;
+		
+		const str = `${user}, ${user.minionName} has finished alching ${quantity}x ${itemName}! ${totalValue.toLocaleString()}gp (${toKMB(
+			totalValue
+		)}) has been added to your bank.`;
 
-        this.client.queuePromise(() => {
-            channel.send(str);
-        })
-    }
+		this.client.queuePromise(() => {
+			channel.send(str);
+		})
+	}
 }

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -1,7 +1,7 @@
 import { Task } from 'klasa';
 
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
-import { UserSettings } from '../../lib/UserSettings';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { channelIsSendable } from '../../lib/util/channelIsSendable';
 import { toKMB } from 'oldschooljs/dist/util/util';
 

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -1,11 +1,11 @@
 import { Task } from 'klasa';
 
-import { AlchingActivityTaskOptions } from "../../lib/types/minions";
+import { AlchingActivityTaskOptions } from '../../lib/types/minions';
 import { UserSettings } from '../../lib/UserSettings';
 import { channelIsSendable } from '../../lib/util/channelIsSendable';
 import { toKMB } from 'oldschooljs/dist/util/util';
 
-export default class extends Task{
+export default class extends Task {
 	async run({itemName, totalValue, quantity, channelID, userID}: AlchingActivityTaskOptions) {
 		const user = await this.client.users.fetch(userID);
 
@@ -13,11 +13,13 @@ export default class extends Task{
 			UserSettings.GP,
 			user.settings.get(UserSettings.GP) + totalValue
 		);
-		
+
 		const channel = this.client.channels.get(channelID);
-		if(!channelIsSendable(channel)) return;
-		
-		const str = `${user}, ${user.minionName} has finished alching ${quantity}x ${itemName}! ${totalValue.toLocaleString()}gp (${toKMB(
+		if (!channelIsSendable(channel)) return;
+
+		const str = `${user}, ${
+			user.minionName
+		} has finished alching ${quantity}x ${itemName}! ${totalValue.toLocaleString()}gp (${toKMB(
 			totalValue
 		)}) has been added to your bank.`;
 

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -6,7 +6,7 @@ import { channelIsSendable } from '../../lib/util/channelIsSendable';
 import { toKMB } from 'oldschooljs/dist/util/util';
 
 export default class extends Task {
-	async run({itemName, totalValue, quantity, channelID, userID}: AlchingActivityTaskOptions) {
+	async run({ itemName, totalValue, quantity, channelID, userID }: AlchingActivityTaskOptions) {
 		const user = await this.client.users.fetch(userID);
 
 		await user.settings.update(
@@ -25,6 +25,6 @@ export default class extends Task {
 
 		this.client.queuePromise(() => {
 			channel.send(str);
-		})
+		});
 	}
 }


### PR DESCRIPTION
Implements the alch command.

Ensures that the user has all required runes and items in order to cast high alchemy on their items. This takes 5 ticks/3 seconds per item.

`+alch rune platelegs` -> confirms with user, then alchs the max amount of rune platelegs possible
`+alch 5 rune platelegs` ->  confirms with user, then alchs 5x rune platelegs, 
`+alch rune platelegs --[cf/confirm]` -> alchs the max amount of rune platelegs without second confirmation.