### PR TITLE
Has graceful equipped

### DIFF
--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -6,11 +6,10 @@ import { Activity, Tasks } from '../../lib/constants';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import reducedClueTime from '../../lib/minions/functions/reducedClueTime';
-import hasArrayOfItemsEquipped from '../../lib/gear/functions/hasArrayOfItemsEquipped';
-import itemID from '../../lib/util/itemID';
 import { ClueActivityTaskOptions } from '../../lib/types/minions';
 import ClueTiers from '../../lib/minions/data/clueTiers';
 import { requiresMinion, minionNotBusy } from '../../lib/minions/decorators';
+import hasGracefulEquipped from '../../lib/gear/functions/hasGracefulEquipped';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -76,19 +75,7 @@ export default class extends BotCommand {
 		const randomAddedDuration = rand(1, 20);
 		duration += (randomAddedDuration * duration) / 100;
 
-		if (
-			hasArrayOfItemsEquipped(
-				[
-					'Graceful hood',
-					'Graceful top',
-					'Graceful legs',
-					'Graceful gloves',
-					'Graceful boots',
-					'Graceful cape'
-				].map(itemID),
-				msg.author.settings.get(UserSettings.Gear.Skilling)
-			)
-		) {
+		if (hasGracefulEquipped(msg.author.settings.get(UserSettings.Gear.Skilling))) {
 			boosts.push(`10% for Graceful`);
 			duration *= 0.9;
 		}

--- a/src/commands/Minion/quest.ts
+++ b/src/commands/Minion/quest.ts
@@ -5,8 +5,7 @@ import { Time, Activity, Tasks, MAX_QP, Events } from '../../lib/constants';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { QuestingActivityTaskOptions } from '../../lib/types/minions';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
-import itemID from '../../lib/util/itemID';
-import hasArrayOfItemsEquipped from '../../lib/gear/functions/hasArrayOfItemsEquipped';
+import hasGracefulEquipped from '../../lib/gear/functions/hasGracefulEquipped';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -41,19 +40,7 @@ export default class extends BotCommand {
 
 		let duration = Time.Minute * 30;
 
-		if (
-			hasArrayOfItemsEquipped(
-				[
-					'Graceful hood',
-					'Graceful top',
-					'Graceful legs',
-					'Graceful gloves',
-					'Graceful boots',
-					'Graceful cape'
-				].map(itemID),
-				msg.author.settings.get(UserSettings.Gear.Skilling)
-			)
-		) {
+		if (hasGracefulEquipped(msg.author.settings.get(UserSettings.Gear.Skilling))) {
 			duration *= 0.9;
 			boosts.push(`10% for Graceful`);
 		}

--- a/src/commands/Minion/rc.ts
+++ b/src/commands/Minion/rc.ts
@@ -4,15 +4,12 @@ import { BotCommand } from '../../lib/BotCommand';
 import { stringMatches, formatDuration, rand, bankHasItem } from '../../lib/util';
 import { Activity, Tasks } from '../../lib/constants';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
-import Runecraft, {
-	RunecraftActivityTaskOptions,
-	gracefulItems
-} from '../../lib/skilling/skills/runecraft';
+import Runecraft, { RunecraftActivityTaskOptions } from '../../lib/skilling/skills/runecraft';
 import { calcMaxRCQuantity } from '../../lib/skilling/functions/calcMaxRCQuantity';
 import itemID from '../../lib/util/itemID';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
-import hasArrayOfItemsEquipped from '../../lib/gear/functions/hasArrayOfItemsEquipped';
 import { SkillsEnum } from '../../lib/skilling/types';
+import hasGracefulEquipped from '../../lib/gear/functions/hasGracefulEquipped';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -66,12 +63,7 @@ export default class extends BotCommand {
 
 		let { tripLength } = rune;
 		const boosts = [];
-		if (
-			hasArrayOfItemsEquipped(
-				gracefulItems.map(itemID),
-				msg.author.settings.get(UserSettings.Gear.Skilling)
-			)
-		) {
+		if (hasGracefulEquipped(msg.author.settings.get(UserSettings.Gear.Skilling))) {
 			tripLength -= rune.tripLength * 0.1;
 			boosts.push(`10% for Graceful`);
 		}

--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -1,6 +1,6 @@
 import { removeDuplicatesFromArray } from './util';
 import resolveItems from './util/resolveItems';
-import { gracefulItems } from './skilling/skills/runecraft';
+import { gracefulItems } from './skilling/skills/agility';
 import { wintertodtItems } from './filterables';
 
 export const bosses = {

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -1,5 +1,6 @@
 import resolveItems from './util/resolveItems';
 import { warmGear } from '../commands/Minion/wt';
+import { gracefulItems } from './skilling/skills/agility';
 
 const barrows = resolveItems([
 	"Ahrim's hood",
@@ -660,16 +661,7 @@ const herblore = resolveItems([
 	...herbs
 ]);
 
-const agility = resolveItems([
-	'Mark of grace',
-	'Graceful hood',
-	'Graceful cape',
-	'Graceful gloves',
-	'Graceful boots',
-	'Graceful legs',
-	'Graceful top',
-	'Amylase crystal'
-]);
+const agility = resolveItems([...gracefulItems, 'Mark of grace', 'Amylase crystal']);
 
 const prayer = resolveItems([
 	'Ensouled goblin head',

--- a/src/lib/gear/functions/hasGracefulEquipped.ts
+++ b/src/lib/gear/functions/hasGracefulEquipped.ts
@@ -1,0 +1,25 @@
+import { GearTypes } from '..';
+import { itemID } from '../../util';
+import hasArrayOfItemsEquipped from './hasArrayOfItemsEquipped';
+import hasItemEquipped from './hasItemEquipped';
+
+export default function hasGracefulEquipped(setup: GearTypes.GearSetup) {
+	if (
+		hasArrayOfItemsEquipped(
+			[
+				'Graceful hood',
+				'Graceful top',
+				'Graceful legs',
+				'Graceful gloves',
+				'Graceful boots'
+			].map(itemID),
+			setup
+		) &&
+		(hasItemEquipped(itemID('Graceful cape'), setup) ||
+			hasItemEquipped(itemID('Agility cape'), setup) ||
+			hasItemEquipped(itemID('Agility cape(t)'), setup))
+	) {
+		return true;
+	}
+	return false;
+}

--- a/src/lib/skilling/skills/agility.ts
+++ b/src/lib/skilling/skills/agility.ts
@@ -93,6 +93,17 @@ const courses: Course[] = [
 	}
 ];
 
+export const gracefulItems = [
+	'Graceful hood',
+	'Graceful top',
+	'Graceful legs',
+	'Graceful gloves',
+	'Graceful boots',
+	'Graceful cape',
+	'Agility cape',
+	'Agility cape(t)'
+];
+
 const Agility = {
 	aliases: ['agility'],
 	Courses: courses,

--- a/src/lib/skilling/skills/runecraft.ts
+++ b/src/lib/skilling/skills/runecraft.ts
@@ -178,15 +178,6 @@ export interface RunecraftActivityTaskOptions extends ActivityTaskOptions {
 	essenceQuantity: number;
 }
 
-export const gracefulItems = [
-	'Graceful hood',
-	'Graceful top',
-	'Graceful legs',
-	'Graceful gloves',
-	'Graceful boots',
-	'Graceful cape'
-];
-
 const Runecraft = {
 	aliases: ['runecraft', 'runecrafting'],
 	Runes,


### PR DESCRIPTION
### Description:

closes #360 
since graceful is a common boost, refactor the method to gear functions for easier use

### Changes:

creation of `hasGracefulEquipped` for easier determining of the user has a full graceful set equipped in a specific gear setup
refactor of `gracefulItems` to agility from rc since its much better suited there
addition of agility cape and trimmed variant to gracefulItems since those count in the main game too

-   [x] I have tested all my changes thoroughly.
