### PR TITLE
correct math in fightcaves and wt commands

### DIFF
--- a/src/commands/Minion/fightcaves.ts
+++ b/src/commands/Minion/fightcaves.ts
@@ -44,7 +44,7 @@ export default class extends BotCommand {
 
 		// Reduce time based on KC
 		const jadKC = user.getKC(TzTokJad);
-		const percentIncreaseFromKC = Math.floor(calcWhatPercent(Math.min(50, jadKC), 50)) / 2;
+		const percentIncreaseFromKC = Math.min(50, jadKC);
 		baseTime = reduceNumByPercent(baseTime, percentIncreaseFromKC);
 		debugStr += `${percentIncreaseFromKC}% from KC`;
 
@@ -61,21 +61,21 @@ export default class extends BotCommand {
 
 	determineChanceOfDeathPreJad(user: KlasaUser) {
 		const attempts = user.settings.get(UserSettings.Stats.FightCavesAttempts);
-		let deathChance = 14 - attempts * 2;
+		let deathChance = Math.max(14 - attempts * 2, 5);
 
 		// -4% Chance of dying before Jad if you have SGS.
 		if (user.hasItemEquippedAnywhere(itemID('Saradomin godsword'))) {
 			deathChance -= 4;
 		}
 
-		return Math.max(deathChance, 5);
+		return deathChance;
 	}
 
 	determineChanceOfDeathInJad(user: KlasaUser) {
 		const attempts = user.settings.get(UserSettings.Stats.FightCavesAttempts);
 		const chance = Math.floor(100 - (Math.log(attempts) / Math.log(Math.sqrt(15))) * 50);
 
-		// Chance of death cannot be 100% or <5>%.
+		// Chance of death cannot be 100% or <5%.
 		return Math.max(Math.min(chance, 99), 5);
 	}
 
@@ -166,7 +166,7 @@ export default class extends BotCommand {
 		);
 
 		const totalDeathChance = (
-			((100 - preJadDeathChance + 1) * (100 - jadDeathChance)) /
+			((100 - preJadDeathChance) * (100 - jadDeathChance)) /
 			100
 		).toFixed(1);
 

--- a/src/commands/Minion/wt.ts
+++ b/src/commands/Minion/wt.ts
@@ -56,7 +56,7 @@ export default class extends BotCommand {
 		let durationPerTodt = Time.Minute * 7.3;
 
 		// Up to a 10% boost for 99 WC
-		const wcBoost = calcWhatPercent(wcLevel + 1, 100) / 10;
+		const wcBoost = (wcLevel + 1) / 10;
 		if (wcBoost > 1) messages.push(`${wcBoost.toFixed(2)}% boost for Woodcutting level`);
 		durationPerTodt = reduceNumByPercent(durationPerTodt, wcBoost);
 


### PR DESCRIPTION
### Description:

calculating the percent of something out of 100 is trivial and does not require use of the util method

### Changes:

Wt.ts: wc boost % 
fightcaves.ts: jadKC boost, pre jad death chance - let sgs actually be useful, displayed chance of survival correction

-   [x] I have tested all my changes thoroughly.
