### PR TITLE
Fix Onyx Amulet Enchant Level

### DIFF
--- a/src/lib/skilling/skills/magic/enchantables.ts
+++ b/src/lib/skilling/skills/magic/enchantables.ts
@@ -83,7 +83,7 @@ const jewelery: Enchantable[] = [
 			.add('Fire rune', 20),
 		output: new Bank().add('Amulet of fury'),
 		xp: 97,
-		level: 82
+		level: 87
 	},
 	{
 		name: 'Onyx ring',


### PR DESCRIPTION
Change the required magic level to enchant an onyx amulet from 82 to 87

Resolves #1748 