### PR TITLE
Fix bank rune lite style tag showing items more than once when repeating the same tag

### DIFF
--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -63,11 +63,11 @@ export default class extends Command {
 		if (typeof pageNumberOrItemName === 'string') {
 			if (pageNumberOrItemName.includes(',')) {
 				const arrItemNameOrID = pageNumberOrItemName.split(',');
-				let view = {};
+				let view: ItemBank = {};
 				for (const nameOrID of arrItemNameOrID) {
 					try {
 						const item = getOSItem(nameOrID);
-						if (bank[item.id]) {
+						if (bank[item.id] && !view[item.id]) {
 							view = addItemToBank(view, item.id, bank[item.id]);
 						}
 					} catch (_) {}


### PR DESCRIPTION
### Description:

-   If you do `+b rune platebody, rune platebody, rune platebody`, it'll show the amount you have of rune platebody 3 times
-   Resolves #814

### Changes:

-   Adds a check to see if the item id is already in the view to be generated

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/95018434-1da0a500-0636-11eb-85b0-0f49b5c89e76.png)
![image](https://user-images.githubusercontent.com/19570528/95018457-4aed5300-0636-11eb-82f9-105e6510322c.png)