### PR TITLE
Prevents WTF items from breaking the bank

### DIFF
--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -2,6 +2,7 @@ import { createCanvas, Image, registerFont } from 'canvas';
 import { MessageAttachment, MessageEmbed } from 'discord.js';
 import * as fs from 'fs';
 import { Command, CommandStore, KlasaMessage, util } from 'klasa';
+import { Items } from 'oldschooljs';
 
 import { Emoji } from '../../lib/constants';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -100,13 +101,12 @@ export default class extends Command {
 			const debug = Boolean(msg.flagArgs.debug);
 			const textBank = [];
 			for (const [id, qty] of Object.entries(bank)) {
-				let item;
-				try {
-					item = getOSItem(id).name;
-				} catch (e) {
-					item = `WTF-${id}`;
-				}
-				textBank.push(`${item}${debug ? `[${id}]` : ''}: ${qty.toLocaleString()}`);
+				const item = Items.get(Number(id));
+				textBank.push(
+					`${item ? item.name : `WTF-${id}`}${
+						debug ? `[${id}]` : ''
+					}: ${qty.toLocaleString()}`
+				);
 			}
 
 			if (msg.flagArgs.full) {

--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -2,7 +2,6 @@ import { createCanvas, Image, registerFont } from 'canvas';
 import { MessageAttachment, MessageEmbed } from 'discord.js';
 import * as fs from 'fs';
 import { Command, CommandStore, KlasaMessage, util } from 'klasa';
-import { Items } from 'oldschooljs';
 
 import { Emoji } from '../../lib/constants';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -101,11 +100,13 @@ export default class extends Command {
 			const debug = Boolean(msg.flagArgs.debug);
 			const textBank = [];
 			for (const [id, qty] of Object.entries(bank)) {
-				textBank.push(
-					`${Items.get(parseInt(id))!.name}${
-						debug ? `[${id}]` : ''
-					}: ${qty.toLocaleString()}`
-				);
+				let item;
+				try {
+					item = getOSItem(id).name;
+				} catch (e) {
+					item = `WTF-${id}`;
+				}
+				textBank.push(`${item}${debug ? `[${id}]` : ''}: ${qty.toLocaleString()}`);
 			}
 
 			if (msg.flagArgs.full) {

--- a/src/extendables/Client.ts
+++ b/src/extendables/Client.ts
@@ -15,9 +15,9 @@ export default class extends Extendable {
 	}
 
 	async fetchItemPrice(this: KlasaClient, itemID: number | string) {
-		// if (!this.production) {
-		// 	return 73;
-		// }
+		if (!this.production) {
+			return 73;
+		}
 
 		if (typeof itemID === 'string') itemID = parseInt(itemID);
 

--- a/src/extendables/Client.ts
+++ b/src/extendables/Client.ts
@@ -25,16 +25,15 @@ export default class extends Extendable {
 			return 1;
 		}
 
-		const currentItems = this.settings!.get(ClientSettings.Prices);
-
-		const currentItem = currentItems[itemID];
-
 		let osItem;
 		try {
 			osItem = getOSItem(itemID);
 		} catch (e) {
 			return 0;
 		}
+
+		const currentItems = this.settings!.get(ClientSettings.Prices);
+		const currentItem = currentItems[itemID];
 		const needsToFetchAgain = osItem.tradeable_on_ge && currentItem.price === 0;
 
 		if (

--- a/src/extendables/Client.ts
+++ b/src/extendables/Client.ts
@@ -15,9 +15,9 @@ export default class extends Extendable {
 	}
 
 	async fetchItemPrice(this: KlasaClient, itemID: number | string) {
-		if (!this.production) {
-			return 73;
-		}
+		// if (!this.production) {
+		// 	return 73;
+		// }
 
 		if (typeof itemID === 'string') itemID = parseInt(itemID);
 
@@ -29,7 +29,12 @@ export default class extends Extendable {
 
 		const currentItem = currentItems[itemID];
 
-		const osItem = getOSItem(itemID);
+		let osItem;
+		try {
+			osItem = getOSItem(itemID);
+		} catch (e) {
+			return 0;
+		}
 		const needsToFetchAgain = osItem.tradeable_on_ge && currentItem.price === 0;
 
 		if (

--- a/src/lib/util/createReadableItemListFromTuple.ts
+++ b/src/lib/util/createReadableItemListFromTuple.ts
@@ -1,8 +1,8 @@
 import { KlasaClient } from 'klasa';
+import { Items } from 'oldschooljs';
 
 import { ItemBank } from '../types';
 import createTupleOfItemsFromBank from './createTupleOfItemsFromBank';
-import getOSItem from './getOSItem';
 
 export default async function createReadableItemListFromBank(
 	client: KlasaClient,
@@ -11,13 +11,8 @@ export default async function createReadableItemListFromBank(
 	const items = await createTupleOfItemsFromBank(client, itemBank);
 	return items
 		.map(([name, qty]) => {
-			let item;
-			try {
-				item = getOSItem(name).name;
-			} catch (e) {
-				item = `WTF-${name}`;
-			}
-			return `${qty.toLocaleString()}x ${item}`;
+			const __item = Items.get(name);
+			return `${qty.toLocaleString()}x ${__item ? __item.name : `WTF-${name}`}`;
 		})
 		.join(', ');
 }

--- a/src/lib/util/createReadableItemListFromTuple.ts
+++ b/src/lib/util/createReadableItemListFromTuple.ts
@@ -1,8 +1,8 @@
 import { KlasaClient } from 'klasa';
-import { Items } from 'oldschooljs';
 
 import { ItemBank } from '../types';
 import createTupleOfItemsFromBank from './createTupleOfItemsFromBank';
+import getOSItem from './getOSItem';
 
 export default async function createReadableItemListFromBank(
 	client: KlasaClient,
@@ -10,6 +10,14 @@ export default async function createReadableItemListFromBank(
 ) {
 	const items = await createTupleOfItemsFromBank(client, itemBank);
 	return items
-		.map(([name, qty]) => `${qty.toLocaleString()}x ${Items.get(name)!.name}`)
+		.map(([name, qty]) => {
+			let item;
+			try {
+				item = getOSItem(name).name;
+			} catch (e) {
+				item = `WTF-${name}`;
+			}
+			return `${qty.toLocaleString()}x ${item}`;
+		})
 		.join(', ');
 }

--- a/src/lib/util/createTupleOfItemsFromBank.ts
+++ b/src/lib/util/createTupleOfItemsFromBank.ts
@@ -11,9 +11,9 @@ export default async function createTupleOfItemsFromBank(client: KlasaClient, ba
 		try {
 			item = getOSItem(itemID).id;
 		} catch (e) {
-			item = Number(itemID) ?? undefined;
+			item = Number(itemID);
 		}
-		readableTuple.push([item!, qty, (await client.fetchItemPrice(item!)) * qty]);
+		readableTuple.push([item, qty, (await client.fetchItemPrice(item!)) * qty]);
 	}
 
 	return readableTuple;

--- a/src/lib/util/createTupleOfItemsFromBank.ts
+++ b/src/lib/util/createTupleOfItemsFromBank.ts
@@ -1,14 +1,19 @@
 import { KlasaClient } from 'klasa';
-import { Items } from 'oldschooljs';
 
 import { ItemBank, ItemTuple } from '../types';
+import getOSItem from './getOSItem';
 
 export default async function createTupleOfItemsFromBank(client: KlasaClient, bank: ItemBank) {
 	const readableTuple: ItemTuple[] = [];
 
 	for (const [itemID, qty] of Object.entries(bank)) {
-		const item = Items.get(parseInt(itemID));
-		readableTuple.push([item!.id, qty, (await client.fetchItemPrice(item!.id)) * qty]);
+		let item;
+		try {
+			item = getOSItem(itemID).id;
+		} catch (e) {
+			item = Number(itemID) ?? undefined;
+		}
+		readableTuple.push([item!, qty, (await client.fetchItemPrice(item!)) * qty]);
 	}
 
 	return readableTuple;

--- a/src/lib/util/createTupleOfItemsFromBank.ts
+++ b/src/lib/util/createTupleOfItemsFromBank.ts
@@ -1,19 +1,15 @@
 import { KlasaClient } from 'klasa';
+import { Items } from 'oldschooljs';
 
 import { ItemBank, ItemTuple } from '../types';
-import getOSItem from './getOSItem';
 
 export default async function createTupleOfItemsFromBank(client: KlasaClient, bank: ItemBank) {
 	const readableTuple: ItemTuple[] = [];
 
 	for (const [itemID, qty] of Object.entries(bank)) {
-		let item;
-		try {
-			item = getOSItem(itemID).id;
-		} catch (e) {
-			item = Number(itemID);
-		}
-		readableTuple.push([item, qty, (await client.fetchItemPrice(item!)) * qty]);
+		const __item = Items.get(Number(itemID));
+		const __itemID = __item ? __item.id : Number(itemID);
+		readableTuple.push([__itemID, qty, (await client.fetchItemPrice(__itemID)) * qty]);
 	}
 
 	return readableTuple;

--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -398,11 +398,10 @@ export default class BankImageTask extends Task {
 			// Check for names flag and draw its shadow and name
 			if (flags.names) {
 				const __item = Items.get(id);
-				const __name = `${
-					__item
-						? `${__item.name!.replace('Grimy', 'Grmy').slice(0, 7)}`
-						: `WTF-${id}`.slice(0, 7)
-				}..`;
+				const __name = `${(__item
+					? `${__item.name.replace('Grimy', 'Grmy')}`
+					: `WTF-${id}`
+				).slice(0, 7)}..`;
 				ctx.fillStyle = 'black';
 				fillTextXTimesInCtx(
 					ctx,


### PR DESCRIPTION
### Description:

-   WTF items were breaking the bot, this allows WTF items to still show on the bank images in case that happens in the future

### Changes:

-   Add some checks on  `bank.ts`, `bankImage.ts`, `Client.ts`, `createTupleOfItemsFromBank.ts` and `createReadableItemListFromTuple.ts`.
-   WTF items that doesn't have a icon will show the icon of the item `7542 - Cake of guidance`
-   Dwarven remains, shown on the picture below, requires the following OSJS PR to be accepted https://github.com/oldschoolgg/oldschooljs/pull/156, but it won't affect this update. All it'll do is show WTF-0 instead of Dwarven remains

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/95027903-7a21b580-0672-11eb-8b43-084ebc1bee2b.png)