### PR TITLE
Fix Patron Tier Needed Message (OSB & BSO)

### DIFF
--- a/src/inhibitors/perkTierCommands.ts
+++ b/src/inhibitors/perkTierCommands.ts
@@ -11,8 +11,11 @@ export default class extends Inhibitor {
 		if (!command.perkTier) return;
 
 		if (getUsersPerkTier(msg.author) < command.perkTier) {
-			throw `You need to be a tier ${command.perkTier -
-				1} patron to use this command. You can become this patron tier at https://www.patreon.com/oldschoolbot`;
+			throw `You need to be a ${
+				command.perkTier - 1 > 0
+					? `tier ${command.perkTier - 1} patron`
+					: `tier ${command.perkTier} patron or server booster`
+			} to use this command. You can become this patron tier at https://www.patreon.com/oldschoolbot`;
 		}
 
 		return false;


### PR DESCRIPTION
### Description:

-   Some patron only commands also allow for server boosters to use. This resulted in the message below which was unclear on what was needed due to the nature of how the tiers are coded:
![image](https://user-images.githubusercontent.com/57806957/95777091-84a40680-0c93-11eb-80b1-50f6eb751a57.png)

- This will be fixed to say: 
![image](https://user-images.githubusercontent.com/57806957/95777125-95547c80-0c93-11eb-9fac-28701d405365.png)
 
### Changes:

-   If the needed `perkTier - 1 = 0`, use `perkTier or server booster` instead in the return message.  

-   [X] I have tested all my changes thoroughly.
