### PR TITLE
Add Little Nightmare to +cl pets

### DIFF
--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -199,6 +199,8 @@ export const pets = {
 		'Tzrek-jad',
 		'Jal-nib-rek'
 	]),
+	'Boss Pets 3': resolveItems(['Little Nightmare']),
+	space2: [],
 	'Slayer Boss Pets': resolveItems([
 		'Noon',
 		'Abyssal orphan',
@@ -207,7 +209,7 @@ export const pets = {
 		'Pet smoke devil',
 		'Ikkle hydra'
 	]),
-	space2: [],
+	space3: [],
 	Other: resolveItems([
 		'Bloodhound',
 		'Herbi',


### PR DESCRIPTION
### Description:

-   Adds Little Nightmare pet to +cl pets.
-   Allows Little Nightmare to be equipped. 
-   Solves issue #773.

### Changes:

-   Add a new section in collection log for pets, 'Boss Pets 3'. 
-   Added Little Nightmare to this section.
-   Added a space between the boss pets and the slayer boss pets.

-   [X] I have tested all my changes thoroughly.
