### PR TITLE
[BSO] Allows dailies to give random mystery boxes

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -272,7 +272,7 @@ const Openables: Openable[] = [
 	}
 ];
 
-const MysteryBoxes = new LootTable()
+export const MysteryBoxes = new LootTable()
 	.oneIn(40, itemNameFromID(3062)!)
 	.oneIn(20, itemNameFromID(3713)!)
 	.oneIn(15, 'Dwarven crate')

--- a/src/lib/simulation/dailyTable.ts
+++ b/src/lib/simulation/dailyTable.ts
@@ -1,6 +1,8 @@
 import Loot from 'oldschooljs/dist/structures/Loot';
 import LootTable from 'oldschooljs/dist/structures/LootTable';
 
+import { MysteryBoxes } from '../openables';
+
 const RareTable = new LootTable()
 	.add('Hornwood helm')
 	.add('Hand fan')
@@ -41,7 +43,7 @@ const DailyTable = new LootTable()
 	.add('Coins', [100_000, 10_000_000])
 	.add(UncommonTable)
 	.add(CommonTable, 1, 2)
-	.add('Mystery box', 1, 2);
+	.add(MysteryBoxes, 1, 2);
 
 export default function dailyRoll(qty = 1, correct = false) {
 	const loot = new Loot();


### PR DESCRIPTION
### Description:

-   Dailies were giving only tradeable mystery boxes. This allows for all mystery boxes (and dwarf crate) to be dropped.

### Changes:

-   Makes MysteryBoxes public by exporting it;
-   Changes mystery box on the DailyTable.ts to be thhe Mystery Boxes loot table.

-   [X] I have tested all my changes thoroughly.
