### PR TITLE
groupkill: linearize kill times

### DIFF
--- a/src/commands/Minion/groupkill.ts
+++ b/src/commands/Minion/groupkill.ts
@@ -24,12 +24,12 @@ export default class extends BotCommand {
 
 	calcDurQty(users: KlasaUser[], monster: KillableMonster, quantity: number | undefined) {
 		const perKillTime = reducedTimeForGroup(users, monster);
-		const maxQty = Math.floor(users[0].maxTripLength / (perKillTime + monster.respawnTime!));
+		const maxQty = Math.floor(users[0].maxTripLength / perKillTime);
 		if (!quantity) quantity = maxQty;
 		if (quantity > maxQty) {
 			throw `The max amount of ${monster.name} this party can kill per trip is ${maxQty}.`;
 		}
-		const duration = maxQty * (perKillTime + monster.respawnTime!) - monster.respawnTime!;
+		const duration = quantity * perKillTime - monster.respawnTime!;
 		return [quantity, duration, perKillTime];
 	}
 
@@ -99,9 +99,7 @@ export default class extends BotCommand {
 				monster.name
 			}. Each kill takes ${formatDuration(perKillTime)} instead of ${formatDuration(
 				monster.timeToFinish
-			)}, and waiting ${formatDuration(
-				monster.respawnTime!
-			)} between kills. - the total trip will take ${formatDuration(duration)}`
+			)}- the total trip will take ${formatDuration(duration)}`
 		);
 	}
 

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -132,7 +132,7 @@ const killableBosses: KillableMonster[] = [
 			[itemID('Dragon warhammer')]: 10
 		},
 		groupKillable: true,
-		respawnTime: 40_000,
+		respawnTime: 20_000,
 		levelRequirements: {
 			prayer: 43
 		},


### PR DESCRIPTION
## Description:

adjusts groupkill time calc to be more linear in its approach of time reduction per person

avg kills per participant over a 40 min trip
old = green
new = pink
![image](https://user-images.githubusercontent.com/7191512/88434554-6cc49100-cdce-11ea-8493-8ad9fefc2da3.png)
the minimum time cutoff happens at about 27 members


## Changes:

corp respawn time set to 20 seconds
### reducedTimeForGroup
- accounts for kc and item boosts 
- additivly tallys a reduction multiplier instead of exponentially
- lower bounds the returned time by the monsters respawn time


-   [x] I have tested all my changes thoroughly.
