### PR TITLE
remove q from continuationChars

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -234,7 +234,7 @@ export const MAX_QP = 278;
 
 export const MIMIC_MONSTER_ID = 23184;
 
-export const continuationChars = 'abdefghjkmnopqrstuvwxyz123456789'.split('');
+export const continuationChars = 'abdefghjkmnoprstuvwxyz123456789'.split('');
 
 export const NIGHTMARES_HP = 2400;
 export const ZAM_HASTA_CRUSH = 65;


### PR DESCRIPTION
### Description:

removed q from continuationChars so that quests isn't sent out instead of trip.

closes #949 

### Changes:

removed q from continuationChars so that quests isn't sent out instead of trip.

-   [x] I have tested all my changes thoroughly.
