### PR TITLE
Fix Fletching Activity Output String

### DIFF
--- a/src/tasks/minions/fletchingActivity.ts
+++ b/src/tasks/minions/fletchingActivity.ts
@@ -28,8 +28,12 @@ export default class extends Task {
 		const newLevel = user.skillLevel(SkillsEnum.Fletching);
 
 		let str = `${user}, ${user.minionName} finished fletching ${quantity} ${
-			fletchableItem.name
-		}s, you also received ${xpReceived.toLocaleString()} XP.`;
+			fletchableItem.name +
+				fletchableItem.name.charAt(fletchableItem.name.length - 1).toLowerCase() ===
+			's'
+				? ''
+				: 's'
+		}, you also received ${xpReceived.toLocaleString()} XP.`;
 
 		if (newLevel > currentLevel) {
 			str += `\n\n${user.minionName}'s Fletching level is now ${newLevel}!`;


### PR DESCRIPTION
### Description:

Fixed the output string of fletching items so if they end with a 's' it won't add another 's' on top of it.

### Changes:

Fixed the output string of fletching items so if they end with a 's' it won't add another 's' on top of it.

### Other checks:

-   [X] I have tested all my changes thoroughly.
