### PR TITLE
Dev

### DIFF
--- a/src/arguments/item.ts
+++ b/src/arguments/item.ts
@@ -8,11 +8,9 @@ import { stringMatches } from '../lib/util';
 export default class extends Argument {
 	async run(itemName: string) {
 		// guarantee all characters are numbers
-		if (
-			!isNaN(parseInt(itemName)) &&
-			parseInt(itemName).toString().length === itemName.length
-		) {
-			return [getOSItem(parseInt(itemName))];
+		const parsed = parseInt(itemName);
+		if (!isNaN(parsed) && parsed.toString().length === itemName.length) {
+			return [getOSItem(parsed)];
 		}
 
 		const osItems = Items.filter(i => stringMatches(i.name, itemName)).array() as Item[];

--- a/src/commands/Minion/gearstats.ts
+++ b/src/commands/Minion/gearstats.ts
@@ -9,7 +9,7 @@ export default class extends BotCommand {
 		super(store, file, directory, {
 			cooldown: 1,
 			oneAtTime: true,
-			usage: '<melee|range|magic>'
+			usage: '<melee|range|mage>'
 		});
 	}
 

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -13,6 +13,7 @@ import { Activity, Tasks } from '../../lib/constants';
 import { MiningActivityTaskOptions } from '../../lib/types/minions';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import itemID from '../../lib/util/itemID';
+import resolveItems from '../../lib/util/resolveItems';
 import { SkillsEnum } from '../../lib/skilling/types';
 
 const pickaxes = [
@@ -48,6 +49,23 @@ const gloves = [
 		reductionPercent: 2
 	}
 ];
+
+const amulets = resolveItems([
+	'Amulet of glory (t)',
+	'Amulet of glory (t6)',
+	'Amulet of glory (t5)',
+	'Amulet of glory (t4)',
+	'Amulet of glory (t3)',
+	'Amulet of glory (t2)',
+	'Amulet of glory (t1)',
+	'Amulet of glory',
+	'Amulet of glory(6)',
+	'Amulet of glory(5)',
+	'Amulet of glory(4)',
+	'Amulet of glory(3)',
+	'Amulet of glory(2)',
+	'Amulet of glory(1)'
+]);
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -110,6 +128,16 @@ export default class extends BotCommand {
 				if (msg.author.hasItemEquippedAnywhere(glove.id)) {
 					timeToMine = Math.floor(timeToMine * ((100 - glove.reductionPercent) / 100));
 					boosts.push(`${glove.reductionPercent}% for ${itemNameFromID(glove.id)}`);
+					break;
+				}
+			}
+		}
+		// Check if the user got a amulet of glory
+		if (ore.name.toLowerCase() === 'gem rock') {
+			for (const amulet of amulets) {
+				if (msg.author.hasItemEquippedAnywhere(amulet)) {
+					timeToMine = Math.floor(timeToMine / 2);
+					boosts.push(`50% for ${itemNameFromID(amulet)}`);
 					break;
 				}
 			}

--- a/src/lib/buyables.ts
+++ b/src/lib/buyables.ts
@@ -194,6 +194,15 @@ const Buyables: Buyable[] = [
 		}),
 		qpRequired: 111,
 		gpCost: 750_000
+	},
+	{
+		name: 'Ball of wool',
+		aliases: ['wool ball', 'ball wool'],
+		outputItems: {
+			[itemID('Ball of wool')]: 1
+		},
+		qpRequired: 0,
+		gpCost: 200
 	}
 ];
 

--- a/src/lib/minions/functions/calculateMonsterFood.ts
+++ b/src/lib/minions/functions/calculateMonsterFood.ts
@@ -7,8 +7,17 @@ import { calcWhatPercent, reduceNumByPercent } from '../../util';
 import { maxDefenceStats, maxOffenceStats } from '../../gear/data/maxGearStats';
 import readableStatName from '../../gear/functions/readableStatName';
 import { inverseOfOffenceStat } from '../../gear/functions/inverseOfStat';
+import hasItemEquipped from '../../gear/functions/hasItemEquipped';
+import { GearTypes } from '../../gear';
 
 const { floor, max } = Math;
+const specialReducers = [
+	{
+		name: 'Elysian Spirit Shield',
+		id: 12817,
+		foodReductionPercent: 17.5
+	}
+];
 
 export default function calculateMonsterFood(
 	monster: O.Readonly<KillableMonster>,
@@ -56,6 +65,20 @@ export default function calculateMonsterFood(
 		85
 	);
 	totalOffensivePercent = floor(max(0, totalOffensivePercent / attackStylesUsed.length)) / 2;
+
+	const userGear = user.rawGear()[attackStyleToUse] as GearTypes.GearSetup;
+	for (const reducer of specialReducers) {
+		if (hasItemEquipped(reducer.id, userGear)) {
+			{
+				messages.push(
+					`You use ${reducer.foodReductionPercent}% less food because you are wearing ${reducer.name}.`
+				);
+				healAmountNeeded = floor(
+					reduceNumByPercent(healAmountNeeded, reducer.foodReductionPercent)
+				);
+			}
+		}
+	}
 
 	messages.push(
 		`You use ${floor(totalPercentOfGearLevel)}% less food because of your defensive stats.`

--- a/src/lib/skilling/skills/crafting/craftables/gems.ts
+++ b/src/lib/skilling/skills/crafting/craftables/gems.ts
@@ -9,7 +9,8 @@ const Gems: Craftable[] = [
 		level: 1,
 		xp: 15,
 		inputItems: resolveNameBank({ 'Uncut opal': 1 }),
-		tickRate: 2
+		tickRate: 2,
+		crushChance: [122 / (98 * 256), 129 / 256]
 	},
 	{
 		name: 'Jade',
@@ -17,7 +18,8 @@ const Gems: Craftable[] = [
 		level: 13,
 		xp: 20,
 		inputItems: resolveNameBank({ 'Uncut Jade': 1 }),
-		tickRate: 2
+		tickRate: 2,
+		crushChance: [145 / (98 * 256), 101 / 256]
 	},
 	{
 		name: 'Red topaz',
@@ -25,7 +27,8 @@ const Gems: Craftable[] = [
 		level: 16,
 		xp: 25,
 		inputItems: resolveNameBank({ 'Uncut red topaz': 1 }),
-		tickRate: 2
+		tickRate: 2,
+		crushChance: [150 / (98 * 256), 91 / 256]
 	},
 	{
 		name: 'Sapphire',

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -1,6 +1,16 @@
 import { Emoji } from '../../constants';
 import itemID from '../../util/itemID';
 import { Ore, SkillsEnum } from '../types';
+import LootTable from 'oldschooljs/dist/structures/LootTable';
+
+const GemRockTable = new LootTable()
+	.add('Uncut opal', 1, 60)
+	.add('Uncut jade', 1, 30)
+	.add('Uncut red topaz', 1, 15)
+	.add('Uncut sapphire', 1, 9)
+	.add('Uncut emerald', 1, 5)
+	.add('Uncut ruby', 1, 5)
+	.add('Uncut diamond', 1, 4);
 
 const ores: Ore[] = [
 	{
@@ -66,6 +76,15 @@ const ores: Ore[] = [
 		respawnTime: 4,
 		petChance: 300_000,
 		nuggets: true
+	},
+	{
+		level: 40,
+		xp: 65,
+		id: 1625,
+		name: 'Gem rock',
+		respawnTime: 6,
+		petChance: 211_886,
+		gems: GemRockTable
 	},
 	{
 		level: 55,

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -38,10 +38,10 @@ const ores: Ore[] = [
 	},
 	{
 		level: 15,
-		xp: 48,
+		xp: 35,
 		id: 440,
 		name: 'Iron ore',
-		respawnTime: 0.2,
+		respawnTime: -0.2,
 		petChance: 750_000
 	},
 	{
@@ -70,7 +70,7 @@ const ores: Ore[] = [
 	},
 	{
 		level: 40,
-		xp: 45,
+		xp: 65,
 		id: 444,
 		name: 'Gold ore',
 		respawnTime: 4,

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -1,4 +1,5 @@
 import { ItemBank } from '../types';
+import LootTable from 'oldschooljs/dist/structures/LootTable';
 
 export enum SkillsEnum {
 	Agility = 'agility',
@@ -25,6 +26,7 @@ export interface Ore {
 	petChance?: number;
 	nuggets?: boolean;
 	minerals?: number;
+	gems?: LootTable;
 }
 
 export interface Bar {

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -126,6 +126,7 @@ export interface Craftable {
 	xp: number;
 	inputItems: ItemBank;
 	tickRate: number;
+	crushChance?: number[];
 }
 
 export interface Fletchable {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -64,7 +64,7 @@ export function toTitleCase(str: string) {
 	return splitStr.join(' ');
 }
 
-export function cleanString(str: string) {
+export function cleanString(str = '') {
 	return str.replace(/[^0-9a-zA-Z+]/gi, '').toUpperCase();
 }
 

--- a/src/lib/util/getOSItem.ts
+++ b/src/lib/util/getOSItem.ts
@@ -15,7 +15,10 @@ export default function getOSItem(itemName: string | number): Item {
 		identifier = itemName;
 	} else {
 		const parsed = parseInt(itemName);
-		identifier = isNaN(parsed) ? cleanItemName(itemName) : parsed;
+		identifier =
+			!isNaN(parsed) && parsed.toString().length === itemName.length
+				? parsed
+				: cleanItemName(itemName);
 	}
 
 	const osItem = Items.get(identifier) as Item | undefined;

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -5,8 +5,6 @@ import { resolveNameBank, toKMB } from 'oldschooljs/dist/util';
 import { noOp, roll, saidYes } from '../../lib/util';
 import getUsersPerkTier from '../../lib/util/getUsersPerkTier';
 import { Time } from '../../lib/constants';
-import hasItemEquipped from '../../lib/gear/functions/hasItemEquipped';
-import { UserSettings } from '../../lib/settings/types/UserSettings';
 import itemID from '../../lib/util/itemID';
 import getOSItem from '../../lib/util/getOSItem';
 
@@ -29,7 +27,7 @@ export default class extends Task {
 		// If bryophyta's staff is equipped when starting the alch activity
 		// calculate how many runes have been saved
 		let savedRunes = 0;
-		if (hasItemEquipped(bryophytasStaffId, user.settings.get(UserSettings.Gear.Skilling))) {
+		if (user.hasItemEquippedAnywhere(bryophytasStaffId)) {
 			for (let i = 0; i < quantity; i++) {
 				if (roll(15)) savedRunes++;
 			}


### PR DESCRIPTION
### Description:


- buyables: add Ball of wool
- mining: add Gem rocks
- mining: set iron and gold to correct xp/ore
- craft: crush semiprecious gems when cutting
- item: use var for parsed parameter - refactor to save 2 `parseInt` executions
- getOSItem: fix parsing non numbers as numbers - fix that prevents item names that start with numbers from being treated as numbers
- cleanString: default to empty str to avoid problems with undefined
- alch throw useful error messages - show when an item is untradeable or not found correctly
- alch: allow runes to be alched
- alchingActivity: allow bryophytas staff in any gear set
- calculateMonsterFood: create specialReducers for food reduction - adds a 17.5% reduction when wearing an ely and creates a framework to add other reductions like this to
- gearstats: magic -> mage

fixes #458 
fixes #528 