### PR TITLE
Deconstructed nightmare staffs

### DIFF
--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -747,13 +747,13 @@ const Createables: Createable[] = [
 		})
 	},
 	{
-		name: 'Deconstructed eldrich nightmare staff',
+		name: 'Deconstructed eldritch nightmare staff',
 		inputItems: resolveNameBank({
-			'Eldrich nightmare staff': 1
+			'Eldritch nightmare staff': 1
 		}),
 		outputItems: resolveNameBank({
 			'Nightmare staff': 1,
-			'Eldrich orb': 1
+			'Eldritch orb': 1
 		})
 	},
 	{

--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -745,6 +745,7 @@ const Createables: Createable[] = [
 		outputItems: resolveNameBank({
 			'Volatile nightmare staff': 1
 		})
+	},
 	{
 		name: 'Deconstructed eldrich nightmare staff',
 		inputItems: resolveNameBank({

--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -745,8 +745,7 @@ const Createables: Createable[] = [
 		outputItems: resolveNameBank({
 			'Volatile nightmare staff': 1
 		})
-	},
-		{
+	{
 		name: 'Deconstructed eldrich nightmare staff',
 		inputItems: resolveNameBank({
 			'Eldrich nightmare staff': 1
@@ -756,7 +755,7 @@ const Createables: Createable[] = [
 			'Eldrich orb': 1
 		})
 	},
-			{
+	{
 		name: 'Deconstructed harmonised nightmare staff',
 		inputItems: resolveNameBank({
 			'Harmonised nightmare staff': 1
@@ -766,7 +765,7 @@ const Createables: Createable[] = [
 			'Harmonised orb': 1
 		})
 	},
-			{
+	{
 		name: 'Deconstructed volatile nightmare staff',
 		inputItems: resolveNameBank({
 			'Eldrich nightmare staff': 1

--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -745,6 +745,36 @@ const Createables: Createable[] = [
 		outputItems: resolveNameBank({
 			'Volatile nightmare staff': 1
 		})
+	},
+		{
+		name: 'Deconstructed eldrich nightmare staff',
+		inputItems: resolveNameBank({
+			'Eldrich nightmare staff': 1
+		}),
+		outputItems: resolveNameBank({
+			'Nightmare staff': 1,
+			'Eldrich orb': 1
+		})
+	},
+			{
+		name: 'Deconstructed harmonised nightmare staff',
+		inputItems: resolveNameBank({
+			'Harmonised nightmare staff': 1
+		}),
+		outputItems: resolveNameBank({
+			'Nightmare staff': 1,
+			'Harmonised orb': 1
+		})
+	},
+			{
+		name: 'Deconstructed volatile nightmare staff',
+		inputItems: resolveNameBank({
+			'Eldrich nightmare staff': 1
+		}),
+		outputItems: resolveNameBank({
+			'Nightmare staff': 1,
+			'Volatile orb': 1
+		})
 	}
 ];
 


### PR DESCRIPTION
Added to creatables to allow for players to deconstruct their created nightmare staffs.


[x] I have not tested all my changes thoroughly.
