### PR TITLE
Add MBs tmb, umb, pmb and hmb alias for easy trading, add some bank filters for the box items, add more items to 'create fix' and allow dragon defender to be changed from (l) to normal

### DIFF
--- a/src/commands/Minion/equippet.ts
+++ b/src/commands/Minion/equippet.ts
@@ -9,7 +9,7 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { removeItemFromBank } from '../../lib/util';
 import resolveItems from '../../lib/util/resolveItems';
 
-const allPetIDs = [
+export const allPetIDs = [
 	...resolveItems([
 		'Doug',
 		'Zippy',

--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -65,7 +65,6 @@ const brokenItems: Createable[] = [
 		outputItems: {
 			[itemID('Fire cape')]: 1
 		},
-		GPCost: 100_000_000,
 		noCl: true
 	},
 	{
@@ -209,6 +208,107 @@ const brokenItems: Createable[] = [
 			[itemID('Avernic defender')]: 1
 		},
 		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix void knight top',
+		inputItems: {
+			20465: 1
+		},
+		outputItems: {
+			[itemID('Void knight top')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix void knight robe',
+		inputItems: {
+			20469: 1
+		},
+		outputItems: {
+			[itemID('Void knight robe')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix elite void top',
+		inputItems: {
+			20467: 1
+		},
+		outputItems: {
+			[itemID('Elite void top')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix elite void robe',
+		inputItems: {
+			20471: 1
+		},
+		outputItems: {
+			[itemID('Elite void robe')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix void knight gloves',
+		inputItems: {
+			20475: 1
+		},
+		outputItems: {
+			[itemID('Void knight gloves')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix void mage helm',
+		inputItems: {
+			20477: 1
+		},
+		outputItems: {
+			[itemID('Void mage helm')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix void ranger helm',
+		inputItems: {
+			20479: 1
+		},
+		outputItems: {
+			[itemID('Void ranger helm')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	},
+	{
+		name: 'Fix void melee helm',
+		inputItems: {
+			20481: 1
+		},
+		outputItems: {
+			[itemID('Void melee helm')]: 1
+		},
+		GPCost: 100_000_000,
+		noCl: true
+	}
+];
+
+const lockedItems: Createable[] = [
+	{
+		name: 'Unlock dragon defender',
+		inputItems: {
+			[itemID('Dragon defender (l)')]: 1
+		},
+		outputItems: {
+			[itemID('Dragon defender')]: 1
+		},
 		noCl: true
 	}
 ];
@@ -3488,7 +3588,8 @@ const Createables: Createable[] = [
 		QPRequired: 205
 	},
 	...crystalTools,
-	...brokenItems
+	...brokenItems,
+	...lockedItems
 ];
 
 export default Createables;

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -1,3 +1,6 @@
+import LootTable from 'oldschooljs/dist/structures/LootTable';
+
+import { allPetIDs } from '../commands/Minion/equippet';
 import { warmGear } from '../commands/Minion/wt';
 import {
 	cluesAll,
@@ -12,6 +15,7 @@ import {
 	wintertodt
 } from './collectionLog';
 import { Eatables } from './eatables';
+import Openables, { tmbTable, umbTable } from './openables';
 import { gracefulItems } from './skilling/skills/agility';
 import Crafting from './skilling/skills/crafting';
 import Fletching from './skilling/skills/fletching';
@@ -830,5 +834,25 @@ export const filterableTypes = [
 		name: 'Clues Rares',
 		aliases: ['clues rare', 'rare clues', 'clue rare', 'rare clue'],
 		items: Object.values(cluesRares).flat(Infinity)
+	},
+	{
+		name: 'Untradeables',
+		aliases: ['untradeables', 'umb'],
+		items: umbTable
+	},
+	{
+		name: 'Tradeables',
+		aliases: ['tradeables', 'tmb'],
+		items: tmbTable
+	},
+	{
+		name: 'Pets',
+		aliases: ['pets', 'pmb'],
+		items: allPetIDs
+	},
+	{
+		name: 'Holiday',
+		aliases: ['holiday', 'hmb', 'rare', 'rares'],
+		items: (Openables.find(o => o.name === 'Holiday Mystery box')!.table as LootTable).allItems
 	}
 ];

--- a/src/lib/itemAliases.ts
+++ b/src/lib/itemAliases.ts
@@ -82,4 +82,9 @@ export function initItemAliases() {
 	setItemAlias(24752, ['Dark graceful legs', 'Black graceful legs']);
 	setItemAlias(24755, ['Dark graceful gloves', 'Black graceful gloves']);
 	setItemAlias(24758, ['Dark graceful boots', 'Black graceful boots']);
+
+	setItemAlias(3062, ['pmb'], false);
+	setItemAlias(3713, ['hmb'], false);
+	setItemAlias(6199, ['tmb'], false);
+	setItemAlias(19939, ['umb'], false);
 }

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -304,14 +304,14 @@ const cantBeDropped = [
 	22664 // JMOD Scythe of Vitur
 ] as number[];
 
-const tmbTable = Items.filter(i => {
+export const tmbTable = Items.filter(i => {
 	if (allItemsIDs.includes(i.id) || cantBeDropped.includes(i.id)) {
 		return false;
 	}
 	return (i as Item).tradeable_on_ge && !(i as Item).duplicate;
 }).map(i => i.id);
 
-const umbTable = Items.filter(i => {
+export const umbTable = Items.filter(i => {
 	if (allItemsIDs.includes(i.id) || cantBeDropped.includes(i.id)) {
 		return false;
 	}


### PR DESCRIPTION
### Description:

- Add some bank filters and mystery box aliases for easy trading
- Add fix void knight items to createables;
- Add 'unlock dragon defender' to createables. No other that can be locked are used to create stuff, that is why I only added that.

### Changes:

- Export some variables in the openables and equippet;
- Added new bank filters (tmb, umb, pmb, hmb) using those variables
- Add void knight armour to createables 'brokenItems' as they are used in raids;
- Add a new 'lockedItems' to createables with items that can be unlocked. Only contains dragon defender.

### Other checks:

-   [X] I have tested all my changes thoroughly.
