### PR TITLE
Command(Bank): Add support for passing multiple item names, runelite bank tags

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,13 +1,20 @@
 import ava from 'ava';
+
 import { stripEmojis } from '../src/lib/util';
 import getOSItem from '../src/lib/util/getOSItem';
 
 ava('stripEmojis', test => {
-	test.deepEqual(stripEmojis('b👏r👏u👏h'), 'bruh');
+	test.is(stripEmojis('b👏r👏u👏h'), 'bruh');
 });
 
 ava('getOSItem', test => {
-	test.deepEqual(getOSItem('Twisted bow').id, 20997);
-	test.deepEqual(getOSItem(20997).id, 20997);
-	test.deepEqual(getOSItem('20997').id, 20997);
+	test.is(getOSItem('Twisted bow').id, 20997);
+	test.is(getOSItem(20997).id, 20997);
+	test.is(getOSItem('20997').id, 20997);
+
+	try {
+		getOSItem('Non-existant item');
+	} catch (err) {
+		test.is(err, 'That item doesnt exist.');
+	}
 });

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,6 +1,13 @@
 import ava from 'ava';
 import { stripEmojis } from '../src/lib/util';
+import getOSItem from '../src/lib/util/getOSItem';
 
-ava('foo', test => {
+ava('stripEmojis', test => {
 	test.deepEqual(stripEmojis('b👏r👏u👏h'), 'bruh');
+});
+
+ava('getOSItem', test => {
+	test.deepEqual(getOSItem('Twisted bow').id, 20997);
+	test.deepEqual(getOSItem(20997).id, 20997);
+	test.deepEqual(getOSItem('20997').id, 20997);
 });

--- a/src/lib/util/getOSItem.ts
+++ b/src/lib/util/getOSItem.ts
@@ -3,7 +3,13 @@ import { Item } from 'oldschooljs/dist/meta/types';
 
 import cleanItemName from './cleanItemName';
 
+const cache = new Map();
+
 export default function getOSItem(itemName: string | number): Item {
+	if (cache.has(itemName)) {
+		return cache.get(itemName);
+	}
+
 	let identifier: string | number | undefined;
 	if (typeof itemName === 'number') {
 		identifier = itemName;
@@ -14,5 +20,6 @@ export default function getOSItem(itemName: string | number): Item {
 
 	const osItem = Items.get(identifier) as Item | undefined;
 	if (!osItem) throw `That item doesnt exist.`;
+	cache.set(itemName, osItem);
 	return osItem;
 }

--- a/src/lib/util/getOSItem.ts
+++ b/src/lib/util/getOSItem.ts
@@ -4,9 +4,15 @@ import { Item } from 'oldschooljs/dist/meta/types';
 import cleanItemName from './cleanItemName';
 
 export default function getOSItem(itemName: string | number): Item {
-	const osItem = Items.get(typeof itemName === 'number' ? itemName : cleanItemName(itemName)) as
-		| Item
-		| undefined;
+	let identifier: string | number | undefined;
+	if (typeof itemName === 'number') {
+		identifier = itemName;
+	} else {
+		const parsed = parseInt(itemName);
+		identifier = isNaN(parsed) ? cleanItemName(itemName) : parsed;
+	}
+
+	const osItem = Items.get(identifier) as Item | undefined;
 	if (!osItem) throw `That item doesnt exist.`;
 	return osItem;
 }


### PR DESCRIPTION
### Description:

-   Add support for passing multiple item names, for example: `+bank Shark, Tuna, Bass`. You can also pass item IDs, runelite bank tags work too. `getOSItem` was modified to handle strings more intelligently. It will try to turn the string into a number, if it works it works, if it doesnt then we consider it an item name.

### Changes:

-  Memoize getOSItem
- Tests

-   [X] I have tested all my changes thoroughly.
