### PR TITLE
Remove 'q' From Continuation Characters

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -234,12 +234,12 @@ export const MAX_QP = 278;
 
 export const MIMIC_MONSTER_ID = 23184;
 
-export const continuationChars = 'abdefghjkmnopqrstuvwxyz123456789'.split('');
+export const continuationChars = 'abdefghjkmnoprstuvwxyz123456789'.split('');
 
 export const NIGHTMARES_HP = 2400;
 export const ZAM_HASTA_CRUSH = 65;
 
-export const SKYRA_DEPRECATED_COMMAND = `This command has been *removed* from Old School Bot. However, the command is available in a bot called **Skyra**. 
+export const SKYRA_DEPRECATED_COMMAND = `This command has been *removed* from Old School Bot. However, the command is available in a bot called **Skyra**.
 
 Skyra invite link: <https://invite.skyra.pw/>
 Skyra commands list & website: <https://skyra.pw/commands>


### PR DESCRIPTION
### Description:

-   Solves issue #949.

### Changes:

-   Remove q from the list of possible continuation characters for non-patrons.

-   [X] I have tested all my changes thoroughly.
