### PR TITLE
Changed ping bso mass command

### DIFF
--- a/src/commands/bso/pingbsomass.ts
+++ b/src/commands/bso/pingbsomass.ts
@@ -18,7 +18,7 @@ export default class extends BotCommand {
 			return;
 		}
 		return msg.send(
-			`<@&759573020464906242> - *Note: You can type \`.roles bso mass\` to remove, or add, this role to yourself.`
+			`<@&759573020464906242> - *Note: You can type \`.roles bso-mass\` to remove, or add, this role to yourself.`
 		);
 	}
 }


### PR DESCRIPTION
Changed bso ping mass command to say `bso-mass` rather than just `bso mass`,
typing `.roles bso mass` currently just returns an error of no role found

![image](https://user-images.githubusercontent.com/76587427/117539905-90c32d00-b004-11eb-9f1f-2a45d6f3f572.png)
