### PR TITLE
Updated grammar on HuntGear message

### DIFF
--- a/src/lib/gear/functions/hasWildyHuntGearEquipped.ts
+++ b/src/lib/gear/functions/hasWildyHuntGearEquipped.ts
@@ -14,7 +14,7 @@ export function hasWildyHuntGearEquipped(setup: GearTypes.GearSetup): [boolean, 
 	};
 
 	if (!userBodyID || !userLegsID) {
-		return [false, `No body and or legs equipped in misc setup.`, 0];
+		return [false, `Body and leg armour equipped in misc setup.`, 0];
 	}
 
 	const userBodyItem = getOSItem(userBodyID);


### PR DESCRIPTION
Current message being returned for hunting in the wilderness without gear didn't make sense gramatically, made a small change for it to make more sense.

### Description:

<!-- What did you change? Describe it here. -->

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

-   [ ] I have tested all my changes thoroughly.
