### PR TITLE
Fix Smelting Bug

### DIFF
--- a/src/tasks/minions/smeltingActivity.ts
+++ b/src/tasks/minions/smeltingActivity.ts
@@ -21,7 +21,7 @@ export default class extends Task {
 		if (bar.chanceOfFail > 0) {
 			let newQuantity = 0;
 			for (let i = 0; i < quantity; i++) {
-				if (randInt(0, 100) < bar.chanceOfFail) {
+				if (randInt(0, 100) > bar.chanceOfFail) {
 					newQuantity++;
 				}
 			}


### PR DESCRIPTION
### Description:

-   Smelting was awarding a successful bar only when the roll fell lower or equal to a bar's fail chance. This causes a reverse effect.
-   For example, this affects BSO more, such where a dwarven bar has a 35% chance of failure but was awarding a successful bar 35% of the time, instead of 100% - 35% = %65 of the time.

### Changes:

-   Change less than (`<`) to greater than (`>`) in the successful bar calculation. --> If randInt(0,100) GREATER THAN bar fail chance, add successful bar.

-   [X] I have tested all my changes thoroughly.
