### PR TITLE
buyables: add Ball of wool

### DIFF
--- a/src/lib/buyables/buyables.ts
+++ b/src/lib/buyables/buyables.ts
@@ -239,6 +239,15 @@ const Buyables: Buyable[] = [
 		}),
 		qpRequired: 0,
 		gpCost: 200
+	},
+	{
+		name: 'Ball of wool',
+		aliases: ['wool ball', 'ball wool'],
+		outputItems: {
+			[itemID('Ball of wool')]: 1
+		},
+		qpRequired: 0,
+		gpCost: 200
 	}
 ];
 


### PR DESCRIPTION
### Description:

- rebased from Dev since that branch is depricated

### Changes:

- addition of ball of wool to buyables, so that amulets can be fully crafted

-   [x] I have tested all my changes thoroughly.
