### PR TITLE
qol changes

### DIFF
--- a/src/commands/Minion/soulwars.ts
+++ b/src/commands/Minion/soulwars.ts
@@ -45,6 +45,11 @@ const imbueables = [
 		tokens: 300
 	},
 	{
+		input: getOSItem('Ring of suffering (r)'),
+		output: getOSItem('Ring of suffering (ri)'),
+		tokens: 300
+	},
+	{
 		input: getOSItem('Berserker ring'),
 		output: getOSItem('Berserker ring (i)'),
 		tokens: 260

--- a/src/commands/OSRS_Fun/finish.ts
+++ b/src/commands/OSRS_Fun/finish.ts
@@ -941,8 +941,9 @@ ${lootMSG.join('\n')}`);
 				let arcKC = -1;
 				let specKC = -1;
 				let petKC = -1;
+				let jarKC = -1;
 				const lootMSG = [];
-				while (loot.length < 4) {
+				while (loot.length < 5) {
 					kc++;
 					if (roll(5000)) {
 						if (!loot.includes('PET')) {
@@ -953,6 +954,17 @@ ${lootMSG.join('\n')}`);
 							);
 						} else {
 							duplicates.push('<:Pet_dark_core:324127377347313674>');
+						}
+					}
+					if (roll(1000)) {
+						if (!loot.includes('JAR')) {
+							loot.push('JAR');
+							jarKC = kc;
+							lootMSG.push(
+								`**Pet Jar of Spirits:** ${jarKC.toLocaleString()} KC <:jarOfSpirits:838735098894614548>`
+							);
+						} else {
+							duplicates.push('<:jarOfSpirits:838735098894614548>');
 						}
 					}
 					if (roll(585)) {

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -534,7 +534,7 @@ export default class extends Extendable {
 					data.challengeMode ? ' in Challenge Mode' : ''
 				}, ${
 					data.users.length === 1
-						? 'as a solo'
+						? 'as a solo.'
 						: `with a team of ${data.users.length} minions.`
 				} ${formattedDuration}`;
 			}

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -686,6 +686,14 @@ const Buyables: Buyable[] = [
 			strength: 65
 		}
 	},
+	{
+		name: 'Torstol',
+		outputItems: resolveNameBank({
+			'Torstol': 1
+		}),
+		itemCost: resolveNameBank({ 'Torstol potion (unf)': 1 })
+		
+	},
 	...sepulchreBuyables,
 	...constructionBuyables,
 	...hunterBuyables,

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -689,10 +689,9 @@ const Buyables: Buyable[] = [
 	{
 		name: 'Torstol',
 		outputItems: resolveNameBank({
-			'Torstol': 1
+			Torstol: 1
 		}),
 		itemCost: resolveNameBank({ 'Torstol potion (unf)': 1 })
-		
 	},
 	...sepulchreBuyables,
 	...constructionBuyables,

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -22,7 +22,7 @@ const twistedAncestral: Createable[] = [
 			[itemID('Twisted ancestral colour kit')]: 1
 		},
 		outputItems: {
-			[itemID('Crystal pickaxe')]: 1
+			[itemID('Twisted ancestral hat')]: 1
 		}
 	},
 	{
@@ -32,7 +32,7 @@ const twistedAncestral: Createable[] = [
 			[itemID('Twisted ancestral colour kit')]: 1
 		},
 		outputItems: {
-			[itemID('Crystal pickaxe')]: 1
+			[itemID('Twisted ancestral robe top')]: 1
 		}
 	},
 	{
@@ -1349,6 +1349,26 @@ const Createables: Createable[] = [
 		},
 		outputItems: {
 			[itemID('Kodai wand')]: 1
+		}
+	},
+	{
+		name: 'Partyhat & specs',
+		inputItems: {
+			[itemID('Blue partyhat')]: 1,
+			[itemID('Sagacious spectacles')]: 1
+		},
+		outputItems: {
+			[itemID('Partyhat & specs')]: 1
+		}
+	},
+	{
+		name: 'Blue partyhat',
+		inputItems: {
+			[itemID('Partyhat & specs')]: 1
+		},
+		outputItems: {
+			[itemID('Blue partyhat')]: 1,
+			[itemID('Sagacious spectacles')]: 1
 		}
 	},
 	...crystalTools,

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -184,7 +184,7 @@ const killableBosses: KillableMonster[] = [
 		itemsRequired: deepResolveItems([
 			["Torag's platebody", "Dharok's platebody", 'Bandos chestplate'],
 			["Torag's platelegs", "Dharok's platelegs", 'Bandos tassets'],
-			'Zamorakian spear'
+			['Zamorakian spear','Zamorakian hasta']
 		]),
 		notifyDrops: resolveItems(['Hellpuppy', 'Jar of souls']),
 		qpRequired: 0,

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -184,7 +184,7 @@ const killableBosses: KillableMonster[] = [
 		itemsRequired: deepResolveItems([
 			["Torag's platebody", "Dharok's platebody", 'Bandos chestplate'],
 			["Torag's platelegs", "Dharok's platelegs", 'Bandos tassets'],
-			['Zamorakian spear','Zamorakian hasta']
+			['Zamorakian spear', 'Zamorakian hasta']
 		]),
 		notifyDrops: resolveItems(['Hellpuppy', 'Jar of souls']),
 		qpRequired: 0,

--- a/src/tasks/minions/herbloreActivity.ts
+++ b/src/tasks/minions/herbloreActivity.ts
@@ -12,7 +12,7 @@ export default class extends Task {
 
 		const mixableItem = Herblore.Mixables.find(mixable => mixable.id === mixableID)!;
 
-		const xpReceived = zahur ? 0 : quantity * mixableItem.xp;
+		const xpReceived = zahur && mixableItem.zahur === true ? 0 : quantity * mixableItem.xp;
 
 		if (mixableItem.outputMultiple) {
 			quantity *= mixableItem.outputMultiple;

--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -140,9 +140,9 @@ export default class extends Task {
 
 		if (!channelIsSendable(channel)) return;
 
-		let output = `${user} ${
+		let output = `${user}, ${
 			user.minionName
-		} finished subdueing Wintertodt ${quantity}x times. You got ${fmXpToGive.toLocaleString()} Firemaking XP, ${wcXpToGive.toLocaleString()} Woodcutting XP and ${conXP.toLocaleString()} Construction XP, you cut ${numberOfRoots}x Bruma roots.`;
+		} finished subduing Wintertodt ${quantity}x times. You got ${fmXpToGive.toLocaleString()} Firemaking XP, ${wcXpToGive.toLocaleString()} Woodcutting XP and ${conXP.toLocaleString()} Construction XP, you cut ${numberOfRoots}x Bruma roots.`;
 
 		if (fmBonusXP > 0) {
 			output += `\n\n**Firemaking Bonus XP:** ${fmBonusXP.toLocaleString()}`;


### PR DESCRIPTION


### Description:

<!-- What did you change? Describe it here. -->

add ring of suffering (r ) to imbue at soulwars
add Jar of spirits to +finish corp
add a (.) to the cox message (for mylife)
made it so if you decant torstol into unf you can reverse it back to clean torstol with "+buy torstol"
added phat and specs to creatables
add zammy hasta to weapons that count at cerb
fixed bug with twisted kits upgrading giving crystal pickaxe
fixed bug when using --zahur on regular potions on accident not giving xp
fixed typo in wintertodt

closes following issues
1540
1572
797
1451
1415
1235 - was bugged and gave c pick
1160
1128

-   [ x] I have tested all my changes thoroughly.
