### PR TITLE
Boost items (axes, pickaxes) accurate levels

### DIFF
--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -5,7 +5,8 @@ import {
 	stringMatches,
 	formatDuration,
 	rand,
-	itemNameFromID
+	itemNameFromID,
+	reduceNumByPercent
 } from '../../lib/util';
 import { BotCommand } from '../../lib/BotCommand';
 import { Activity, Tasks } from '../../lib/constants';
@@ -97,7 +98,7 @@ export default class extends BotCommand {
 				msg.author.hasItemEquippedOrInBank(axe.id) &&
 				msg.author.skillLevel(SkillsEnum.Woodcutting) >= axe.wcLvl
 			) {
-				timetoChop = Math.floor(timetoChop * ((100 - axe.reductionPercent) / 100));
+				timetoChop = reduceNumByPercent(timetoChop, axe.reductionPercent);
 				boosts.push(`${axe.reductionPercent}% for ${itemNameFromID(axe.id)}`);
 				break;
 			}

--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -19,19 +19,23 @@ import { SkillsEnum } from '../../lib/skilling/types';
 const axes = [
 	{
 		id: itemID('3rd age axe'),
-		reductionPercent: 13
+		reductionPercent: 13,
+		wcLvl: 61
 	},
 	{
 		id: itemID('Gilded axe'),
-		reductionPercent: 12
+		reductionPercent: 12,
+		wcLvl: 41
 	},
 	{
 		id: itemID('Infernal axe'),
-		reductionPercent: 11
+		reductionPercent: 11,
+		wcLvl: 61
 	},
 	{
 		id: itemID('Dragon axe'),
-		reductionPercent: 9
+		reductionPercent: 9,
+		wcLvl: 61
 	}
 ];
 
@@ -88,13 +92,14 @@ export default class extends BotCommand {
 
 		// If the user has an axe apply boost
 		const boosts = [];
-		if (msg.author.skillLevel(SkillsEnum.Woodcutting) >= 61) {
-			for (const axe of axes) {
-				if (msg.author.hasItemEquippedOrInBank(axe.id)) {
-					timetoChop = Math.floor(timetoChop * ((100 - axe.reductionPercent) / 100));
-					boosts.push(`${axe.reductionPercent}% for ${itemNameFromID(axe.id)}`);
-					break;
-				}
+		for (const axe of axes) {
+			if (
+				msg.author.hasItemEquippedOrInBank(axe.id) &&
+				msg.author.skillLevel(SkillsEnum.Woodcutting) >= axe.wcLvl
+			) {
+				timetoChop = Math.floor(timetoChop * ((100 - axe.reductionPercent) / 100));
+				boosts.push(`${axe.reductionPercent}% for ${itemNameFromID(axe.id)}`);
+				break;
 			}
 		}
 

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -19,22 +19,22 @@ const pickaxes = [
 	{
 		id: itemID('3rd age pickaxe'),
 		reductionPercent: 13,
-		mineLvl: 61
+		miningLvl: 61
 	},
 	{
 		id: itemID('Gilded pickaxe'),
 		reductionPercent: 11,
-		mineLvl: 41
+		miningLvl: 41
 	},
 	{
 		id: itemID('Infernal pickaxe'),
 		reductionPercent: 10,
-		mineLvl: 61
+		miningLvl: 61
 	},
 	{
 		id: itemID('Dragon pickaxe'),
 		reductionPercent: 6,
-		mineLvl: 61
+		miningLvl: 61
 	}
 ];
 
@@ -104,7 +104,7 @@ export default class extends BotCommand {
 		for (const pickaxe of pickaxes) {
 			if (
 				msg.author.hasItemEquippedOrInBank(pickaxe.id) &&
-				msg.author.skillLevel(SkillsEnum.Mining) >= pickaxe.mineLvl
+				msg.author.skillLevel(SkillsEnum.Mining) >= pickaxe.miningLvl
 			) {
 				timeToMine = Math.floor(timeToMine * ((100 - pickaxe.reductionPercent) / 100));
 				boosts.push(`${pickaxe.reductionPercent}% for ${itemNameFromID(pickaxe.id)}`);

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -6,7 +6,8 @@ import {
 	stringMatches,
 	formatDuration,
 	rand,
-	itemNameFromID
+	itemNameFromID,
+	reduceNumByPercent
 } from '../../lib/util';
 import Mining from '../../lib/skilling/skills/mining';
 import { Activity, Tasks } from '../../lib/constants';
@@ -106,7 +107,7 @@ export default class extends BotCommand {
 				msg.author.hasItemEquippedOrInBank(pickaxe.id) &&
 				msg.author.skillLevel(SkillsEnum.Mining) >= pickaxe.miningLvl
 			) {
-				timeToMine = Math.floor(timeToMine * ((100 - pickaxe.reductionPercent) / 100));
+				timeToMine = reduceNumByPercent(timeToMine, pickaxe.reductionPercent);
 				boosts.push(`${pickaxe.reductionPercent}% for ${itemNameFromID(pickaxe.id)}`);
 				break;
 			}
@@ -114,7 +115,7 @@ export default class extends BotCommand {
 		if (msg.author.skillLevel(SkillsEnum.Mining) >= 60) {
 			for (const glove of gloves) {
 				if (msg.author.hasItemEquippedAnywhere(glove.id)) {
-					timeToMine = Math.floor(timeToMine * ((100 - glove.reductionPercent) / 100));
+					timeToMine = reduceNumByPercent(timeToMine, glove.reductionPercent);
 					boosts.push(`${glove.reductionPercent}% for ${itemNameFromID(glove.id)}`);
 					break;
 				}

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -18,19 +18,23 @@ import { SkillsEnum } from '../../lib/skilling/types';
 const pickaxes = [
 	{
 		id: itemID('3rd age pickaxe'),
-		reductionPercent: 13
+		reductionPercent: 13,
+		mineLvl: 61
 	},
 	{
 		id: itemID('Gilded pickaxe'),
-		reductionPercent: 11
+		reductionPercent: 11,
+		mineLvl: 41
 	},
 	{
 		id: itemID('Infernal pickaxe'),
-		reductionPercent: 10
+		reductionPercent: 10,
+		mineLvl: 61
 	},
 	{
 		id: itemID('Dragon pickaxe'),
-		reductionPercent: 6
+		reductionPercent: 6,
+		mineLvl: 61
 	}
 ];
 
@@ -97,15 +101,17 @@ export default class extends BotCommand {
 
 		// For each pickaxe, if they have it, give them its' bonus and break.
 		const boosts = [];
-		if (msg.author.skillLevel(SkillsEnum.Mining) >= 61) {
-			for (const pickaxe of pickaxes) {
-				if (msg.author.hasItemEquippedOrInBank(pickaxe.id)) {
-					timeToMine = Math.floor(timeToMine * ((100 - pickaxe.reductionPercent) / 100));
-					boosts.push(`${pickaxe.reductionPercent}% for ${itemNameFromID(pickaxe.id)}`);
-					break;
-				}
+		for (const pickaxe of pickaxes) {
+			if (
+				msg.author.hasItemEquippedOrInBank(pickaxe.id) &&
+				msg.author.skillLevel(SkillsEnum.Mining) >= pickaxe.mineLvl
+			) {
+				timeToMine = Math.floor(timeToMine * ((100 - pickaxe.reductionPercent) / 100));
+				boosts.push(`${pickaxe.reductionPercent}% for ${itemNameFromID(pickaxe.id)}`);
+				break;
 			}
-
+		}
+		if (msg.author.skillLevel(SkillsEnum.Mining) >= 60) {
 			for (const glove of gloves) {
 				if (msg.author.hasItemEquippedAnywhere(glove.id)) {
 					timeToMine = Math.floor(timeToMine * ((100 - glove.reductionPercent) / 100));


### PR DESCRIPTION
### Description:

Changed so that gilded axe/pickaxe boost from lvl 41, changed mining gloves to boost from 60 mining (mining guild). Closes #188 

### Changes:

Changed so that gilded axe/pickaxe boost from lvl 41, changed mining gloves to boost from 60 mining (mining guild)

-   [X] I have tested all my changes thoroughly.
