### PR TITLE
Fix Nightmare CL's Layout

### DIFF
--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -3,16 +3,16 @@ import { removeDuplicatesFromArray } from './util';
 import resolveItems from './util/resolveItems';
 
 const nightmareLog = resolveItems([
-	'Little nightmare',
-	'Jar of dreams',
-	'Nightmare staff',
 	"Inquisitor's great helm",
 	"Inquisitor's hauberk",
 	"Inquisitor's plateskirt",
 	"Inquisitor's mace",
+	'Nightmare staff',
 	'Eldritch orb',
+	'Volatile orb',
 	'Harmonised orb',
-	'Volatile orb'
+	'Jar of dreams',
+	'Little nightmare'
 ]);
 
 export const bosses = {


### PR DESCRIPTION
### Description:

-   Rearrange the Nightmare CL to be more consistent with the other bosses. 
-   Helping everyone's OCD by fixing issue #767.

### Changes:

-   Rearranging: pet at the end, better grouping.

-   [X] I have tested all my changes thoroughly.
