### PR TITLE
[BSO] Removes bank title border and hamstare if the bankBg is not the default

### DIFF
--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -145,7 +145,7 @@ export default class BankImageTask extends Task {
 		this.itemIconImagesCache.set(itemID, image);
 	}
 
-	drawBorder(canvas: Canvas) {
+	drawBorder(canvas: Canvas, titleLine = true) {
 		const ctx = canvas.getContext('2d');
 		// Draw top border
 		ctx.fillStyle = ctx.createPattern(this.borderHorizontal, 'repeat-x');
@@ -160,11 +160,13 @@ export default class BankImageTask extends Task {
 		ctx.restore();
 
 		// Draw title line
-		ctx.save();
-		ctx.fillStyle = ctx.createPattern(this.borderHorizontal, 'repeat-x');
-		ctx.translate(this.borderVertical?.width!, 27);
-		ctx.fillRect(0, 0, canvas.width, this.borderHorizontal?.height!);
-		ctx.restore();
+		if (titleLine) {
+			ctx.save();
+			ctx.fillStyle = ctx.createPattern(this.borderHorizontal, 'repeat-x');
+			ctx.translate(this.borderVertical?.width!, 27);
+			ctx.fillRect(0, 0, canvas.width, this.borderHorizontal?.height!);
+			ctx.restore();
+		}
 
 		// Draw left border
 		ctx.save();
@@ -336,11 +338,13 @@ export default class BankImageTask extends Task {
 
 		// Skips border if noBorder is set
 		if (noBorder !== 1) {
-			this.drawBorder(canvas);
+			this.drawBorder(canvas, bgImage.name === 'Default');
 		}
 
 		// Adds hamstare
-		this.addsHamstare(canvas, Boolean(wide));
+		if (bgImage.name === 'Default') {
+			this.addsHamstare(canvas, Boolean(wide));
+		}
 
 		if (showValue) {
 			title += ` (Value: ${partial ? `${toKMB(partialValue)} of ` : ''}${toKMB(totalValue)})`;

--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -370,7 +370,7 @@ export default class BankImageTask extends Task {
 		for (let i = 0; i < items.length; i++) {
 			if (i % itemsPerRow === 0) yLoc += Math.floor((itemSize + spacer / 2) * 1.08);
 			xLoc = Math.floor(
-				spacer + (i % itemsPerRow) * ((canvas.width - 40) / itemsPerRow) + distanceFromSide
+				spacer + (i % itemsPerRow) * ((canvas.width - 24) / itemsPerRow) + distanceFromSide
 			);
 			const [id, quantity, value] = items[i];
 			const item = await this.getItemImage(id);


### PR DESCRIPTION
### Description:

-   Checks if the bankBg is the default before it tries to draw the title border and the hamstare
-   Removes the awkward spacing on the right of the bank image and makes the distance the same as the left side

### Changes:

-   Removes bank title border and hamstare if the bankBg is not the default
-   Changed the formula of the items spacing a little bit

-   [X] I have tested all my changes thoroughly.
