### PR TITLE
[OSB] Remove title border from custom BGs and fix item spacing

### DIFF
--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -283,7 +283,7 @@ export default class BankImageTask extends Task {
 		}
 
 		let width = wide
-			? 6 + this.borderVertical?.width! + 20 + Math.ceil(Math.sqrt(items.length)) * (36 + 21)
+			? 5 + this.borderVertical?.width! + 20 + Math.ceil(Math.sqrt(items.length)) * (36 + 21)
 			: 488;
 		if (width < 488) width = 488;
 		const itemsPerRow = Math.floor((width - this.borderVertical?.width! * 2) / (36 + 20));

--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -140,7 +140,7 @@ export default class BankImageTask extends Task {
 		this.itemIconImagesCache.set(itemID, image);
 	}
 
-	drawBorder(canvas: Canvas) {
+	drawBorder(canvas: Canvas, titleLine = true) {
 		const ctx = canvas.getContext('2d');
 		// Draw top border
 		ctx.fillStyle = ctx.createPattern(this.borderHorizontal, 'repeat-x');
@@ -155,11 +155,13 @@ export default class BankImageTask extends Task {
 		ctx.restore();
 
 		// Draw title line
-		ctx.save();
-		ctx.fillStyle = ctx.createPattern(this.borderHorizontal, 'repeat-x');
-		ctx.translate(this.borderVertical?.width!, 27);
-		ctx.fillRect(0, 0, canvas.width, this.borderHorizontal?.height!);
-		ctx.restore();
+		if (titleLine) {
+			ctx.save();
+			ctx.fillStyle = ctx.createPattern(this.borderHorizontal, 'repeat-x');
+			ctx.translate(this.borderVertical?.width!, 27);
+			ctx.fillRect(0, 0, canvas.width, this.borderHorizontal?.height!);
+			ctx.restore();
+		}
 
 		// Draw left border
 		ctx.save();
@@ -281,18 +283,18 @@ export default class BankImageTask extends Task {
 		}
 
 		let width = wide
-			? Math.ceil(Math.sqrt(items.length) + 1) * itemSize +
-			  Math.ceil(Math.sqrt(items.length) + 1) * spacer * 2 +
-			  distanceFromSide * 2
+			? 6 + this.borderVertical?.width! + 20 + Math.ceil(Math.sqrt(items.length)) * (36 + 21)
 			: 488;
 		if (width < 488) width = 488;
-		const itemsPerRow = Math.floor(width / (distanceFromSide + itemSize + spacer));
-		const canvasHeight = Math.floor(
+		const itemsPerRow = Math.floor((width - this.borderVertical?.width! * 2) / (36 + 20));
+		const canvasHeight =
 			Math.floor(
-				Math.ceil(items.length / itemsPerRow) * Math.floor((itemSize + spacer / 2) * 1.08)
-			) +
-				itemSize * 1.5
-		);
+				Math.floor(
+					Math.ceil(items.length / itemsPerRow) *
+						Math.floor((itemSize + spacer / 2) * 1.08)
+				) +
+					itemSize * 1.5
+			) - 2;
 		const canvas = createCanvas(width, canvasHeight <= 331 ? 331 : canvasHeight);
 
 		const ctx = canvas.getContext('2d');
@@ -313,7 +315,7 @@ export default class BankImageTask extends Task {
 
 		// Skips border if noBorder is set
 		if (noBorder !== 1) {
-			this.drawBorder(canvas);
+			this.drawBorder(canvas, bgImage.name === 'Default');
 		}
 		if (showValue) {
 			title += ` (Value: ${partial ? `${toKMB(partialValue)} of ` : ''}${toKMB(totalValue)})`;
@@ -338,15 +340,18 @@ export default class BankImageTask extends Task {
 		let yLoc = 0;
 		for (let i = 0; i < items.length; i++) {
 			if (i % itemsPerRow === 0) yLoc += Math.floor((itemSize + spacer / 2) * 1.08);
-			xLoc = Math.floor(
-				spacer + (i % itemsPerRow) * ((canvas.width - 40) / itemsPerRow) + distanceFromSide
-			);
+			// For some reason, it starts drawing at -2 so we compensate that
+			// Adds the border width
+			// Adds distance from side
+			// 36 + 21 is the itemLength + the space between each item
+			xLoc = 2 + this.borderVertical?.width! + 20 + (i % itemsPerRow) * (36 + 21);
 			const [id, quantity, value] = items[i];
 			const item = await this.getItemImage(id);
 			if (!item) {
 				this.client.emit(Events.Warn, `Item with ID[${id}] has no item image.`);
 				continue;
 			}
+
 			ctx.drawImage(
 				item,
 				Math.floor(xLoc + (itemSize - item.width) / 2),


### PR DESCRIPTION
### Description:

-   Title border no longer shows on custom bgs;
-   Changed the item x location formula to make items spaced equally from the start to the end of the line
-- It now will always be 20 pixels from the left border, spaced equally between 21 pixels and 20 pixels away from the right border (21 pixels without using --wide, due to the default bg width and items per row)
-  The item spacing makes it much better to look at.

### Changes:

-   Changes canvasWidth and xLoc formula;
-   Adds a condition to draw title only if the user BG is the default.

-   [X] I have tested all my changes thoroughly.
