### PR TITLE
Solo Raids at 200 kc

### DIFF
--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -838,7 +838,7 @@ export default class extends BotCommand {
 
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,
-			minSize: msg.author.getMinigameScore(6969) > 200 ? 1 : 2,
+			minSize: msg.author.getMinigameScore(6969) > 199 ? 1 : 2,
 			maxSize: 50,
 			message: `${msg.author.username} is starting a party to defeat the Chambers of Xeric! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
 			customDenier: user => {


### PR DESCRIPTION
Changed the minigame count check from “> 200” to “> 199” to let players with 200 cox kc solo as was seemingly intended.