### PR TITLE
Fix giving hunter xp from aerial fishing

### DIFF
--- a/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
+++ b/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
@@ -106,7 +106,7 @@ export default class extends Task {
 		}
 
 		await user.addXP(SkillsEnum.Fishing, fishXpReceived);
-		await user.addXP(SkillsEnum.Agility, huntXpReceived);
+		await user.addXP(SkillsEnum.Hunter, huntXpReceived);
 		await user.addItemsToBank(loot.values(), true);
 		await user.incrementCreatureScore(bluegill.id, bluegillCaught);
 		await user.incrementCreatureScore(commonTench.id, commonTenchCaught);


### PR DESCRIPTION
### Description:

Fix so aerial fishing gives hunter experience.

### Changes:

Fix so aerial fishing gives hunter experience.

### Other checks:

-   [X] I have tested all my changes thoroughly.
