### PR TITLE
firemaking: give bonus exp for pyromancer pieces

### DIFF
--- a/src/commands/Minion/wt.ts
+++ b/src/commands/Minion/wt.ts
@@ -21,7 +21,20 @@ import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { Eatables } from '../../lib/minions/data/Eatables';
 
-const pyroPieces = resolveItems([
+export const warmGear = resolveItems([
+	'Staff of fire',
+	'Fire battlestaff',
+	'Lava battlestaff',
+	'Steam battlestaff',
+	'Smoke battlestaff',
+	'Mystic fire staff',
+	'Mystic lava staff',
+	'Mystic steam staff',
+	'Mystic smoke staff',
+	'Infernal axe',
+	'Infernal pickaxe',
+	'Bruma torch',
+	'Tome of fire',
 	'Pyromancer hood',
 	'Pyromancer garb',
 	'Pyromancer robe',
@@ -62,20 +75,24 @@ export default class extends BotCommand {
 
 		const baseHealAmountNeeded = 20 * 8;
 		let healAmountNeeded = baseHealAmountNeeded;
+		let warmGearAmount = 0;
 
-		for (const piece of pyroPieces) {
+		for (const piece of warmGear) {
 			if (hasItemEquipped(piece, msg.author.settings.get(UserSettings.Gear.Skilling))) {
-				healAmountNeeded -= 14;
-				durationPerTodt = reduceNumByPercent(durationPerTodt, 5);
+				warmGearAmount++;
 			}
+			if (warmGearAmount > 4) break;
 		}
+
+		healAmountNeeded -= warmGearAmount * 15;
+		durationPerTodt = reduceNumByPercent(durationPerTodt, 5 * warmGearAmount);
 
 		if (healAmountNeeded !== baseHealAmountNeeded) {
 			messages.push(
 				`${calcWhatPercent(
 					baseHealAmountNeeded - healAmountNeeded,
 					baseHealAmountNeeded
-				)}% less food for wearing Pyromancer pieces`
+				)}% less food for wearing warm gear`
 			);
 		}
 

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -1,4 +1,5 @@
 import resolveItems from './util/resolveItems';
+import { warmGear } from '../commands/Minion/wt';
 
 const barrows = resolveItems([
 	"Ahrim's hood",
@@ -820,5 +821,10 @@ export const filterableTypes = [
 		name: 'Wintertodt',
 		aliases: ['wintertodt', 'todt', 'wt'],
 		items: wintertodtItems
+	},
+	{
+		name: 'Warm gear',
+		aliases: ['warm gear', 'warm'],
+		items: warmGear
 	}
 ];

--- a/src/lib/skilling/skills/firemaking.ts
+++ b/src/lib/skilling/skills/firemaking.ts
@@ -65,11 +65,19 @@ const burnables: Burnable[] = [
 	}
 ];
 
+const pyromancerItems: { [key: number]: number } = {
+	[itemID('Pyromancer hood')]: 0.4,
+	[itemID('Pyromancer garb')]: 0.8,
+	[itemID('Pyromancer robe')]: 0.6,
+	[itemID('Pyromancer boots')]: 0.2
+};
+
 const Firemaking = {
 	aliases: ['fm', 'firemaking'],
 	Burnables: burnables,
 	id: SkillsEnum.Firemaking,
-	emoji: Emoji.Firemaking
+	emoji: Emoji.Firemaking,
+	pyromancerItems
 };
 
 export default Firemaking;

--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -13,6 +13,8 @@ import { Emoji, Events } from '../../../lib/constants';
 import { ItemBank } from '../../../lib/types';
 import { MinigameIDsEnum } from '../../../lib/minions/data/minigames';
 import { ClientSettings } from '../../../lib/settings/types/ClientSettings';
+import Firemaking from '../../../lib/skilling/skills/firemaking';
+import hasArrayOfItemsEquipped from '../../../lib/gear/functions/hasArrayOfItemsEquipped';
 
 const PointsTable = new SimpleTable<number>()
 	.add(420)
@@ -91,8 +93,31 @@ export default class extends Task {
 		const fmLvl = user.skillLevel(SkillsEnum.Firemaking);
 		const wcLvl = user.skillLevel(SkillsEnum.Woodcutting);
 
-		const fmXpToGive = Math.floor(fmLvl * 100 * quantity + numberOfRoots * (fmLvl * 3));
+		let fmXpToGive = Math.floor(fmLvl * 100 * quantity + numberOfRoots * (fmLvl * 3));
+		let fmBonusXP = 0;
 		const wcXpToGive = Math.floor(numberOfRoots * (wcLvl * 0.3));
+
+		// If they have the entire pyromancer outfit, give an extra 0.5% xp bonus
+		if (
+			hasArrayOfItemsEquipped(
+				Object.keys(Firemaking.pyromancerItems).map(i => parseInt(i)),
+				user.settings.get(UserSettings.Gear.Skilling)
+			)
+		) {
+			const amountToAdd = Math.floor(fmXpToGive * (2.5 / 100));
+			fmXpToGive += amountToAdd;
+			fmBonusXP += amountToAdd;
+		} else {
+			// For each pyromancer item, check if they have it, give its' XP boost if so.
+			for (const [itemID, bonus] of Object.entries(Firemaking.pyromancerItems)) {
+				if (user.hasItemEquippedAnywhere(parseInt(itemID))) {
+					const amountToAdd = Math.floor(fmXpToGive * (bonus / 100));
+					fmXpToGive += amountToAdd;
+					fmBonusXP += amountToAdd;
+				}
+			}
+		}
+
 		await user.addXP(SkillsEnum.Woodcutting, wcXpToGive);
 		await user.addXP(SkillsEnum.Firemaking, fmXpToGive);
 		const newLevel = user.skillLevel(SkillsEnum.Firemaking);
@@ -115,6 +140,10 @@ export default class extends Task {
 		let output = `${user} ${
 			user.minionName
 		} finished subdueing Wintertodt ${quantity}x times. You got ${fmXpToGive.toLocaleString()} Firemaking XP and ${wcXpToGive.toLocaleString()} Woodcutting XP, you cut ${numberOfRoots}x Bruma roots.`;
+
+		if (fmBonusXP > 0) {
+			output += `\n\n**Firemaking Bonus XP:** ${fmBonusXP.toLocaleString()}`;
+		}
 
 		if (newLevel > currentLevel) {
 			output += `\n\n${user.minionName}'s Firemaking level is now ${newLevel}!`;


### PR DESCRIPTION
### Description:

give bonus exp for firemaking activities while wearing pyromancer garb 

### Changes:

filterables.ts - add warm gear list
firemaking.ts - add array of pyro pieces with exp bonus percents
firemakingActivity.ts - check for worn pyromancer pieces and give bonus exp accordingly
wt.ts - add more warm gear items and refactor check to only allow max of 5 warm pieces for bonus purposes
wintertodtActivity.ts - check for worn pyromancer pieces and give bonus exp accordingly

-   [x] I have tested all my changes thoroughly.
