### PR TITLE
fix minion activity readout for smithing

### DIFF
--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -179,7 +179,9 @@ export default class extends Extendable {
 			case Activity.Smithing: {
 				const data = currentTask as SmithingActivityTaskOptions;
 
-				const SmithableItem = Smithing.Bars.find(item => item.id === data.smithedBarID);
+				const SmithableItem = Smithing.SmithableItems.find(
+					item => item.id === data.smithedBarID
+				);
 
 				return `${this.minionName} is currently smithing ${data.quantity}x ${
 					SmithableItem!.name


### PR DESCRIPTION
### Description:

search on the Items array instead of Bars when looking for smithed items

### Changes:

-   [x] I have tested all my changes thoroughly.
