### PR TITLE
Have Sea Kraken Check Range Setup Instead of Melee Setup

### DIFF
--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -365,7 +365,7 @@ const killableMonsters: KillableMonster[] = [
 		attackStyleToUse: GearSetupTypes.Range,
 		attackStylesUsed: [GearStat.AttackMagic],
 		minimumGearRequirements: {
-			[GearSetupTypes.Melee]: {
+			[GearSetupTypes.Range]: {
 				[GearStat.DefenceMagic]: 150,
 				[GearStat.AttackRanged]: 80
 			}


### PR DESCRIPTION
### Description:

-   Appropriately checks range setup for joining/creating a Sea Kraken mass.
-   Fixes issue #862. 

### Changes:

-   Changes Sea Kraken's `minimumGearRequirements` to check for `GearSetupTypes.Range` instead of `GearSetupTypes.Melee`.

-   [X] I have tested all my changes thoroughly.
