### PR TITLE
Fix favorite not working on 1 page banks

### DIFF
--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -142,7 +142,8 @@ export default class extends Command {
 				bank,
 				title: `${msg.author.username}'s Bank`,
 				flags: { ...msg.flagArgs, page: 0 },
-				background: msg.author.settings.get(UserSettings.BankBackground)
+				background: msg.author.settings.get(UserSettings.BankBackground),
+				user: msg.author
 			});
 		}
 


### PR DESCRIPTION
### Description:

-   Resolves #845 

### Changes:

-   Bank with less than 1 page page was missing the user param

-   [X] I have tested all my changes thoroughly.
