### PR TITLE
craft: crush semiprecious gems when cutting

### DIFF
--- a/src/lib/skilling/skills/crafting/craftables/gems.ts
+++ b/src/lib/skilling/skills/crafting/craftables/gems.ts
@@ -9,7 +9,8 @@ const Gems: Craftable[] = [
 		level: 1,
 		xp: 15,
 		inputItems: resolveNameBank({ 'Uncut opal': 1 }),
-		tickRate: 2
+		tickRate: 2,
+		crushChance: [122 / (98 * 256), 129 / 256]
 	},
 	{
 		name: 'Jade',
@@ -17,7 +18,8 @@ const Gems: Craftable[] = [
 		level: 13,
 		xp: 20,
 		inputItems: resolveNameBank({ 'Uncut Jade': 1 }),
-		tickRate: 2
+		tickRate: 2,
+		crushChance: [145 / (98 * 256), 101 / 256]
 	},
 	{
 		name: 'Red topaz',
@@ -25,7 +27,8 @@ const Gems: Craftable[] = [
 		level: 16,
 		xp: 25,
 		inputItems: resolveNameBank({ 'Uncut red topaz': 1 }),
-		tickRate: 2
+		tickRate: 2,
+		crushChance: [150 / (98 * 256), 91 / 256]
 	},
 	{
 		name: 'Sapphire',

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -126,6 +126,7 @@ export interface Craftable {
 	xp: number;
 	inputItems: ItemBank;
 	tickRate: number;
+	crushChance?: number[];
 }
 
 export interface Fletchable {


### PR DESCRIPTION
### Description:

addition of the crushing formula to the crafting activity to correctly determine the number of gems crushed when attempting to cut them

### Changes:

addition of `crushChance` field to Craftables type
filling in of that field for opal, jade, and red topaz
calculations to determine number of gems crushed and to give the exp and loot for those

-   [x] I have tested all my changes thoroughly.
