### PR TITLE
Fix All Caps for Runecrafting

### DIFF
--- a/src/commands/Minion/rc.ts
+++ b/src/commands/Minion/rc.ts
@@ -36,7 +36,7 @@ export default class extends BotCommand {
 			quantity = null;
 		}
 
-		if (name.endsWith('s')) name = name.slice(0, name.length - 1);
+		if (name.endsWith('s') || name.endsWith('S')) name = name.slice(0, name.length - 1);
 
 		const rune = Runecraft.Runes.find(
 			_rune =>


### PR DESCRIPTION
### Description:

-   Allows for a rune name to be all caps _and_ plural.
-   Helps Bender not break his caps lock key when runecrafting. Fixes issue #771.

### Changes:

-  Removes capital 'S' if found at the end of a rune name.

-   [X] I have tested all my changes thoroughly.
