### PR TITLE
Cox qol changes

### DIFF
--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -39,7 +39,7 @@ const uniques = [
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '[mass|solo]',
+			usage: '[mass|solo|gear]',
 			usageDelim: ' ',
 			oneAtTime: true,
 			altProtection: true,
@@ -51,7 +51,7 @@ export default class extends BotCommand {
 
 	async run(msg: KlasaMessage, [type]: [string | undefined]) {
 		if (msg.flagArgs.simulate) {
-			const arr = Array(20).fill(msg.author);
+			const arr = Array(15).fill(msg.author);
 			const normalTable = table([
 				[
 					'Team Size',
@@ -63,7 +63,7 @@ export default class extends BotCommand {
 					'Death Chance - Normal'
 				],
 				...(await Promise.all(
-					[1, 2, 3, 4, 5, 6, 7, 8, 9, 20].map(async i => {
+					[1, 2, 3, 4, 5, 6, 7, 8, 9, 15].map(async i => {
 						let ar = arr.slice(0, i);
 						return [
 							ar.length,
@@ -91,10 +91,27 @@ export default class extends BotCommand {
 				totalUniques += cl.amount(item);
 			}
 			const totalPoints = msg.author.settings.get(UserSettings.TotalCoxPoints);
+			const { total } = calculateUserGearPercents(msg.author);
+			const normalSolo = await calcCoxDuration([msg.author], false);
+			const normalTeam = await calcCoxDuration(Array(2).fill(msg.author), false);
+			const cmSolo = await calcCoxDuration([msg.author], true);
+			const cmTeam = await calcCoxDuration(Array(2).fill(msg.author), true);
 			return msg.channel
 				.send(`<:Twisted_bow:403018312402862081> Chamber's of Xeric <:Olmlet:324127376873357316>
-**Normal:** ${normal} KC
-**Challenge Mode:** ${cm} KC
+**Normal:** ${normal} KC (Solo ${Emoji.CombatSword} ${calcWhatPercent(
+				normalSolo.reductions[msg.author.id],
+				normalSolo.totalReduction
+			).toFixed(1)}%, Team ${Emoji.CombatSword} ${calcWhatPercent(
+				normalTeam.reductions[msg.author.id],
+				normalTeam.totalReduction
+			).toFixed(1)})
+**Challenge Mode:** ${cm} KC (Solo ${Emoji.CombatSword} ${calcWhatPercent(
+				cmSolo.reductions[msg.author.id],
+				cmSolo.totalReduction
+			).toFixed(1)}%, Team ${Emoji.CombatSword} ${calcWhatPercent(
+				cmTeam.reductions[msg.author.id],
+				cmTeam.totalReduction
+			).toFixed(1)})
 **Total Points:** ${totalPoints}
 **Total Uniques:** ${totalUniques} ${
 				totalUniques > 0
@@ -102,7 +119,19 @@ export default class extends BotCommand {
 							totalPoints / totalUniques
 					  ).toLocaleString()} pts)`
 					: ''
-			}`);
+			}
+**Gear Score:** ${Emoji.Gear}${total.toFixed(1)}%`);
+		}
+
+		if (type === 'gear') {
+			const { melee, range, mage, total } = calculateUserGearPercents(msg.author);
+			return msg.channel
+				.send(`**Melee Gear Score:** <:Elder_maul:403018312247803906> ${melee.toFixed(1)}%
+**Range Gear Score:** <:Twisted_bow:403018312402862081> ${range.toFixed(1)}%
+**Mage Gear Score:** <:Kodai_insignia:403018312264712193> ${mage.toFixed(1)}%
+**Total Gear Score:** ${Emoji.Gear} ${total.toFixed(1)}%
+**Death Chance Solo:** ${Emoji.Skull} ${(await createTeam([msg.author], false))[0].deathChance.toFixed(1)}%, CM ${Emoji.Skull} ${(await createTeam([msg.author], true))[0].deathChance.toFixed(1)}%
+**Death Chance Team:** ${Emoji.Skull} ${(await createTeam(Array(2).fill(msg.author), false))[0].deathChance.toFixed(1)}%, CM ${Emoji.Skull} ${(await createTeam(Array(2).fill(msg.author), true))[0].deathChance.toFixed(1)}%`);
 		}
 
 		if (type !== 'mass' && type !== 'solo') {

--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -130,8 +130,16 @@ export default class extends BotCommand {
 **Range Gear Score:** <:Twisted_bow:403018312402862081> ${range.toFixed(1)}%
 **Mage Gear Score:** <:Kodai_insignia:403018312264712193> ${mage.toFixed(1)}%
 **Total Gear Score:** ${Emoji.Gear} ${total.toFixed(1)}%
-**Death Chance Solo:** ${Emoji.Skull} ${(await createTeam([msg.author], false))[0].deathChance.toFixed(1)}%, CM ${Emoji.Skull} ${(await createTeam([msg.author], true))[0].deathChance.toFixed(1)}%
-**Death Chance Team:** ${Emoji.Skull} ${(await createTeam(Array(2).fill(msg.author), false))[0].deathChance.toFixed(1)}%, CM ${Emoji.Skull} ${(await createTeam(Array(2).fill(msg.author), true))[0].deathChance.toFixed(1)}%`);
+**Death Chance Solo:** ${Emoji.Skull} ${(
+				await createTeam([msg.author], false)
+			)[0].deathChance.toFixed(1)}%, CM ${Emoji.Skull} ${(
+				await createTeam([msg.author], true)
+			)[0].deathChance.toFixed(1)}%
+**Death Chance Team:** ${Emoji.Skull} ${(
+				await createTeam(Array(2).fill(msg.author), false)
+			)[0].deathChance.toFixed(1)}%, CM ${Emoji.Skull} ${(
+				await createTeam(Array(2).fill(msg.author), true)
+			)[0].deathChance.toFixed(1)}%`);
 		}
 
 		if (type !== 'mass' && type !== 'solo') {

--- a/src/commands/Testing/setkc.ts
+++ b/src/commands/Testing/setkc.ts
@@ -15,7 +15,9 @@ export default class extends BotCommand {
 
 	async run(msg: KlasaMessage, [kc]: [number]) {
 		const entity = await getMinigameEntity(msg.author.id);
+		if(!msg.flagArgs.cm) {
 		entity.Raids = kc;
+		}
 		entity.RaidsChallengeMode = kc;
 		await entity.save();
 

--- a/src/commands/Testing/setkc.ts
+++ b/src/commands/Testing/setkc.ts
@@ -15,8 +15,8 @@ export default class extends BotCommand {
 
 	async run(msg: KlasaMessage, [kc]: [number]) {
 		const entity = await getMinigameEntity(msg.author.id);
-		if(!msg.flagArgs.cm) {
-		entity.Raids = kc;
+		if (!msg.flagArgs.cm) {
+			entity.Raids = kc;
 		}
 		entity.RaidsChallengeMode = kc;
 		await entity.save();

--- a/src/commands/Utility/checkmasses.ts
+++ b/src/commands/Utility/checkmasses.ts
@@ -40,9 +40,11 @@ export default class extends BotCommand {
 		const massStr = masses
 			.map(
 				m =>
-					`${m.type}${m.data.challengeMode?` CM`:``}: ${m.data.users.length} users returning to <#${
-						m.channel_id
-					}> in ${formatDuration(m.finish_date.getTime() - now)}`
+					`${m.type}${m.data.challengeMode ? ` CM` : ``}: ${
+						m.data.users.length
+					} users returning to <#${m.channel_id}> in ${formatDuration(
+						m.finish_date.getTime() - now
+					)}`
 			)
 			.join('\n');
 		return msg.channel.send(`**Masses in this server:**

--- a/src/commands/Utility/checkmasses.ts
+++ b/src/commands/Utility/checkmasses.ts
@@ -18,17 +18,20 @@ export default class extends BotCommand {
 		if (!msg.guild) return null;
 		const channelIDs = msg.guild.channels.filter(c => c.type === 'text').map(c => c.id);
 
-		const masses: any[] = await getConnection().query(
+		let masses: any[] = await getConnection().query(
 			`
-SELECT *
-FROM activity
-WHERE
-completed = false AND 
-group_activity = true AND
-channel_id = ANY($1);
+	SELECT *
+	FROM activity
+	WHERE
+	completed = false AND
+	group_activity = true AND
+	channel_id = ANY($1)
+	ORDER by finish_date ASC;
 `,
 			[channelIDs]
 		);
+
+		masses = masses.filter(m => m.data.users.length > 1);
 
 		if (masses.length === 0) {
 			return msg.channel.send(`There are no active masses in this server.`);
@@ -37,7 +40,7 @@ channel_id = ANY($1);
 		const massStr = masses
 			.map(
 				m =>
-					`${m.type}: ${m.data.users.length} users returning to <#${
+					`${m.type}${m.data.challengeMode?` CM`:``}: ${m.data.users.length} users returning to <#${
 						m.channel_id
 					}> in ${formatDuration(m.finish_date.getTime() - now)}`
 			)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -89,6 +89,8 @@ export const enum Emoji {
 	Tangleroot = '<:tangleroot:324127378978635778>',
 	Herblore = '<:herblore:630911040535658496>',
 	Purple = '🟪',
+	Green = '🟩',
+	Blue = '🟦',
 	Thieving = '<:thieving:630910829352452123>',
 	Hunter = '<:hunter:630911040166559784>',
 	Ely = '<:ely:784453586033049630>',

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -67,7 +67,7 @@ export async function createTeam(
 
 		const kc = await u.getMinigameScore(cm ? 'RaidsChallengeMode' : 'Raids');
 		const kcChange = kcPointsEffect(kc);
-		if (kcChange < 0) points = reduceNumByPercent(points, kcChange);
+		if (kcChange < 0) points = reduceNumByPercent(points, Math.abs(kcChange));
 		else points = increaseNumByPercent(points, kcChange);
 
 		const kcPercent = Math.min(100, calcWhatPercent(kc, 100));
@@ -101,7 +101,7 @@ export async function createTeam(
 		}
 
 		points = Math.floor(randomVariation(points, 5));
-		if (points < 1 || points > 50_000) {
+		if (points < 1 || points > 60_000) {
 			captureMessage(`${u.username} had ${points} points in a team of ${users.length}.`);
 			points = 10_000;
 		}
@@ -110,8 +110,8 @@ export async function createTeam(
 		res.push({
 			id: u.id,
 			personalPoints: points,
-			canReceiveAncientTablet: bank.has('Ancient tablet'),
-			canReceiveDust: bank.has('Metamorphic dust'),
+			canReceiveAncientTablet: !bank.has('Ancient tablet'),
+			canReceiveDust: true,
 			deaths,
 			deathChance
 		});
@@ -122,15 +122,32 @@ export async function createTeam(
 function calcSetupPercent(
 	maxStats: GearStats,
 	userStats: GearStats,
-	heavyPenalizeStat: keyof GearStats
+	heavyPenalizeStat: keyof GearStats,
+	ignoreStats: (keyof GearStats)[],
+	melee: boolean
 ) {
-	let numKeys = Object.values(maxStats).filter(i => i > 0).length;
+	let numKeys = 0;
 	let totalPercent = 0;
 	for (const [key, val] of Object.entries(maxStats) as [keyof GearStats, number][]) {
-		if (val <= 0) continue;
+		if (val <= 0 || ignoreStats.includes(key)) continue;
 		const rawPercent = Math.min(100, calcWhatPercent(userStats[key], val));
-		totalPercent += rawPercent / numKeys;
+		totalPercent += rawPercent;
+		numKeys++;
 	}
+	// For melee compare the highest melee attack stat of max setup with the highest melee attack stat of the user
+	if (melee) {
+		let maxMeleeStat = Math.max(
+			maxStats['attack_stab'],
+			Math.max(maxStats['attack_slash'], maxStats['attack_crush'])
+		);
+		let userMeleeStat = Math.max(
+			userStats['attack_stab'],
+			Math.max(userStats['attack_slash'], userStats['attack_crush'])
+		);
+		totalPercent += Math.min(100, calcWhatPercent(userMeleeStat, maxMeleeStat));
+		numKeys++;
+	}
+	totalPercent /= numKeys;
 	// Heavy penalize for having less than 50% in the main stat of this setup.
 	if (userStats[heavyPenalizeStat] < maxStats[heavyPenalizeStat] / 2) {
 		totalPercent = Math.floor(Math.max(0, totalPercent / 2));
@@ -184,17 +201,23 @@ export function calculateUserGearPercents(user: KlasaUser) {
 	const melee = calcSetupPercent(
 		maxMeleeSum,
 		sumOfSetupStats(user.getGear('melee')),
-		'melee_strength'
+		'melee_strength',
+		['attack_stab', 'attack_slash', 'attack_crush', 'attack_ranged', 'attack_magic'],
+		true
 	);
 	const range = calcSetupPercent(
 		maxRangeSum,
 		sumOfSetupStats(user.getGear('range')),
-		'ranged_strength'
+		'ranged_strength',
+		['attack_stab', 'attack_slash', 'attack_crush', 'attack_magic'],
+		false
 	);
 	const mage = calcSetupPercent(
 		maxMageSum,
 		sumOfSetupStats(user.getGear('mage')),
-		'magic_damage'
+		'magic_damage',
+		['attack_stab', 'attack_slash', 'attack_crush', 'attack_ranged'],
+		false
 	);
 	return {
 		melee,
@@ -270,6 +293,7 @@ const speedReductionForGear = 15;
 const speedReductionForKC = 40;
 const totalSpeedReductions = speedReductionForGear + speedReductionForKC + 10 + 5;
 const baseDuration = Time.Minute * 83;
+const baseCmDuration = Time.Minute * 110;
 
 const { ceil } = Math;
 function calcPerc(perc: number, num: number) {
@@ -318,6 +342,10 @@ const itemBoosts = [
 		{
 			item: getOSItem('Bandos godsword'),
 			boost: 2.5
+		},
+		{
+			item: getOSItem('Bandos godsword (or)'),
+			boost: 2.5
 		}
 	]
 ];
@@ -359,11 +387,16 @@ export async function calcCoxDuration(
 	}
 	let duration = baseDuration;
 
-	duration = reduceNumByPercent(duration, totalReduction);
-	duration -= duration * (teamSizeBoostPercent(size) / 100);
-	if (challengeMode) {
-		duration *= 2;
+	if(challengeMode) {
+		duration = baseCmDuration;
+		duration = reduceNumByPercent(duration, totalReduction / 1.3);
 	}
+	else {
+		duration = reduceNumByPercent(duration, totalReduction);
+	}
+
+
+	duration -= duration * (teamSizeBoostPercent(size) / 100);
 
 	duration = randomVariation(duration, 5);
 	return { duration, reductions, totalReduction: totalSpeedReductions / size };

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -387,14 +387,12 @@ export async function calcCoxDuration(
 	}
 	let duration = baseDuration;
 
-	if(challengeMode) {
+	if (challengeMode) {
 		duration = baseCmDuration;
 		duration = reduceNumByPercent(duration, totalReduction / 1.3);
-	}
-	else {
+	} else {
 		duration = reduceNumByPercent(duration, totalReduction);
 	}
-
 
 	duration -= duration * (teamSizeBoostPercent(size) / 100);
 

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -283,7 +283,7 @@ async function kcEffectiveness(u: KlasaUser, challengeMode: boolean, isSolo: boo
 	const kc = await u.getMinigameScore(challengeMode ? 'RaidsChallengeMode' : 'Raids');
 	let cap = isSolo ? 250 : 400;
 	if (challengeMode) {
-		cap /= 2.5;
+		cap = isSolo ? 75 : 100;
 	}
 	const kcEffectiveness = Math.min(100, calcWhatPercent(kc, cap));
 	return kcEffectiveness;

--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -69,7 +69,7 @@ export default class extends Task {
 			const isPurple = userLoot.items().some(([item]) => purpleItems.includes(item.id));
 			const isGreen = userLoot.items().some(([item]) => greenItems.includes(item.id));
 			const isBlue = userLoot.items().some(([item]) => blueItems.includes(item.id));
-			const emote = isBlue? Emoji.Blue : isGreen? Emoji.Green : Emoji.Purple;
+			const emote = isBlue ? Emoji.Blue : isGreen ? Emoji.Green : Emoji.Purple;
 			if (isPurple) {
 				const itemsToAnnounce = filterBankFromArrayOfItems(purpleItems, _userLoot);
 				this.client.emit(

--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -15,6 +15,8 @@ import resolveItems from '../../../lib/util/resolveItems';
 import { sendToChannelID } from '../../../lib/util/webhook';
 
 const notPurple = resolveItems(['Torn prayer scroll', 'Dark relic']);
+const greenItems = resolveItems(['Twisted ancestral colour kit']);
+const blueItems = resolveItems(['Metamorphic dust']);
 const purpleItems = Object.values(coxLog)
 	.flat(2)
 	.filter(i => !notPurple.includes(i));
@@ -65,18 +67,21 @@ export default class extends Task {
 			totalLoot.add(userLoot);
 
 			const isPurple = userLoot.items().some(([item]) => purpleItems.includes(item.id));
+			const isGreen = userLoot.items().some(([item]) => greenItems.includes(item.id));
+			const isBlue = userLoot.items().some(([item]) => blueItems.includes(item.id));
+			const emote = isBlue? Emoji.Blue : isGreen? Emoji.Green : Emoji.Purple;
 			if (isPurple) {
 				const itemsToAnnounce = filterBankFromArrayOfItems(purpleItems, _userLoot);
 				this.client.emit(
 					Events.ServerNotification,
-					`${Emoji.Purple} ${user.username} just received **${new Bank(
+					`${emote} ${user.username} just received **${new Bank(
 						itemsToAnnounce
 					)}** on their ${formatOrdinal(
 						await user.getMinigameScore(challengeMode ? 'RaidsChallengeMode' : 'Raids')
 					)} raid.`
 				);
 			}
-			const str = isPurple ? `${Emoji.Purple} ||${userLoot}||` : userLoot.toString();
+			const str = isPurple ? `${emote} ||${userLoot}||` : userLoot.toString();
 			const deathStr = deaths === 0 ? '' : new Array(deaths).fill(Emoji.Skull).join(' ');
 
 			resultMessage += `\n${deathStr} **${user}** received: ${str} (${personalPoints?.toLocaleString()} pts, ${


### PR DESCRIPTION
### Description:

I've adapted the gear calculation, adjusted the cm times and added various qol features.

### Changes:

Major changes:
- I've changed the gear calculation to ignore the attack stats of other attack styles
  In the case of melee, this has been changed to compare the highest melee attack stats of the bis setup, with the highest attack stat the user. So this means a high slash bonus works now too.
  This could have some unwanted consequences, but I haven't been able to find any. Because you basically need an one handed weapon with defender to get the required melee strength and defenses. So inq mace with ddef should still be the only bis 
- Challenge mode times have been adjusted to start at ~1h30m at 0kc, and end at ~55m at max kc bonus for solo raids (and same ratio for masses). On recommendation of Keyzz and Anime Lewds.
- Additionally the kc cap for challenge mode has been lowered to 75 for solo and 100 for masses. On recommendation of Keyzz and Anime Lewds.

Minor changes:
- Fixed a bug where lowering points for low kc wasn't working
- Increased to points cap to 60k (from 50k), because a solo cm raid gives you 52k points
- Added the gear and boost score scores to the `+raid` command
- Added a `+raid gear` command, which shows you a break down of your gear score, and shows you your death chances
- Changed that dust will now give you 🟦, and a kit will give you 🟩. Instead of the normal 🟪
- Changed checkmasses to be sorted on finish time, to include if a raid is cm and to exclude solo masses
- Added a --cm flag to setkc for testing purposes (to only set your cm kc)
- Changed that dust can always be received (like ingame). And ancient tablet can now be received if it's not already in your bank
- Added bgs (or) to the boosts

### Other checks:

- I have tested all my changes thoroughly.
- All changes got the official JerCord seal of approval

- Just couldn't test if all the emojis were right. And couldn't test masses, although we tested the points and duration with `+raid --simulate`
