### PR TITLE
[BSO] Fix Fish Sack

### DIFF
--- a/src/commands/Minion/fish.ts
+++ b/src/commands/Minion/fish.ts
@@ -88,12 +88,12 @@ export default class extends BotCommand {
 
 		let duration = quantity * scaledTimePerFish;
 
-		if (duration > msg.author.maxTripLength) {
+		if (duration > maxTripLength) {
 			throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
-				msg.author.maxTripLength
+				maxTripLength
 			)}, try a lower quantity. The highest amount of ${
 				fish.name
-			} you can fish is ${Math.floor(msg.author.maxTripLength / scaledTimePerFish)}.`;
+			} you can fish is ${Math.floor(maxTripLength / scaledTimePerFish)}.`;
 		}
 
 		if (fish.bait) {


### PR DESCRIPTION
### Description:

-   Resolves #746 
-   Fish Sack was changing the variable `maxTripLength`, but the final check was using the `msg.author.maxTripLength`

### Changes:

-   Changes usages of `msg.author.maxTripLength` to `maxTripLength`.

-   [X] I have tested all my changes thoroughly.
