### PR TITLE
[BSO] Remove duplicates from untradeable boxes

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -18,7 +18,6 @@ interface Openable {
 }
 
 const HolidayItems = new LootTable()
-	.oneIn(100, 'Halloween mask set')
 	.add('Chicken head')
 	.add('Chicken wings')
 	.add('Chicken legs')
@@ -186,7 +185,6 @@ const PetsTable = new LootTable()
 	.add('Youngllef');
 
 const PartyhatTable = new LootTable()
-	.oneIn(100, 'Partyhat set')
 	.oneIn(50, 'Black partyhat')
 	.oneIn(20, 'Rainbow partyhat')
 	.add('Red Partyhat')

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -18,6 +18,7 @@ interface Openable {
 }
 
 const HolidayItems = new LootTable()
+	.oneIn(100, 'Halloween mask set')
 	.add('Chicken head')
 	.add('Chicken wings')
 	.add('Chicken legs')
@@ -185,6 +186,7 @@ const PetsTable = new LootTable()
 	.add('Youngllef');
 
 const PartyhatTable = new LootTable()
+	.oneIn(100, 'Partyhat set')
 	.oneIn(50, 'Black partyhat')
 	.oneIn(20, 'Rainbow partyhat')
 	.add('Red Partyhat')
@@ -274,8 +276,11 @@ function getRandomItem(tradeables: boolean): number {
 		if (allItemsIDs.includes(i.id) || cantBeDropped.includes(i.id)) {
 			return false;
 		}
-
-		if (!tradeables) return !(i as Item).tradeable && !(i as Item).duplicate;
+		if (!tradeables) {
+			// remove item id 0 (Dwarf remains) to avoid possible bank problems and only allow items that are
+			// not trade-able or duplicates to be dropped
+			return (i as Item).id !== 0 && !(i as Item).tradeable && !(i as Item).duplicate;
+		}
 		return (i as Item).tradeable_on_ge;
 	}).random().id;
 }

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -275,7 +275,8 @@ function getRandomItem(tradeables: boolean): number {
 			return false;
 		}
 
-		return (i as Item).tradeable_on_ge === tradeables;
+		if (!tradeables) return !(i as Item).tradeable && !(i as Item).duplicate;
+		return (i as Item).tradeable_on_ge;
 	}).random().id;
 }
 


### PR DESCRIPTION
### Description:

Remove duplicates from untradeable boxes. Most items that were dropping from it were duplicates and not recognized by the bot for commands like equip or sellto. Right now, UMBs are giving tradeable items too that don't have the 'tradeable_on_ge' tag. Also remove holiday sets (phat and hween) from TMB and moves it to their respective tables, with a much rare change to be obtainable (1 in 100).

### Changes:

-   getRandomItem now checks if the parameter tradeable is true or false. If it is false, it'll remove items marked as 'tradeable' and 'duplicate' and the itemID 0 (Dwarf Remains). This itemID can cause problems with the bank functions;
- Added halloween mask set to HolidayItems LootTable with a 1 in 100 chance;
- Added partyhat set to PartyhatTable LootTable with a 1 in 100 chance.


-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/91466800-0536b100-e866-11ea-9380-41be3cb9c407.png)
![image](https://user-images.githubusercontent.com/19570528/91466855-1b447180-e866-11ea-816f-16be43336ac6.png)
Image of the 10,000 items generated: https://cdn.discordapp.com/attachments/727257275663777904/748574105426722927/file.jpg