### PR TITLE
Changed 3a Axe boost

### DIFF
--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -20,7 +20,7 @@ import itemID from '../../lib/util/itemID';
 const axes = [
 	{
 		id: itemID('3rd age axe'),
-		reductionPercent: 13,
+		reductionPercent: 12,
 		wcLvl: 61
 	},
 	{


### PR DESCRIPTION
Changed 3A axe boost from 13% down to 12% to match gilded/crystal

same reason as pickaxe pr, also monke brain could figure out how to add two patches in one PR LOL