### PR TITLE
Add Raids Drops to the Collection Log [BSO]

### DIFF
--- a/src/tasks/minions/raidsActivity.ts
+++ b/src/tasks/minions/raidsActivity.ts
@@ -67,7 +67,7 @@ export default class extends Task {
 			)}||, personal points: ${personalPoints}, ${Math.round(
 				(personalPoints! / totalPoints) * 10000
 			) / 100}%`;
-			await user.addItemsToBank(userLoot);
+			await user.addItemsToBank(userLoot, true);
 		}
 
 		queuedMessageSend(this.client, channelID, resultMessage);


### PR DESCRIPTION
### Description:

-  Adds raid drops to the collection log.

### Changes:

-   Added true to the function `await user.addItemsToBank(userLoot, true);` to enable collection log logging.

-   [X] I have tested all my changes thoroughly.
