### PR TITLE
command for minion that locks gambling (BSO)

### DIFF
--- a/src/commands/Minion/dice.ts
+++ b/src/commands/Minion/dice.ts
@@ -31,6 +31,8 @@ export default class extends BotCommand {
 		} else {
 			if (msg.author.isIronman) throw `You're an ironman and you cant play dice.`;
 
+			if (msg.author.lockedGambling) throw `You're locked from gambling and cant play dice.`;
+
 			if (amount < 5_000_000) {
 				throw `You must dice atleast 5m.`;
 			}

--- a/src/commands/Minion/duel.ts
+++ b/src/commands/Minion/duel.ts
@@ -43,6 +43,8 @@ export default class extends BotCommand {
 
 		if (msg.author.isIronman) throw `You can't duel someone as an ironman.`;
 		if (user.isIronman) throw `You can't duel someone as an ironman.`;
+		if (msg.author.lockedGambling) throw `You can't duel someone with locked gambling account.`;
+		if (user.lockedGambling) throw `You can't duel someone with locked gambling account.`;
 		if (!(user instanceof User)) throw `You didn't mention a user to duel.`;
 		if (user.id === msg.author.id) throw `You cant duel yourself.`;
 		if (user.bot) throw `You cant duel a bot.`;

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -148,24 +148,9 @@ Type \`confirm\` if you understand the above information, and want to lock your 
 					errors: ['time']
 				}
 			);
-
-			if (msg.author.settings.get(UserSettings.GP) < 19_000_000) {
-				throw `You don't have enough gold to lock your account from gambling. You need atleast ${toKMB(
-					19_000_000
-				)} GP.`;
-			}
-
-			msg.author.log(
-				`just locked account from gambling, previous settings: ${JSON.stringify(
-					msg.author.settings.toJSON()
-				)}`
-			);
 			await msg.author.removeGP(19_000_000);
 
-			await msg.author.settings.update([
-				[UserSettings.Minion.lockedGambling, true],
-				[UserSettings.Minion.HasBought, true]
-			]);
+			await msg.author.settings.update([[UserSettings.Minion.lockedGambling, true]]);
 			return msg.send('You are now locked from gambling.');
 		} catch (err) {
 			return msg.channel.send('Cancelled the request to lock gambling.');

--- a/src/extendables/UserExtendables.ts
+++ b/src/extendables/UserExtendables.ts
@@ -43,6 +43,12 @@ export default class extends Extendable {
 		return this.settings.get(UserSettings.Minion.Ironman);
 	}
 
+	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+	// @ts-ignore 2784
+	public get lockedGambling(this: User) {
+		return this.settings.get(UserSettings.Minion.lockedGambling);
+	}
+
 	/**
 	 * Toggle whether this user is busy or not, this adds another layer of locking the user
 	 * from economy actions.

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -29,6 +29,7 @@ Client.defaultUserSchema
 			.add('hasBought', 'boolean', { default: false })
 			.add('dailyDuration', 'integer', { default: 0 })
 			.add('ironman', 'boolean', { default: false })
+			.add('lockedGambling', 'boolean', { default: false })
 			.add('icon', 'string', { default: null })
 			.add('equippedPet', 'integer', { default: null })
 	)

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -47,6 +47,7 @@ export namespace UserSettings {
 		export const HasBought = T<boolean>('minion.hasBought');
 		export const DailyDuration = T<number>('minion.dailyDuration');
 		export const Ironman = T<boolean>('minion.ironman');
+		export const lockedGambling = T<boolean>('minion.lockGambling');
 		export const Icon = T<string | null>('minion.icon');
 		export const EquippedPet = T<number | null>('minion.equippedPet');
 	}

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -47,7 +47,7 @@ export namespace UserSettings {
 		export const HasBought = T<boolean>('minion.hasBought');
 		export const DailyDuration = T<number>('minion.dailyDuration');
 		export const Ironman = T<boolean>('minion.ironman');
-		export const lockedGambling = T<boolean>('minion.lockGambling');
+		export const lockedGambling = T<boolean>('minion.lockedGambling');
 		export const Icon = T<string | null>('minion.icon');
 		export const EquippedPet = T<number | null>('minion.equippedPet');
 	}

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -159,6 +159,7 @@ declare module 'discord.js' {
 		minionName: string;
 		hasMinion: boolean;
 		isIronman: boolean;
+		lockedGambling: boolean;
 		maxTripLength: number;
 		rawSkills: Skills;
 	}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -32,6 +32,7 @@ export interface SettingsEntry {
 		name?: string;
 		hasBought: boolean;
 		ironman: boolean;
+		lockedGamble: boolean;
 	};
 }
 


### PR DESCRIPTION
### Description:

Added a command for minion +minion lockgamble, that locks the user from using dice and duel similar to how ironmen was locked. To make it not a troll command the command itself costs 1M to use and in total 20M to lock account from gambling.
The cost amount was put in place to prevent people from using the command to troll others and spam the command. 

closes #547

### Changes:

Added a command for minion +minion lockgamble, that locks the user from using dice and duel.
Added a stored boolean variable lockedGambling. 

-   [X] I have tested all my changes thoroughly.
