### PR TITLE
Fix Food Usage Calculation for Bossing

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -500,7 +500,12 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 		}
 
 		// Check food
-		if (monster.healAmountNeeded && monster.attackStyleToUse && monster.attackStylesUsed) {
+		if (
+			monster.healAmountNeeded &&
+			monster.attackStyleToUse &&
+			monster.attackStylesUsedMonster &&
+			monster.attackStylesUsedPlayer
+		) {
 			const [healAmountNeeded, foodMessages] = calculateMonsterFood(monster, msg.author);
 			messages = messages.concat(foodMessages);
 			await removeFoodFromUser(

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -333,7 +333,8 @@ const killableMonsters: KillableMonster[] = [
 		qpRequired: 26,
 		healAmountNeeded: 20 * 20,
 		attackStyleToUse: GearSetupTypes.Melee,
-		attackStylesUsed: [GearStat.AttackCrush],
+		attackStylesUsedMonster: [GearStat.AttackCrush],
+		attackStylesUsedPlayer: [GearStat.AttackCrush],
 		minimumGearRequirements: {
 			[GearSetupTypes.Melee]: {
 				[GearStat.DefenceCrush]: 150,
@@ -363,7 +364,8 @@ const killableMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		healAmountNeeded: 20 * 20,
 		attackStyleToUse: GearSetupTypes.Range,
-		attackStylesUsed: [GearStat.AttackMagic],
+		attackStylesUsedMonster: [GearStat.AttackMagic],
+		attackStylesUsedPlayer: [GearStat.AttackRanged],
 		minimumGearRequirements: {
 			[GearSetupTypes.Range]: {
 				[GearStat.DefenceMagic]: 150,
@@ -391,12 +393,13 @@ const killableMonsters: KillableMonster[] = [
 		qpRequired: 999,
 		healAmountNeeded: 20 * 25,
 		attackStyleToUse: GearSetupTypes.Melee,
-		attackStylesUsed: [
+		attackStylesUsedMonster: [
 			GearStat.AttackStab,
 			GearStat.AttackSlash,
 			GearStat.AttackMagic,
 			GearStat.AttackRanged
 		],
+		attackStylesUsedPlayer: [GearStat.AttackStab],
 		minimumGearRequirements: {
 			[GearSetupTypes.Melee]: {
 				[GearStat.AttackStab]: 100,
@@ -443,7 +446,8 @@ const killableMonsters: KillableMonster[] = [
 		]),
 		healAmountNeeded: 9 * 20,
 		attackStyleToUse: GearSetupTypes.Melee,
-		attackStylesUsed: [GearStat.AttackStab, GearStat.AttackRanged],
+		attackStylesUsedMonster: [GearStat.AttackStab, GearStat.AttackRanged],
+		attackStylesUsedPlayer: [GearStat.AttackCrush],
 		minimumGearRequirements: {
 			[GearSetupTypes.Melee]: {
 				[GearStat.DefenceRanged]: 57 + 120,
@@ -496,7 +500,8 @@ export const NightmareMonster: KillableMonster = {
 	]),
 	healAmountNeeded: 40 * 20,
 	attackStyleToUse: GearSetupTypes.Melee,
-	attackStylesUsed: [GearStat.AttackSlash],
+	attackStylesUsedMonster: [GearStat.AttackSlash],
+	attackStylesUsedPlayer: [GearStat.AttackCrush],
 	minimumGearRequirements: {
 		[GearSetupTypes.Melee]: {
 			[GearStat.DefenceSlash]: 150,

--- a/src/lib/minions/functions/calculateMonsterFood.ts
+++ b/src/lib/minions/functions/calculateMonsterFood.ts
@@ -13,9 +13,19 @@ export default function calculateMonsterFood(
 	user: O.Readonly<KlasaUser>
 ): [number, string[]] {
 	const messages: string[] = [];
-	let { healAmountNeeded, attackStyleToUse, attackStylesUsed } = monster;
+	let {
+		healAmountNeeded,
+		attackStyleToUse,
+		attackStylesUsedMonster,
+		attackStylesUsedPlayer
+	} = monster;
 
-	if (!healAmountNeeded || !attackStyleToUse || !attackStylesUsed) {
+	if (
+		!healAmountNeeded ||
+		!attackStyleToUse ||
+		!attackStylesUsedMonster ||
+		!attackStylesUsedPlayer
+	) {
 		return [0, messages];
 	}
 
@@ -25,7 +35,7 @@ export default function calculateMonsterFood(
 
 	let totalPercentOfGearLevel = 0;
 	let totalOffensivePercent = 0;
-	for (const style of attackStylesUsed) {
+	for (const style of attackStylesUsedMonster) {
 		const inverseStyle = inverseOfOffenceStat(style);
 		const usersStyle = gearStats[inverseStyle];
 		const maxStyle = maxDefenceStats[inverseStyle]!;
@@ -34,15 +44,21 @@ export default function calculateMonsterFood(
 			`Your ${inverseStyle} bonus is ${percent}% of the best (${usersStyle} out of ${maxStyle})`
 		);
 		totalPercentOfGearLevel += percent;
+	}
 
+	for (const style of attackStylesUsedPlayer) {
 		totalOffensivePercent += floor(calcWhatPercent(gearStats[style], maxOffenceStats[style]));
+		messages.push(
+			`Your ${style} bonus is ${totalOffensivePercent}% of the best (${gearStats[style]} out of ${maxOffenceStats[style]})`
+		);
 	}
 
 	totalPercentOfGearLevel = Math.min(
-		floor(max(0, totalPercentOfGearLevel / attackStylesUsed.length)),
+		floor(max(0, totalPercentOfGearLevel / attackStylesUsedMonster.length)),
 		85
 	);
-	totalOffensivePercent = floor(max(0, totalOffensivePercent / attackStylesUsed.length)) / 2;
+	totalOffensivePercent =
+		floor(max(0, totalOffensivePercent / attackStylesUsedPlayer.length)) / 2;
 
 	messages.push(
 		`You use ${floor(totalPercentOfGearLevel)}% less food because of your defensive stats.`

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -74,8 +74,18 @@ export interface KillableMonster {
 	 * How much healing (health points restored) is needed per kill.
 	 */
 	healAmountNeeded?: number;
+	/**
+	 * The gear setup type to pull the gear stats from.
+	 */
 	attackStyleToUse?: GearSetupTypes;
-	attackStylesUsed?: OffenceGearStat[];
+	/**
+	 * The style of attack used by the Monster.
+	 */
+	attackStylesUsedMonster?: OffenceGearStat[];
+	/**
+	 * The style of attack used by the Player.
+	 */
+	attackStylesUsedPlayer?: OffenceGearStat[];
 	/**
 	 * The minimum *required* gear stats to fight this monster.
 	 */


### PR DESCRIPTION
### Description:

-   Resolves issue #829, with some additional fixes.
-   The current bug uses the same attack style for both the monster and the player. This means, even though the monster is weak to crush and attacks with slash, the function would calculate your slash attack bonus for reducing food, even though it had forced you to use a crush weapon. This means that the current BIS is godsword over inquisitor's mace + elysian spirit shield at The Nightmare, for example.
-   Caused an over usage for food in most bossing which requires food.

### Changes:

-  Add separate attack styles used for Monster and Player. This lets the `calculateMonsterFood()` function use the monster's attack styles in your defensive gear calculator and the player's attack style in your offensive gear calculation.

-   [X] I have tested all my changes thoroughly.
