### PR TITLE
Multi loot casket(BSO)

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -5,7 +5,7 @@ import Loot from 'oldschooljs/dist/structures/Loot';
 import { Events, MIMIC_MONSTER_ID } from '../../lib/constants';
 import { BotCommand } from '../../lib/BotCommand';
 import botOpenables from '../../lib/openables';
-import { stringMatches, roll, addBanks, itemNameFromID } from '../../lib/util';
+import { stringMatches, roll, addBanks, itemNameFromID, rand } from '../../lib/util';
 import createReadableItemListFromBank from '../../lib/util/createReadableItemListFromTuple';
 import { cluesRares } from '../../lib/collectionLog';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -74,7 +74,7 @@ export default class extends BotCommand {
 
 		await msg.author.removeItemFromBank(clueTier.id, quantity);
 
-		let loot = clueTier.table.open(quantity);
+		let loot = clueTier.table.open(quantity * rand(1, 3));
 
 		let mimicNumber = 0;
 		if (clueTier.mimicChance) {


### PR DESCRIPTION
### Description:

Added back the possibility to get 1 to 3 x loot for every opened casket.

### Changes:

Changed it to random 1 to 3 x loot for every opened casket.

-   [X] I have tested all my changes thoroughly.
