### PR TITLE
create item argument to resolve items passed to commands using the usage string

### DIFF
--- a/src/arguments/integer.ts
+++ b/src/arguments/integer.ts
@@ -8,6 +8,19 @@ export default class extends Argument {
 
 	run(arg: string, possible: Possible, message: KlasaMessage) {
 		const { min, max } = possible;
+
+		/* 
+			remove all valid characters from the passed arg
+			if there are still some remaining, the passed arg is an invalid kmb number
+			throw and return
+			
+			this fixes "3rd age" items from being resolved as integers
+		*/
+		const checkValidKMB = arg.replace(/[0-9,_.kmb]/gi, '');
+		if (checkValidKMB.length > 0) {
+			throw message.language.get('RESOLVER_INVALID_INT', possible.name);
+		}
+
 		const number = Util.fromKMB(arg.replace(/[,_]/gi, ''));
 		if (!Number.isInteger(number)) {
 			throw message.language.get('RESOLVER_INVALID_INT', possible.name);

--- a/src/arguments/item.ts
+++ b/src/arguments/item.ts
@@ -1,0 +1,20 @@
+import { Argument } from 'klasa';
+import { Items } from 'oldschooljs';
+
+import { Item } from 'oldschooljs/dist/meta/types';
+import getOSItem from '../lib/util/getOSItem';
+import { stringMatches } from '../lib/util';
+
+export default class extends Argument {
+	async run(itemName: string) {
+		// guarantee all characters are numbers
+		if (parseInt(itemName).toString().length === itemName.length) {
+			return [getOSItem(parseInt(itemName))];
+		}
+
+		const osItems = Items.filter(i => stringMatches(i.name, itemName)).array() as Item[];
+		if (!osItems.length) throw `${itemName} doesnt exist.`;
+
+		return osItems;
+	}
+}

--- a/src/arguments/restItem.ts
+++ b/src/arguments/restItem.ts
@@ -1,0 +1,26 @@
+import { Argument, ArgumentStore, Possible, KlasaMessage } from 'klasa';
+
+export default class extends Argument {
+	public constructor(store: ArgumentStore, file: string[], directory: string) {
+		super(store, file, directory, { name: '...item', aliases: ['...item'] });
+	}
+
+	async run(arg: string, possible: Possible, message: KlasaMessage): Promise<any> {
+		if (!arg) return this.store.get('item')!.run(arg, possible, message);
+
+		const {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+			// @ts-ignore
+			args,
+			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+			// @ts-ignore
+			usage: { usageDelim }
+		} = // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+			// @ts-ignore
+			message.prompter;
+
+		const index = args.indexOf(arg);
+		const rest = args.splice(index, args.length - index).join(usageDelim);
+		return this.store.get('item')!.run(rest, possible, message);
+	}
+}

--- a/src/commands/Minion/drop.ts
+++ b/src/commands/Minion/drop.ts
@@ -1,9 +1,8 @@
 import { KlasaMessage, CommandStore } from 'klasa';
-import { Items } from 'oldschooljs';
 
 import { BotCommand } from '../../lib/BotCommand';
-import { stringMatches } from '../../lib/util';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { Item } from 'oldschooljs/dist/meta/types';
 
 const options = {
 	max: 1,
@@ -15,23 +14,27 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			cooldown: 4,
-			usage: '<quantity:int{1}> <itemname:...string>',
+			usage: '[quantity:int{1}] (item:...item)',
 			usageDelim: ' ',
 			oneAtTime: true
 		});
 	}
 
-	async run(msg: KlasaMessage, [quantity, itemName]: [number, string]) {
+	async run(msg: KlasaMessage, [quantity, item]: [number, Item[]]) {
 		const userBank = msg.author.settings.get(UserSettings.Bank);
-		const osItem = Items.find(i => stringMatches(itemName, i.name) && Boolean(userBank[i.id]));
+		const osItem = item.find(i => userBank[i.id]);
 
 		if (!osItem) {
-			throw `I couldn't find any items matching this name that you own.`;
+			throw `You don't have any of this item to drop!`;
 		}
 
-		const hasItem = await msg.author.hasItem(osItem.id, quantity, false);
-		if (!hasItem) {
-			throw `You don't have ${quantity}x ${osItem.name}.`;
+		const numItemsHas = userBank[osItem.id];
+		if (!quantity) {
+			quantity = numItemsHas;
+		}
+
+		if (quantity > numItemsHas) {
+			throw `You dont have ${quantity}x ${osItem.name}.`;
 		}
 
 		if (!msg.flagArgs.confirm && !msg.flagArgs.cf) {


### PR DESCRIPTION
### Description:

creates the `item` klasa argument to resolve items by declaring a variable will be an item in the commands usage string

modifies the integer argument to only accept valid KMB numbers

closes #156 

### Changes:

- creation of src/arguments/item.ts and src/arguments/restItem.ts
- number checking in the integer argument to only accept valid KMB numbers, throw if otherwise
- refactor drop, equip, equippet, sacrifice, sell, sellto, unequip to declare their item variable as a `...item` in the usage string and use that accordingly in the command

-   [x] I have tested all my changes thoroughly.
