### PR TITLE
ironman: reset minigame scores on becming ironman

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -141,6 +141,7 @@ Type \`confirm\` if you understand the above information, and want to become an 
 				UserSettings.GP,
 				UserSettings.QP,
 				UserSettings.MonsterScores,
+				UserSettings.MinigameScores,
 				UserSettings.ClueScores,
 				UserSettings.BankBackground,
 				UserSettings.SacrificedValue,


### PR DESCRIPTION
### Description:

fixes #434 

### Changes:

resets `UserSettings.MinigameScores` on becoming an ironman

-   [x] I have tested all my changes thoroughly.
