### PR TITLE
[OSB] Fix zamorakian hasta requiring 15 crafting, 11 is the correct level

### DIFF
--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -701,7 +701,7 @@ const Createables: Createable[] = [
 		requiredSkills: {
 			fishing: 55,
 			firemaking: 35,
-			crafting: 15,
+			crafting: 11,
 			smithing: 5
 		},
 		GPCost: 300_000


### PR DESCRIPTION
### Description:

-   Fix zamorakian hasta requiring 15 crafting, 11 is the correct level

### Changes:

-   Fix zamorakian hasta requiring 15 crafting, 11 is the correct level

-   [X] I have tested all my changes thoroughly.
