### PR TITLE
Add item aliases

### DIFF
--- a/src/arguments/item.ts
+++ b/src/arguments/item.ts
@@ -2,6 +2,7 @@ import { Argument } from 'klasa';
 import { Items } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 
+import { itemAliases } from '../lib/itemAliases';
 import { stringMatches } from '../lib/util';
 import getOSItem from '../lib/util/getOSItem';
 
@@ -12,7 +13,10 @@ export default class extends Argument {
 		if (!isNaN(parsed)) {
 			return [getOSItem(parsed)];
 		}
-		const osItems = Items.filter(i => stringMatches(i.name, itemName)).array() as Item[];
+		const osItems = [
+			...(Items.filter(i => stringMatches(i.name, itemName)).array() as Item[]),
+			...(itemAliases.filter(i => stringMatches(i.name, itemName)) as Item[])
+		];
 		if (!osItems.length) throw `${itemName} doesnt exist.`;
 		return osItems;
 	}

--- a/src/arguments/item.ts
+++ b/src/arguments/item.ts
@@ -1,9 +1,9 @@
 import { Argument } from 'klasa';
 import { Items } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
+import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 
-import { itemAliases } from '../lib/itemAliases';
-import { stringMatches } from '../lib/util';
+import { cleanString, stringMatches } from '../lib/util';
 import getOSItem from '../lib/util/getOSItem';
 
 export default class extends Argument {
@@ -13,10 +13,9 @@ export default class extends Argument {
 		if (!isNaN(parsed)) {
 			return [getOSItem(parsed)];
 		}
-		const osItems = [
-			...(Items.filter(i => stringMatches(i.name, itemName)).array() as Item[]),
-			...(itemAliases.filter(i => stringMatches(i.name, itemName)) as Item[])
-		];
+		const osItems = Items.filter(
+			i => itemNameMap.get(cleanString(itemName)) === i.id || stringMatches(i.name, itemName)
+		).array() as Item[];
 		if (!osItems.length) throw `${itemName} doesnt exist.`;
 		return osItems;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import pLimit from 'p-limit';
 
 import { botToken, sentryDSN } from './config';
 import { clientOptions, clientProperties } from './lib/config/config';
+import { initItemAliases } from './lib/itemAliases';
 
 if (sentryDSN) {
 	Sentry.init({
@@ -37,6 +38,7 @@ class OldSchoolBot extends Client {
 
 	public init = async (): Promise<this> => {
 		await Items.fetchAll();
+		initItemAliases();
 		return this;
 	};
 }

--- a/src/lib/itemAliases.ts
+++ b/src/lib/itemAliases.ts
@@ -1,0 +1,83 @@
+import { Item } from 'oldschooljs/dist/meta/types';
+
+import getOSItem from './util/getOSItem';
+
+export const itemAliases: Item[] = [];
+
+function setItemAlias(id: number, name: string | string[]) {
+	// Add the item to the custom items array
+	if (typeof name === 'string') {
+		itemAliases.push({
+			...getOSItem(id),
+			id,
+			name
+		});
+	} else {
+		for (const _name of name) {
+			itemAliases.push({
+				...getOSItem(id),
+				id,
+				name: _name
+			});
+		}
+	}
+}
+
+export function initItemAliases() {
+	// Graceful sets -- Arceuus
+	setItemAlias(13579, ['Arceuus graceful hood', 'Purple graceful hood']);
+	setItemAlias(13581, ['Arceuus graceful cape', 'Purple graceful cape']);
+	setItemAlias(13583, ['Arceuus graceful top', 'Purple graceful top']);
+	setItemAlias(13585, ['Arceuus graceful legs', 'Purple graceful legs']);
+	setItemAlias(13587, ['Arceuus graceful gloves', 'Purple graceful gloves']);
+	setItemAlias(13589, ['Arceuus graceful boots', 'Purple graceful boots']);
+	// Graceful sets -- Port Piscarilius
+	setItemAlias(13591, ['Piscarilius graceful hood', 'Cyan graceful hood']);
+	setItemAlias(13593, ['Piscarilius graceful cape', 'Cyan graceful cape']);
+	setItemAlias(13595, ['Piscarilius graceful top', 'Cyan graceful top']);
+	setItemAlias(13597, ['Piscarilius graceful legs', 'Cyan graceful legs']);
+	setItemAlias(13599, ['Piscarilius graceful gloves', 'Cyan graceful gloves']);
+	setItemAlias(13601, ['Piscarilius graceful boots', 'Cyan graceful boots']);
+	// Graceful sets -- Lovakengj
+	setItemAlias(13603, ['Lovakengj graceful hood', 'Yellow graceful hood']);
+	setItemAlias(13605, ['Lovakengj graceful cape', 'Yellow graceful cape']);
+	setItemAlias(13607, ['Lovakengj graceful top', 'Yellow graceful top']);
+	setItemAlias(13609, ['Lovakengj graceful legs', 'Yellow graceful legs']);
+	setItemAlias(13611, ['Lovakengj graceful gloves', 'Yellow graceful gloves']);
+	setItemAlias(13613, ['Lovakengj graceful boots', 'Yellow graceful boots']);
+	// Graceful sets -- Shayzien
+	setItemAlias(13615, ['Shayzien graceful hood', 'Red graceful hood']);
+	setItemAlias(13617, ['Shayzien graceful cape', 'Red graceful cape']);
+	setItemAlias(13619, ['Shayzien graceful top', 'Red graceful top']);
+	setItemAlias(13621, ['Shayzien graceful legs', 'Red graceful legs']);
+	setItemAlias(13623, ['Shayzien graceful gloves', 'Red graceful gloves']);
+	setItemAlias(13625, ['Shayzien graceful boots', 'Red graceful boots']);
+	// Graceful sets -- Hosidius
+	setItemAlias(13627, ['Hosidius graceful hood', 'Green graceful hood']);
+	setItemAlias(13629, ['Hosidius graceful cape', 'Green graceful cape']);
+	setItemAlias(13631, ['Hosidius graceful top', 'Green graceful top']);
+	setItemAlias(13633, ['Hosidius graceful legs', 'Green graceful legs']);
+	setItemAlias(13635, ['Hosidius graceful gloves', 'Green graceful gloves']);
+	setItemAlias(13637, ['Hosidius graceful boots', 'Green graceful boots']);
+	// Graceful sets -- All cities
+	setItemAlias(13667, ['Kourend graceful hood', 'White graceful hood']);
+	setItemAlias(13669, ['Kourend graceful cape', 'White graceful cape']);
+	setItemAlias(13671, ['Kourend graceful top', 'White graceful top']);
+	setItemAlias(13673, ['Kourend graceful legs', 'White graceful legs']);
+	setItemAlias(13675, ['Kourend graceful gloves', 'White graceful gloves']);
+	setItemAlias(13677, ['Kourend graceful boots', 'White graceful boots']);
+	// Graceful sets -- Brimhaven
+	setItemAlias(21061, ['Brimhaven graceful hood', 'Dark blue graceful hood']);
+	setItemAlias(21064, ['Brimhaven graceful cape', 'Dark blue graceful cape']);
+	setItemAlias(21067, ['Brimhaven graceful top', 'Dark blue graceful top']);
+	setItemAlias(21070, ['Brimhaven graceful legs', 'Dark blue graceful legs']);
+	setItemAlias(21073, ['Brimhaven graceful gloves', 'Dark blue graceful gloves']);
+	setItemAlias(21076, ['Brimhaven graceful boots', 'Dark blue graceful boots']);
+	// Graceful sets -- Brimhaven
+	setItemAlias(24743, ['Hallowed graceful hood', 'Black graceful hood']);
+	setItemAlias(24746, ['Hallowed graceful cape', 'Black graceful cape']);
+	setItemAlias(24749, ['Hallowed graceful top', 'Black graceful top']);
+	setItemAlias(24752, ['Hallowed graceful legs', 'Black graceful legs']);
+	setItemAlias(24755, ['Hallowed graceful gloves', 'Black graceful gloves']);
+	setItemAlias(24758, ['Hallowed graceful boots', 'Black graceful boots']);
+}

--- a/src/lib/itemAliases.ts
+++ b/src/lib/itemAliases.ts
@@ -4,7 +4,7 @@ import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 import { cleanString } from './util';
 import getOSItem from './util/getOSItem';
 
-function setItemAlias(id: number, name: string | string[]) {
+function setItemAlias(id: number, name: string | string[], rename = true) {
 	let firstName: string | null = null;
 	// Add the item to the custom items array
 	if (typeof name === 'string') {
@@ -19,10 +19,12 @@ function setItemAlias(id: number, name: string | string[]) {
 		}
 	}
 	// Update the item name to it's first alias
-	Items.set(id, {
-		...getOSItem(id),
-		name: firstName!
-	});
+	if (rename) {
+		Items.set(id, {
+			...getOSItem(id),
+			name: firstName!
+		});
+	}
 }
 
 export function initItemAliases() {

--- a/src/lib/itemAliases.ts
+++ b/src/lib/itemAliases.ts
@@ -1,26 +1,28 @@
-import { Item } from 'oldschooljs/dist/meta/types';
+import { Items } from 'oldschooljs';
+import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 
+import { cleanString } from './util';
 import getOSItem from './util/getOSItem';
 
-export const itemAliases: Item[] = [];
-
 function setItemAlias(id: number, name: string | string[]) {
+	let firstName: string | null = null;
 	// Add the item to the custom items array
 	if (typeof name === 'string') {
-		itemAliases.push({
-			...getOSItem(id),
-			id,
-			name
-		});
+		firstName = name;
+		const cleanName = cleanString(name);
+		itemNameMap.set(cleanName, id);
 	} else {
 		for (const _name of name) {
-			itemAliases.push({
-				...getOSItem(id),
-				id,
-				name: _name
-			});
+			if (!firstName) firstName = _name;
+			const cleanName = cleanString(_name);
+			itemNameMap.set(cleanName, id);
 		}
 	}
+	// Update the item name to it's first alias
+	Items.set(id, {
+		...getOSItem(id),
+		name: firstName!
+	});
 }
 
 export function initItemAliases() {

--- a/src/lib/itemAliases.ts
+++ b/src/lib/itemAliases.ts
@@ -2,27 +2,25 @@ import { Items } from 'oldschooljs';
 import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 
 import { cleanString } from './util';
-import getOSItem from './util/getOSItem';
 
 function setItemAlias(id: number, name: string | string[], rename = true) {
 	let firstName: string | null = null;
 	// Add the item to the custom items array
 	if (typeof name === 'string') {
 		firstName = name;
-		const cleanName = cleanString(name);
-		itemNameMap.set(cleanName, id);
+		itemNameMap.set(cleanString(name), id);
 	} else {
 		for (const _name of name) {
 			if (!firstName) firstName = _name;
-			const cleanName = cleanString(_name);
-			itemNameMap.set(cleanName, id);
+			itemNameMap.set(cleanString(_name), id);
 		}
 	}
 	// Update the item name to it's first alias
 	if (rename) {
 		Items.set(id, {
-			...getOSItem(id),
-			name: firstName!
+			...Items.get(id),
+			name: firstName!,
+			id
 		});
 	}
 }

--- a/tests/itemAlias.test.ts
+++ b/tests/itemAlias.test.ts
@@ -1,0 +1,56 @@
+import { Items } from 'oldschooljs';
+
+import ItemArgument from '../src/arguments/item';
+import { initItemAliases } from '../src/lib/itemAliases';
+import getOSItem from '../src/lib/util/getOSItem';
+
+function mockArgument(arg: any) {
+	return new arg(
+		{
+			name: 'arguments',
+			client: {
+				options: {
+					pieceDefaults: {
+						arguments: {}
+					}
+				}
+			}
+		},
+		['1'],
+		'',
+		{}
+	);
+}
+
+describe('Item Alias', () => {
+	beforeAll(async () => {
+		await Items.fetchAll();
+		initItemAliases();
+	});
+	test('itemArg parameter', () => {
+		const itemArg = mockArgument(ItemArgument);
+		const expectedResults = [
+			[
+				'Graceful cape',
+				[
+					getOSItem(11852), // Graceful cape (Regular)
+					getOSItem(11853), // Duplicate Graceful cape (Regular)
+					getOSItem(13582), // Duplicate Graceful cape (Arceuus)
+					getOSItem(13594), // Duplicate Graceful cape (Piscarilius)
+					getOSItem(13606), // Duplicate Graceful cape (Lovakengj)
+					getOSItem(13618), // Duplicate Graceful cape (Shayzien)
+					getOSItem(13630), // Duplicate Graceful cape (Hosidius)
+					getOSItem(13670), // Duplicate Graceful cape (Kourend)
+					getOSItem(21066), // Duplicate Graceful cape (Agility Arena)
+					getOSItem(24748) // Duplicate Graceful cape (Hallowed Sepulchre)
+				]
+			],
+			['Black graceful cape', [getOSItem(24746)]],
+			['Hallowed graceful cape', [getOSItem(24746)]],
+			[24746, [getOSItem(24746)]]
+		];
+		for (const [input, output] of expectedResults) {
+			expect(itemArg.run(input)).resolves.toEqual(output);
+		}
+	});
+});

--- a/tests/itemAlias.test.ts
+++ b/tests/itemAlias.test.ts
@@ -3,24 +3,7 @@ import { Items } from 'oldschooljs';
 import ItemArgument from '../src/arguments/item';
 import { initItemAliases } from '../src/lib/itemAliases';
 import getOSItem from '../src/lib/util/getOSItem';
-
-function mockArgument(arg: any) {
-	return new arg(
-		{
-			name: 'arguments',
-			client: {
-				options: {
-					pieceDefaults: {
-						arguments: {}
-					}
-				}
-			}
-		},
-		['1'],
-		'',
-		{}
-	);
-}
+import { mockArgument } from './utils';
 
 describe('Item Alias', () => {
 	beforeAll(async () => {

--- a/tests/itemArg.test.ts
+++ b/tests/itemArg.test.ts
@@ -1,22 +1,5 @@
 import ItemArgument from '../src/arguments/item';
-
-function mockArgument(arg: any) {
-	return new arg(
-		{
-			name: 'arguments',
-			client: {
-				options: {
-					pieceDefaults: {
-						arguments: {}
-					}
-				}
-			}
-		},
-		['1'],
-		'',
-		{}
-	);
-}
+import { mockArgument } from './utils';
 
 describe('itemArg', () => {
 	test('stripEmojis', () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,17 @@
+export function mockArgument(arg: any) {
+	return new arg(
+		{
+			name: 'arguments',
+			client: {
+				options: {
+					pieceDefaults: {
+						arguments: {}
+					}
+				}
+			}
+		},
+		['1'],
+		'',
+		{}
+	);
+}


### PR DESCRIPTION
### Description:

-   Allows us to implement item aliases;
-   Add `setItemAlias(id: number, name: string | string[], rename = true)`;
-   When adding a new alias, it'll rename the item to the first alias defined if `rename` is set to true (Mostly alias will be used for items that have the same name, aka: Graceful items, some ornaments, castle wars armours, etc;
-   This will increase the time for items.ts (argument) to run from 6.726ms AVG to 8.269ms AVG due to the double checking for each item.

### Changes:

-   Add a new startup init called `initItemAliases`;
-   Makes the item.ts argument to check for the itemNameMap primary and then check for the item name if not in the itemNameMap;
-   Create the itemAliases file
-   Create itemAlises test file

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/94997179-e7085300-057f-11eb-8bcf-afd9612eaa72.png)
![image](https://user-images.githubusercontent.com/19570528/94997195-fab3b980-057f-11eb-97b5-b3d8358732da.png)
