### PR TITLE
Adjust 3a/gilded pickaxe boost

### DIFF
--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -19,28 +19,23 @@ import resolveItems from '../../lib/util/resolveItems';
 
 const pickaxes = [
 	{
-		id: itemID('3rd age pickaxe'),
+		id: itemID('Crystal pickaxe'),
+		reductionPercent: 12,
+		miningLvl: 71
+	},
+	{
+		id: itemID('Infernal pickaxe'),
 		reductionPercent: 11,
 		miningLvl: 61
 	},
 	{
-		id: itemID('Crystal pickaxe'),
-		reductionPercent: 11,
-		miningLvl: 71
-	},
-	{
-		id: itemID('Gilded pickaxe'),
-		reductionPercent: 11,
-		miningLvl: 41
-	},
-	{
-		id: itemID('Infernal pickaxe'),
-		reductionPercent: 10,
+		id: itemID('3rd age pickaxe'),
+		reductionPercent: 9,
 		miningLvl: 61
 	},
 	{
 		id: itemID('Dragon pickaxe'),
-		reductionPercent: 6,
+		reductionPercent: 9,
 		miningLvl: 61
 	}
 ];


### PR DESCRIPTION
### Description:

Removed gilded pickaxe boost and edited 3rd age pickaxe to be same boost as dragon pickaxe and adjusted all boosts to reflect chop so that less confusion appears between the whole skills since all the % boosts are just arbitrary numbers to begin with.

### Changes:

Removed gilded pickaxe boost and edited 3rd age pickaxe to be same boost as dragon pickaxe and adjusted all boosts to reflect chop so that less confusion appears between the whole skills since all the % boosts are just arbitrary numbers to begin with.

### Other checks:

-   [x] I have tested all my changes thoroughly.
