### PR TITLE
Fix Barbarian Fishing Requirements and Rates

### DIFF
--- a/src/commands/Minion/fish.ts
+++ b/src/commands/Minion/fish.ts
@@ -74,14 +74,30 @@ export default class extends BotCommand {
 			quantity = Math.floor(msg.author.maxTripLength / scaledTimePerFish);
 		}
 
-		let duration = quantity * scaledTimePerFish;
+		let duration = 0;
+
+		if (fish.name === 'Barbarian fishing') {
+			duration = quantity * fish.timePerFish;
+		}
+		else {
+			duration = quantity * scaledTimePerFish;
+		}
 
 		if (duration > msg.author.maxTripLength) {
-			throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
-				msg.author.maxTripLength
-			)}, try a lower quantity. The highest amount of ${
-				fish.name
-			} you can fish is ${Math.floor(msg.author.maxTripLength / scaledTimePerFish)}.`;
+			if (fish.name === 'Barbarian fishing') {
+				throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
+					msg.author.maxTripLength
+				)}, try a lower quantity. The highest amount of ${
+					fish.name
+				} you can fish is ${Math.floor(msg.author.maxTripLength / fish.timePerFish)}.`;
+			}
+			else {
+				throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
+					msg.author.maxTripLength
+				)}, try a lower quantity. The highest amount of ${
+					fish.name
+				} you can fish is ${Math.floor(msg.author.maxTripLength / scaledTimePerFish)}.`;
+			}
 		}
 
 		if (fish.bait) {

--- a/src/commands/Minion/fish.ts
+++ b/src/commands/Minion/fish.ts
@@ -113,9 +113,18 @@ export default class extends BotCommand {
 		await addSubTaskToActivityTask(this.client, Tasks.SkillingTicker, data);
 		msg.author.incrementMinionDailyDuration(duration);
 
-		const response = `${msg.author.minionName} is now fishing ${quantity}x ${
-			fish.name
-		}, it'll take around ${formatDuration(duration)} to finish.`;
+		let response = '';
+
+		if (fish.name === 'Barbarian fishing') {
+			response = `${msg.author.minionName} is now attempting to fish ${quantity}x ${
+				fish.name
+			}, it'll take around ${formatDuration(duration)} to finish.`;
+		}
+		else {
+			response = `${msg.author.minionName} is now fishing ${quantity}x ${
+				fish.name
+			}, it'll take around ${formatDuration(duration)} to finish.`;
+		}
 
 		return msg.send(response);
 	}

--- a/src/commands/Minion/fish.ts
+++ b/src/commands/Minion/fish.ts
@@ -119,8 +119,7 @@ export default class extends BotCommand {
 			response = `${msg.author.minionName} is now attempting to fish ${quantity}x ${
 				fish.name
 			}, it'll take around ${formatDuration(duration)} to finish.`;
-		}
-		else {
+		} else {
 			response = `${msg.author.minionName} is now fishing ${quantity}x ${
 				fish.name
 			}, it'll take around ${formatDuration(duration)} to finish.`;

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -30,7 +30,7 @@ export default class extends Task {
 		let fishChanceSalmon = 0;
 		let fishChanceTrout = 0;
 		let fishFailed = 0;
-		let attemptedQuantity = quantity;
+		const attemptedQuantity = quantity;
 
 		if (fish.name === 'Barbarian fishing') {
 			for (let i = 0; i < attemptedQuantity; i++) {
@@ -38,7 +38,8 @@ export default class extends Task {
 				fishChanceSalmon = Math.random();
 				fishChanceTrout = Math.random();
 				if (
-					(fishChanceSturgeon <= (8 + Math.floor(0.5714 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
+					fishChanceSturgeon <=
+						(8 + Math.floor(0.5714 * user.skillLevel(SkillsEnum.Fishing))) / 255 &&
 					user.skillLevel(SkillsEnum.Fishing) >= 70 &&
 					user.skillLevel(SkillsEnum.Agility) >= 45
 				) {
@@ -46,7 +47,8 @@ export default class extends Task {
 					agilityXpReceived += 7;
 					leapingSturgeon += 1;
 				} else if (
-					(fishChanceSalmon <= (16 + Math.floor(0.8616 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
+					fishChanceSalmon <=
+						(16 + Math.floor(0.8616 * user.skillLevel(SkillsEnum.Fishing))) / 255 &&
 					user.skillLevel(SkillsEnum.Fishing) >= 58 &&
 					user.skillLevel(SkillsEnum.Agility) >= 30
 				) {
@@ -54,13 +56,13 @@ export default class extends Task {
 					leapingSalmon += 1;
 					agilityXpReceived += 6;
 				} else if (
-					(fishChanceTrout <= ((32 + Math.floor(1.632 * user.skillLevel(SkillsEnum.Fishing)))/255)
-				)) {
+					fishChanceTrout <=
+					(32 + Math.floor(1.632 * user.skillLevel(SkillsEnum.Fishing))) / 255
+				) {
 					xpReceived += 50;
 					leapingTrout += 1;
 					agilityXpReceived += 5;
-				}
-				else {;
+				} else {
 					fishFailed += 1;
 				}
 			}
@@ -128,9 +130,7 @@ export default class extends Task {
 			}. You received ${xpReceived.toLocaleString()} fishing XP and ${agilityXpReceived.toLocaleString()} Agility XP. ${
 				user.minionName
 			} asks if you'd like them to do another of the same trip.
-			\n\nYou received: ${leapingSturgeon}x Leaping sturgeon, ${leapingSalmon}x Leaping salmon, and ${
-				leapingTrout
-			}x Leaping trout, and failed to catch a fish in ${fishFailed}/${quantity} attempts.`;
+			\n\nYou received: ${leapingSturgeon}x Leaping sturgeon, ${leapingSalmon}x Leaping salmon, and ${leapingTrout}x Leaping trout, and failed to catch a fish in ${fishFailed}/${quantity} attempts.`;
 			if (newLevel > currentLevel) {
 				str += `\n\n${user.minionName}'s Fishing level is now ${newLevel}!`;
 			}

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -38,7 +38,7 @@ export default class extends Task {
 				fishChanceSalmon = Math.random();
 				fishChanceTrout = Math.random();
 				if (
-					(fishChanceSturgeon < (8 + Math.floor(0.5714 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
+					(fishChanceSturgeon <= (8 + Math.floor(0.5714 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
 					user.skillLevel(SkillsEnum.Fishing) >= 70 &&
 					user.skillLevel(SkillsEnum.Agility) >= 45
 				) {
@@ -46,7 +46,7 @@ export default class extends Task {
 					agilityXpReceived += 7;
 					leapingSturgeon += 1;
 				} else if (
-					(fishChanceSalmon < (16 + Math.floor(0.8616 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
+					(fishChanceSalmon <= (16 + Math.floor(0.8616 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
 					user.skillLevel(SkillsEnum.Fishing) >= 58 &&
 					user.skillLevel(SkillsEnum.Agility) >= 30
 				) {
@@ -54,7 +54,7 @@ export default class extends Task {
 					leapingSalmon += 1;
 					agilityXpReceived += 6;
 				} else if (
-					(fishChanceTrout < ((32 + Math.floor(1.632 * user.skillLevel(SkillsEnum.Fishing)))/255)
+					(fishChanceTrout <= ((32 + Math.floor(1.632 * user.skillLevel(SkillsEnum.Fishing)))/255)
 				)) {
 					xpReceived += 50;
 					leapingTrout += 1;

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -26,18 +26,27 @@ export default class extends Task {
 		let leapingSalmon = 0;
 		let leapingTrout = 0;
 		let agilityXpReceived = 0;
+		let fishChanceSturgeon = 0;
+		let fishChanceSalmon = 0;
+		let fishChanceTrout = 0;
+		let fishFailed = 0;
+		let attemptedQuantity = quantity;
+
 		if (fish.name === 'Barbarian fishing') {
-			for (let i = 0; i < quantity; i++) {
+			for (let i = 0; i < attemptedQuantity; i++) {
+				fishChanceSturgeon = Math.random();
+				fishChanceSalmon = Math.random();
+				fishChanceTrout = Math.random();
 				if (
-					roll(255 / (8 + Math.floor(0.5714 * user.skillLevel(SkillsEnum.Fishing)))) &&
+					(fishChanceSturgeon < (8 + Math.floor(0.5714 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
 					user.skillLevel(SkillsEnum.Fishing) >= 70 &&
-					user.skillLevel(SkillsEnum.Agility) >= 48
+					user.skillLevel(SkillsEnum.Agility) >= 45
 				) {
 					xpReceived += 80;
 					agilityXpReceived += 7;
 					leapingSturgeon += 1;
 				} else if (
-					roll(255 / (16 + Math.floor(0.8616 * user.skillLevel(SkillsEnum.Fishing)))) &&
+					(fishChanceSalmon < (16 + Math.floor(0.8616 * user.skillLevel(SkillsEnum.Fishing)))/255) &&
 					user.skillLevel(SkillsEnum.Fishing) >= 58 &&
 					user.skillLevel(SkillsEnum.Agility) >= 30
 				) {
@@ -45,11 +54,14 @@ export default class extends Task {
 					leapingSalmon += 1;
 					agilityXpReceived += 6;
 				} else if (
-					roll(255 / (32 + Math.floor(1.632 * user.skillLevel(SkillsEnum.Fishing))))
-				) {
+					(fishChanceTrout < ((32 + Math.floor(1.632 * user.skillLevel(SkillsEnum.Fishing)))/255)
+				)) {
 					xpReceived += 50;
 					leapingTrout += 1;
 					agilityXpReceived += 5;
+				}
+				else {;
+					fishFailed += 1;
 				}
 			}
 		} else {
@@ -111,12 +123,14 @@ export default class extends Task {
 
 		str += `\n\nYou received: ${await createReadableItemListFromBank(this.client, loot)}.`;
 		if (fish.name === 'Barbarian fishing') {
-			str = `${user}, ${user.minionName} finished fishing ${quantity} ${
+			str = `${user}, ${user.minionName} finished attempting to fish ${quantity} ${
 				fish.name
-			}, you also received ${xpReceived.toLocaleString()} fishing XP and ${agilityXpReceived.toLocaleString()} Agility XP. ${
+			}. You received ${xpReceived.toLocaleString()} fishing XP and ${agilityXpReceived.toLocaleString()} Agility XP. ${
 				user.minionName
 			} asks if you'd like them to do another of the same trip.
-			\n\nYou received: ${leapingSturgeon}x Leaping sturgeon, ${leapingSalmon}x Leaping salmon, and ${leapingTrout}x Leaping trout.`;
+			\n\nYou received: ${leapingSturgeon}x Leaping sturgeon, ${leapingSalmon}x Leaping salmon, and ${
+				leapingTrout
+			}x Leaping trout, and failed to catch a fish in ${fishFailed}/${quantity} attempts.`;
 			if (newLevel > currentLevel) {
 				str += `\n\n${user.minionName}'s Fishing level is now ${newLevel}!`;
 			}


### PR DESCRIPTION
### Description:

- Previously, leaping sturgeons had a 48 agility requirement. This has been fixed to 45. 
- Previously, the minion always obtained a leaping trout even though there is supposed to be a chance for a failed roll. This roll for a failed catch has been added. Exp rates are now normalized thanks to this addition.

### Changes:

-  Add a chance to NOT catch a fish during barbarian fishing.
- Changed the message received when starting a barbarian fishing run to reflect that a player now attempts a certain amount of fish.
- Changed the message received when minion finishes a barb fishing run to reflect that a player failed a fish an amount of failed/attempts.

-   [X] I have tested all my changes thoroughly.
