### PR TITLE
[OSB] Fixes GWD bosses not requiring items to kill

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -4,7 +4,7 @@ import { bosses } from '../../../../collectionLog';
 import { Time } from '../../../../constants';
 import { GearSetupTypes, GearStat } from '../../../../gear/types';
 import itemID from '../../../../util/itemID';
-import resolveItems from '../../../../util/resolveItems';
+import resolveItems, { deepResolveItems } from '../../../../util/resolveItems';
 import { KillableMonster } from '../../../types';
 
 const killableBosses: KillableMonster[] = [
@@ -65,7 +65,11 @@ const killableBosses: KillableMonster[] = [
 		attackStylesUsed: [GearStat.AttackRanged],
 		minimumGearRequirements: {
 			[GearStat.AttackRanged]: 30 + 17 + 69 + 7
-		}
+		},
+		itemsRequired: deepResolveItems([
+			["Karil's leathertop", 'Armadyl chestplate'],
+			["Karil's leatherskirt", 'Armadyl chainskirt']
+		])
 	},
 	{
 		id: Monsters.Kreearra.id,
@@ -93,7 +97,11 @@ const killableBosses: KillableMonster[] = [
 		attackStylesUsed: [GearStat.AttackRanged, GearStat.AttackSlash],
 		minimumGearRequirements: {
 			[GearStat.AttackRanged]: 30 + 17 + 69 + 7
-		}
+		},
+		itemsRequired: deepResolveItems([
+			["Karil's leathertop", 'Armadyl chestplate'],
+			["Karil's leatherskirt", 'Armadyl chainskirt']
+		])
 	},
 	{
 		id: Monsters.KrilTsutsaroth.id,
@@ -122,7 +130,11 @@ const killableBosses: KillableMonster[] = [
 		minimumGearRequirements: {
 			[GearStat.DefenceSlash]: 200,
 			[GearStat.AttackStab]: 80
-		}
+		},
+		itemsRequired: deepResolveItems([
+			["Karil's leathertop", 'Armadyl chestplate'],
+			["Karil's leatherskirt", 'Armadyl chainskirt']
+		])
 	}
 ];
 


### PR DESCRIPTION
### Description:

-   GWD bosses were being able to be killed without the required items (Karil's leathertop or Armadyl chestplate and Karil's leatherskirt or Armadyl chainskirt).

### Changes:

-   Adds back the `itemsRequired` property to the `gwd.ts` monsters.

-   [X] I have tested all my changes thoroughly.
