### PR TITLE
[OSB] Fixes daily pet roll error

### DIFF
--- a/src/commands/Minion/daily.ts
+++ b/src/commands/Minion/daily.ts
@@ -143,7 +143,9 @@ export default class DailyCommand extends BotCommand {
 		} Diango says..** That's ${correct}! ${reward}\n`;
 
 		if (triviaCorrect && roll(13)) {
-			const pet = pets[Math.floor(Math.random() * pets.length)];
+			const pet = Object.values(pets)[
+				Math.floor(Math.random() * (Object.values(pets).length - 1))
+			];
 			const userPets = {
 				...user.settings.get(UserSettings.Pets)
 			};

--- a/src/commands/Minion/daily.ts
+++ b/src/commands/Minion/daily.ts
@@ -19,9 +19,9 @@ const { triviaQuestions } = JSON.parse(
 	fs.readFileSync('./resources/trivia-questions.json').toString()
 );
 
-import * as pets from '../../../data/pets';
 import { BotCommand } from '../../lib/BotCommand';
 import { COINS_ID, Emoji, SupportServer, Time } from '../../lib/constants';
+import pets from '../../lib/pets';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import dailyRoll from '../../lib/simulation/dailyTable';
@@ -142,10 +142,10 @@ export default class DailyCommand extends BotCommand {
 			Emoji.Diango
 		} Diango says..** That's ${correct}! ${reward}\n`;
 
+		console.log(pets);
+
 		if (triviaCorrect && roll(13)) {
-			const pet = Object.values(pets)[
-				Math.floor(Math.random() * (Object.values(pets).length - 1))
-			];
+			const pet = pets[Math.floor(Math.random() * pets.length)];
 			const userPets = {
 				...user.settings.get(UserSettings.Pets)
 			};

--- a/src/commands/Minion/daily.ts
+++ b/src/commands/Minion/daily.ts
@@ -142,8 +142,6 @@ export default class DailyCommand extends BotCommand {
 			Emoji.Diango
 		} Diango says..** That's ${correct}! ${reward}\n`;
 
-		console.log(pets);
-
 		if (triviaCorrect && roll(13)) {
 			const pet = pets[Math.floor(Math.random() * pets.length)];
 			const userPets = {


### PR DESCRIPTION
### Description:

- Dailies were rarely giving errors. This was caused because the pet roll was trying to roll on 45, but the pets array goes from 0 to 44.

### Changes:

- Changes the roll to be between 0 and 44 (pet length - 1)
- Changes the pet object to access the `Objects.value` of it. Accessing pets directly was causing issues with its prototype properties.

[X] I have tested all my changes thoroughly.
