### PR TITLE
[BSO] Shows the name of the mystery box received from trivia and givebox and some more MB improvements

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -153,7 +153,7 @@ export default class extends BotCommand {
 					: ``
 			}`,
 			title: opened,
-			flags: { showNewCL: 1 },
+			flags: { showNewCL: 1, wide: Object.keys(loot).length > 250 ? 1 : 0 },
 			user: msg.author
 		});
 	}
@@ -194,7 +194,7 @@ export default class extends BotCommand {
 		return msg.channel.sendBankImage({
 			bank: loot.values(),
 			title: `You opened ${quantity} ${botOpenable.name}`,
-			flags: { showNewCL: 1 },
+			flags: { showNewCL: 1, wide: Object.keys(loot.values()).length > 250 ? 1 : 0 },
 			user: msg.author
 		});
 	}

--- a/src/commands/bso/givebox.ts
+++ b/src/commands/bso/givebox.ts
@@ -5,6 +5,7 @@ import { PerkTier, Time } from '../../lib/constants';
 import { getRandomMysteryBox } from '../../lib/openables';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { formatDuration, itemID, roll } from '../../lib/util';
+import getOSItem from '../../lib/util/getOSItem';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -30,6 +31,10 @@ export default class extends BotCommand {
 
 		await user.addItemsToBank({ [box]: 1 });
 
-		return msg.channel.send(`Gave a mystery box to ${user.username}.`);
+		return msg.channel.send(
+			`Gave ${[19939].includes(box) ? 'an' : 'a'} **${getOSItem(box).name}** to ${
+				user.username
+			}.`
+		);
 	}
 }

--- a/src/commands/bso/spawnbox.ts
+++ b/src/commands/bso/spawnbox.ts
@@ -7,6 +7,7 @@ import { BotCommand } from '../../lib/BotCommand';
 import { Color, PerkTier } from '../../lib/constants';
 import { getRandomMysteryBox } from '../../lib/openables';
 import { itemID, roll, stringMatches } from '../../lib/util';
+import getOSItem from '../../lib/util/getOSItem';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -48,7 +49,9 @@ export default class extends BotCommand {
 			const box = roll(10) ? getRandomMysteryBox() : itemID('Mystery box');
 			await winner.addItemsToBank({ [box]: 1 });
 			return msg.channel.send(
-				`Congratulations, ${winner}! You got it. I've given you: **1x Mystery box**.`
+				`Congratulations, ${winner}! You got it. I've given you: **1x ${
+					getOSItem(box).name
+				}**.`
 			);
 		} catch (err) {
 			return msg.channel.send(`Nobody got it! :(`);

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -303,18 +303,23 @@ const cantBeDropped = [
 	itemID('Dwarven bar')
 ] as number[];
 
+const tmbTable = Items.filter(i => {
+	if (allItemsIDs.includes(i.id) || cantBeDropped.includes(i.id)) {
+		return false;
+	}
+	return (i as Item).tradeable_on_ge && !(i as Item).duplicate;
+}).map(i => i.id);
+
+const umbTable = Items.filter(i => {
+	if (allItemsIDs.includes(i.id) || cantBeDropped.includes(i.id)) {
+		return false;
+	}
+	return !(i as Item).tradeable && !(i as Item).duplicate;
+}).map(i => i.id);
+
 function getRandomItem(tradeables: boolean): number {
-	return Items.filter(i => {
-		if (allItemsIDs.includes(i.id) || cantBeDropped.includes(i.id)) {
-			return false;
-		}
-		if (!tradeables) {
-			// remove item id 0 (Dwarf remains) to avoid possible bank problems and only allow items that are
-			// not trade-able or duplicates to be dropped
-			return (i as Item).id !== 0 && !(i as Item).tradeable && !(i as Item).duplicate;
-		}
-		return (i as Item).tradeable_on_ge;
-	}).random().id;
+	const table = tradeables ? tmbTable : umbTable;
+	return table[Math.floor(Math.random() * table.length)];
 }
 
 export default Openables;

--- a/src/monitors/mboxes.ts
+++ b/src/monitors/mboxes.ts
@@ -4,7 +4,9 @@ import { Items } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 
 import { Color, SupportServer, Time } from '../lib/constants';
-import { resolveNameBank, roll, stringMatches } from '../lib/util';
+import { getRandomMysteryBox } from '../lib/openables';
+import { itemID, resolveNameBank, roll, stringMatches } from '../lib/util';
+import getOSItem from '../lib/util/getOSItem';
 
 export default class extends Monitor {
 	public lastDrop = 0;
@@ -53,9 +55,12 @@ export default class extends Monitor {
 			);
 
 			const winner = collected.first()?.author!;
-			await winner.addItemsToBank(resolveNameBank({ 'Mystery box': 1 }));
+			const box = roll(10) ? getRandomMysteryBox() : itemID('Mystery box');
+			await winner.addItemsToBank(resolveNameBank({ [box]: 1 }));
 			return msg.channel.send(
-				`Congratulations, ${winner}! You got it. I've given you: **1x Mystery box**.`
+				`Congratulations, ${winner}! You got it. I've given you: **1x ${
+					getOSItem(box).name
+				}**.`
 			);
 		} catch (err) {
 			return msg.channel.send(`Nobody got it! :(`);


### PR DESCRIPTION
### Description:

-   Shows the name of the mystery box received from trivia and givebox and allows the random item trivia to give a random mystery box

### Changes:

-   Added random box to mbox monitor
-   Changed the saying to be 1x [the box received], instead of always being Mystery box
-   Define the TMB and UMB LootTable on start instead of each time it is called;
-   Adds --wide to open.ts if the loot received is above 250 items, to improve performance.

-   [X] I have tested all my changes thoroughly.
