### PR TITLE
Aug 1 feedback

### DIFF
--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -44,18 +44,18 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			cooldown: 1,
-			usage: '[quantity:int{1}] <item:...item>',
+			usage: '[quantity:int{1}] (item:...item)',
 			usageDelim: ' ',
 			oneAtTime: true
 		});
 	}
 
 	@minionNotBusy
-	async run(msg: KlasaMessage, [quantity = null, item]: [number | null, Item[]]) {
+	async run(msg: KlasaMessage, [quantity = null, itemArray]: [number | null, Item[]]) {
 		const userBank = msg.author.settings.get(UserSettings.Bank);
-		const osItem = item.find(i => userBank[i.id] && i.highalch && i.tradeable);
+		const osItem = itemArray.find(i => userBank[i.id] && i.highalch && i.tradeable);
 		if (!osItem) {
-			throw `You don't have any of this item to alch.`;
+			throw `You don't have any of this item to alch, or it is untradeable.`;
 		}
 
 		if (unalchables.some(item => item === osItem.id)) {

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -10,7 +10,7 @@ import {
 	formatDuration,
 	removeBankFromBank,
 	resolveNameBank,
-	itemID
+	addBanks
 } from '../../lib/util';
 import createReadableItemListFromBank from '../../lib/util/createReadableItemListFromTuple';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
@@ -38,8 +38,6 @@ const unlimitedFireRuneProviders = resolveItems([
 	'Tome of fire'
 ]);
 
-const unalchables = [itemID('Nature rune'), itemID('Fire rune')];
-
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
@@ -56,10 +54,6 @@ export default class extends BotCommand {
 		const osItem = itemArray.find(i => userBank[i.id] && i.highalch && i.tradeable);
 		if (!osItem) {
 			throw `You don't have any of this item to alch, or it is untradeable.`;
-		}
-
-		if (unalchables.some(item => item === osItem.id)) {
-			throw `This item cannot be alched.`;
 		}
 
 		// 5 tick action
@@ -89,12 +83,13 @@ export default class extends BotCommand {
 		}
 
 		const alchValue = quantity * osItem.highalch;
-
-		const consumedItems = resolveNameBank({
-			...(fireRuneCost > 0 ? { 'Fire rune': fireRuneCost } : {}),
-			'Nature rune': quantity,
-			[osItem.name]: quantity
-		});
+		const consumedItems = addBanks([
+			resolveNameBank({
+				...(fireRuneCost > 0 ? { 'Fire rune': fireRuneCost } : {}),
+				'Nature rune': quantity
+			}),
+			{ [osItem.id]: quantity }
+		]);
 
 		const consumedItemsString = await createReadableItemListFromBank(
 			this.client,

--- a/src/commands/Minion/gearstats.ts
+++ b/src/commands/Minion/gearstats.ts
@@ -9,7 +9,7 @@ export default class extends BotCommand {
 		super(store, file, directory, {
 			cooldown: 1,
 			oneAtTime: true,
-			usage: '<melee|range|magic>'
+			usage: '<melee|range|mage>'
 		});
 	}
 

--- a/src/lib/minions/functions/calculateMonsterFood.ts
+++ b/src/lib/minions/functions/calculateMonsterFood.ts
@@ -7,8 +7,17 @@ import { calcWhatPercent, reduceNumByPercent } from '../../util';
 import { maxDefenceStats, maxOffenceStats } from '../../gear/data/maxGearStats';
 import readableStatName from '../../gear/functions/readableStatName';
 import { inverseOfOffenceStat } from '../../gear/functions/inverseOfStat';
+import hasItemEquipped from '../../gear/functions/hasItemEquipped';
+import { GearTypes } from '../../gear';
 
 const { floor, max } = Math;
+const specialReducers = [
+	{
+		name: 'Elysian Spirit Shield',
+		id: 12817,
+		foodReductionPercent: 17.5
+	}
+];
 
 export default function calculateMonsterFood(
 	monster: O.Readonly<KillableMonster>,
@@ -56,6 +65,20 @@ export default function calculateMonsterFood(
 		85
 	);
 	totalOffensivePercent = floor(max(0, totalOffensivePercent / attackStylesUsed.length)) / 2;
+
+	const userGear = user.rawGear()[attackStyleToUse] as GearTypes.GearSetup;
+	for (const reducer of specialReducers) {
+		if (hasItemEquipped(reducer.id, userGear)) {
+			{
+				messages.push(
+					`You use ${reducer.foodReductionPercent}% less food because you are wearing ${reducer.name}.`
+				);
+				healAmountNeeded = floor(
+					reduceNumByPercent(healAmountNeeded, reducer.foodReductionPercent)
+				);
+			}
+		}
+	}
 
 	messages.push(
 		`You use ${floor(totalPercentOfGearLevel)}% less food because of your defensive stats.`

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -64,7 +64,7 @@ export function toTitleCase(str: string) {
 	return splitStr.join(' ');
 }
 
-export function cleanString(str: string) {
+export function cleanString(str = '') {
 	return str.replace(/[^0-9a-zA-Z+]/gi, '').toUpperCase();
 }
 

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -5,8 +5,6 @@ import { resolveNameBank, toKMB } from 'oldschooljs/dist/util';
 import { noOp, roll, saidYes } from '../../lib/util';
 import getUsersPerkTier from '../../lib/util/getUsersPerkTier';
 import { Time } from '../../lib/constants';
-import hasItemEquipped from '../../lib/gear/functions/hasItemEquipped';
-import { UserSettings } from '../../lib/settings/types/UserSettings';
 import itemID from '../../lib/util/itemID';
 import getOSItem from '../../lib/util/getOSItem';
 
@@ -29,7 +27,7 @@ export default class extends Task {
 		// If bryophyta's staff is equipped when starting the alch activity
 		// calculate how many runes have been saved
 		let savedRunes = 0;
-		if (hasItemEquipped(bryophytasStaffId, user.settings.get(UserSettings.Gear.Skilling))) {
+		if (user.hasItemEquippedAnywhere(bryophytasStaffId)) {
 			for (let i = 0; i < quantity; i++) {
 				if (roll(15)) savedRunes++;
 			}


### PR DESCRIPTION
### Description:

addresses feedback from testing on aug 1st

fixes #458

### Changes:

cleanString: default to empty str to avoid problems with undefined
- this addresses an error where it would try to send an empty string somehow and discord would throw because of that

alch: throw useful error messages
alch: allow runes to be alched
alchingActivity: allow bryophytas staff in any gear set

calculateMonsterFood: create specialReducers for food reduction
- by popular demand, this reduces heal amount needed by 17.5% if the user has an ely equipped in the gear setup used to attack the monster with

gearstats: magic -> mage

-   [x] I have tested all my changes thoroughly.
