### PR TITLE
Dev fix empty discord messages

### DIFF
--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -41,7 +41,7 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			cooldown: 1,
-			usage: '[quantity:int{1}] <item:...item>',
+			usage: '[quantity:int{1}] (item:...item)',
 			usageDelim: ' ',
 			oneAtTime: true,
 			description: 'Allows you to send your minion to alch items from your bank',
@@ -51,11 +51,11 @@ export default class extends BotCommand {
 
 	@minionNotBusy
 	@requiresMinion
-	async run(msg: KlasaMessage, [quantity = null, item]: [number | null, Item[]]) {
+	async run(msg: KlasaMessage, [quantity = null, itemArray]: [number | null, Item[]]) {
 		const userBank = msg.author.settings.get(UserSettings.Bank);
-		const osItem = item.find(i => userBank[i.id] && i.highalch && i.tradeable);
+		const osItem = itemArray.find(i => userBank[i.id] && i.highalch && i.tradeable);
 		if (!osItem) {
-			return msg.send(`You don't have any of this item to alch.`);
+			return msg.send(`You don't have any of this item to alch, or it is untradeable.`);
 		}
 
 		// 5 tick action

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -95,7 +95,7 @@ export function toTitleCase(str: string) {
 	return splitStr.join(' ');
 }
 
-export function cleanString(str: string) {
+export function cleanString(str = '') {
 	return str.replace(/[^0-9a-zA-Z+]/gi, '').toUpperCase();
 }
 


### PR DESCRIPTION
### Description:

-  rebased from Dev since that branch is depricated

### Changes:

- cleanstring is defaulted to empty string to avoid it like crashing out when trying to do string operations on an undefined object, this caused discord api errors that looked like
`DiscordAPIError: Cannot send an empty message`
`at RequestHandler.execute (D:\Git\OldSchoolBot\oldschoolbot\node_modules\discord.js\src\rest\RequestHandler.js:170:25)`
`at runMicrotasks (<anonymous>)`
`at processTicksAndRejections (internal/process/task_queues.js:94:5)`

- alch was changed to let its `...item` arg throw its own error messages which give the user a better idea of what they did wrong when the command doesnt work

-   [x] I have tested all my changes thoroughly.
