### PR TITLE
Add Zammy Hasta Reversion to Creatables

### DIFF
--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -713,7 +713,7 @@ const Createables: Createable[] = [
 		}),
 		outputItems: resolveNameBank({
 			'Zamorakian spear': 1
-		}),
+		})
 	},
 	// Nightmare
 	{

--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -706,6 +706,15 @@ const Createables: Createable[] = [
 		},
 		GPCost: 300_000
 	},
+	{
+		name: 'Zamorakian spear',
+		inputItems: resolveNameBank({
+			'Zamorakian hasta': 1,
+		}),
+		outputItems: resolveNameBank({
+			'Zamorakian spear': 1,
+		})
+	},
 	// Nightmare
 	{
 		name: 'Eldritch nightmare staff',

--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -709,11 +709,11 @@ const Createables: Createable[] = [
 	{
 		name: 'Zamorakian spear',
 		inputItems: resolveNameBank({
-			'Zamorakian hasta': 1,
+			'Zamorakian hasta': 1
 		}),
 		outputItems: resolveNameBank({
-			'Zamorakian spear': 1,
-		})
+			'Zamorakian spear': 1
+		}),
 	},
 	// Nightmare
 	{


### PR DESCRIPTION
Should allow for people to revert their hasta to a spear for free like in game. Dunno if it actually works since I’m on mobile and don’t have a test bot.

-   [] I have not tested all my changes thoroughly.
