### PR TITLE
[BSO] Changed clue opening extra rolls

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -141,8 +141,6 @@ export default class extends BotCommand {
 			msg.author.incrementMonsterScore(MIMIC_MONSTER_ID, mimicNumber);
 		}
 
-		console.log(extraClueRolls);
-
 		return msg.channel.sendBankImage({
 			bank: loot,
 			content: `You have completed ${nthCasket} ${clueTier.name.toLowerCase()} Treasure Trails.${

--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -142,7 +142,9 @@ export default class extends BotCommand {
 			bank: loot,
 			content: `You have completed ${nthCasket} ${clueTier.name.toLowerCase()} Treasure Trails.${
 				newQuantity > quantity
-					? ` You also received ${newQuantity - quantity} extra rolls on your rewards!`
+					? ` You also received ${newQuantity - quantity} extra roll${
+							newQuantity - quantity > 1 ? 's' : ''
+					  } on your rewards!`
 					: ``
 			}`,
 			title: opened,

--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -5,7 +5,7 @@ import Loot from 'oldschooljs/dist/structures/Loot';
 import { Events, MIMIC_MONSTER_ID } from '../../lib/constants';
 import { BotCommand } from '../../lib/BotCommand';
 import botOpenables from '../../lib/openables';
-import { stringMatches, roll, addBanks, itemNameFromID, rand } from '../../lib/util';
+import { stringMatches, roll, addBanks, itemNameFromID } from '../../lib/util';
 import createReadableItemListFromBank from '../../lib/util/createReadableItemListFromTuple';
 import { cluesRares } from '../../lib/collectionLog';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -74,7 +74,8 @@ export default class extends BotCommand {
 
 		await msg.author.removeItemFromBank(clueTier.id, quantity);
 
-		let loot = clueTier.table.open(quantity * rand(1, 3));
+		const newQuantity = Math.floor(Math.random() * (quantity * 3 - quantity + 1) + quantity);
+		let loot = clueTier.table.open(newQuantity);
 
 		let mimicNumber = 0;
 		if (clueTier.mimicChance) {
@@ -135,9 +136,15 @@ export default class extends BotCommand {
 			msg.author.incrementMonsterScore(MIMIC_MONSTER_ID, mimicNumber);
 		}
 
+		console.log(newQuantity);
+
 		return msg.channel.sendBankImage({
 			bank: loot,
-			content: `You have completed ${nthCasket} ${clueTier.name.toLowerCase()} Treasure Trails.`,
+			content: `You have completed ${nthCasket} ${clueTier.name.toLowerCase()} Treasure Trails.${
+				newQuantity > quantity
+					? ` You also received ${newQuantity - quantity} extra rolls on your rewards!`
+					: ``
+			}`,
 			title: opened,
 			flags: { showNewCL: 1 },
 			user: msg.author


### PR DESCRIPTION
# Description:

-   People on BSO were complaining about how their large openings were being 'messed up' because you were better opening 1 at time to avoid opening 500 and rolling on x1 multiplier.

### Changes:

- Changed how extra rolls work for clue openings. Currently, you either get 1x, 2x or 3x the total amount you opened. That creates the possibility that someone may lose all their extra rolls (or gain a lot). Most people on BSO currently are doing small openings to prevent losing too much. This change make it fair, as a number between the opened one and 3 times that is chosen. Realistically, someone can still get 0 extra rolls, but that is much more rare.

-   [X] I have tested all my changes thoroughly.

https://images-ext-2.discordapp.net/external/2pyBGC4YMPbdtLoMtjBH6hb49VmBLUuVMeo4TRGZ6Ms/https/i.imgur.com/reT0SmE.png?width=597&height=910
![image](https://user-images.githubusercontent.com/19570528/91215061-591c8b00-e6ea-11ea-8fff-f74bdf4cee00.png)

![image](https://user-images.githubusercontent.com/19570528/91215067-5c177b80-e6ea-11ea-86af-b4f5ad8d7981.png)
