### PR TITLE
Improve and add more testing commands

### DIFF
--- a/src/commands/Testing/clean.ts
+++ b/src/commands/Testing/clean.ts
@@ -1,0 +1,43 @@
+import { CommandStore, KlasaMessage } from 'klasa';
+
+import { BotCommand } from '../../lib/BotCommand';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			cooldown: 1,
+			oneAtTime: true,
+			aliases: ['clear']
+		});
+		// this.enabled = !this.client.production;
+	}
+
+	async run(msg: KlasaMessage) {
+		// Make 100% sure this command can never be used in prod
+		if (
+			this.client.production ||
+			!this.client.user ||
+			this.client.user.id === '156230339621027840'
+		) {
+			return;
+		}
+
+		if (!msg.flagArgs.bank) {
+			await msg.author.settings.reset();
+			await msg.author.settings.update(UserSettings.Minion.HasBought, true);
+		} else {
+			await msg.author.settings.update(UserSettings.Bank, {});
+			await msg.author.settings.update(UserSettings.CollectionLogBank, {});
+			await msg.author.settings.update(UserSettings.GP, 0);
+		}
+
+		return msg.send(
+			`${
+				!msg.flagArgs.bank
+					? 'Your minion is reset! You can use --bank to clear only your bank!'
+					: 'You cleared your bank!'
+			}`
+		);
+	}
+}

--- a/src/commands/Testing/clean.ts
+++ b/src/commands/Testing/clean.ts
@@ -10,7 +10,7 @@ export default class extends BotCommand {
 			oneAtTime: true,
 			aliases: ['clear']
 		});
-		// this.enabled = !this.client.production;
+		this.enabled = !this.client.production;
 	}
 
 	async run(msg: KlasaMessage) {
@@ -27,9 +27,11 @@ export default class extends BotCommand {
 			await msg.author.settings.reset();
 			await msg.author.settings.update(UserSettings.Minion.HasBought, true);
 		} else {
-			await msg.author.settings.update(UserSettings.Bank, {});
-			await msg.author.settings.update(UserSettings.CollectionLogBank, {});
-			await msg.author.settings.update(UserSettings.GP, 0);
+			await msg.author.settings.update([
+				[UserSettings.Bank, {}],
+				[UserSettings.CollectionLogBank, {}],
+				[UserSettings.GP, 0]
+			]);
 		}
 
 		return msg.send(

--- a/src/commands/Testing/clean.ts
+++ b/src/commands/Testing/clean.ts
@@ -18,7 +18,7 @@ export default class extends BotCommand {
 		if (
 			this.client.production ||
 			!this.client.user ||
-			this.client.user.id === '156230339621027840'
+			this.client.user.id === '303730326692429825'
 		) {
 			return;
 		}

--- a/src/commands/Testing/hax.ts
+++ b/src/commands/Testing/hax.ts
@@ -1,5 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
-import { Util } from 'oldschooljs';
+import { Bank, Util } from 'oldschooljs';
+import { resolveNameBank } from 'oldschooljs/dist/util';
 
 import { BotCommand } from '../../lib/BotCommand';
 import { MAX_QP } from '../../lib/constants';
@@ -102,11 +103,13 @@ export default class extends BotCommand {
 				ammo: { item: itemID('Unholy blessing'), quantity: 1 },
 				'2h': { item: itemID('Armadyl godsword'), quantity: 1 }
 			};
-			await msg.author.settings.update(UserSettings.Gear.Range, rangeGear);
-			await msg.author.settings.update(UserSettings.Gear.Mage, mageGear);
-			await msg.author.settings.update(UserSettings.Gear.Melee, meleeGear);
-			await msg.author.settings.update(UserSettings.Gear.Skilling, skillingGear);
-			await msg.author.settings.update(UserSettings.Gear.Misc, miscGear);
+			await msg.author.settings.update([
+				[UserSettings.Gear.Range, rangeGear],
+				[UserSettings.Gear.Mage, mageGear],
+				[UserSettings.Gear.Melee, meleeGear],
+				[UserSettings.Gear.Skilling, skillingGear],
+				[UserSettings.Gear.Misc, miscGear]
+			]);
 		} else {
 			await this.client.queuePromise(async () =>
 				msg.channel.send(
@@ -115,99 +118,99 @@ export default class extends BotCommand {
 				)
 			);
 		}
-		const loot = {
-			[itemID('Zamorakian spear')]: 1,
-			[itemID('Zamorakian hasta')]: 1,
-			[itemID("Ahrim's robetop")]: 1,
-			[itemID("Ahrim's robeskirt")]: 1,
-			[itemID("Verac's brassard")]: 1,
-			[itemID("Verac's helm")]: 1,
-			[itemID("Verac's plateskirt")]: 1,
-			[itemID("Verac's flail")]: 1,
-			[itemID("Dharok's helm")]: 1,
-			[itemID("Dharok's platebody")]: 1,
-			[itemID("Dharok's platelegs")]: 1,
-			[itemID("Dharok's greataxe")]: 1,
-			[itemID("Guthan's helm")]: 1,
-			[itemID("Guthan's platebody")]: 1,
-			[itemID("Guthan's chainskirt")]: 1,
-			[itemID("Guthan's warspear")]: 1,
-			[itemID("Karil's coif")]: 1,
-			[itemID("Karil's leathertop")]: 1,
-			[itemID("Karil's leatherskirt")]: 1,
-			[itemID("Karil's crossbow")]: 1,
-			[itemID('Bandos godsword')]: 1,
-			[itemID('Spectral spirit shield')]: 1,
-			[itemID('Saradomin godsword')]: 1,
-			[itemID('Dragon warhammer')]: 1,
-			[itemID('Dragonhunter lance')]: 1,
-			[itemID("Iban's staff")]: 1,
-			[itemID('Dragonfire shield')]: 1,
-			[itemID('Anti-dragon shield')]: 1,
-			[itemID('Berserker ring')]: 1,
-			[itemID('Warrior ring')]: 1,
-			[itemID('Archers ring')]: 1,
-			[itemID('Seers ring')]: 1,
-			[itemID('Treasonous ring')]: 1,
-			[itemID('Tyrannical ring')]: 1,
-			[itemID('Tyrannical ring (i)')]: 1,
-			[itemID('Ranger boots')]: 1,
-			[itemID('Armadyl crossbow')]: 1,
-			[itemID('Twisted buckler')]: 1,
-			[itemID('Occult necklace')]: 1,
-			[itemID("Inquisitor's great helm")]: 1,
-			[itemID("Inquisitor's hauberk")]: 1,
-			[itemID("Inquisitor's plateskirt")]: 1,
-			[itemID("Inquisitor's mace")]: 1,
-			22114: 1, // Mythical cape
-			[itemID('Elder maul')]: 1,
-			[itemID('Blade of saeldor')]: 1,
-			[itemID('3rd age axe')]: 1,
-			[itemID('3rd age pickaxe')]: 1,
-			[itemID('Saradomin brew(4)')]: 10000,
-			[itemID('Prayer potion(4)')]: 10000,
-			[itemID('Super restore(4)')]: 10000,
-			[itemID('Justiciar faceguard')]: 1,
-			[itemID('Justiciar chestguard')]: 1,
-			[itemID('Justiciar legguards')]: 1,
-			[itemID('Ancient wyvern shield')]: 1,
-			[itemID('Ring of suffering')]: 1,
-			[itemID('Ring of suffering (i)')]: 1,
-			[itemID('Maple blackjack(d)')]: 1,
-			[itemID("Dinh's bulwark")]: 1,
-			[itemID('Guardian boots')]: 1,
-			[itemID('Crystal helm')]: 1,
-			[itemID('3rd age vambraces')]: 1,
-			[itemID('Crystal shield')]: 1,
-			[itemID('Neitiznot faceguard')]: 1,
-			[itemID('Leaf-bladed battleaxe')]: 1,
-			[itemID('Berserker ring (i)')]: 1,
-			[itemID('Dragon javelin')]: 1,
-			[itemID('Black chinchompa')]: 1,
-			[itemID('Saradomin mitre')]: 1,
-			[itemID('Dragonbone necklace')]: 1,
-			[itemID('Proselyte hauberk')]: 1,
-			[itemID('Proselyte cuisse')]: 1,
-			[itemID('Devout boots')]: 1,
-			[itemID('Holy book')]: 1,
-			[itemID('Holy wraps')]: 1,
-			[itemID('Ring of the gods (i)')]: 1,
-			[itemID('Ring of the gods')]: 1,
-			[itemID("Rada's blessing 4")]: 1,
-			[itemID('Saradomin crozier')]: 1,
-			[itemID('Penance gloves')]: 1,
-			[itemID('Spottier cape')]: 1,
-			[itemID('Boots of lightness')]: 1,
-			[itemID('Amulet of power')]: 1,
-			[itemID('Amulet of fury')]: 1
-		};
+		const loot = new Bank();
+		loot.add(
+			resolveNameBank({
+				'Zamorakian spear': 1,
+				'Zamorakian hasta': 1,
+				"Ahrim's robetop": 1,
+				"Ahrim's robeskirt": 1,
+				"Verac's brassard": 1,
+				"Verac's helm": 1,
+				"Verac's plateskirt": 1,
+				"Verac's flail": 1,
+				"Dharok's helm": 1,
+				"Dharok's platebody": 1,
+				"Dharok's platelegs": 1,
+				"Dharok's greataxe": 1,
+				"Guthan's helm": 1,
+				"Guthan's platebody": 1,
+				"Guthan's chainskirt": 1,
+				"Guthan's warspear": 1,
+				"Karil's coif": 1,
+				"Karil's leathertop": 1,
+				"Karil's leatherskirt": 1,
+				"Karil's crossbow": 1,
+				'Bandos godsword': 1,
+				'Spectral spirit shield': 1,
+				'Saradomin godsword': 1,
+				'Dragon warhammer': 1,
+				'Dragonhunter lance': 1,
+				"Iban's staff": 1,
+				'Dragonfire shield': 1,
+				'Anti-dragon shield': 1,
+				'Berserker ring': 1,
+				'Warrior ring': 1,
+				'Archers ring': 1,
+				'Seers ring': 1,
+				'Treasonous ring': 1,
+				'Tyrannical ring': 1,
+				'Tyrannical ring (i)': 1,
+				'Ranger boots': 1,
+				'Armadyl crossbow': 1,
+				'Twisted buckler': 1,
+				'Occult necklace': 1,
+				"Inquisitor's great helm": 1,
+				"Inquisitor's hauberk": 1,
+				"Inquisitor's plateskirt": 1,
+				"Inquisitor's mace": 1,
+				'Elder maul': 1,
+				'Blade of saeldor': 1,
+				'3rd age axe': 1,
+				'3rd age pickaxe': 1,
+				'Saradomin brew(4)': 10_000,
+				'Prayer potion(4)': 10_000,
+				'Super restore(4)': 10_000,
+				'Justiciar faceguard': 1,
+				'Justiciar chestguard': 1,
+				'Justiciar legguards': 1,
+				'Ancient wyvern shield': 1,
+				'Ring of suffering': 1,
+				'Ring of suffering (i)': 1,
+				'Maple blackjack(d)': 1,
+				"Dinh's bulwark": 1,
+				'Guardian boots': 1,
+				'Crystal helm': 1,
+				'3rd age vambraces': 1,
+				'Crystal shield': 1,
+				'Neitiznot faceguard': 1,
+				'Leaf-bladed battleaxe': 1,
+				'Berserker ring (i)': 1,
+				'Dragon javelin': 1,
+				'Black chinchompa': 1,
+				'Saradomin mitre': 1,
+				'Dragonbone necklace': 1,
+				'Proselyte hauberk': 1,
+				'Proselyte cuisse': 1,
+				'Devout boots': 1,
+				'Holy book': 1,
+				'Holy wraps': 1,
+				'Ring of the gods (i)': 1,
+				'Ring of the gods': 1,
+				"Rada's blessing 4": 1,
+				'Saradomin crozier': 1,
+				'Penance gloves': 1,
+				'Spottier cape': 1,
+				'Boots of lightness': 1,
+				'Amulet of power': 1,
+				22114: 1,
+				'Amulet of fury': 1
+			})
+		);
 		for (const item of Eatables) {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-			// @ts-ignore
-			loot[item.id] = 1000;
+			loot.add(item.id, 1_000);
 		}
-		await msg.author.addItemsToBank(loot);
-		await msg.author.addItemsToBank({ 995: 1 });
+		await msg.author.addItemsToBank(loot.bank);
 		return msg.send(
 			`Gave you 99 in all skills, ${Util.toKMB(
 				2_147_483_647

--- a/src/commands/Testing/hax.ts
+++ b/src/commands/Testing/hax.ts
@@ -1,9 +1,12 @@
 import { CommandStore, KlasaMessage } from 'klasa';
+import { Util } from 'oldschooljs';
 
 import { BotCommand } from '../../lib/BotCommand';
+import { MAX_QP } from '../../lib/constants';
 import { Eatables } from '../../lib/eatables';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Skills from '../../lib/skilling/skills';
+import itemID from '../../lib/util/itemID';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -23,19 +26,192 @@ export default class extends BotCommand {
 		) {
 			return;
 		}
-
 		const paths = Object.values(Skills).map(sk => `skills.${sk.id}`);
-
-		msg.author.settings.update(paths.map(path => [path, 14_000_000]));
-		msg.author.settings.update(UserSettings.GP, 1_000_000_000);
-		msg.author.settings.update(UserSettings.QP, 250);
-		const loot = {};
+		await msg.author.settings.update(paths.map(path => [path, 13_034_431]));
+		await msg.author.settings.update(UserSettings.GP, 2_147_483_647);
+		await msg.author.settings.update(UserSettings.QP, MAX_QP);
+		await msg.author.settings.update(UserSettings.SacrificedValue, 10_000_000_000);
+		if (!msg.author.minionIsBusy) {
+			const rangeGear = {
+				'2h': { item: itemID('Heavy ballista'), quantity: 1 },
+				head: { item: itemID('Armadyl helmet'), quantity: 1 },
+				neck: { item: itemID('Necklace of anguish'), quantity: 1 },
+				body: { item: itemID('Armadyl chestplate'), quantity: 1 },
+				legs: { item: itemID('Armadyl chainskirt'), quantity: 1 },
+				feet: { item: itemID('Pegasian boots'), quantity: 1 },
+				cape: { item: itemID("Ava's assembler"), quantity: 1 },
+				shield: null,
+				hands: { item: itemID('Barrows gloves'), quantity: 1 },
+				ring: { item: itemID('Archers ring (i)'), quantity: 1 },
+				weapon: null,
+				ammo: { item: itemID('Onyx bolts (e)'), quantity: 99 }
+			};
+			const mageGear = {
+				head: { item: itemID('Ancestral hat'), quantity: 1 },
+				neck: { item: itemID('3rd age amulet'), quantity: 1 },
+				body: { item: itemID('Ancestral robe top'), quantity: 1 },
+				legs: { item: itemID('Ancestral robe bottom'), quantity: 1 },
+				feet: { item: itemID('Eternal boots'), quantity: 1 },
+				cape: { item: itemID('Imbued saradomin cape'), quantity: 1 },
+				shield: { item: itemID('Arcane spirit shield'), quantity: 1 },
+				hands: { item: itemID('Tormented bracelet'), quantity: 1 },
+				ring: { item: itemID('Seers ring (i)'), quantity: 1 },
+				weapon: { item: itemID('Kodai wand'), quantity: 1 },
+				ammo: null,
+				'2h': null
+			};
+			const meleeGear = {
+				head: { item: itemID('Fighter hat'), quantity: 1 },
+				neck: { item: itemID('Amulet of torture'), quantity: 1 },
+				body: { item: itemID('Bandos chestplate'), quantity: 1 },
+				legs: { item: itemID('Bandos tassets'), quantity: 1 },
+				feet: { item: itemID('Boots of brimstone'), quantity: 1 },
+				cape: { item: itemID('Ardougne cloak 4'), quantity: 1 },
+				shield: { item: itemID('Avernic defender'), quantity: 1 },
+				hands: { item: itemID('Ferocious gloves'), quantity: 1 },
+				ring: { item: itemID('Treasonous ring (i)'), quantity: 1 },
+				weapon: { item: itemID('Ghrazi rapier'), quantity: 1 },
+				ammo: { item: itemID('Unholy blessing'), quantity: 1 },
+				'2h': null
+			};
+			const skillingGear = {
+				head: { item: itemID('Graceful hood'), quantity: 1 },
+				neck: { item: itemID('Amulet of glory (t6)'), quantity: 1 },
+				body: { item: itemID('Graceful top'), quantity: 1 },
+				legs: { item: itemID('Graceful legs'), quantity: 1 },
+				feet: { item: itemID('Graceful boots'), quantity: 1 },
+				cape: { item: itemID('Graceful cape'), quantity: 1 },
+				shield: { item: itemID('Elysian spirit shield'), quantity: 1 },
+				hands: { item: itemID('Graceful gloves'), quantity: 1 },
+				ring: { item: itemID('Ring of the gods'), quantity: 1 },
+				weapon: { item: itemID('Crystal pickaxe'), quantity: 1 },
+				ammo: null,
+				'2h': null
+			};
+			const miscGear = {
+				head: { item: itemID('Warrior helm'), quantity: 1 },
+				neck: { item: itemID('Amulet of torture'), quantity: 1 },
+				body: { item: itemID('Bandos chestplate'), quantity: 1 },
+				legs: { item: itemID('Bandos tassets'), quantity: 1 },
+				feet: { item: itemID('Primordial boots'), quantity: 1 },
+				cape: { item: itemID('Infernal cape'), quantity: 1 },
+				shield: null,
+				hands: { item: itemID('Ferocious gloves'), quantity: 1 },
+				ring: { item: itemID('Warrior ring (i)'), quantity: 1 },
+				weapon: null,
+				ammo: { item: itemID('Unholy blessing'), quantity: 1 },
+				'2h': { item: itemID('Armadyl godsword'), quantity: 1 }
+			};
+			await msg.author.settings.update(UserSettings.Gear.Range, rangeGear);
+			await msg.author.settings.update(UserSettings.Gear.Mage, mageGear);
+			await msg.author.settings.update(UserSettings.Gear.Melee, meleeGear);
+			await msg.author.settings.update(UserSettings.Gear.Skilling, skillingGear);
+			await msg.author.settings.update(UserSettings.Gear.Misc, miscGear);
+		} else {
+			await this.client.queuePromise(async () =>
+				msg.channel.send(
+					'As you are busy, BiS gear was not added to your gear presets. Run this again when you are not busy to have BiS gear equipped!',
+					{ split: false }
+				)
+			);
+		}
+		const loot = {
+			[itemID('Zamorakian spear')]: 1,
+			[itemID('Zamorakian hasta')]: 1,
+			[itemID("Ahrim's robetop")]: 1,
+			[itemID("Ahrim's robeskirt")]: 1,
+			[itemID("Verac's brassard")]: 1,
+			[itemID("Verac's helm")]: 1,
+			[itemID("Verac's plateskirt")]: 1,
+			[itemID("Verac's flail")]: 1,
+			[itemID("Dharok's helm")]: 1,
+			[itemID("Dharok's platebody")]: 1,
+			[itemID("Dharok's platelegs")]: 1,
+			[itemID("Dharok's greataxe")]: 1,
+			[itemID("Guthan's helm")]: 1,
+			[itemID("Guthan's platebody")]: 1,
+			[itemID("Guthan's chainskirt")]: 1,
+			[itemID("Guthan's warspear")]: 1,
+			[itemID("Karil's coif")]: 1,
+			[itemID("Karil's leathertop")]: 1,
+			[itemID("Karil's leatherskirt")]: 1,
+			[itemID("Karil's crossbow")]: 1,
+			[itemID('Bandos godsword')]: 1,
+			[itemID('Spectral spirit shield')]: 1,
+			[itemID('Saradomin godsword')]: 1,
+			[itemID('Dragon warhammer')]: 1,
+			[itemID('Dragonhunter lance')]: 1,
+			[itemID("Iban's staff")]: 1,
+			[itemID('Dragonfire shield')]: 1,
+			[itemID('Anti-dragon shield')]: 1,
+			[itemID('Berserker ring')]: 1,
+			[itemID('Warrior ring')]: 1,
+			[itemID('Archers ring')]: 1,
+			[itemID('Seers ring')]: 1,
+			[itemID('Treasonous ring')]: 1,
+			[itemID('Tyrannical ring')]: 1,
+			[itemID('Tyrannical ring (i)')]: 1,
+			[itemID('Ranger boots')]: 1,
+			[itemID('Armadyl crossbow')]: 1,
+			[itemID('Twisted buckler')]: 1,
+			[itemID('Occult necklace')]: 1,
+			[itemID("Inquisitor's great helm")]: 1,
+			[itemID("Inquisitor's hauberk")]: 1,
+			[itemID("Inquisitor's plateskirt")]: 1,
+			[itemID("Inquisitor's mace")]: 1,
+			22114: 1, // Mythical cape
+			[itemID('Elder maul')]: 1,
+			[itemID('Blade of saeldor')]: 1,
+			[itemID('3rd age axe')]: 1,
+			[itemID('3rd age pickaxe')]: 1,
+			[itemID('Saradomin brew(4)')]: 10000,
+			[itemID('Prayer potion(4)')]: 10000,
+			[itemID('Super restore(4)')]: 10000,
+			[itemID('Justiciar faceguard')]: 1,
+			[itemID('Justiciar chestguard')]: 1,
+			[itemID('Justiciar legguards')]: 1,
+			[itemID('Ancient wyvern shield')]: 1,
+			[itemID('Ring of suffering')]: 1,
+			[itemID('Ring of suffering (i)')]: 1,
+			[itemID('Maple blackjack(d)')]: 1,
+			[itemID("Dinh's bulwark")]: 1,
+			[itemID('Guardian boots')]: 1,
+			[itemID('Crystal helm')]: 1,
+			[itemID('3rd age vambraces')]: 1,
+			[itemID('Crystal shield')]: 1,
+			[itemID('Neitiznot faceguard')]: 1,
+			[itemID('Leaf-bladed battleaxe')]: 1,
+			[itemID('Berserker ring (i)')]: 1,
+			[itemID('Dragon javelin')]: 1,
+			[itemID('Black chinchompa')]: 1,
+			[itemID('Saradomin mitre')]: 1,
+			[itemID('Dragonbone necklace')]: 1,
+			[itemID('Proselyte hauberk')]: 1,
+			[itemID('Proselyte cuisse')]: 1,
+			[itemID('Devout boots')]: 1,
+			[itemID('Holy book')]: 1,
+			[itemID('Holy wraps')]: 1,
+			[itemID('Ring of the gods (i)')]: 1,
+			[itemID('Ring of the gods')]: 1,
+			[itemID("Rada's blessing 4")]: 1,
+			[itemID('Saradomin crozier')]: 1,
+			[itemID('Penance gloves')]: 1,
+			[itemID('Spottier cape')]: 1,
+			[itemID('Boots of lightness')]: 1,
+			[itemID('Amulet of power')]: 1,
+			[itemID('Amulet of fury')]: 1
+		};
 		for (const item of Eatables) {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 			// @ts-ignore
 			loot[item.id] = 1000;
 		}
-		msg.author.addItemsToBank(loot);
-		return msg.send(`Gave you 99 in all skills, 1b GP, 250 QP, and 1k of all eatable foods`);
+		await msg.author.addItemsToBank(loot);
+		await msg.author.addItemsToBank({ 995: 1 });
+		return msg.send(
+			`Gave you 99 in all skills, ${Util.toKMB(
+				2_147_483_647
+			)} GP, ${MAX_QP} QP, 1k of all eatable foods, BiS gear in all slots and enough items to kill most bosses!`
+		);
 	}
 }

--- a/src/commands/Testing/setgp.ts
+++ b/src/commands/Testing/setgp.ts
@@ -7,7 +7,7 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '<amount:int{1}>'
+			usage: '<amount:int{1,2147483647}>'
 		});
 		this.enabled = !this.client.production;
 	}

--- a/src/commands/Testing/setqp.ts
+++ b/src/commands/Testing/setqp.ts
@@ -1,18 +1,20 @@
 import { CommandStore, KlasaMessage } from 'klasa';
-import { toKMB } from 'oldschooljs/dist/util/util';
 
 import { BotCommand } from '../../lib/BotCommand';
+import { MAX_QP } from '../../lib/constants';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '<amount:int{1}>'
+			usage: '<qp:int{0,2147483647}>',
+			cooldown: 1,
+			oneAtTime: true
 		});
 		this.enabled = !this.client.production;
 	}
 
-	async run(msg: KlasaMessage, [gp]: [number]) {
+	async run(msg: KlasaMessage, [qp = 0]: [number]) {
 		// Make 100% sure this command can never be used in prod
 		if (
 			this.client.production ||
@@ -22,7 +24,8 @@ export default class extends BotCommand {
 			return;
 		}
 
-		await msg.author.settings.update(UserSettings.GP, gp);
-		return msg.send(`Your cash stack is now ${toKMB(gp)}`);
+		if (qp > MAX_QP) qp = MAX_QP;
+		await msg.author.settings.update(UserSettings.QP, qp);
+		return msg.send(`You set yout quest points to ${qp}.`);
 	}
 }

--- a/src/commands/Testing/setqp.ts
+++ b/src/commands/Testing/setqp.ts
@@ -7,7 +7,7 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '<qp:int{0,2147483647}>',
+			usage: '<qp:int{0,50000}>',
 			cooldown: 1,
 			oneAtTime: true
 		});

--- a/src/commands/Testing/spawn.ts
+++ b/src/commands/Testing/spawn.ts
@@ -10,7 +10,7 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			cooldown: 1,
-			usage: '[qty:integer{1,1000000}] (item:...item)',
+			usage: '[qty:integer{1,2147483647}] (item:...item)',
 			usageDelim: ' ',
 			oneAtTime: true
 		});
@@ -38,9 +38,9 @@ export default class extends BotCommand {
 		}
 
 		const osItem = itemArray[0];
-		await msg.author.addItemsToBank({ [osItem.id]: qty });
+		await msg.author.addItemsToBank({ [osItem.id]: qty }, true);
 
-		for (const setup of ['range', 'melee', 'mage', 'skilling']) {
+		for (const setup of ['range', 'melee', 'mage', 'skilling', 'misc']) {
 			if (msg.flagArgs[setup]) {
 				try {
 					await this.client.commands.get('equip')!.run(msg, [setup, 1, [osItem]]);


### PR DESCRIPTION
### Description/Changes:

-   Some testing commands were lacking and people would expend a lot of time figuring out what were missing and spawning things
-   `+hax` now adds every item in this page [https://oldschool.runescape.wiki/w/Armour/Highest_bonuses], set MAX_QP, Max cash stack, fightcave potions, all foods and auto-equip best mage, range, slash melee gear, graceful, and so on
-   `+clean` Add new command. Resets the user minion. `+clean --bank` only clears the user bank
-   `+setqp` Add new command. Allows the user to set the QP to it's desired amount
-   `+setgp` Removed 1B limit
-   `+spawn` Remove 1M limit, make spawned items automatically added to collectionLog, Allow items to be equipped on misc gear set.

-   [X] I have tested all my changes thoroughly.
