### PR TITLE
Allow skipper to be used while in-bank due to the pet nature

### DIFF
--- a/src/commands/Minion/daily.ts
+++ b/src/commands/Minion/daily.ts
@@ -148,7 +148,9 @@ export default class DailyCommand extends BotCommand {
 			Emoji.Diango
 		} Diango says..** That's ${correct}! ${reward}\n`;
 
-		const hasSkipper = msg.author.equippedPet() === itemID('Skipper');
+		const hasSkipper =
+			msg.author.equippedPet() === itemID('Skipper') ||
+			msg.author.numItemsInBankSync(itemID('Skipper')) > 0;
 		if (triviaCorrect && hasSkipper) {
 			loot[COINS_ID] *= 1.5;
 			dmStr += `\n<:skipper:755853421801766912> Skipper has negotiated with Diango and gotten you 50% extra GP from your daily!`;

--- a/src/commands/Minion/sacrifice.ts
+++ b/src/commands/Minion/sacrifice.ts
@@ -59,7 +59,9 @@ export default class extends BotCommand {
 		let priceOfItem = itemIsTradeable(osItem.id)
 			? await this.client.fetchItemPrice(osItem.id)
 			: 1;
-		const hasSkipper = msg.author.equippedPet() === itemID('Skipper');
+		const hasSkipper =
+			msg.author.equippedPet() === itemID('Skipper') ||
+			msg.author.numItemsInBankSync(itemID('Skipper')) > 0;
 		if (hasSkipper) {
 			priceOfItem *= 1.4;
 		}

--- a/src/commands/Minion/sell.ts
+++ b/src/commands/Minion/sell.ts
@@ -49,7 +49,9 @@ export default class extends BotCommand {
 			return msg.send(`You dont have ${quantity}x ${osItem.name}.`);
 		}
 
-		const hasSkipper = msg.author.equippedPet() === itemID('Skipper');
+		const hasSkipper =
+			msg.author.equippedPet() === itemID('Skipper') ||
+			msg.author.numItemsInBankSync(itemID('Skipper')) > 0;
 
 		if (totalPrice > 3 && !hasSkipper) {
 			totalPrice = Math.floor(totalPrice * 0.8);


### PR DESCRIPTION
### Description:

- Due to Skipper pet nature, people haven't been use it much, as it's benefits only works on commands that are used while minions are already on trips and with pets that benefits said trips.
- This PR will make it so Skipper effects will work by having it on the bank. It fits the pet narrative, as it is an accountant and should work from bank too.

### Changes:

- Changes the `hasSkipper` variable to account for either if `equippedPet` or `numItemsInBankSync > 0`

### Other checks:

-   [X] I have tested all my changes thoroughly.
