### PR TITLE
[OSB] Add improved food handling for +mass and +k

### DIFF
--- a/src/commands/Minion/groupkill.ts
+++ b/src/commands/Minion/groupkill.ts
@@ -2,18 +2,15 @@ import { CommandStore, KlasaMessage, KlasaUser } from 'klasa';
 
 import { BotCommand } from '../../lib/BotCommand';
 import { Activity, Emoji, Tasks } from '../../lib/constants';
-import { Eatables } from '../../lib/eatables';
 import { ironsCantUse, minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { findMonster, reducedTimeForGroup } from '../../lib/minions/functions';
 import calculateMonsterFood from '../../lib/minions/functions/calculateMonsterFood';
 import hasEnoughFoodForMonster from '../../lib/minions/functions/hasEnoughFoodForMonster';
+import removeFoodFromUser from '../../lib/minions/functions/removeFoodFromUser';
 import { GroupMonsterActivityTaskOptions, KillableMonster } from '../../lib/minions/types';
-import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { MakePartyOptions } from '../../lib/types';
-import { addItemToBank, formatDuration } from '../../lib/util';
+import { formatDuration } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
-
-const { ceil } = Math;
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -59,8 +56,13 @@ export default class extends BotCommand {
 				throw `${user.username} doesn't have the requirements for this monster: ${reason}`;
 			}
 
-			if (1 > 2 && !hasEnoughFoodForMonster(monster, user, quantity)) {
-				throw `${user.username} doesn't have enough food.`;
+			if (1 > 2 && !hasEnoughFoodForMonster(monster, user, quantity, users.length)) {
+				throw `${
+					users.length === 1 ? `You don't` : `${user.username} doesn't`
+				} have enough food. You need at least ${monster?.healAmountNeeded! *
+					quantity} HP in food to ${
+					users.length === 1 ? 'start the mass' : 'enter the mass'
+				}.`;
 			}
 		}
 	}
@@ -92,15 +94,21 @@ export default class extends BotCommand {
 					return [true, `you don't have the requirements for this monster; ${reason}`];
 				}
 
-				if (1 > 2) {
+				if (monster.healAmountNeeded) {
 					try {
 						calculateMonsterFood(monster, user);
 					} catch (err) {
 						return [true, err];
 					}
 
-					if (!hasEnoughFoodForMonster(monster, user, 2)) {
-						return [true, "you don't have enough food."];
+					// Ensure people have enough food for at least 2 full KC
+					// This makes it so the users will always have enough food for any amount of KC
+					if (1 > 2 && !hasEnoughFoodForMonster(monster, user, 2)) {
+						return [
+							true,
+							`You don't have enough food. You need at least ${monster.healAmountNeeded *
+								2} HP in food to enter the mass.`
+						];
 					}
 				}
 
@@ -114,41 +122,16 @@ export default class extends BotCommand {
 
 		this.checkReqs(users, monster, quantity);
 
-		if (1 > 2) {
+		if (1 > 2 && monster.healAmountNeeded) {
 			for (const user of users) {
-				await user.settings.sync(true);
-				let [healAmountNeeded] = calculateMonsterFood(monster, user);
-
-				healAmountNeeded = Math.ceil(healAmountNeeded / users.length);
-
-				for (const food of Eatables) {
-					const amountNeeded = ceil(healAmountNeeded / food.healAmount!) * quantity;
-					if (user.numItemsInBankSync(food.id) < amountNeeded) {
-						if (Eatables.indexOf(food) === Eatables.length - 1) {
-							throw `You don't have enough food to kill ${
-								monster.name
-							}! You need enough food to heal atleast ${healAmountNeeded} HP (${healAmountNeeded /
-								quantity} per kill) You can use these food items: ${Eatables.map(
-								i => i.name
-							).join(', ')}.`;
-						}
-						continue;
-					}
-
-					await user.removeItemFromBank(food.id, amountNeeded);
-
-					// Track this food cost in Economy Stats
-					await this.client.settings.update(
-						ClientSettings.EconomyStats.PVMCost,
-						addItemToBank(
-							this.client.settings.get(ClientSettings.EconomyStats.PVMCost),
-							food.id,
-							amountNeeded
-						)
-					);
-
-					break;
-				}
+				const [healAmountNeeded] = calculateMonsterFood(monster, user);
+				await removeFoodFromUser(
+					this.client,
+					user,
+					Math.ceil(healAmountNeeded / users.length) * quantity,
+					Math.ceil(healAmountNeeded / quantity),
+					monster.name
+				);
 			}
 		}
 

--- a/src/commands/Minion/groupkill.ts
+++ b/src/commands/Minion/groupkill.ts
@@ -94,7 +94,7 @@ export default class extends BotCommand {
 					return [true, `you don't have the requirements for this monster; ${reason}`];
 				}
 
-				if (monster.healAmountNeeded) {
+				if (1 > 2 && monster.healAmountNeeded) {
 					try {
 						calculateMonsterFood(monster, user);
 					} catch (err) {

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -70,8 +70,16 @@ async function _setup(
 						const [customDenied, reason] = options.customDenier(user);
 						if (customDenied) {
 							user.send(`You couldn't join this mass, for this reason: ${reason}`);
+							reaction.users.remove(user);
 							return false;
 						}
+					}
+
+					if (
+						(reaction.emoji.id === ReactionEmoji.Join && user === options.leader) ||
+						(user !== options.leader && reaction.emoji.id !== ReactionEmoji.Join)
+					) {
+						reaction.users.remove(user);
 					}
 
 					return ([

--- a/src/lib/minions/functions/getUserFoodFromBank.ts
+++ b/src/lib/minions/functions/getUserFoodFromBank.ts
@@ -1,0 +1,30 @@
+import { addBanks } from 'oldschooljs/dist/util';
+import { O } from 'ts-toolbelt';
+
+import { Eatables } from '../../eatables';
+import { Bank, ItemBank } from '../../types';
+
+export default function getUserFoodFromBank(
+	userBank: O.Readonly<Bank>,
+	totalHealingNeeded: number
+): false | ItemBank {
+	let totalHealingCalc = totalHealingNeeded;
+	let foodToRemove: Bank = {};
+	// Gets all the eatables in the user bank
+	for (const eatable of Eatables.sort((i, j) => (i.healAmount > j.healAmount ? 1 : -1))) {
+		const inBank = userBank[eatable.id];
+		const toRemove = Math.ceil(totalHealingCalc / eatable.healAmount);
+		if (!inBank) continue;
+		if (inBank >= toRemove) {
+			totalHealingCalc -= Math.ceil(eatable.healAmount * toRemove);
+			foodToRemove = addBanks([foodToRemove, { [eatable.id]: toRemove }]);
+			break;
+		} else {
+			totalHealingCalc -= Math.ceil(eatable.healAmount * inBank);
+			foodToRemove = addBanks([foodToRemove, { [eatable.id]: inBank }]);
+		}
+	}
+	// Check if qty is still above 0. If it is, it means the user doesn't have enough food.
+	if (totalHealingCalc > 0) return false;
+	return foodToRemove;
+}

--- a/src/lib/minions/functions/hasEnoughFoodForMonster.ts
+++ b/src/lib/minions/functions/hasEnoughFoodForMonster.ts
@@ -4,7 +4,7 @@ import { O } from 'ts-toolbelt';
 import { UserSettings } from '../../settings/types/UserSettings';
 import { KillableMonster } from '../types';
 import calculateMonsterFood from './calculateMonsterFood';
-import { getUserFoodFromBank } from './removeFoodFromUser';
+import getUserFoodFromBank from './getUserFoodFromBank';
 
 export default function hasEnoughFoodForMonster(
 	monster: O.Readonly<KillableMonster>,

--- a/src/lib/minions/functions/hasEnoughFoodForMonster.ts
+++ b/src/lib/minions/functions/hasEnoughFoodForMonster.ts
@@ -1,28 +1,24 @@
 import { KlasaUser } from 'klasa';
 import { O } from 'ts-toolbelt';
 
-import { Eatables } from '../../eatables';
+import { UserSettings } from '../../settings/types/UserSettings';
 import { KillableMonster } from '../types';
 import calculateMonsterFood from './calculateMonsterFood';
+import { getUserFoodFromBank } from './removeFoodFromUser';
 
 export default function hasEnoughFoodForMonster(
 	monster: O.Readonly<KillableMonster>,
 	user: O.Readonly<KlasaUser>,
-	quantity: number
+	quantity: number,
+	totalPartySize = 1
 ) {
-	const [healAmountNeeded] = calculateMonsterFood(monster, user);
-
-	for (const food of Eatables) {
-		const amountNeeded = Math.ceil(healAmountNeeded / food.healAmount!) * quantity;
-		if (user.numItemsInBankSync(food.id) < amountNeeded) {
-			if (Eatables.indexOf(food) === Eatables.length - 1) {
-				return false;
-			}
-			continue;
-		}
-
-		return true;
+	if (monster.healAmountNeeded) {
+		return (
+			getUserFoodFromBank(
+				user.settings.get(UserSettings.Bank),
+				Math.ceil(calculateMonsterFood(monster, user)[0] / totalPartySize) * quantity
+			) !== false
+		);
 	}
-
-	return false;
+	return true;
 }

--- a/src/lib/minions/functions/removeFoodFromUser.ts
+++ b/src/lib/minions/functions/removeFoodFromUser.ts
@@ -1,0 +1,56 @@
+import { KlasaClient, KlasaUser } from 'klasa';
+import { addBanks, removeBankFromBank } from 'oldschooljs/dist/util';
+import { O } from 'ts-toolbelt';
+
+import { Eatables } from '../../eatables';
+import { ClientSettings } from '../../settings/types/ClientSettings';
+import { UserSettings } from '../../settings/types/UserSettings';
+import { Bank, ItemBank } from '../../types';
+
+export function getUserFoodFromBank(
+	userBank: O.Readonly<Bank>,
+	totalHealingNeeded: number
+): false | ItemBank {
+	let totalHealingCalc = totalHealingNeeded;
+	let foodToRemove: Bank = {};
+	// Gets all the eatables in the user bank
+	for (const eatable of Eatables.sort((i, j) => (i.healAmount > j.healAmount ? 1 : -1))) {
+		const inBank = userBank[eatable.id];
+		const toRemove = Math.ceil(totalHealingCalc / eatable.healAmount);
+		if (!inBank) continue;
+		if (inBank >= toRemove) {
+			totalHealingCalc -= Math.ceil(eatable.healAmount * toRemove);
+			foodToRemove = addBanks([foodToRemove, { [eatable.id]: toRemove }]);
+			break;
+		} else {
+			totalHealingCalc -= Math.ceil(eatable.healAmount * inBank);
+			foodToRemove = addBanks([foodToRemove, { [eatable.id]: inBank }]);
+		}
+	}
+	// Check if qty is still above 0. If it is, it means the user doesn't have enough food.
+	if (totalHealingCalc > 0) return false;
+	return foodToRemove;
+}
+
+export default async function removeFoodFromUser(
+	client: KlasaClient,
+	user: KlasaUser,
+	totalHealingNeeded: number,
+	healPerAction: number,
+	activityName: string
+) {
+	await user.settings.sync(true);
+	const userBank = user.settings.get(UserSettings.Bank);
+	const foodToRemove = getUserFoodFromBank(userBank, totalHealingNeeded);
+	if (!foodToRemove) {
+		throw `You don't have enough food to kill ${activityName}! You need enough food to heal at least ${totalHealingNeeded} HP (${healPerAction} per kill). You can use these food items: ${Eatables.map(
+			i => i.name
+		).join(', ')}.`;
+	} else {
+		await user.settings.update(UserSettings.Bank, removeBankFromBank(userBank, foodToRemove));
+		await client.settings.update(
+			ClientSettings.EconomyStats.PVMCost,
+			addBanks([client.settings.get(ClientSettings.EconomyStats.PVMCost), foodToRemove])
+		);
+	}
+}

--- a/src/lib/minions/functions/removeFoodFromUser.ts
+++ b/src/lib/minions/functions/removeFoodFromUser.ts
@@ -1,36 +1,10 @@
 import { KlasaClient, KlasaUser } from 'klasa';
 import { addBanks, removeBankFromBank } from 'oldschooljs/dist/util';
-import { O } from 'ts-toolbelt';
 
 import { Eatables } from '../../eatables';
 import { ClientSettings } from '../../settings/types/ClientSettings';
 import { UserSettings } from '../../settings/types/UserSettings';
-import { Bank, ItemBank } from '../../types';
-
-export function getUserFoodFromBank(
-	userBank: O.Readonly<Bank>,
-	totalHealingNeeded: number
-): false | ItemBank {
-	let totalHealingCalc = totalHealingNeeded;
-	let foodToRemove: Bank = {};
-	// Gets all the eatables in the user bank
-	for (const eatable of Eatables.sort((i, j) => (i.healAmount > j.healAmount ? 1 : -1))) {
-		const inBank = userBank[eatable.id];
-		const toRemove = Math.ceil(totalHealingCalc / eatable.healAmount);
-		if (!inBank) continue;
-		if (inBank >= toRemove) {
-			totalHealingCalc -= Math.ceil(eatable.healAmount * toRemove);
-			foodToRemove = addBanks([foodToRemove, { [eatable.id]: toRemove }]);
-			break;
-		} else {
-			totalHealingCalc -= Math.ceil(eatable.healAmount * inBank);
-			foodToRemove = addBanks([foodToRemove, { [eatable.id]: inBank }]);
-		}
-	}
-	// Check if qty is still above 0. If it is, it means the user doesn't have enough food.
-	if (totalHealingCalc > 0) return false;
-	return foodToRemove;
-}
+import getUserFoodFromBank from './getUserFoodFromBank';
 
 export default async function removeFoodFromUser(
 	client: KlasaClient,


### PR DESCRIPTION
### Description:

-   Improve food removal when the food updates are re-added;
-   Adds a little handler for mass reactions, to avoid users having to react two times.
-- That still doesn't fix the reaction not accounting if the user reacts too fast while the mass reactions are still being generated.

### Changes:

- Add a couple new functions that can be used to handle food usage. 
-- `hasEnoughFoodForMonster` will return true or false depending if the user has enough food to fulfil the function params;
-- `getUserFoodFromBank` will return the best food combination to remove from the user bank, according to the total healing amount needed or false, if the user doesn't have enough food to filly heal that amount;
-- `removeFoodFromUser` will try to remove food form the user bank and will throw an error if it can't.
- Add reaction removal if leader tries to join or non-leader tries to start/stop mass [triggers reaction rate-limit but it is executed at next possible time]

-   [X] I have tested all my changes thoroughly.
