### PR TITLE
Adjust 3a/gilded axe boost

### DIFF
--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -19,23 +19,18 @@ import itemID from '../../lib/util/itemID';
 
 const axes = [
 	{
-		id: itemID('3rd age axe'),
-		reductionPercent: 12,
-		wcLvl: 61
-	},
-	{
 		id: itemID('Crystal axe'),
 		reductionPercent: 12,
 		wcLvl: 61
 	},
 	{
-		id: itemID('Gilded axe'),
-		reductionPercent: 12,
-		wcLvl: 41
-	},
-	{
 		id: itemID('Infernal axe'),
 		reductionPercent: 11,
+		wcLvl: 61
+	},
+	{
+		id: itemID('3rd age axe'),
+		reductionPercent: 9,
 		wcLvl: 61
 	},
 	{


### PR DESCRIPTION
### Description:

Removed gilded axe boost and edited 3rd age axe to be same boost as dragon axe

### Changes:

Removed gilded axe boost and edited 3rd age axe to be same boost as dragon axe

### Other checks:

-   [x] I have tested all my changes thoroughly.
