### PR TITLE
Add Minerals to Iron Ore

### DIFF
--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -53,6 +53,7 @@ const ores: Ore[] = [
 		name: 'Iron ore',
 		respawnTime: -0.2,
 		petChance: 750_000,
+		minerals: 100,
 		clueScrollChance: 741_600
 	},
 	{


### PR DESCRIPTION
### Description:

Allows players to receive minerals from iron ore.

### Changes:

Added minerals to iron ore with the respective 1/100 drop rate.

### Other checks:

-   [X] I have tested all my changes thoroughly.
