### PR TITLE
Name of mass leader when mass cancel

### DIFF
--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -127,7 +127,7 @@ async function _setup(
 					case ReactionEmoji.Stop: {
 						if (user === options.leader) {
 							reject(
-								`The leader ${options.leader.username} cancelled this ${
+								`The leader (${options.leader.username}) cancelled this ${
 									options.party ? 'party' : 'mass'
 								}!`
 							);

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -127,7 +127,7 @@ async function _setup(
 					case ReactionEmoji.Stop: {
 						if (user === options.leader) {
 							reject(
-								`The leader cancelled this ${options.party ? 'party' : 'mass'}!`
+								`The leader ${options.leader.username} cancelled this ${options.party ? 'party' : 'mass'}!`
 							);
 							collector.stop('partyCreatorEnd');
 						}

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -127,7 +127,9 @@ async function _setup(
 					case ReactionEmoji.Stop: {
 						if (user === options.leader) {
 							reject(
-								`The leader ${options.leader.username} cancelled this ${options.party ? 'party' : 'mass'}!`
+								`The leader ${options.leader.username} cancelled this ${
+									options.party ? 'party' : 'mass'
+								}!`
 							);
 							collector.stop('partyCreatorEnd');
 						}


### PR DESCRIPTION
### Description:

Added the username of the person that cancelled the mass for less confusion in mass channel. Closes #492 

### Changes:

Added the username of the person that cancelled the mass for less confusion in mass channel. 

-   [X] I have tested all my changes thoroughly.
