### PR TITLE
#revertZippy

### DIFF
--- a/src/tasks/minions/clueActivity.ts
+++ b/src/tasks/minions/clueActivity.ts
@@ -2,7 +2,7 @@ import { Task } from 'klasa';
 
 import clueTiers from '../../lib/minions/data/clueTiers';
 import { ClueActivityTaskOptions } from '../../lib/types/minions';
-import { Events, Time } from '../../lib/constants';
+import { Events } from '../../lib/constants';
 import { channelIsSendable } from '../../lib/util/channelIsSendable';
 import { roll, multiplyBank, addItemToBank, itemID, rand, addBanks } from '../../lib/util';
 import { getRandomMysteryBox } from '../../lib/openables';
@@ -49,7 +49,7 @@ export default class extends Task {
 			loot = multiplyBank(loot, 2);
 			loot[getRandomMysteryBox()] = 1;
 		}
-		if (user.equippedPet() === itemID('Zippy') && duration > Time.Minute * 10) {
+		if (user.equippedPet() === itemID('Zippy')) {
 			let bonusLoot = {};
 			for (let i = 0; i < rand(1, 4); i++) {
 				const { item } = possibleFound.roll()[0];


### PR DESCRIPTION
### Description:

-  Reverts Zippy back to his original state as Magna said he was going to do: 
![image](https://user-images.githubusercontent.com/57806957/92983646-b480a400-f472-11ea-93eb-1587494a4ee5.png)
- Now only a one button push to resolve the movement. 

### Changes:

-   Removes needing to do a trip over 10 minutes. Note: This keeps the _slight_ increased chance of an easy or beginner casket and the _slight_ reduction for the chance of a mystery box.

-   [X] I have tested all my changes thoroughly.
