### PR TITLE
Added clues filterables

### DIFF
--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -1,7 +1,6 @@
 import { removeDuplicatesFromArray } from './util';
 import resolveItems from './util/resolveItems';
 import Agility, { gracefulItems } from './skilling/skills/agility';
-import { wintertodtItems } from './filterables';
 
 export const bosses = {
 	Zulrah: resolveItems([
@@ -1218,6 +1217,21 @@ export const quest = {
 	])
 };
 
+export const wintertodt = {
+	'': resolveItems([
+		'Phoenix',
+		'Pyromancer hood',
+		'Pyromancer garb',
+		'Pyromancer robe',
+		'Pyromancer boots',
+		'Warm gloves',
+		'Bruma torch',
+		'Burnt page',
+		'Tome of fire',
+		'Dragon axe'
+	])
+};
+
 export const skillingLog = {
 	Mining: resolveItems([
 		'Prospector helmet',
@@ -1234,11 +1248,7 @@ export const skillingLog = {
 	Fishing: resolveItems(['Big swordfish', 'Big shark', 'Big bass', 'Heron']),
 	Agility: resolveItems([...gracefulItems, 'Mark of grace', 'Giant squirrel']),
 	MonkeyBackpacks: Agility.MonkeyBackpacks.map(i => i.id),
-	Firemaking: wintertodtItems
-};
-
-export const wintertodt = {
-	'': wintertodtItems
+	Firemaking: Object.values(wintertodt).flat(Infinity)
 };
 
 export const coxLog = {

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -4,6 +4,17 @@ import { gracefulItems } from './skilling/skills/agility';
 import { Eatables } from './eatables';
 import Crafting from './skilling/skills/crafting/crafting';
 import Fletching from './skilling/skills/fletching/fletching';
+import {
+	cluesAll,
+	cluesBeginner,
+	cluesEasy,
+	cluesElite,
+	cluesHard,
+	cluesMaster,
+	cluesMedium,
+	cluesShared,
+	wintertodt
+} from './collectionLog';
 
 const ores = resolveItems([
 	`Copper ore`,
@@ -658,19 +669,6 @@ const prayer = resolveItems([
 
 const food = resolveItems(Eatables.map(food => food.name));
 
-export const wintertodtItems = resolveItems([
-	'Phoenix',
-	'Pyromancer hood',
-	'Pyromancer garb',
-	'Pyromancer robe',
-	'Pyromancer boots',
-	'Warm gloves',
-	'Bruma torch',
-	'Burnt page',
-	'Tome of fire',
-	'Dragon axe'
-]);
-
 export const filterableTypes = [
 	{
 		name: 'Smithing',
@@ -780,11 +778,51 @@ export const filterableTypes = [
 	{
 		name: 'Wintertodt',
 		aliases: ['wintertodt', 'todt', 'wt'],
-		items: wintertodtItems
+		items: Object.entries(wintertodt).flat(Infinity)
 	},
 	{
 		name: 'Warm gear',
 		aliases: ['warm gear', 'warm'],
 		items: warmGear
+	},
+	{
+		name: 'Beginner Clues',
+		aliases: ['clues beginner', 'beginner clues'],
+		items: Object.entries(cluesBeginner).flat(Infinity)
+	},
+	{
+		name: 'Easy Clues',
+		aliases: ['clues easy', 'easy clues'],
+		items: Object.entries(cluesEasy).flat(Infinity)
+	},
+	{
+		name: 'Medium Clues',
+		aliases: ['clues medium', 'medium clues'],
+		items: Object.entries(cluesMedium).flat(Infinity)
+	},
+	{
+		name: 'Hard Clues',
+		aliases: ['clues hard', 'hard clues'],
+		items: Object.entries(cluesHard).flat(Infinity)
+	},
+	{
+		name: 'Elite Clues',
+		aliases: ['clues elite', 'elite clues'],
+		items: Object.entries(cluesElite).flat(Infinity)
+	},
+	{
+		name: 'Master Clues',
+		aliases: ['clues master', 'master clues'],
+		items: Object.entries(cluesMaster).flat(Infinity)
+	},
+	{
+		name: 'All Clues',
+		aliases: ['clues all', 'all clues'],
+		items: Object.entries(cluesAll).flat(Infinity)
+	},
+	{
+		name: 'Clues Shared',
+		aliases: ['clues shared', 'shared clues'],
+		items: Object.entries(cluesShared).flat(Infinity)
 	}
 ];

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -12,6 +12,7 @@ import {
 	cluesHard,
 	cluesMaster,
 	cluesMedium,
+	cluesRares,
 	cluesShared,
 	wintertodt
 } from './collectionLog';
@@ -778,7 +779,7 @@ export const filterableTypes = [
 	{
 		name: 'Wintertodt',
 		aliases: ['wintertodt', 'todt', 'wt'],
-		items: Object.entries(wintertodt).flat(Infinity)
+		items: Object.values(wintertodt).flat(Infinity)
 	},
 	{
 		name: 'Warm gear',
@@ -788,41 +789,46 @@ export const filterableTypes = [
 	{
 		name: 'Beginner Clues',
 		aliases: ['clues beginner', 'beginner clues'],
-		items: Object.entries(cluesBeginner).flat(Infinity)
+		items: Object.values(cluesBeginner).flat(Infinity)
 	},
 	{
 		name: 'Easy Clues',
 		aliases: ['clues easy', 'easy clues'],
-		items: Object.entries(cluesEasy).flat(Infinity)
+		items: Object.values(cluesEasy).flat(Infinity)
 	},
 	{
 		name: 'Medium Clues',
 		aliases: ['clues medium', 'medium clues'],
-		items: Object.entries(cluesMedium).flat(Infinity)
+		items: Object.values(cluesMedium).flat(Infinity)
 	},
 	{
 		name: 'Hard Clues',
 		aliases: ['clues hard', 'hard clues'],
-		items: Object.entries(cluesHard).flat(Infinity)
+		items: Object.values(cluesHard).flat(Infinity)
 	},
 	{
 		name: 'Elite Clues',
 		aliases: ['clues elite', 'elite clues'],
-		items: Object.entries(cluesElite).flat(Infinity)
+		items: Object.values(cluesElite).flat(Infinity)
 	},
 	{
 		name: 'Master Clues',
 		aliases: ['clues master', 'master clues'],
-		items: Object.entries(cluesMaster).flat(Infinity)
+		items: Object.values(cluesMaster).flat(Infinity)
 	},
 	{
 		name: 'All Clues',
 		aliases: ['clues all', 'all clues'],
-		items: Object.entries(cluesAll).flat(Infinity)
+		items: Object.values(cluesAll).flat(Infinity)
 	},
 	{
 		name: 'Clues Shared',
 		aliases: ['clues shared', 'shared clues'],
-		items: Object.entries(cluesShared).flat(Infinity)
+		items: Object.values(cluesShared).flat(Infinity)
+	},
+	{
+		name: 'Clues Rares',
+		aliases: ['clues rares', 'rares clues'],
+		items: Object.values(cluesRares).flat(Infinity)
 	}
 ];

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -788,47 +788,47 @@ export const filterableTypes = [
 	},
 	{
 		name: 'Beginner Clues',
-		aliases: ['clues beginner', 'beginner clues'],
+		aliases: ['clues beginner', 'beginner clues', 'clue beginner', 'beginner clue'],
 		items: Object.values(cluesBeginner).flat(Infinity)
 	},
 	{
 		name: 'Easy Clues',
-		aliases: ['clues easy', 'easy clues'],
+		aliases: ['clues easy', 'easy clues', 'clue easy', 'easy clue'],
 		items: Object.values(cluesEasy).flat(Infinity)
 	},
 	{
 		name: 'Medium Clues',
-		aliases: ['clues medium', 'medium clues'],
+		aliases: ['clues medium', 'medium clues', 'clue medium', 'medium clue'],
 		items: Object.values(cluesMedium).flat(Infinity)
 	},
 	{
 		name: 'Hard Clues',
-		aliases: ['clues hard', 'hard clues'],
+		aliases: ['clues hard', 'hard clues', 'clue hard', 'hard clue'],
 		items: Object.values(cluesHard).flat(Infinity)
 	},
 	{
 		name: 'Elite Clues',
-		aliases: ['clues elite', 'elite clues'],
+		aliases: ['clues elite', 'elite clues', 'clue elite', 'elite clue'],
 		items: Object.values(cluesElite).flat(Infinity)
 	},
 	{
 		name: 'Master Clues',
-		aliases: ['clues master', 'master clues'],
+		aliases: ['clues master', 'master clues', 'clue master', 'master clue'],
 		items: Object.values(cluesMaster).flat(Infinity)
 	},
 	{
 		name: 'All Clues',
-		aliases: ['clues all', 'all clues'],
+		aliases: ['clues all', 'all clues', 'clue all', 'all clue'],
 		items: Object.values(cluesAll).flat(Infinity)
 	},
 	{
 		name: 'Clues Shared',
-		aliases: ['clues shared', 'shared clues'],
+		aliases: ['clues shared', 'shared clues', 'clue shared', 'shared clue'],
 		items: Object.values(cluesShared).flat(Infinity)
 	},
 	{
 		name: 'Clues Rares',
-		aliases: ['clues rares', 'rares clues'],
+		aliases: ['clues rare', 'rare clues', 'clue rare', 'rare clue'],
 		items: Object.values(cluesRares).flat(Infinity)
 	}
 ];


### PR DESCRIPTION
### Description:

-   Was asked if it was possible to add clues filterable to the bank filters.

### Changes:

- Added bank filters for all clues (beginner, easy, medium, hard, elite, master, shared, rares, all);
- For that, I had to fix a cross-reference that collectionLog.ts had. It was referencing filterables.ts on the wintertodt items. Trying to load the clue scrolls collection was resulting in errors on the JS files. I transferred it to collectionLog.ts and was able to reference items on collectionLog.ts from filterables.ts.

-   [X] I have tested all my changes thoroughly.
