### PR TITLE
crafting fletching and smithing items fixes

### DIFF
--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -19,6 +19,7 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
+			aliases: ['tan'],
 			altProtection: true,
 			oneAtTime: true,
 			cooldown: 1,

--- a/src/lib/skilling/skills/crafting/craftables/built.ts
+++ b/src/lib/skilling/skills/crafting/craftables/built.ts
@@ -4,7 +4,7 @@ import { resolveNameBank } from '../../../../util';
 
 const Built: Craftable[] = [
 	{
-		name: 'Serpentine helmet',
+		name: 'Serpentine helm (uncharged)',
 		id: itemID('Serpentine helm (uncharged)'),
 		level: 52,
 		xp: 120,
@@ -27,7 +27,7 @@ const Built: Craftable[] = [
 		tickRate: 3
 	},
 	{
-		name: 'Toxic staff of the dead',
+		name: 'Toxic staff (uncharged)',
 		id: itemID('Toxic staff (uncharged)'),
 		level: 59,
 		xp: 0,
@@ -35,7 +35,7 @@ const Built: Craftable[] = [
 		tickRate: 3
 	},
 	{
-		name: 'Trident of the swamp',
+		name: 'Uncharged toxic trident',
 		id: itemID('Uncharged toxic trident'),
 		level: 59,
 		xp: 0,

--- a/src/lib/skilling/skills/fletching/fletchables/bows.ts
+++ b/src/lib/skilling/skills/fletching/fletchables/bows.ts
@@ -54,7 +54,7 @@ const Bows: Fletchable[] = [
 	{
 		name: 'Oak longbow (u)',
 		id: itemID('Oak longbow (u)'),
-		level: 20,
+		level: 25,
 		xp: 25,
 		inputItems: resolveNameBank({ 'Oak logs': 1 }),
 		tickRate: 3
@@ -62,7 +62,7 @@ const Bows: Fletchable[] = [
 	{
 		name: 'Oak longbow',
 		id: itemID('Oak longbow'),
-		level: 20,
+		level: 25,
 		xp: 25,
 		inputItems: resolveNameBank({ 'Oak longbow (u)': 1, 'Bow string': 1 }),
 		tickRate: 2

--- a/src/lib/skilling/skills/smithing/iron.ts
+++ b/src/lib/skilling/skills/smithing/iron.ts
@@ -6,7 +6,7 @@ const Iron: SmithedBar[] = [
 	{
 		name: 'Iron dagger',
 		level: 15,
-		xp: 12.5,
+		xp: 25,
 		id: itemID('Iron dagger'),
 		inputBars: { [itemID('Iron bar')]: 1 },
 		timeToUse: Time.Second * 3.4,
@@ -15,7 +15,7 @@ const Iron: SmithedBar[] = [
 	{
 		name: 'Iron axe',
 		level: 16,
-		xp: 12.5,
+		xp: 25,
 		id: itemID('Iron axe'),
 		inputBars: { [itemID('Iron bar')]: 1 },
 		timeToUse: Time.Second * 3.4,

--- a/src/lib/skilling/skills/smithing/steel.ts
+++ b/src/lib/skilling/skills/smithing/steel.ts
@@ -6,7 +6,7 @@ const Steel: SmithedBar[] = [
 	{
 		name: 'Steel dagger',
 		level: 30,
-		xp: 25.0,
+		xp: 37.5,
 		id: itemID('Steel dagger'),
 		inputBars: { [itemID('Steel bar')]: 1 },
 		timeToUse: Time.Second * 3.4,

--- a/src/tasks/minions/smeltingActivity.ts
+++ b/src/tasks/minions/smeltingActivity.ts
@@ -19,7 +19,7 @@ export default class extends Task {
 		const bar = Smelting.Bars.find(bar => bar.id === barID);
 		if (!bar) return;
 
-		// If this bar has a chance of failing to smith, calculate that here.
+		// If this bar has a chance of failing to smelt, calculate that here.
 		const oldQuantity = quantity;
 		if (bar.chanceOfFail > 0) {
 			let newQuantity = 0;
@@ -43,7 +43,7 @@ export default class extends Task {
 		await user.addXP(SkillsEnum.Smithing, xpReceived);
 		const newLevel = user.skillLevel(SkillsEnum.Smithing);
 
-		let str = `${user}, ${user.minionName} finished smithing ${quantity}x ${
+		let str = `${user}, ${user.minionName} finished smelting ${quantity}x ${
 			bar.name
 		}, you also received ${xpReceived.toLocaleString()} XP. ${
 			user.minionName


### PR DESCRIPTION
### Description:

set tan as an alias of craft since people ask me all the time how to tan stuff

zulrah crafted items were inconsistently names from how others are dealt with in the bot so they got renamed to the result item you get from crafting them

some fletching and smithing items had from level or exp values

the smelt command still said smith when it finished

### Changes:

-   [x] I have tested all my changes thoroughly.
