### PR TITLE
Added Harm boost to Scorpia

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -187,7 +187,8 @@ const killableBosses: KillableMonster[] = [
 		notifyDrops: resolveItems(["Scorpia's offspring"]),
 		qpRequired: 0,
 		itemInBankBoosts: {
-			[itemID('Occult necklace')]: 10
+			[itemID('Occult necklace')]: 5,
+			[itemID('Harmonised nightmare staff')]: 10
 		},
 		defaultAttackStyles: [SkillsEnum.Magic],
 		combatXpMultiplier: 1.3


### PR DESCRIPTION
Added harm 10% boost to scorpia,
changed occult boost from 10 to 5% as this was a bit high in comparison to the dps increase a harm gives