### PR TITLE
Raids points algorithm

### DIFF
--- a/src/commands/Minion/check.ts
+++ b/src/commands/Minion/check.ts
@@ -8,12 +8,12 @@ import {
 	getMageContribution
 } from '../../lib/minions/functions/raidsCalculations';
 import {
-	minimumMeleeGear,
-	minimumMageGear,
-	minimumRangeGear,
 	testMeleeGear,
 	testMageGear,
-	testRangeGear
+	testRangeGear,
+	minimumMeleeGear,
+	minimumMageGear,
+	minimumRangeGear
 } from '../../lib/gear/raidsGear';
 
 export default class extends BotCommand {
@@ -26,23 +26,37 @@ export default class extends BotCommand {
 			rangeGear: minimumRangeGear,
 			mageGear: minimumMageGear
 		});
+
 		const TEST_GEAR_SCORE = calcTotalGearScore({
 			meleeGear: testMeleeGear,
 			rangeGear: testRangeGear,
 			mageGear: testMageGear
 		});
+		const meleeGear = testMeleeGear;
+		const rangeGear = testRangeGear;
+		const mageGear = testMageGear;
+
+		// const TEST_GEAR_SCORE = calcTotalGearScore(msg.author.getCombatGear());
+		// const { meleeGear, rangeGear, mageGear } = msg.author.getCombatGear();
 		const difference = TEST_GEAR_SCORE - BASE_GEAR_SCORE;
 		const gearMultiplier = Math.min(2, (difference * 3) / BASE_GEAR_SCORE);
 
-		const res = `min melee: ${getMeleeContribution(
+		const minGearRequired = `min melee: ${getMeleeContribution(
 			minimumMeleeGear
 		)}\nmin range: ${getRangeContribution(minimumRangeGear)}\nmin mage: ${getMageContribution(
 			minimumMageGear
-		)}\n\ntest melee: ${getMeleeContribution(
-			testMeleeGear
-		)}\ntest range: ${getRangeContribution(testRangeGear)}\ntest mage: ${getMageContribution(
-			testMageGear
-		)}\n\nBASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nDifference: ${difference}\nMultiplier: ${gearMultiplier}`;
+		)}\n\n`;
+
+		const testGearUsed = `test melee: ${getMeleeContribution(
+			meleeGear
+		)}\ntest range: ${getRangeContribution(rangeGear)}\ntest mage: ${getMageContribution(
+			mageGear
+		)}\n\n`;
+
+		const res =
+			`${minGearRequired}` +
+			`${testGearUsed}` +
+			`BASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nDifference: ${difference}\nMultiplier: ${gearMultiplier}`;
 
 		return msg.send(res);
 	}

--- a/src/commands/Minion/check.ts
+++ b/src/commands/Minion/check.ts
@@ -5,7 +5,8 @@ import {
 	calcTotalGearScore,
 	getMeleeContribution,
 	getRangeContribution,
-	getMageContribution
+	getMageContribution,
+	getKcMultiplier
 } from '../../lib/minions/functions/raidsCalculations';
 import {
 	testMeleeGear,
@@ -15,9 +16,10 @@ import {
 	minimumMageGear,
 	minimumRangeGear
 } from '../../lib/gear/raidsGear';
+import { Time } from 'oldschooljs/dist/constants';
 
 export default class extends BotCommand {
-	async run(msg: KlasaMessage) {
+	async run(msg: KlasaMessage, [kc = 0]: [number]) {
 		/**
 		 * THIS IS A TEMPORARY COMMAND TO HELP TESTING.
 		 */
@@ -53,10 +55,17 @@ export default class extends BotCommand {
 			mageGear
 		)}\n\n`;
 
+		const totalMultiplier = 1 + gearMultiplier + getKcMultiplier(kc);
+		const BASE_TIME = Time.Minute * 100;
+		const BASE_POINTS = 8_000;
+		const timeAndPointsRes = `Time: ${BASE_TIME / totalMultiplier} Points: ${BASE_POINTS *
+			totalMultiplier}`;
 		const res =
 			`${minGearRequired}` +
 			`${testGearUsed}` +
-			`BASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nDifference: ${difference}\nMultiplier: ${gearMultiplier}`;
+			`BASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nDifference: ${difference}\nGear Multiplier: ${gearMultiplier}` +
+			`Total multiplier: ${totalMultiplier}` +
+			`${timeAndPointsRes}`;
 
 		return msg.send(res);
 	}

--- a/src/commands/Minion/check.ts
+++ b/src/commands/Minion/check.ts
@@ -1,0 +1,32 @@
+import { KlasaMessage } from 'klasa';
+
+import { BotCommand } from '../../lib/BotCommand';
+import { calcTotalGearScore } from '../../lib/minions/functions/raidsCalculations';
+import {
+	minimumMeleeGear,
+	minimumMageGear,
+	minimumRangeGear,
+	testMeleeGear,
+	testMageGear,
+	testRangeGear
+} from '../../lib/gear/raidsGear';
+
+export default class extends BotCommand {
+	async run(msg: KlasaMessage) {
+		/**
+		 * THIS IS A TEMPORARY COMMAND TO HELP TESTING.
+		 */
+		const BASE_GEAR_SCORE = calcTotalGearScore([
+			minimumMeleeGear,
+			minimumRangeGear,
+			minimumMageGear
+		]);
+		const TEST_GEAR_SCORE = calcTotalGearScore([testMeleeGear, testRangeGear, testMageGear]);
+		const Multiplier = Math.min(2, TEST_GEAR_SCORE / BASE_GEAR_SCORE);
+
+		return msg.send(
+			`BASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nMultiplier: ${Multiplier}
+			`
+		);
+	}
+}

--- a/src/commands/Minion/check.ts
+++ b/src/commands/Minion/check.ts
@@ -1,4 +1,4 @@
-import { KlasaMessage } from 'klasa';
+import { KlasaMessage, CommandStore } from 'klasa';
 
 import { BotCommand } from '../../lib/BotCommand';
 import {
@@ -17,9 +17,18 @@ import {
 	minimumRangeGear
 } from '../../lib/gear/raidsGear';
 import { Time } from 'oldschooljs/dist/constants';
+import { formatDuration } from '../../util';
 
 export default class extends BotCommand {
-	async run(msg: KlasaMessage, [kc = 0]: [number]) {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			cooldown: 1,
+			usage: '[quantity:integer{1}]',
+			usageDelim: ' '
+		});
+	}
+
+	async run(msg: KlasaMessage, [kc = 1]: [number]) {
 		/**
 		 * THIS IS A TEMPORARY COMMAND TO HELP TESTING.
 		 */
@@ -28,7 +37,6 @@ export default class extends BotCommand {
 			rangeGear: minimumRangeGear,
 			mageGear: minimumMageGear
 		});
-
 		const TEST_GEAR_SCORE = calcTotalGearScore({
 			meleeGear: testMeleeGear,
 			rangeGear: testRangeGear,
@@ -54,17 +62,19 @@ export default class extends BotCommand {
 		)}\ntest range: ${getRangeContribution(rangeGear)}\ntest mage: ${getMageContribution(
 			mageGear
 		)}\n\n`;
-
-		const totalMultiplier = 1 + gearMultiplier + getKcMultiplier(kc);
+		const kcMultiplier = getKcMultiplier(kc);
+		const totalMultiplier = 1 + gearMultiplier + kcMultiplier;
 		const BASE_TIME = Time.Minute * 100;
 		const BASE_POINTS = 8_000;
-		const timeAndPointsRes = `Time: ${BASE_TIME / totalMultiplier} Points: ${BASE_POINTS *
-			totalMultiplier}`;
+		const timeAndPointsRes = `Time: ${formatDuration(
+			BASE_TIME / totalMultiplier
+		)}\n Points: ${Math.floor(BASE_POINTS * totalMultiplier)}`;
 		const res =
 			`${minGearRequired}` +
 			`${testGearUsed}` +
-			`BASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nDifference: ${difference}\nGear Multiplier: ${gearMultiplier}` +
-			`Total multiplier: ${totalMultiplier}` +
+			`BASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nDifference: ${difference}\nGear Multiplier: ${gearMultiplier}\n` +
+			`KC Multiplier: ${kcMultiplier}\n` +
+			`Total multiplier: ${totalMultiplier}\n\n` +
 			`${timeAndPointsRes}`;
 
 		return msg.send(res);

--- a/src/commands/Minion/check.ts
+++ b/src/commands/Minion/check.ts
@@ -1,7 +1,12 @@
 import { KlasaMessage } from 'klasa';
 
 import { BotCommand } from '../../lib/BotCommand';
-import { calcTotalGearScore } from '../../lib/minions/functions/raidsCalculations';
+import {
+	calcTotalGearScore,
+	getMeleeContribution,
+	getRangeContribution,
+	getMageContribution
+} from '../../lib/minions/functions/raidsCalculations';
 import {
 	minimumMeleeGear,
 	minimumMageGear,
@@ -16,17 +21,29 @@ export default class extends BotCommand {
 		/**
 		 * THIS IS A TEMPORARY COMMAND TO HELP TESTING.
 		 */
-		const BASE_GEAR_SCORE = calcTotalGearScore([
-			minimumMeleeGear,
-			minimumRangeGear,
-			minimumMageGear
-		]);
-		const TEST_GEAR_SCORE = calcTotalGearScore([testMeleeGear, testRangeGear, testMageGear]);
-		const Multiplier = Math.min(2, TEST_GEAR_SCORE / BASE_GEAR_SCORE);
+		const BASE_GEAR_SCORE = calcTotalGearScore({
+			meleeGear: minimumMeleeGear,
+			rangeGear: minimumRangeGear,
+			mageGear: minimumMageGear
+		});
+		const TEST_GEAR_SCORE = calcTotalGearScore({
+			meleeGear: testMeleeGear,
+			rangeGear: testRangeGear,
+			mageGear: testMageGear
+		});
+		const difference = TEST_GEAR_SCORE - BASE_GEAR_SCORE;
+		const gearMultiplier = Math.min(2, (difference * 3) / BASE_GEAR_SCORE);
 
-		return msg.send(
-			`BASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nMultiplier: ${Multiplier}
-			`
-		);
+		const res = `min melee: ${getMeleeContribution(
+			minimumMeleeGear
+		)}\nmin range: ${getRangeContribution(minimumRangeGear)}\nmin mage: ${getMageContribution(
+			minimumMageGear
+		)}\n\ntest melee: ${getMeleeContribution(
+			testMeleeGear
+		)}\ntest range: ${getRangeContribution(testRangeGear)}\ntest mage: ${getMageContribution(
+			testMageGear
+		)}\n\nBASE: ${BASE_GEAR_SCORE}\nTEST: ${TEST_GEAR_SCORE}\nDifference: ${difference}\nMultiplier: ${gearMultiplier}`;
+
+		return msg.send(res);
 	}
 }

--- a/src/commands/Minion/mraid.ts
+++ b/src/commands/Minion/mraid.ts
@@ -196,7 +196,7 @@ export default class extends BotCommand {
 			const userGearMultiplier = getGearMultiplier(user.getCombatGear());
 			const userKcMultiplier = getKcMultiplier(
 				// TODO: use correct kc lookup value
-				user.settings.get(UserSettings.MonsterScores)[1]
+				user.settings.get(UserSettings.MonsterScores)[1] ?? 1
 			);
 			// range 1 - 5
 			const userMultiplier = userGearMultiplier + userKcMultiplier + 1;

--- a/src/commands/Minion/mraid.ts
+++ b/src/commands/Minion/mraid.ts
@@ -198,6 +198,7 @@ export default class extends BotCommand {
 				// TODO: use correct kc lookup value
 				user.settings.get(UserSettings.MonsterScores)[1]
 			);
+			// range 1 - 5
 			const userMultiplier = userGearMultiplier + userKcMultiplier + 1;
 			const userPoints = BASE_POINTS * userMultiplier;
 			teamMultiplier += userMultiplier;

--- a/src/commands/Minion/mraid.ts
+++ b/src/commands/Minion/mraid.ts
@@ -195,10 +195,10 @@ export default class extends BotCommand {
 		let teamMultiplier = 0;
 		for (const user of newUsers) {
 			const userGearScore = calcTotalGearScore(Object.values(user.getCombatGear()));
-			const userGearMultiplier = Math.max(2, userGearScore / BASE_GEAR_SCORE);
+			const userGearMultiplier = Math.min(2, userGearScore / BASE_GEAR_SCORE);
 			const userKcMultiplier = Math.min(
 				2,
-				Math.log(user.settings.get(UserSettings.MonsterScores)['RAIDS']) / Math.log(20)
+				Math.log(user.settings.get(UserSettings.MonsterScores)[1]) / Math.log(20)
 			);
 			const userPoints = BASE_POINTS * (userGearMultiplier + userKcMultiplier);
 			teamMultiplier += userGearMultiplier + userKcMultiplier;

--- a/src/commands/Minion/spawn.ts
+++ b/src/commands/Minion/spawn.ts
@@ -1,0 +1,33 @@
+import { KlasaMessage, CommandStore } from 'klasa';
+
+import { BotCommand } from '../../lib/BotCommand';
+import getOSItem from '../../lib/util/getOSItem';
+import { Emoji } from '../../lib/constants';
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			cooldown: 1,
+			usage: '<number:int{1,100}> <itemname:...string>',
+			usageDelim: ' ',
+			oneAtTime: true
+		});
+	}
+
+	async run(msg: KlasaMessage, [qty, itemName]: [number, number]) {
+		const osItem = getOSItem(itemName);
+		await msg.author.addItemsToBank({ [osItem.id]: qty });
+		for (const setup of ['range', 'melee', 'mage']) {
+			if (msg.flagArgs[setup]) {
+				try {
+					await this.client.commands.get('equip')!.run(msg, [setup, 1, osItem.name]);
+					return msg.send(`Equipped 1x ${osItem.name} to your ${setup} setup.`);
+				} catch (err) {
+					return msg.send(`Failed to equip item. Equip it yourself ${Emoji.PeepoNoob}`);
+				}
+			}
+		}
+
+		return msg.send(`Gave you ${qty}x ${osItem.name}.`);
+	}
+}

--- a/src/lib/gear/raidsGear.ts
+++ b/src/lib/gear/raidsGear.ts
@@ -16,13 +16,13 @@ const minimumMeleeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Ammo]: null,
 	[EquipmentSlot.Body]: singular("Torag's platebody"),
 	[EquipmentSlot.Cape]: null,
-	[EquipmentSlot.Feet]: null,
+	[EquipmentSlot.Feet]: singular('Rune boots'),
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: singular('Helm Of Neitiznot'),
 	[EquipmentSlot.Legs]: singular("Torag's platelegs"),
-	[EquipmentSlot.Neck]: singular('Amulet of power'),
+	[EquipmentSlot.Neck]: singular('Amulet of glory'),
 	[EquipmentSlot.Ring]: null,
-	[EquipmentSlot.Shield]: null,
+	[EquipmentSlot.Shield]: singular('Rune kiteshield'),
 	[EquipmentSlot.Weapon]: singular('Dragon scimitar')
 };
 
@@ -33,7 +33,7 @@ const minimumMageGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Cape]: null,
 	[EquipmentSlot.Feet]: singular('Mystic boots'),
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
-	[EquipmentSlot.Head]: null,
+	[EquipmentSlot.Head]: singular('Mystic hat'),
 	[EquipmentSlot.Legs]: singular('Mystic robe bottom'),
 	[EquipmentSlot.Neck]: singular('Amulet of power'),
 	[EquipmentSlot.Ring]: null,
@@ -43,12 +43,12 @@ const minimumMageGear: GearTypes.GearSetup = {
 
 const minimumRangeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.TwoHanded]: null,
-	[EquipmentSlot.Ammo]: singular('Steel arrow'),
+	[EquipmentSlot.Ammo]: singular('Adamant arrow'),
 	[EquipmentSlot.Body]: singular("Black d'hide body"),
 	[EquipmentSlot.Cape]: null,
-	[EquipmentSlot.Feet]: null,
+	[EquipmentSlot.Feet]: singular('Snakeskin boots'),
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
-	[EquipmentSlot.Head]: null,
+	[EquipmentSlot.Head]: singular('Snakeskin bandana'),
 	[EquipmentSlot.Legs]: singular("Black d'hide chaps"),
 	[EquipmentSlot.Neck]: singular('Amulet of power'),
 	[EquipmentSlot.Ring]: null,
@@ -67,8 +67,8 @@ const testMeleeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Legs]: singular('Bandos Tassets'),
 	[EquipmentSlot.Neck]: singular('Amulet of glory'),
 	[EquipmentSlot.Ring]: singular('Berserker ring'),
-	[EquipmentSlot.Shield]: singular('Dragon defender'),
-	[EquipmentSlot.Weapon]: singular('Abyssal whip')
+	[EquipmentSlot.Shield]: singular('Dragonfire shield'),
+	[EquipmentSlot.Weapon]: singular('Dragon scimitar')
 };
 
 const testMageGear: GearTypes.GearSetup = {
@@ -88,7 +88,7 @@ const testMageGear: GearTypes.GearSetup = {
 
 const testRangeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.TwoHanded]: null,
-	[EquipmentSlot.Ammo]: singular('Dragon bolts'),
+	[EquipmentSlot.Ammo]: singular('Onyx bolts (e)'),
 	[EquipmentSlot.Body]: singular('Armadyl chestplate'),
 	[EquipmentSlot.Cape]: singular(`Ava's assembler`),
 	[EquipmentSlot.Feet]: singular('Ranger boots'),

--- a/src/lib/gear/raidsGear.ts
+++ b/src/lib/gear/raidsGear.ts
@@ -16,12 +16,12 @@ const minimumMeleeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Ammo]: null,
 	[EquipmentSlot.Body]: singular("Torag's platebody"),
 	[EquipmentSlot.Cape]: null,
-	[EquipmentSlot.Feet]: singular('Rune boots'),
+	[EquipmentSlot.Feet]: null,
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: singular('Helm Of Neitiznot'),
 	[EquipmentSlot.Legs]: singular("Torag's platelegs"),
-	[EquipmentSlot.Neck]: singular('Amulet of glory'),
-	[EquipmentSlot.Ring]: singular('Warrior ring'),
+	[EquipmentSlot.Neck]: singular('Amulet of power'),
+	[EquipmentSlot.Ring]: null,
 	[EquipmentSlot.Shield]: null,
 	[EquipmentSlot.Weapon]: singular('Dragon scimitar')
 };
@@ -29,31 +29,83 @@ const minimumMeleeGear: GearTypes.GearSetup = {
 const minimumMageGear: GearTypes.GearSetup = {
 	[EquipmentSlot.TwoHanded]: null,
 	[EquipmentSlot.Ammo]: null,
-	[EquipmentSlot.Body]: singular("Ahrim's robetop"),
+	[EquipmentSlot.Body]: singular('Mystic robetop'),
 	[EquipmentSlot.Cape]: null,
-	[EquipmentSlot.Feet]: null,
+	[EquipmentSlot.Feet]: singular('Mystic boots'),
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: null,
-	[EquipmentSlot.Legs]: singular("Ahrim's robeskirt"),
-	[EquipmentSlot.Neck]: singular('Amulet of glory'),
-	[EquipmentSlot.Ring]: singular('Seers ring'),
+	[EquipmentSlot.Legs]: singular('Mystic robe bottom'),
+	[EquipmentSlot.Neck]: singular('Amulet of power'),
+	[EquipmentSlot.Ring]: null,
 	[EquipmentSlot.Shield]: null,
 	[EquipmentSlot.Weapon]: singular('Fire battlestaff')
 };
 
 const minimumRangeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.TwoHanded]: null,
-	[EquipmentSlot.Ammo]: null,
-	[EquipmentSlot.Body]: singular("Karil's leathertop"),
+	[EquipmentSlot.Ammo]: singular('Steel arrow'),
+	[EquipmentSlot.Body]: singular("Black d'hide body"),
 	[EquipmentSlot.Cape]: null,
-	[EquipmentSlot.Feet]: singular('Snakeskin boots'),
+	[EquipmentSlot.Feet]: null,
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: null,
-	[EquipmentSlot.Legs]: singular("Karil's leatherskirt"),
-	[EquipmentSlot.Neck]: singular('Amulet of glory'),
-	[EquipmentSlot.Ring]: singular('Archers ring'),
+	[EquipmentSlot.Legs]: singular("Black d'hide chaps"),
+	[EquipmentSlot.Neck]: singular('Amulet of power'),
+	[EquipmentSlot.Ring]: null,
 	[EquipmentSlot.Shield]: null,
 	[EquipmentSlot.Weapon]: singular('Magic shortbow')
 };
 
-export { minimumMeleeGear, minimumMageGear, minimumRangeGear };
+const testMeleeGear: GearTypes.GearSetup = {
+	[EquipmentSlot.TwoHanded]: null,
+	[EquipmentSlot.Ammo]: null,
+	[EquipmentSlot.Body]: singular('Bandos chestplate'),
+	[EquipmentSlot.Cape]: null,
+	[EquipmentSlot.Feet]: null,
+	[EquipmentSlot.Hands]: singular('Barrows gloves'),
+	[EquipmentSlot.Head]: singular('Helm Of Neitiznot'),
+	[EquipmentSlot.Legs]: singular('Bandos Tassets'),
+	[EquipmentSlot.Neck]: singular('Amulet of glory'),
+	[EquipmentSlot.Ring]: singular('Berserker ring'),
+	[EquipmentSlot.Shield]: singular('Dragon defender'),
+	[EquipmentSlot.Weapon]: singular('Abyssal whip')
+};
+
+const testMageGear: GearTypes.GearSetup = {
+	[EquipmentSlot.TwoHanded]: null,
+	[EquipmentSlot.Ammo]: null,
+	[EquipmentSlot.Body]: singular("Ahrim's robetop"),
+	[EquipmentSlot.Cape]: null,
+	[EquipmentSlot.Feet]: singular('Wizard boots'),
+	[EquipmentSlot.Hands]: singular('Barrows gloves'),
+	[EquipmentSlot.Head]: singular("Ahrim's hood"),
+	[EquipmentSlot.Legs]: singular("Ahrim's robeskirt"),
+	[EquipmentSlot.Neck]: singular('amulet of glory'),
+	[EquipmentSlot.Ring]: singular('Seers ring'),
+	[EquipmentSlot.Shield]: singular(`Malediction ward`),
+	[EquipmentSlot.Weapon]: singular('Toxic staff of the dead')
+};
+
+const testRangeGear: GearTypes.GearSetup = {
+	[EquipmentSlot.TwoHanded]: null,
+	[EquipmentSlot.Ammo]: singular('Dragon bolts'),
+	[EquipmentSlot.Body]: singular('Armadyl chestplate'),
+	[EquipmentSlot.Cape]: singular(`Ava's assembler`),
+	[EquipmentSlot.Feet]: singular('Ranger boots'),
+	[EquipmentSlot.Hands]: singular('Barrows gloves'),
+	[EquipmentSlot.Head]: singular('Armadyl helmet'),
+	[EquipmentSlot.Legs]: singular('Armadyl chainskirt'),
+	[EquipmentSlot.Neck]: singular('amulet of glory'),
+	[EquipmentSlot.Ring]: singular('Archers ring'),
+	[EquipmentSlot.Shield]: singular('Odium ward'),
+	[EquipmentSlot.Weapon]: singular('Armadyl crossbow')
+};
+
+export {
+	minimumMeleeGear,
+	minimumMageGear,
+	minimumRangeGear,
+	testMeleeGear,
+	testMageGear,
+	testRangeGear
+};

--- a/src/lib/gear/raidsGear.ts
+++ b/src/lib/gear/raidsGear.ts
@@ -1,7 +1,6 @@
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 
 import { GearTypes } from '.';
-import { sumOfSetupStats } from './functions/sumOfSetupStats';
 import getOSItem from '../util/getOSItem';
 
 function singular(itemName: string): GearTypes.GearSlotItem {
@@ -12,22 +11,22 @@ function singular(itemName: string): GearTypes.GearSlotItem {
 	};
 }
 
-const minimumMeleeGear: GearTypes.GearStats = sumOfSetupStats({
+const minimumMeleeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.TwoHanded]: null,
 	[EquipmentSlot.Ammo]: null,
 	[EquipmentSlot.Body]: singular("Torag's platebody"),
 	[EquipmentSlot.Cape]: null,
-	[EquipmentSlot.Feet]: null,
+	[EquipmentSlot.Feet]: singular('Rune boots'),
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: singular('Helm Of Neitiznot'),
 	[EquipmentSlot.Legs]: singular("Torag's platelegs"),
-	[EquipmentSlot.Neck]: null,
+	[EquipmentSlot.Neck]: singular('Amulet of glory'),
 	[EquipmentSlot.Ring]: singular('Warrior ring'),
 	[EquipmentSlot.Shield]: null,
 	[EquipmentSlot.Weapon]: singular('Dragon scimitar')
-});
+};
 
-const minimumMageGear: GearTypes.GearStats = sumOfSetupStats({
+const minimumMageGear: GearTypes.GearSetup = {
 	[EquipmentSlot.TwoHanded]: null,
 	[EquipmentSlot.Ammo]: null,
 	[EquipmentSlot.Body]: singular("Ahrim's robetop"),
@@ -36,25 +35,25 @@ const minimumMageGear: GearTypes.GearStats = sumOfSetupStats({
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: null,
 	[EquipmentSlot.Legs]: singular("Ahrim's robeskirt"),
-	[EquipmentSlot.Neck]: null,
+	[EquipmentSlot.Neck]: singular('Amulet of glory'),
 	[EquipmentSlot.Ring]: singular('Seers ring'),
 	[EquipmentSlot.Shield]: null,
 	[EquipmentSlot.Weapon]: singular('Fire battlestaff')
-});
+};
 
-const minimumRangeGear: GearTypes.GearStats = sumOfSetupStats({
+const minimumRangeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.TwoHanded]: null,
 	[EquipmentSlot.Ammo]: null,
 	[EquipmentSlot.Body]: singular("Karil's leathertop"),
 	[EquipmentSlot.Cape]: null,
-	[EquipmentSlot.Feet]: null,
+	[EquipmentSlot.Feet]: singular('Snakeskin boots'),
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: null,
 	[EquipmentSlot.Legs]: singular("Karil's leatherskirt"),
-	[EquipmentSlot.Neck]: null,
+	[EquipmentSlot.Neck]: singular('Amulet of glory'),
 	[EquipmentSlot.Ring]: singular('Archers ring'),
 	[EquipmentSlot.Shield]: null,
 	[EquipmentSlot.Weapon]: singular('Magic shortbow')
-});
+};
 
 export { minimumMeleeGear, minimumMageGear, minimumRangeGear };

--- a/src/lib/gear/raidsGear.ts
+++ b/src/lib/gear/raidsGear.ts
@@ -20,8 +20,8 @@ const minimumMeleeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Hands]: singular('Mithril gloves'),
 	[EquipmentSlot.Head]: singular('Helm Of Neitiznot'),
 	[EquipmentSlot.Legs]: singular("Torag's platelegs"),
-	[EquipmentSlot.Neck]: singular('Amulet of glory'),
-	[EquipmentSlot.Ring]: null,
+	[EquipmentSlot.Neck]: singular('Amulet of power'),
+	[EquipmentSlot.Ring]: singular('Berserker ring'),
 	[EquipmentSlot.Shield]: singular('Rune kiteshield'),
 	[EquipmentSlot.Weapon]: singular('Dragon scimitar')
 };
@@ -36,14 +36,14 @@ const minimumMageGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Head]: singular('Mystic hat'),
 	[EquipmentSlot.Legs]: singular('Mystic robe bottom'),
 	[EquipmentSlot.Neck]: singular('Amulet of power'),
-	[EquipmentSlot.Ring]: null,
+	[EquipmentSlot.Ring]: singular('Seers ring'),
 	[EquipmentSlot.Shield]: null,
-	[EquipmentSlot.Weapon]: singular('Fire battlestaff')
+	[EquipmentSlot.Weapon]: singular('Ancient staff')
 };
 
 const minimumRangeGear: GearTypes.GearSetup = {
-	[EquipmentSlot.TwoHanded]: null,
-	[EquipmentSlot.Ammo]: singular('Adamant arrow'),
+	[EquipmentSlot.TwoHanded]: singular('Magic shortbow'),
+	[EquipmentSlot.Ammo]: singular('Rune arrow'),
 	[EquipmentSlot.Body]: singular("Black d'hide body"),
 	[EquipmentSlot.Cape]: null,
 	[EquipmentSlot.Feet]: singular('Snakeskin boots'),
@@ -51,9 +51,9 @@ const minimumRangeGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Head]: singular('Snakeskin bandana'),
 	[EquipmentSlot.Legs]: singular("Black d'hide chaps"),
 	[EquipmentSlot.Neck]: singular('Amulet of power'),
-	[EquipmentSlot.Ring]: null,
+	[EquipmentSlot.Ring]: singular('Archers ring'),
 	[EquipmentSlot.Shield]: null,
-	[EquipmentSlot.Weapon]: singular('Magic shortbow')
+	[EquipmentSlot.Weapon]: null
 };
 
 const testMeleeGear: GearTypes.GearSetup = {
@@ -80,7 +80,7 @@ const testMageGear: GearTypes.GearSetup = {
 	[EquipmentSlot.Hands]: singular('Barrows gloves'),
 	[EquipmentSlot.Head]: singular("Ahrim's hood"),
 	[EquipmentSlot.Legs]: singular("Ahrim's robeskirt"),
-	[EquipmentSlot.Neck]: singular('amulet of glory'),
+	[EquipmentSlot.Neck]: singular('Amulet of glory'),
 	[EquipmentSlot.Ring]: singular('Seers ring'),
 	[EquipmentSlot.Shield]: singular(`Malediction ward`),
 	[EquipmentSlot.Weapon]: singular('Toxic staff of the dead')

--- a/src/lib/minions/functions/raidsCalculations.ts
+++ b/src/lib/minions/functions/raidsCalculations.ts
@@ -1,0 +1,82 @@
+import { GearTypes } from '../../gear';
+
+import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
+import getOSItem from '../../util/getOSItem';
+
+const attackMultipliers = {
+	attack: 3,
+	strength: 6,
+	damage: 10
+};
+
+const relevantMeleeStats = [
+	'attack_stab',
+	'attack_slash',
+	'attack_crush',
+	'defence_stab',
+	'defence_slash',
+	'defence_crush',
+	'defence_magic',
+	'defence_ranged',
+	'melee_strength',
+	'prayer'
+];
+
+const relevantRangeStats = [
+	'attack_ranged',
+	'defence_stab',
+	'defence_slash',
+	'defence_crush',
+	'defence_magic',
+	'defence_ranged',
+	'ranged_strength',
+	'prayer'
+];
+
+const relevantMagicStats = [
+	'attack_magic',
+	'defence_stab',
+	'defence_slash',
+	'defence_crush',
+	'defence_magic',
+	'defence_ranged',
+	'magic_damage',
+	'prayer'
+];
+
+const relevantGearStats = [relevantMeleeStats, relevantRangeStats, relevantMagicStats];
+
+function gearContribution(setup: GearTypes.GearSetup, relevantStats: string[]): number {
+	let sum = 0;
+
+	for (const key of Object.values(EquipmentSlot) as EquipmentSlot[]) {
+		// Get the item equipped in that slot...
+		const itemSlot = setup[key];
+		if (!itemSlot) continue;
+		const item = getOSItem(itemSlot.item);
+		for (const keyToAdd of relevantStats) {
+			if (!item.equipment) continue;
+			const attackMultiplier = Object.entries(attackMultipliers).find(stat =>
+				keyToAdd.includes(stat[0])
+			);
+			const multiplier = item.weapon
+				? 8 - item.weapon['attack_speed']
+				: typeof attackMultiplier !== 'undefined'
+				? attackMultiplier[1]
+				: 1;
+			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+			// @ts-ignore
+			sum += item.equipment[keyToAdd] * multiplier;
+		}
+	}
+
+	return sum;
+}
+
+export function calcTotalGearScore(gearSets: GearTypes.GearSetup[]): number {
+	let sum = 0;
+	for (let i = 0; i < 3; i++) {
+		sum += gearContribution(gearSets[i], relevantGearStats[i]);
+	}
+	return sum;
+}

--- a/src/lib/minions/functions/raidsCalculations.ts
+++ b/src/lib/minions/functions/raidsCalculations.ts
@@ -3,9 +3,9 @@ import { GearTypes } from '../../gear';
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 import getOSItem from '../../util/getOSItem';
 
-const attackMultipliers = {
-	attack: 3,
-	strength: 6,
+const attackStyleMultipliers = {
+	attack: 5,
+	strength: 7,
 	damage: 10
 };
 
@@ -54,19 +54,25 @@ function gearContribution(setup: GearTypes.GearSetup, relevantStats: string[]): 
 		const itemSlot = setup[key];
 		if (!itemSlot) continue;
 		const item = getOSItem(itemSlot.item);
+		if (!item.equipment) continue;
+		// Only try to add the stats we care about for each style
 		for (const keyToAdd of relevantStats) {
-			if (!item.equipment) continue;
-			const attackMultiplier = Object.entries(attackMultipliers).find(stat =>
+			// If the stat is an attack stat get that multiplier
+			const attackStyleMultiplier = Object.entries(attackStyleMultipliers).find(stat =>
 				keyToAdd.includes(stat[0])
 			);
+
+			// Set attack multiplier to thefound multiplier or 0.5 if its not an attack style
+			const attackMultiplier =
+				typeof attackStyleMultiplier !== 'undefined' ? attackStyleMultiplier[1] : 0.5;
+
+			// If the item is set the multiplier to 8 - weapon speed (speed in value of ticks per attack) lower is faster
 			const multiplier = item.weapon
-				? 8 - item.weapon['attack_speed']
-				: typeof attackMultiplier !== 'undefined'
-				? attackMultiplier[1]
-				: 1;
+				? 8 - item.weapon['attack_speed'] + attackMultiplier
+				: attackMultiplier;
 			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 			// @ts-ignore
-			sum += item.equipment[keyToAdd] * multiplier;
+			sum += Math.floor(item.equipment[keyToAdd] * multiplier);
 		}
 	}
 
@@ -76,6 +82,7 @@ function gearContribution(setup: GearTypes.GearSetup, relevantStats: string[]): 
 export function calcTotalGearScore(gearSets: GearTypes.GearSetup[]): number {
 	let sum = 0;
 	for (let i = 0; i < 3; i++) {
+		console.log(gearContribution(gearSets[i], relevantGearStats[i]));
 		sum += gearContribution(gearSets[i], relevantGearStats[i]);
 	}
 	return sum;

--- a/src/lib/minions/functions/raidsCalculations.ts
+++ b/src/lib/minions/functions/raidsCalculations.ts
@@ -120,9 +120,11 @@ export function getGearMultiplier(gearSets): number {
 		mageGear: minimumMageGear,
 		rangeGear: minimumRangeGear
 	});
+	// 3 * difference between user gear and base gear to accentuate the gear difference
 	return Math.min(2, (3 * (userGearScore - BASE_GEAR_SCORE)) / BASE_GEAR_SCORE);
 }
 
 export function getKcMultiplier(kc: number): number {
+	// log base 30 of kc: returns 1 with kc 30 and 2 with kc 900
 	return Math.min(2, Math.log(kc) / Math.log(30));
 }

--- a/src/lib/minions/functions/raidsCalculations.ts
+++ b/src/lib/minions/functions/raidsCalculations.ts
@@ -2,6 +2,7 @@ import { GearTypes } from '../../gear';
 
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 import getOSItem from '../../util/getOSItem';
+import { sumOfSetupStats } from '../../gear/functions/sumOfSetupStats';
 
 const statMultipliers = {
 	prayer: 1,
@@ -11,9 +12,6 @@ const statMultipliers = {
 };
 
 const relevantMeleeStats = [
-	'attack_stab',
-	'attack_slash',
-	'attack_crush',
 	'defence_stab',
 	'defence_slash',
 	'defence_crush',
@@ -80,7 +78,16 @@ function gearContribution(setup: GearTypes.GearSetup, relevantStats: string[]): 
 }
 
 export function getMeleeContribution(setup: GearTypes.GearSetup): number {
-	return gearContribution(setup, relevantMeleeStats);
+	const statsSum = sumOfSetupStats(setup);
+	// find the highest of the attack stats and only count that as relevant
+	const stat =
+		statsSum.attack_stab >= statsSum.attack_slash &&
+		statsSum.attack_stab >= statsSum.attack_crush
+			? 'attack_stab'
+			: statsSum.attack_slash >= statsSum.attack_crush
+			? 'attack_slash'
+			: 'attack_crush';
+	return gearContribution(setup, relevantMeleeStats.concat([stat]));
 }
 
 export function getRangeContribution(setup: GearTypes.GearSetup): number {

--- a/src/lib/minions/functions/raidsCalculations.ts
+++ b/src/lib/minions/functions/raidsCalculations.ts
@@ -3,7 +3,8 @@ import { GearTypes } from '../../gear';
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 import getOSItem from '../../util/getOSItem';
 
-const attackStyleMultipliers = {
+const statMultipliers = {
+	prayer: 1,
 	attack: 5,
 	strength: 7,
 	damage: 10
@@ -33,7 +34,7 @@ const relevantRangeStats = [
 	'prayer'
 ];
 
-const relevantMagicStats = [
+const relevantMageStats = [
 	'attack_magic',
 	'defence_stab',
 	'defence_slash',
@@ -43,8 +44,6 @@ const relevantMagicStats = [
 	'magic_damage',
 	'prayer'
 ];
-
-const relevantGearStats = [relevantMeleeStats, relevantRangeStats, relevantMagicStats];
 
 function gearContribution(setup: GearTypes.GearSetup, relevantStats: string[]): number {
 	let sum = 0;
@@ -56,34 +55,49 @@ function gearContribution(setup: GearTypes.GearSetup, relevantStats: string[]): 
 		const item = getOSItem(itemSlot.item);
 		if (!item.equipment) continue;
 		// Only try to add the stats we care about for each style
-		for (const keyToAdd of relevantStats) {
-			// If the stat is an attack stat get that multiplier
-			const attackStyleMultiplier = Object.entries(attackStyleMultipliers).find(stat =>
-				keyToAdd.includes(stat[0])
+		for (const statToAdd of relevantStats) {
+			// If the stat has a multiplier get it
+			const statsMultiplier = Object.entries(statMultipliers).find(stat =>
+				statToAdd.includes(stat[0])
 			);
 
-			// Set attack multiplier to thefound multiplier or 0.5 if its not an attack style
-			const attackMultiplier =
-				typeof attackStyleMultiplier !== 'undefined' ? attackStyleMultiplier[1] : 0.5;
+			// Set stat multiplier to the found multiplier or default 0.5 if it has none
+			const statMultiplier =
+				typeof statsMultiplier !== 'undefined' ? statsMultiplier[1] : 0.5;
 
-			// If the item is set the multiplier to 8 - weapon speed (speed in value of ticks per attack) lower is faster
+			// If the item is a weapon set the multiplier to 8 - weapon speed (speed in value of ticks per attack) lower is faster
 			const multiplier = item.weapon
-				? 8 - item.weapon['attack_speed'] + attackMultiplier
-				: attackMultiplier;
+				? (8 - item.weapon['attack_speed']) * statMultiplier
+				: statMultiplier;
+
 			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 			// @ts-ignore
-			sum += Math.floor(item.equipment[keyToAdd] * multiplier);
+			sum += Math.floor(item.equipment[statToAdd] * multiplier);
 		}
 	}
 
 	return sum;
 }
 
-export function calcTotalGearScore(gearSets: GearTypes.GearSetup[]): number {
-	let sum = 0;
-	for (let i = 0; i < 3; i++) {
-		console.log(gearContribution(gearSets[i], relevantGearStats[i]));
-		sum += gearContribution(gearSets[i], relevantGearStats[i]);
-	}
-	return sum;
+export function getMeleeContribution(setup: GearTypes.GearSetup): number {
+	return gearContribution(setup, relevantMeleeStats);
+}
+
+export function getRangeContribution(setup: GearTypes.GearSetup): number {
+	return gearContribution(setup, relevantRangeStats);
+}
+
+export function getMageContribution(setup: GearTypes.GearSetup): number {
+	return gearContribution(setup, relevantMageStats);
+}
+
+// TODO: fix this maybe
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+export function calcTotalGearScore(gearSets): number {
+	return (
+		getMeleeContribution(gearSets.meleeGear) +
+		getMageContribution(gearSets.mageGear) +
+		getRangeContribution(gearSets.rangeGear)
+	);
 }

--- a/src/lib/minions/functions/raidsCalculations.ts
+++ b/src/lib/minions/functions/raidsCalculations.ts
@@ -3,6 +3,7 @@ import { GearTypes } from '../../gear';
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 import getOSItem from '../../util/getOSItem';
 import { sumOfSetupStats } from '../../gear/functions/sumOfSetupStats';
+import { minimumMeleeGear, minimumMageGear, minimumRangeGear } from '../../gear/raidsGear';
 
 const statMultipliers = {
 	prayer: 1,
@@ -107,4 +108,21 @@ export function calcTotalGearScore(gearSets): number {
 		getMageContribution(gearSets.mageGear) +
 		getRangeContribution(gearSets.rangeGear)
 	);
+}
+
+// TODO: fix this maybe
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+export function getGearMultiplier(gearSets): number {
+	const userGearScore = calcTotalGearScore(gearSets);
+	const BASE_GEAR_SCORE = calcTotalGearScore({
+		meleeGear: minimumMeleeGear,
+		mageGear: minimumMageGear,
+		rangeGear: minimumRangeGear
+	});
+	return Math.min(2, (3 * (userGearScore - BASE_GEAR_SCORE)) / BASE_GEAR_SCORE);
+}
+
+export function getKcMultiplier(kc: number): number {
+	return Math.min(2, Math.log(kc) / Math.log(30));
 }

--- a/src/tasks/minions/raidsActivity.ts
+++ b/src/tasks/minions/raidsActivity.ts
@@ -28,6 +28,8 @@ const uniques = [
 	22396
 ];
 
+// TODO: increment users kc score
+
 export default class extends Task {
 	async run({ channelID, team, challengeMode, duration }: RaidsActivityTaskOptions) {
 		const loot = ChambersOfXeric.complete({


### PR DESCRIPTION
### Description:

creates raidsCalculations:

`gearContribution` - iterates all the "relevant" stats its been passed and gives them a multiple, multiplying the score and summing each together.  Weapons have their attack speed multiply that multiplier to accentuate their importance.
	
`getMeleeContribution` - only makes the highest accuracy stat the "relevant" one to avoid artificial inflation of gear score

`getGearMultiplier` - returns a range of 0-2 of the difference between the users gear and the specified base required gear multiplited by three in order to have the base be good gear and still get a good range out of the difference

`getKcMultiplier` - returns a range of 0-2 of the log base 30 of the users KC which is 1 at 30 and 2 at 900

mraid:
	uses the calculated gear multiplier to multiply a base points value of 8k to get a range from 8k - 40k for a users points at the end of the raid
	divides the base time by the teams avg multiplier to get a range from 100mins - 20mins
	
adds a `check` command in order to test gear scores and see gear multipliers and difference between sets

### Changes:

-   [] I have tested all my changes thoroughly.
