### PR TITLE
Adds Sarachnis Uniques to the CL

### DIFF
--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -157,6 +157,7 @@ export const bosses = {
 	'Chaos Fanatic': resolveItems(['Malediction shard 1', 'Odium shard 1', 'Pet chaos elemental']),
 	'Crazy Arch': resolveItems(['Malediction shard 2', 'Odium shard 2', 'Fedora']),
 	Scorpia: resolveItems(['Malediction shard 3', 'Odium shard 3', "Scorpia's offspring"]),
+	Sarachnis: resolveItems(['Giant egg sac(full)', 'Sarachnis cudgel', 'Jar of eyes', 'Sraracha']),
 	Nightmare: nightmareLog
 };
 export const pets = {

--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -157,7 +157,6 @@ export const bosses = {
 	'Chaos Fanatic': resolveItems(['Malediction shard 1', 'Odium shard 1', 'Pet chaos elemental']),
 	'Crazy Arch': resolveItems(['Malediction shard 2', 'Odium shard 2', 'Fedora']),
 	Scorpia: resolveItems(['Malediction shard 3', 'Odium shard 3', "Scorpia's offspring"]),
-	Sarachnis: resolveItems(['Giant egg sac(full)', 'Sarachnis cudgel', 'Jar of eyes', 'Sraracha']),
 	Nightmare: nightmareLog
 };
 export const pets = {


### PR DESCRIPTION
### Description:

-  Add the Sarachnis unique drops to +cl boss. Solves issue #765.

### Changes:

-   Added Sarachnis's uniques to it's own section in the collectionLog file.

-   [X] I have tested all my changes thoroughly.
