### PR TITLE
Exclusive item boosts

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -468,35 +468,11 @@ Type \`confirm\` if you understand the above information, and want to become an 
 			}
 		}
 
-		if (monster.itemInBankBoosts) {
-			for (const [itemID, boostAmount] of Object.entries(monster.itemInBankBoosts)) {
-				if (!msg.author.hasItemEquippedOrInBank(parseInt(itemID))) continue;
-				timeToFinish *= (100 - boostAmount) / 100;
-				boosts.push(`${boostAmount}% for ${itemNameFromID(parseInt(itemID))}`);
-			}
-		}
-
-		if (monster.exclusiveItemInBankBoosts) {
-			for (const boostSet of monster.exclusiveItemInBankBoosts) {
-				let highestBoostAmount = null;
-				let highestBoostItem = null;
-
-				// find the highest boost that the player has
-				for (const [itemID, boostAmount] of Object.entries(boostSet)) {
-					if (!msg.author.hasItemEquippedOrInBank(parseInt(itemID))) continue;
-					if (!highestBoostAmount || boostAmount > highestBoostAmount) {
-						highestBoostAmount = boostAmount;
-						highestBoostItem = itemID;
-					}
-				}
-
-				if (highestBoostAmount && highestBoostItem) {
-					timeToFinish *= (100 - highestBoostAmount) / 100;
-					boosts.push(
-						`${highestBoostAmount}% for ${itemNameFromID(parseInt(highestBoostItem))}`
-					);
-				}
-			}
+		for (const [itemID, boostAmount] of Object.entries(
+			msg.author.resolveAvailableItemBoosts(monster)
+		)) {
+			timeToFinish *= (100 - boostAmount) / 100;
+			boosts.push(`${boostAmount}% for ${itemNameFromID(parseInt(itemID))}`);
 		}
 
 		// If no quantity provided, set it to the max.

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -476,6 +476,29 @@ Type \`confirm\` if you understand the above information, and want to become an 
 			}
 		}
 
+		if (monster.exclusiveItemInBankBoosts) {
+			for (const boostSet of monster.exclusiveItemInBankBoosts) {
+				let highestBoostAmount = null;
+				let highestBoostItem = null;
+
+				// find the highest boost that the player has
+				for (const [itemID, boostAmount] of Object.entries(boostSet)) {
+					if (!msg.author.hasItemEquippedOrInBank(parseInt(itemID))) continue;
+					if (!highestBoostAmount || boostAmount > highestBoostAmount) {
+						highestBoostAmount = boostAmount;
+						highestBoostItem = itemID;
+					}
+				}
+
+				if (highestBoostAmount && highestBoostItem) {
+					timeToFinish *= (100 - highestBoostAmount) / 100;
+					boosts.push(
+						`${highestBoostAmount}% for ${itemNameFromID(parseInt(highestBoostItem))}`
+					);
+				}
+			}
+		}
+
 		// If no quantity provided, set it to the max.
 		if (quantity === null) {
 			quantity = floor(msg.author.maxTripLength / timeToFinish);

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -41,35 +41,12 @@ export default class MinionCommand extends BotCommand {
 
 		const ownedBoostItems = [];
 		let totalItemBoost = 0;
-		if (monster.itemInBankBoosts) {
-			for (const [itemID, boostAmount] of Object.entries(monster.itemInBankBoosts)) {
-				if (!msg.author.hasItemEquippedOrInBank(parseInt(itemID))) continue;
-				timeToFinish *= (100 - boostAmount) / 100;
-				totalItemBoost += boostAmount;
-				ownedBoostItems.push(itemNameFromID(parseInt(itemID)));
-			}
-		}
-
-		if (monster.exclusiveItemInBankBoosts) {
-			for (const boostSet of monster.exclusiveItemInBankBoosts) {
-				let highestBoostAmount = null;
-				let highestBoostItem = null;
-
-				// find the highest boost that the player has
-				for (const [itemID, boostAmount] of Object.entries(boostSet)) {
-					if (!msg.author.hasItemEquippedOrInBank(parseInt(itemID))) continue;
-					if (!highestBoostAmount || boostAmount > highestBoostAmount) {
-						highestBoostAmount = boostAmount;
-						highestBoostItem = itemID;
-					}
-				}
-
-				if (highestBoostAmount && highestBoostItem) {
-					timeToFinish *= (100 - highestBoostAmount) / 100;
-					totalItemBoost += highestBoostAmount;
-					ownedBoostItems.push(itemNameFromID(parseInt(highestBoostItem)));
-				}
-			}
+		for (const [itemID, boostAmount] of Object.entries(
+			msg.author.resolveAvailableItemBoosts(monster)
+		)) {
+			timeToFinish *= (100 - boostAmount) / 100;
+			totalItemBoost += boostAmount;
+			ownedBoostItems.push(itemNameFromID(parseInt(itemID)));
 		}
 
 		const maxCanKill = Math.floor(msg.author.maxTripLength / timeToFinish);
@@ -102,7 +79,7 @@ export default class MinionCommand extends BotCommand {
 				str.push(
 					`You own ${ownedBoostItems.join(
 						', '
-					)} for a total boost of **${totalItemBoost}**\n`
+					)} for a total boost of **${totalItemBoost}**%.\n`
 				);
 			}
 		}

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -49,6 +49,29 @@ export default class MinionCommand extends BotCommand {
 				ownedBoostItems.push(itemNameFromID(parseInt(itemID)));
 			}
 		}
+
+		if (monster.exclusiveItemInBankBoosts) {
+			for (const boostSet of monster.exclusiveItemInBankBoosts) {
+				let highestBoostAmount = null;
+				let highestBoostItem = null;
+
+				// find the highest boost that the player has
+				for (const [itemID, boostAmount] of Object.entries(boostSet)) {
+					if (!msg.author.hasItemEquippedOrInBank(parseInt(itemID))) continue;
+					if (!highestBoostAmount || boostAmount > highestBoostAmount) {
+						highestBoostAmount = boostAmount;
+						highestBoostItem = itemID;
+					}
+				}
+
+				if (highestBoostAmount && highestBoostItem) {
+					timeToFinish *= (100 - highestBoostAmount) / 100;
+					totalItemBoost += highestBoostAmount;
+					ownedBoostItems.push(itemNameFromID(parseInt(highestBoostItem)));
+				}
+			}
+		}
+
 		const maxCanKill = Math.floor(msg.author.maxTripLength / timeToFinish);
 
 		const QP = msg.author.settings.get(UserSettings.QP);

--- a/src/commands/Owner/rp.ts
+++ b/src/commands/Owner/rp.ts
@@ -107,7 +107,7 @@ export default class extends BotCommand {
 					allItems: i.table?.allItems || [],
 					itemsRequired: i.itemsRequired,
 					qpRequired: i.qpRequired,
-					itemInBankBoosts: i.itemInBankBoosts,
+					exclusiveItemInBankBoosts: i.itemInBankBoosts,
 					groupKillable: i.groupKillable,
 					respawnTime: i.respawnTime,
 					levelRequirements: i.levelRequirements,

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -1,5 +1,6 @@
 import { User } from 'discord.js';
 import { Extendable, ExtendableStore, KlasaClient, KlasaUser } from 'klasa';
+import { Bank } from 'oldschooljs';
 import Monster from 'oldschooljs/dist/structures/Monster';
 import SimpleTable from 'oldschooljs/dist/structures/SimpleTable';
 
@@ -7,7 +8,7 @@ import { Activity, Emoji, Events, MAX_QP, PerkTier, Time, ZALCANO_ID } from '../
 import ClueTiers from '../../lib/minions/data/clueTiers';
 import killableMonsters, { NightmareMonster } from '../../lib/minions/data/killableMonsters';
 import { Planks } from '../../lib/minions/data/planks';
-import { GroupMonsterActivityTaskOptions } from '../../lib/minions/types';
+import { GroupMonsterActivityTaskOptions, KillableMonster } from '../../lib/minions/types';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Skills from '../../lib/skilling/skills';
 import Agility from '../../lib/skilling/skills/agility';
@@ -760,5 +761,30 @@ export default class extends Extendable {
 			UserSettings.CreatureScores,
 			addItemToBank(currentCreatureScores, creatureID, amountToAdd)
 		);
+	}
+
+	public resolveAvailableItemBoosts(this: User, monster: KillableMonster) {
+		const boosts = new Bank();
+		if (monster.itemInBankBoosts) {
+			for (const boostSet of monster.itemInBankBoosts) {
+				let highestBoostAmount = null;
+				let highestBoostItem = null;
+
+				// find the highest boost that the player has
+				for (const [itemID, boostAmount] of Object.entries(boostSet)) {
+					const parsedId = parseInt(itemID);
+					if (!this.hasItemEquippedOrInBank(parsedId)) continue;
+					if (!highestBoostAmount || boostAmount > highestBoostAmount) {
+						highestBoostAmount = boostAmount;
+						highestBoostItem = parsedId;
+					}
+				}
+
+				if (highestBoostAmount && highestBoostItem) {
+					boosts.add(highestBoostItem, highestBoostAmount);
+				}
+			}
+		}
+		return boosts.bank;
 	}
 }

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -767,14 +767,14 @@ export default class extends Extendable {
 		const boosts = new Bank();
 		if (monster.itemInBankBoosts) {
 			for (const boostSet of monster.itemInBankBoosts) {
-				let highestBoostAmount = null;
-				let highestBoostItem = null;
+				let highestBoostAmount = 0;
+				let highestBoostItem = 0;
 
 				// find the highest boost that the player has
 				for (const [itemID, boostAmount] of Object.entries(boostSet)) {
 					const parsedId = parseInt(itemID);
 					if (!this.hasItemEquippedOrInBank(parsedId)) continue;
-					if (!highestBoostAmount || boostAmount > highestBoostAmount) {
+					if (boostAmount > highestBoostAmount) {
 						highestBoostAmount = boostAmount;
 						highestBoostItem = parsedId;
 					}

--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -19,9 +19,11 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 7,
 		notifyDrops: resolveItems(['Pet general graardor']),
 		qpRequired: 75,
-		itemInBankBoosts: {
-			[itemID('Dragon warhammer')]: 10
-		},
+		itemInBankBoosts: [
+			{
+				[itemID('Dragon warhammer')]: 10
+			}
+		],
 		groupKillable: true,
 		respawnTime: Time.Minute * 1.5,
 		levelRequirements: {
@@ -41,15 +43,15 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 7,
 		notifyDrops: resolveItems(['Pet zilyana']),
 		qpRequired: 75,
-		exclusiveItemInBankBoosts: [
+		itemInBankBoosts: [
 			{
 				[itemID('Ranger boots')]: 5,
 				[itemID('Pegasian boots')]: 7
+			},
+			{
+				[itemID('Armadyl crossbow')]: 5
 			}
 		],
-		itemInBankBoosts: {
-			[itemID('Armadyl crossbow')]: 5
-		},
 		groupKillable: true,
 		respawnTime: Time.Minute * 1.5,
 		levelRequirements: {
@@ -74,9 +76,11 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 7,
 		notifyDrops: resolveItems(["Pet kree'arra"]),
 		qpRequired: 75,
-		itemInBankBoosts: {
-			[itemID('Armadyl crossbow')]: 5
-		},
+		itemInBankBoosts: [
+			{
+				[itemID('Armadyl crossbow')]: 5
+			}
+		],
 		groupKillable: true,
 		respawnTime: Time.Minute * 1.5,
 		levelRequirements: {
@@ -100,9 +104,11 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 7,
 		notifyDrops: resolveItems(["Pet k'ril tsutsaroth"]),
 		qpRequired: 75,
-		itemInBankBoosts: {
-			[itemID('Dragon warhammer')]: 10
-		},
+		itemInBankBoosts: [
+			{
+				[itemID('Dragon warhammer')]: 10
+			}
+		],
 		groupKillable: true,
 		respawnTime: Time.Minute * 1.5,
 		levelRequirements: {

--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -41,8 +41,13 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 7,
 		notifyDrops: resolveItems(['Pet zilyana']),
 		qpRequired: 75,
+		exclusiveItemInBankBoosts: [
+			{
+				[itemID('Ranger boots')]: 5,
+				[itemID('Pegasian boots')]: 7
+			}
+		],
 		itemInBankBoosts: {
-			[itemID('Ranger boots')]: 5,
 			[itemID('Armadyl crossbow')]: 5
 		},
 		groupKillable: true,

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -26,10 +26,14 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Baby mole']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Barrows gloves')]: 5,
-			[itemID('Berserker ring')]: 5
-		},
+		itemInBankBoosts: [
+			{
+				[itemID('Barrows gloves')]: 5
+			},
+			{
+				[itemID('Berserker ring')]: 5
+			}
+		],
 		levelRequirements: {
 			prayer: 43
 		}
@@ -47,9 +51,11 @@ const killableBosses: KillableMonster[] = [
 		itemsRequired: resolveItems(['Armadyl chestplate', 'Armadyl chainskirt']),
 		notifyDrops: resolveItems(['Vorki', 'Jar of decay', 'Draconic visage', 'Skeletal visage']),
 		qpRequired: 205,
-		itemInBankBoosts: {
-			[itemID('Dragon warhammer')]: 10
-		},
+		itemInBankBoosts: [
+			{
+				[itemID('Dragon warhammer')]: 10
+			}
+		],
 		levelRequirements: {
 			prayer: 43
 		}
@@ -71,14 +77,16 @@ const killableBosses: KillableMonster[] = [
 			'Pet snakeling'
 		]),
 		qpRequired: 75,
-		itemInBankBoosts: {
-			[itemID('Barrows gloves')]: 5,
-			[itemID("Iban's staff")]: 2
-		},
-		exclusiveItemInBankBoosts: [
+		itemInBankBoosts: [
 			{
 				[itemID('Ranger boots')]: 5,
 				[itemID('Pegasian boots')]: 7
+			},
+			{
+				[itemID("Iban's staff")]: 2
+			},
+			{
+				[itemID('Barrows gloves')]: 5
 			}
 		],
 		levelRequirements: {
@@ -113,9 +121,11 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Jar of sand', 'Kalphite princess']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Dragon warhammer')]: 10
-		},
+		itemInBankBoosts: [
+			{
+				[itemID('Dragon warhammer')]: 10
+			}
+		],
 		levelRequirements: {
 			prayer: 43
 		},
@@ -145,10 +155,10 @@ const killableBosses: KillableMonster[] = [
 			'Pet dark core'
 		]),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Bandos godsword')]: 5,
-			[itemID('Dragon warhammer')]: 10
-		},
+		itemInBankBoosts: [
+			{ [itemID('Dragon warhammer')]: 10 },
+			{ [itemID('Bandos godsword')]: 5 }
+		],
 		groupKillable: true,
 		respawnTime: 20_000,
 		levelRequirements: {
@@ -180,11 +190,11 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Hellpuppy', 'Jar of souls']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Spectral spirit shield')]: 10,
-			[itemID('Bandos chestplate')]: 5,
-			[itemID('Bandos tassets')]: 5
-		},
+		itemInBankBoosts: [
+			{ [itemID('Spectral spirit shield')]: 10 },
+			{ [itemID('Bandos chestplate')]: 5 },
+			{ [itemID('Bandos tassets')]: 5 }
+		],
 		levelRequirements: {
 			prayer: 43
 		}

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -73,9 +73,14 @@ const killableBosses: KillableMonster[] = [
 		qpRequired: 75,
 		itemInBankBoosts: {
 			[itemID('Barrows gloves')]: 5,
-			[itemID('Ranger boots')]: 5,
 			[itemID("Iban's staff")]: 2
 		},
+		exclusiveItemInBankBoosts: [
+			{
+				[itemID('Ranger boots')]: 5,
+				[itemID('Pegasian boots')]: 7
+			}
+		],
 		levelRequirements: {
 			prayer: 43
 		},

--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -24,10 +24,7 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Callisto cub']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Barrows gloves')]: 2,
-			[itemID('Berserker ring')]: 2
-		}
+		itemInBankBoosts: [{ [itemID('Barrows gloves')]: 2 }, { [itemID('Berserker ring')]: 2 }]
 	},
 	{
 		id: Monsters.Vetion.id,
@@ -47,9 +44,7 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(["Vet'ion jr.", 'Skeleton champion scroll']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Dragon warhammer')]: 3
-		}
+		itemInBankBoosts: [{ [itemID('Dragon warhammer')]: 3 }]
 	},
 	{
 		id: Monsters.Venenatis.id,
@@ -69,9 +64,7 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Venenatis spiderling']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Barrows gloves')]: 3
-		}
+		itemInBankBoosts: [{ [itemID('Barrows gloves')]: 3 }]
 	},
 	{
 		id: Monsters.ChaosElemental.id,
@@ -89,10 +82,7 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Pet chaos elemental']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Archers ring')]: 3,
-			[itemID('Barrows gloves')]: 3
-		}
+		itemInBankBoosts: [{ [itemID('Archers ring')]: 3 }, { [itemID('Barrows gloves')]: 3 }]
 	},
 	{
 		id: Monsters.ChaosFanatic.id,
@@ -106,10 +96,10 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 6,
 		notifyDrops: resolveItems(['Pet chaos elemental']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID("Karil's leathertop")]: 3,
-			[itemID("Karil's leatherskirt")]: 3
-		}
+		itemInBankBoosts: [
+			{ [itemID("Karil's leathertop")]: 3 },
+			{ [itemID("Karil's leatherskirt")]: 3 }
+		]
 	},
 	{
 		id: Monsters.CrazyArchaeologist.id,
@@ -122,9 +112,7 @@ const killableBosses: KillableMonster[] = [
 		canBeKilled: true,
 		difficultyRating: 6,
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Occult necklace')]: 10
-		}
+		itemInBankBoosts: [{ [itemID('Occult necklace')]: 10 }]
 	},
 	{
 		id: Monsters.KingBlackDragon.id,
@@ -154,9 +142,7 @@ const killableBosses: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Prince black dragon', 'Draconic visage']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Armadyl crossbow')]: 10
-		}
+		itemInBankBoosts: [{ [itemID('Armadyl crossbow')]: 10 }]
 	},
 	{
 		id: Monsters.Scorpia.id,
@@ -170,9 +156,7 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 8,
 		notifyDrops: resolveItems(["Scorpia's offspring"]),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Occult necklace')]: 10
-		}
+		itemInBankBoosts: [{ [itemID('Occult necklace')]: 10 }]
 	}
 ];
 

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -24,11 +24,11 @@ const killableMonsters: KillableMonster[] = [
 		itemsRequired: resolveItems([]),
 		notifyDrops: resolveItems([]),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Barrows gloves')]: 2,
-			[itemID("Iban's staff")]: 5,
-			[itemID('Strange old lockpick')]: 7
-		},
+		itemInBankBoosts: [
+			{ [itemID('Barrows gloves')]: 2 },
+			{ [itemID("Iban's staff")]: 5 },
+			{ [itemID('Strange old lockpick')]: 7 }
+		],
 		levelRequirements: {
 			prayer: 43
 		},
@@ -60,10 +60,10 @@ const killableMonsters: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Pet dagannoth prime']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Armadyl chestplate')]: 2,
-			[itemID('Armadyl chainskirt')]: 2
-		},
+		itemInBankBoosts: [
+			{ [itemID('Armadyl chestplate')]: 2 },
+			{ [itemID('Armadyl chainskirt')]: 2 }
+		],
 		levelRequirements: {
 			prayer: 43
 		}
@@ -88,10 +88,7 @@ const killableMonsters: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Pet dagannoth rex']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Occult necklace')]: 5,
-			[itemID("Iban's staff")]: 5
-		},
+		itemInBankBoosts: [{ [itemID('Occult necklace')]: 5 }, { [itemID("Iban's staff")]: 5 }],
 		levelRequirements: {
 			prayer: 43
 		}
@@ -116,11 +113,11 @@ const killableMonsters: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Pet dagannoth supreme']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Bandos chestplate')]: 2,
-			[itemID('Bandos tassets')]: 2,
-			[itemID('Saradomin godsword')]: 2
-		},
+		itemInBankBoosts: [
+			{ [itemID('Bandos chestplate')]: 2 },
+			{ [itemID('Bandos tassets')]: 2 },
+			{ [itemID('Saradomin godsword')]: 2 }
+		],
 		levelRequirements: {
 			prayer: 43
 		}
@@ -189,9 +186,7 @@ const killableMonsters: KillableMonster[] = [
 		]),
 		notifyDrops: resolveItems(['Dragon warhammer']),
 		qpRequired: 30,
-		itemInBankBoosts: {
-			[itemID('Ring of the gods')]: 3
-		},
+		itemInBankBoosts: [{ [itemID('Ring of the gods')]: 3 }],
 		levelRequirements: {
 			prayer: 43
 		}
@@ -295,9 +290,7 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 0,
 		itemsRequired: resolveItems(['Anti-dragon shield']),
 		qpRequired: 0,
-		itemInBankBoosts: {
-			[itemID('Zamorakian spear')]: 10
-		}
+		itemInBankBoosts: [{ [itemID('Zamorakian spear')]: 10 }]
 	},
 	{
 		id: Monsters.Ankou.id,

--- a/src/lib/minions/functions/reducedTimeForGroup.ts
+++ b/src/lib/minions/functions/reducedTimeForGroup.ts
@@ -27,19 +27,20 @@ export default async function reducedTimeForGroup(
 	}
 
 	for (let i = 0; i < users.length; i++) {
-		const userKc = users[i].settings.get(UserSettings.MonsterScores)[monster.id] ?? 1;
+		const user = users[i];
+		const userKc = user.settings.get(UserSettings.MonsterScores)[monster.id] ?? 1;
 		const [, userKcReduction] = reducedTimeFromKC(monster, userKc);
 		let userItemBoost = 0;
-		if (monster.itemInBankBoosts) {
-			for (const [itemID, boostAmount] of Object.entries(monster.itemInBankBoosts)) {
-				if (!users[i].hasItemEquippedOrInBank(parseInt(itemID))) continue;
-				userItemBoost += boostAmount;
-			}
+		for (const [itemID, boostAmount] of Object.entries(
+			user.resolveAvailableItemBoosts(monster)
+		)) {
+			if (!user.hasItemEquippedOrInBank(parseInt(itemID))) continue;
+			userItemBoost += boostAmount;
 		}
 		// 1 per user, i/15 for incentive to group (more people compounding i bonus), then add the users kc and item boost percent
 		let multiplier = 1 + i / 15 + userKcReduction / 100 + userItemBoost / 100;
 		reductionMultiplier += multiplier;
-		messages.push(`${multiplier.toFixed(2)}x bonus from ${users[i].username}`);
+		messages.push(`${multiplier.toFixed(2)}x bonus from ${user.username}`);
 	}
 
 	return [

--- a/src/lib/minions/functions/reducedTimeForGroup.ts
+++ b/src/lib/minions/functions/reducedTimeForGroup.ts
@@ -31,10 +31,7 @@ export default async function reducedTimeForGroup(
 		const userKc = user.settings.get(UserSettings.MonsterScores)[monster.id] ?? 1;
 		const [, userKcReduction] = reducedTimeFromKC(monster, userKc);
 		let userItemBoost = 0;
-		for (const [itemID, boostAmount] of Object.entries(
-			user.resolveAvailableItemBoosts(monster)
-		)) {
-			if (!user.hasItemEquippedOrInBank(parseInt(itemID))) continue;
+		for (const [, boostAmount] of Object.entries(user.resolveAvailableItemBoosts(monster))) {
 			userItemBoost += boostAmount;
 		}
 		// 1 per user, i/15 for incentive to group (more people compounding i bonus), then add the users kc and item boost percent

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -65,6 +65,12 @@ export interface KillableMonster {
 	 */
 	itemInBankBoosts?: ItemBank;
 	/**
+	 * An array of objects of ([key: itemID]: boostPercentage) boosts that apply to
+	 * this monster. For each set, only the item with the greatest boost (that the user also possesses)
+	 * will be used as boost.
+	 */
+	exclusiveItemInBankBoosts?: ItemBank[];
+	/**
 	 * Whether or not this monster can be groupkilled.
 	 */
 	groupKillable?: true;

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -60,16 +60,11 @@ export interface KillableMonster {
 	qpRequired: number;
 
 	/**
-	 * A object of ([key: itemID]: boostPercentage) boosts that apply to
-	 * this monster.
-	 */
-	itemInBankBoosts?: ItemBank;
-	/**
 	 * An array of objects of ([key: itemID]: boostPercentage) boosts that apply to
 	 * this monster. For each set, only the item with the greatest boost (that the user also possesses)
 	 * will be used as boost.
 	 */
-	exclusiveItemInBankBoosts?: ItemBank[];
+	itemInBankBoosts?: ItemBank[];
 	/**
 	 * Whether or not this monster can be groupkilled.
 	 */

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -206,6 +206,11 @@ declare module 'discord.js' {
 		bank(options?: GetUserBankOptions): Bank;
 		getPOH(): Promise<PoHTable>;
 		getGear(gearType: GearSetupType): GearSetup;
+
+		/**
+		 * Get item boosts the user has available for the given `KillableMonster`.
+		 */
+		resolveAvailableItemBoosts(monster: KillableMonster): ItemBank;
 		perkTier: PerkTier;
 		/**
 		 * Returns this users Collection Log bank.

--- a/src/lib/util/formatItemBoosts.ts
+++ b/src/lib/util/formatItemBoosts.ts
@@ -1,10 +1,22 @@
 import { ItemBank } from '../types';
 import { itemNameFromID } from '../util';
 
-export function formatItemBoosts(items: ItemBank) {
+export function formatItemBoosts(items: ItemBank[]) {
 	const str = [];
-	for (const [itemID, boostAmount] of Object.entries(items)) {
-		str.push(`${boostAmount}% for ${itemNameFromID(parseInt(itemID))}`);
+	for (const itemSet of items) {
+		const itemEntries = Object.entries(itemSet);
+		const multiple = itemEntries.length > 1;
+		const bonusStr = [];
+
+		for (const [itemID, boostAmount] of itemEntries) {
+			bonusStr.push(`${boostAmount}% for ${itemNameFromID(parseInt(itemID))}`);
+		}
+
+		if (multiple) {
+			str.push(`(${bonusStr.join(' OR ')})`);
+		} else {
+			str.push(bonusStr.join(''));
+		}
 	}
 	return str.join(', ');
 }


### PR DESCRIPTION
### Description:

Adds a new type of item boosts: exclusive
- Picks the best item boost from a subset, i.e. pick pegasian boots over ranger boots, but not both.

### Changes:

- Pegasian boots now have +7% boost in the same places ranger boots have a boost
- Moved all monster item boosts to new system
  - No other boosts have been introduced, except for Pegasians
- Reformatted `+monster` slightly to show the boost exclusivity.
- Added `Minion#resolveAvailableItemBoosts` which returns all boosts the user currently has in respect to the given monster.
  - Respects item boost exclusivity

### Other checks:

-   [x] I have tested all my changes thoroughly.
  - Also tested with multiple 'boost sets', i.e. armadyl crossbow / dragon crossbow, where ACB is picked over DCB (due to having higher boost)

![sdf](https://media.discordapp.net/attachments/648196527294251020/813129715673858048/unknown.png)
![sdf](https://i.imgur.com/dleiIv1.png)