### PR TITLE
mining: set iron and gold to correct xp/ore

### DIFF
--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -38,10 +38,10 @@ const ores: Ore[] = [
 	},
 	{
 		level: 15,
-		xp: 48,
+		xp: 35,
 		id: 440,
 		name: 'Iron ore',
-		respawnTime: 0.2,
+		respawnTime: -0.2,
 		petChance: 750_000
 	},
 	{
@@ -70,7 +70,7 @@ const ores: Ore[] = [
 	},
 	{
 		level: 40,
-		xp: 45,
+		xp: 65,
 		id: 444,
 		name: 'Gold ore',
 		respawnTime: 4,


### PR DESCRIPTION
### Description:

set iron ore xp to 35 to reflect in game, respawn time is reduced to maintain current xp rates
set gold xp to 65 to reflect in game

graph showing the xp rates after the change, with the proposed gem rock introduction between them
![image](https://user-images.githubusercontent.com/7191512/89579703-3ccfb180-d802-11ea-9536-dade2486ce28.png)
blue iron
green gem
red gold

-   [] I have tested all my changes thoroughly.
