### PR TITLE
Add Little Nightmare to Pet Mystery Boxes

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -182,7 +182,8 @@ const PetsTable = new LootTable()
 	.add('Pet penance queen')
 	.add('Phoenix')
 	.add('Smolcano')
-	.add('Youngllef');
+	.add('Youngllef')
+	.add('Little nightmare');
 
 const PartyhatTable = new LootTable()
 	.oneIn(50, 'Black partyhat')


### PR DESCRIPTION
### Description:

-    Little Nightmare pet is currently unobtainable from pet mystery boxes. This adds the Little Nightmare pet to the possible pet loot. 
-    Fixes #1035.

### Changes:

-    Added Little Nightmare to the PetsTable loot table, from which pet mystery boxes pulls possible loot from.

### Other checks:

-   [X] I have tested all my changes thoroughly.
