### PR TITLE
Add Occult/Anguish/Tormented/Torture ornament creation to createables

### DIFF
--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -493,6 +493,90 @@ const ornamentKits: Createable[] = [
 			'Armadyl godsword ornament kit': 1
 		}),
 		noCl: true
+	},
+	{
+		name: 'Amulet of torture (or)',
+		inputItems: resolveNameBank({
+			'Amulet of torture': 1,
+			'Torture ornament kit': 1
+		}),
+		outputItems: resolveNameBank({
+			'Amulet of torture (or)': 1
+		})
+	},
+	{
+		name: 'Revert amulet of torture',
+		inputItems: resolveNameBank({
+			'Amulet of torture (or)': 1
+		}),
+		outputItems: resolveNameBank({
+			'Amulet of torture': 1,
+			'Torture ornament kit': 1
+		}),
+		noCl: true
+	},
+	{
+		name: 'Necklace of anguish (or)',
+		inputItems: resolveNameBank({
+			'Necklace of anguish': 1,
+			'Anguish ornament kit': 1
+		}),
+		outputItems: resolveNameBank({
+			'Necklace of anguish (or)': 1
+		})
+	},
+	{
+		name: 'Revert necklace of anguish',
+		inputItems: resolveNameBank({
+			'Necklace of anguish (or)': 1
+		}),
+		outputItems: resolveNameBank({
+			'Necklace of anguish': 1,
+			'Anguish ornament kit': 1
+		}),
+		noCl: true
+	},
+	{
+		name: 'Tormented bracelet (or)',
+		inputItems: resolveNameBank({
+			'Tormented bracelet': 1,
+			'Tormented ornament kit': 1
+		}),
+		outputItems: resolveNameBank({
+			'Tormented bracelet (or)': 1
+		})
+	},
+	{
+		name: 'Revert tormented bracelet',
+		inputItems: resolveNameBank({
+			'Tormented bracelet (or)': 1
+		}),
+		outputItems: resolveNameBank({
+			'Tormented bracelet': 1,
+			'Tormented ornament kit': 1
+		}),
+		noCl: true
+	},
+	{
+		name: 'Occult necklace (or)',
+		inputItems: resolveNameBank({
+			'Occult necklace': 1,
+			'Occult ornament kit': 1
+		}),
+		outputItems: resolveNameBank({
+			'Occult necklace (or)': 1
+		})
+	},
+	{
+		name: 'Revert occult necklace',
+		inputItems: resolveNameBank({
+			'Occult necklace (or)': 1
+		}),
+		outputItems: resolveNameBank({
+			'Occult necklace': 1,
+			'Occult ornament kit': 1
+		}),
+		noCl: true
 	}
 ];
 


### PR DESCRIPTION
### Description:

- Add the possibility to add and remove ornaments to the Amulet of Torture, Necklace of Anguish, Tormented Bracelet and Occult Necklace

### Changes:

- Add those items to the createables.ts, with the possibility to rever the item back to its normal form.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/101501545-a3024780-394e-11eb-9519-2d5573342d35.png)
![image](https://user-images.githubusercontent.com/19570528/101501573-ab5a8280-394e-11eb-928d-cc5b28882e83.png)