### PR TITLE
shieldRightHalf-exploit-fix

### DIFF
--- a/src/lib/buyables.ts
+++ b/src/lib/buyables.ts
@@ -193,7 +193,7 @@ const Buyables: Buyable[] = [
 			'Shield right half': 1
 		}),
 		qpRequired: 111,
-		gpCost: 750_000
+		gpCost: 1_500_000
 	}
 ];
 


### PR DESCRIPTION
### Description:

The shield right half was put at a price making sacrificing stuff devalued because you can buy the halfs from the store for under sacrifice value. The other problem with it being so close to +sell value is that if GE one day gets a increased shield half price, the bot GP would be infinit. 

### Changes:

Doubled the GP cost for shield right half from 750k (the in game buy price) to 1.5M, this also makes it more balanced considering all other buyable items in the +buy ''store''

-   [X] I have tested all my changes thoroughly.
