### PR TITLE
Bank value filter

### DIFF
--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -31,7 +31,8 @@ export default class extends BotCommand {
 			);
 		}
 
-		const bank = parseBank({
+		const bank = await parseBank({
+			client: this.client,
 			inputBank: baseBank,
 			flags: msg.flagArgs,
 			inputStr: typeof pageNumberOrItemName === 'string' ? pageNumberOrItemName : undefined

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -117,7 +117,8 @@ export async function parseBank({
 	const filter = filterableTypes.find(type =>
 		type.aliases.some(alias => flagsKeys.includes(alias))
 	);
-	const [valueFilter, valueTarget] = parseFilterAndTarget(flags.value);
+	const [priceFilter, priceTarget] = parseFilterAndTarget(flags.price);
+	const [stackPriceFilter, stackPriceTarget] = parseFilterAndTarget(flags.stackprice);
 	const [quantityFilter, quantityTarget] = parseFilterAndTarget(flags.quantity);
 
 	const outputBank = new Bank();
@@ -130,13 +131,13 @@ export async function parseBank({
 			continue;
 		}
 		if (
-			valueFilter !== null &&
-			valueTarget !== null &&
+			priceFilter !== null &&
+			priceTarget !== null &&
 			client &&
 			!satisfiesQuantitativeFilter(
 				await client.fetchItemPrice(item.id),
-				valueFilter,
-				valueTarget
+				priceFilter,
+				priceTarget
 			)
 		) {
 			continue;
@@ -150,6 +151,20 @@ export async function parseBank({
 		}
 
 		const qty = _qty === 0 ? Math.max(1, inputBank.amount(item.id)) : _qty;
+
+		if (
+			stackPriceFilter !== null &&
+			stackPriceTarget !== null &&
+			client &&
+			!satisfiesQuantitativeFilter(
+				(await client.fetchItemPrice(item.id)) * qty,
+				stackPriceFilter,
+				stackPriceTarget
+			)
+		) {
+			continue;
+		}
+
 		if (filter && !filter.items.includes(item.id)) continue;
 
 		if (inputBank.amount(item.id) < qty) continue;


### PR DESCRIPTION
### Description:

Adds `quantity`, `price` and `stackprice` filters to `+bank`.
These can also be used in conjunction with greater than/less than operators, i.e. `+b --quantity=<5`

### Changes:

- Made `parseBank` async in order to retrieve item prices
  - Add KlasaClient as arg to `parseBank`
- Code for parsing and evaluating equality operations
  - Parses k/m/b
- Unit test parsing and evaluation, as well as quantity filters

### Other checks:

-   [x] I have tested all my changes thoroughly.

Note:
This likely isn't done, just wanted to raise it so I wouldn't forget and get feedback whilst I work on other stuff.

![sdf](https://i.imgur.com/67DAlUc.png)
![sdf](https://i.imgur.com/MgOwaKh.png)
