### PR TITLE
Fix wide banks not showing 1 row of items on very large banks

### DIFF
--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -288,7 +288,7 @@ export default class BankImageTask extends Task {
 			? 5 + this.borderVertical?.width! + 20 + Math.ceil(Math.sqrt(items.length)) * (36 + 21)
 			: 488;
 		if (width < 488) width = 488;
-		const itemsPerRow = Math.floor((width - this.borderVertical?.width! * 2) / (36 + 20));
+		const itemsPerRow = Math.floor((width - this.borderVertical?.width! * 2) / (36 + 21));
 		const canvasHeight =
 			Math.floor(
 				Math.floor(
@@ -356,7 +356,7 @@ export default class BankImageTask extends Task {
 
 			ctx.drawImage(
 				item,
-				Math.floor(xLoc + (itemSize - item.width) / 2),
+				Math.floor(xLoc + (itemSize - item.width) / 2) + 2,
 				Math.floor(yLoc + (itemSize - item.height) / 2),
 				item.width,
 				item.height


### PR DESCRIPTION
### Description:

-   Banks with lots of items were having an rounding error when deciding the width of the bank

### Changes:

-   Add 1 pixel to the itemsPerRow to be the same as the one used in the width calculator
-   Add 2 pixels to the item x position to center the item on its 'frame' (the 36x36 item grid)

-   [X] I have tested all my changes thoroughly.
