### PR TITLE
fletching: use name as unique id because of arrow shafts

### DIFF
--- a/src/commands/Minion/fletch.ts
+++ b/src/commands/Minion/fletch.ts
@@ -107,7 +107,7 @@ export default class extends BotCommand {
 		}
 
 		const data: FletchingActivityTaskOptions = {
-			fletchableID: fletchableItem.id,
+			fletchableName: fletchableItem.name,
 			userID: msg.author.id,
 			channelID: msg.channel.id,
 			quantity,

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -37,7 +37,6 @@ import { Emoji, Activity, Time } from '../../lib/constants';
 import ClueTiers from '../../lib/minions/data/clueTiers';
 import Prayer from '../../lib/skilling/skills/prayer';
 import Monster from 'oldschooljs/dist/structures/Monster';
-import Fletching from '../../lib/skilling/skills/fletching/fletching';
 import { MinigameIDsEnum } from '../../lib/minions/data/minigames';
 
 export default class extends Extendable {
@@ -260,12 +259,9 @@ export default class extends Extendable {
 			}
 			case Activity.Fletching: {
 				const data = currentTask as FletchingActivityTaskOptions;
-				const fletchable = Fletching.Fletchables.find(
-					item => item.id === data.fletchableID
-				);
 
 				return `${this.minionName} is currently fletching ${data.quantity}x ${
-					fletchable!.name
+					data.fletchableName
 				}. ${formattedDuration} Your ${
 					Emoji.Fletching
 				} Fletching level is ${this.skillLevel(SkillsEnum.Fletching)}`;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -77,7 +77,7 @@ export interface CraftingActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface FletchingActivityTaskOptions extends ActivityTaskOptions {
-	fletchableID: number;
+	fletchableName: string;
 	channelID: string;
 	quantity: number;
 }

--- a/src/tasks/minions/fletchingActivity.ts
+++ b/src/tasks/minions/fletchingActivity.ts
@@ -10,7 +10,7 @@ import Fletching from '../../lib/skilling/skills/fletching/fletching';
 
 export default class extends Task {
 	async run({
-		fletchableID,
+		fletchableName,
 		quantity,
 		userID,
 		channelID,
@@ -21,7 +21,7 @@ export default class extends Task {
 		const currentLevel = user.skillLevel(SkillsEnum.Fletching);
 
 		const fletchableItem = Fletching.Fletchables.find(
-			fletchable => fletchable.id === fletchableID
+			fletchable => fletchable.name === fletchableName
 		);
 
 		if (!fletchableItem) return;


### PR DESCRIPTION
### Description:

use flechables name as a unique identifier
this fixes the problem with crafting arrow shafts out of different logs where it would resolve to only regular log shafts in the activity completion

closes #293 

-   [x] I have tested all my changes thoroughly.
