### PR TITLE
[OSB] Fix pet icon location on gear interface

### DIFF
--- a/src/lib/gear/functions/generateGearImage.ts
+++ b/src/lib/gear/functions/generateGearImage.ts
@@ -276,7 +276,7 @@ export async function generateGearImage(
 		ctx.drawImage(
 			image,
 			178 + slotSize / 2 - image.width / 2,
-			200 + slotSize / 2 - image.height / 2,
+			190 + slotSize / 2 - image.height / 2,
 			image.width,
 			image.height
 		);


### PR DESCRIPTION
### Description:

-   Pet icon was 10 pixels below where it should be

### Changes:

-   Increase pet icon by 10 pixels

-   [X] I have tested all my changes thoroughly.
