### PR TITLE
Allow Ironmen to Join Nightmare Masses

### DIFF
--- a/src/commands/Minion/groupkill.ts
+++ b/src/commands/Minion/groupkill.ts
@@ -71,6 +71,7 @@ export default class extends BotCommand {
 			leader: msg.author,
 			minSize: 2,
 			maxSize: 50,
+			ironmanAllowed: false,
 			message: `${msg.author.username} is doing a ${monster.name} mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
 			customDenier: user => {
 				if (!user.hasMinion) {

--- a/src/commands/Minion/nightmare.ts
+++ b/src/commands/Minion/nightmare.ts
@@ -91,6 +91,7 @@ export default class extends BotCommand {
 			leader: msg.author,
 			minSize: 2,
 			maxSize: 10,
+			ironmanAllowed: true,
 			message: `${msg.author.username} is doing a ${NightmareMonster.name} mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
 			customDenier: user => {
 				if (!user.hasMinion) {

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -53,7 +53,7 @@ async function _setup(
 				confirmMessage,
 				(reaction: MessageReaction, user: KlasaUser) => {
 					if (
-						user.isIronman ||
+						(!options.ironmanAllowed && user.isIronman) ||
 						user.bot ||
 						user.minionIsBusy ||
 						!reaction.emoji.id ||

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -144,6 +144,7 @@ export interface MakePartyOptions {
 	minSize: number;
 	leader: KlasaUser;
 	message: string;
+	ironmanAllowed: boolean;
 	usersAllowed?: string[];
 	party?: boolean;
 	customDenier?(user: KlasaUser): [boolean, string] | [boolean];


### PR DESCRIPTION
### Description:

-   Allows ironmen to join Nightmare masses.
-   Allows ironmen to immediately start Nightmare masses using the reacts.
-   Resolves issue #769.
-   Adds functionality to allow party options to process whether or not an ironman can react and join/start certain masses.

### Changes:

-   Adds an ironmanAllowed option to MakePartyOptions interface.
-   Denys ironmen reactions only `if (!options.ironmanAllowed && user.isIronman)` -> Only if the specific party options for a mass does not allow ironman and if user is an ironman.

-   [X] I have tested all my changes thoroughly.
