### PR TITLE
[BSO] Add Neitiznot faceguard to createables

### DIFF
--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -3168,6 +3168,28 @@ const Createables: Createable[] = [
 			smithing: 5
 		},
 		GPCost: 300_000
+	},
+	{
+		name: 'Neitiznot faceguard',
+		inputItems: resolveNameBank({
+			'Helm of neitiznot': 1,
+			'Basilisk jaw': 1
+		}),
+		outputItems: resolveNameBank({
+			'Neitiznot faceguard': 1
+		}),
+		QPRequired: 77
+	},
+	{
+		name: 'Basilisk jaw',
+		inputItems: resolveNameBank({
+			'Neitiznot faceguard': 1
+		}),
+		outputItems: resolveNameBank({
+			'Helm of neitiznot': 1,
+			'Basilisk jaw': 1
+		}),
+		QPRequired: 77
 	}
 	/* {
 		name: 'Toxic blowpipe (empty)',


### PR DESCRIPTION
### Description:

-   Add Neitiznot faceguard as a possible createable now that it is required for CoX

### Changes:

-   Add Neitiznot faceguard as a possible createable now that it is required for CoX

-   [X] I have tested all my changes thoroughly.
