### PR TITLE
[BSO] Adds dwarven crate, dwarven ore and dwarven warhammer to KingGoldemar uniques

### DIFF
--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -501,7 +501,8 @@ const killableMonsters: KillableMonster[] = [
 		respawnTime: Time.Second * 20,
 		levelRequirements: {
 			prayer: 43
-		}
+		},
+		uniques: resolveItems(['Dwarven warhammer', 'Dwarven crate', 'Dwarven ore'])
 	},
 	{
 		id: SeaKraken.id,


### PR DESCRIPTION
### Description:

-   King Goldenmar masses weren't giving the purple icon for the rare drops, now it does.

### Changes:

-   Adds 'Dwarven warhammer', 'Dwarven crate' and 'Dwarven ore' to the uniques array.

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/93964200-779b9380-fd35-11ea-8ab1-dee791bc653c.png)