### PR TITLE
Allow Specific Mass Sizes for Nightmare / Groupkill (GWD, Corp)

### DIFF
--- a/src/commands/Minion/groupkill.ts
+++ b/src/commands/Minion/groupkill.ts
@@ -67,14 +67,18 @@ export default class extends BotCommand {
 
 		this.checkReqs([msg.author], monster, 2);
 
-		let maximumSize = 50;
-		if (maximumSizeForParty) maximumSize = maximumSizeForParty;
+		const maximumSize = 50;
 
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,
 			minSize: 2,
-			maxSize: maximumSize - 1,
-			message: `${msg.author.username} is doing a ${monster.name} mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave. The maximum size for this mass is ${maximumSize}.`,
+			maxSize: (maximumSizeForParty ?? maximumSize) - 1,
+			message: `${msg.author.username} is doing a ${
+				monster.name
+			} mass! Anyone can click the ${
+				Emoji.Join
+			} reaction to join, click it again to leave. The maximum size for this mass is ${maximumSizeForParty ??
+				maximumSize}.`,
 			customDenier: user => {
 				if (!user.hasMinion) {
 					return [true, "you don't have a minion."];

--- a/src/commands/Minion/nightmare.ts
+++ b/src/commands/Minion/nightmare.ts
@@ -87,14 +87,18 @@ export default class extends BotCommand {
 	async run(msg: KlasaMessage, [type, maximumSizeForParty]: ['mass' | 'solo', number]) {
 		this.checkReqs([msg.author], NightmareMonster, 2);
 
-		let maximumSize = 10;
-		if (type === 'mass' && maximumSizeForParty) maximumSize = maximumSizeForParty;
+		const maximumSize = 10;
 
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,
 			minSize: 2,
-			maxSize: maximumSize - 1,
-			message: `${msg.author.username} is doing a ${NightmareMonster.name} mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave. The maximum size for this mass is ${maximumSize}.`,
+			maxSize: (maximumSizeForParty ?? maximumSize) - 1,
+			message: `${msg.author.username} is doing a ${
+				NightmareMonster.name
+			} mass! Anyone can click the ${
+				Emoji.Join
+			} reaction to join, click it again to leave. The maximum size for this mass is ${maximumSizeForParty ??
+				maximumSize}.`,
 			customDenier: user => {
 				if (!user.hasMinion) {
 					return [true, "you don't have a minion."];

--- a/src/commands/Minion/nightmare.ts
+++ b/src/commands/Minion/nightmare.ts
@@ -92,7 +92,7 @@ export default class extends BotCommand {
 
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,
-			minSize: 1,
+			minSize: 2,
 			maxSize: maximumSize - 1,
 			message: `${msg.author.username} is doing a ${NightmareMonster.name} mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave. The maximum size for this mass is ${maximumSize}.`,
 			customDenier: user => {

--- a/src/commands/Minion/nightmare.ts
+++ b/src/commands/Minion/nightmare.ts
@@ -47,7 +47,7 @@ const inquisitorItems = resolveItems([
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '<mass|solo>',
+			usage: '<mass|solo> [maximumSize:int{2,10}]',
 			usageDelim: ' ',
 			oneAtTime: true,
 			altProtection: true,
@@ -84,14 +84,17 @@ export default class extends BotCommand {
 
 	@minionNotBusy
 	@requiresMinion
-	async run(msg: KlasaMessage, [type]: ['mass' | 'solo']) {
+	async run(msg: KlasaMessage, [type, maximumSizeForParty]: ['mass' | 'solo', number]) {
 		this.checkReqs([msg.author], NightmareMonster, 2);
+
+		let maximumSize = 10;
+		if (type === 'mass' && maximumSizeForParty) maximumSize = maximumSizeForParty;
 
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,
-			minSize: 2,
-			maxSize: 10,
-			message: `${msg.author.username} is doing a ${NightmareMonster.name} mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
+			minSize: 1,
+			maxSize: maximumSize - 1,
+			message: `${msg.author.username} is doing a ${NightmareMonster.name} mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave. The maximum size for this mass is ${maximumSize}.`,
 			customDenier: user => {
 				if (!user.hasMinion) {
 					return [true, "you don't have a minion."];

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -156,7 +156,7 @@ async function _setup(
 
 			collector.once('end', () => {
 				confirmMessage.removeAllReactions();
-				startTrip();
+				setTimeout(() => startTrip(), 750);
 			});
 		});
 


### PR DESCRIPTION
### Description:

-   Allow users to specify the max mass size for a nightmare or groupkill (GWD, Corp) mass.
-   Resolves feature request #855.  

### Changes:

- Add functionality for a specific mass size from 2 to 10 (including leader) for nightmare.
- Add functionality for a specific mass size from 2 to 50 (including leader) for groupkill (GWD, Corp).
- Add a timeout feature to the function startTrip() so it allows time for the remove user debounce and processes users accordingly.

-   [X] I have tested all my changes thoroughly.
