### PR TITLE
BSO: Return the correct ID's from mystery boxes

### DIFF
--- a/src/lib/simulation/mysteryBox.ts
+++ b/src/lib/simulation/mysteryBox.ts
@@ -1,11 +1,50 @@
 import Loot from 'oldschooljs/dist/structures/Loot';
 import { Items } from 'oldschooljs';
+import { Item } from 'oldschooljs/dist/meta/types';
+import ClueTiers from '../minions/data/clueTiers';
+import { ClueTier } from '../minions/types';
+
+function findNonDuplicate(item: Item): number | null {
+	const nonDuplicate = Items.find(i => i.name === item.name) as Item | null;
+
+	return nonDuplicate?.id ?? null;
+}
+
+function getClueTier(item: Item, type: 'casket' | 'clue'): ClueTier | null {
+	const clueRegex = item.name.startsWith('Clue scroll')
+		? /Clue scroll \((.*)\)/
+		: /Challenge scroll \((.*)\)/;
+	const matchRegex = type === 'casket' ? /Casket \((.*)\)/ : clueRegex;
+
+	const tierMatch = item.name.match(matchRegex);
+	const tier = tierMatch ? tierMatch[1] : 'beginner';
+
+	return ClueTiers.find(clueTier => clueTier.name.toLowerCase() === tier.toLowerCase()) ?? null;
+}
+
+function getRandomItemId(): number {
+	const item = Items.random() as Item;
+
+	if (item.name.startsWith('Casket')) {
+		return getClueTier(item, 'casket')?.id ?? getRandomItemId();
+	}
+
+	if (item.name.startsWith('Challenge scroll') || item.name.startsWith('Clue scroll')) {
+		return getClueTier(item, 'clue')?.scrollID ?? getRandomItemId();
+	}
+
+	if (item.duplicate) {
+		return findNonDuplicate(item) ?? getRandomItemId();
+	}
+
+	return item.id;
+}
 
 export const mysteryBox = (qty = 1) => {
 	const loot = new Loot();
 
 	for (let i = 0; i < qty; i++) {
-		loot.add(Items.random().id, 1);
+		loot.add(getRandomItemId(), 1);
 	}
 
 	return loot.values();


### PR DESCRIPTION
If a clue scroll or casket is rolled, it will get the correct ID for it based on the `ClueTier` that it should belong to.

If a duplicate item is rolled, it will try to find the non-duplicate version and return that, if not it will re-roll 
