### PR TITLE
Changed operator on catch level requirements

### DIFF
--- a/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
+++ b/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
@@ -43,7 +43,7 @@ export default class extends Task {
 			loot.add(bluegill.table.roll());
 
 			if (
-				currentRoll > 82 &&
+				currentRoll >= 82 &&
 				currentFishLevel >= greaterSiren.fishLvl! &&
 				currentHuntLevel >= greaterSiren.level!
 			) {
@@ -51,7 +51,7 @@ export default class extends Task {
 				continue;
 			}
 			if (
-				currentRoll > 67 &&
+				currentRoll >= 67 &&
 				currentFishLevel >= mottledEel.fishLvl! &&
 				currentHuntLevel >= mottledEel.level!
 			) {
@@ -59,7 +59,7 @@ export default class extends Task {
 				continue;
 			}
 			if (
-				currentRoll > 52 &&
+				currentRoll >= 52 &&
 				currentFishLevel >= commonTench.fishLvl! &&
 				currentHuntLevel >= commonTench.level!
 			) {

--- a/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
+++ b/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
@@ -44,24 +44,24 @@ export default class extends Task {
 
 			if (
 				currentRoll > 82 &&
-				currentFishLevel > greaterSiren.fishLvl! &&
-				currentHuntLevel > greaterSiren.level!
+				currentFishLevel >= greaterSiren.fishLvl! &&
+				currentHuntLevel >= greaterSiren.level!
 			) {
 				greaterSirenCaught++;
 				continue;
 			}
 			if (
 				currentRoll > 67 &&
-				currentFishLevel > mottledEel.fishLvl! &&
-				currentHuntLevel > mottledEel.level!
+				currentFishLevel >= mottledEel.fishLvl! &&
+				currentHuntLevel >= mottledEel.level!
 			) {
 				mottledEelCaught++;
 				continue;
 			}
 			if (
 				currentRoll > 52 &&
-				currentFishLevel > commonTench.fishLvl! &&
-				currentHuntLevel > commonTench.level!
+				currentFishLevel >= commonTench.fishLvl! &&
+				currentHuntLevel >= commonTench.level!
 			) {
 				commonTenchCaught++;
 				continue;


### PR DESCRIPTION
Having the exact stats required to catch each fish from Aerial fishing meant you were unable to actually catch them as it seemed to be requiring one level higher than requirement. Changed it from currentFishLevel > greaterSiren.fishLvl to currentFishLevel >= greaterSiren.fishLvl

Hopefully this works +foshy

### Description:

<!-- What did you change? Describe it here. -->

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

-   [ ] I have tested all my changes thoroughly.
