### PR TITLE
Add favourite as an alias to fav command

### DIFF
--- a/src/commands/Minion/favorite.ts
+++ b/src/commands/Minion/favorite.ts
@@ -9,7 +9,7 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			usage: '[item:item]',
-			aliases: ['fav'],
+			aliases: ['fav', 'favourite'],
 			description: 'Favorites an item so it displays at the top of your bank.',
 			examples: ['+favorite twisted bow'],
 			categoryFlags: ['minion']


### PR DESCRIPTION
### Description:

Add `favourite` (British English spelling) as an alias to the fav bank command.

### Other checks:

-   [x] I have tested all my changes thoroughly.
