### PR TITLE
Add Sandworms to Buyables

### DIFF
--- a/src/lib/buyables/buyables.ts
+++ b/src/lib/buyables/buyables.ts
@@ -232,6 +232,15 @@ const Buyables: Buyable[] = [
 		gpCost: 1500
 	},
 	{
+		name: 'Sandworms',
+		aliases: ['sandworms'],
+		outputItems: resolveNameBank({
+			'Sandworms': 1
+		}),
+		qpRequired: 0,
+		gpCost: 200
+	},
+	{
 		name: 'Chocolate bar',
 		aliases: ['chocolate bar', 'chocolate'],
 		outputItems: resolveNameBank({

--- a/src/lib/buyables/buyables.ts
+++ b/src/lib/buyables/buyables.ts
@@ -235,7 +235,7 @@ const Buyables: Buyable[] = [
 		name: 'Sandworms',
 		aliases: ['sandworms'],
 		outputItems: resolveNameBank({
-			'Sandworms': 1
+			Sandworms: 1
 		}),
 		qpRequired: 0,
 		gpCost: 200


### PR DESCRIPTION
Adds sandworms to buyables (at 200gp ea as a filler given I don't know how you want your scaling on prices v. in game osrs prices). Now that food has a purpose it seems like fishing anglers might be an activity players would like to engage in.

-   [x] I have not tested all my changes thoroughly.
