### PR TITLE
Boost Fixes + Revert Twisted Ancestral

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -55,6 +55,39 @@ const twistedAncestral: Createable[] = [
 		outputItems: {
 			[itemID('Twisted ancestral robe bottom')]: 1
 		}
+	},
+	{
+		name: 'Revert ancestral robe bottom',
+		inputItems: {
+			[itemID('Twisted ancestral robe bottom')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral robe bottom')]: 1,
+			[itemID('Twisted ancestral colour kit')]: 1	
+		},
+		noCl: true
+	},
+	{
+		name: 'Revert ancestral robe top',
+		inputItems: {
+			[itemID('Twisted ancestral robe top')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral robe top')]: 1,
+			[itemID('Twisted ancestral colour kit')]: 1	
+		},
+		noCl: true
+	},
+	{
+		name: 'Revert ancestral robe hat',
+		inputItems: {
+			[itemID('Twisted ancestral robe hat')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral robe hat')]: 1,
+			[itemID('Twisted ancestral colour kit')]: 1	
+		},
+		noCl: true
 	}
 ];
 

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -63,7 +63,7 @@ const twistedAncestral: Createable[] = [
 		},
 		outputItems: {
 			[itemID('Ancestral robe bottom')]: 1,
-			[itemID('Twisted ancestral colour kit')]: 1	
+			[itemID('Twisted ancestral colour kit')]: 1
 		},
 		noCl: true
 	},
@@ -74,7 +74,7 @@ const twistedAncestral: Createable[] = [
 		},
 		outputItems: {
 			[itemID('Ancestral robe top')]: 1,
-			[itemID('Twisted ancestral colour kit')]: 1	
+			[itemID('Twisted ancestral colour kit')]: 1
 		},
 		noCl: true
 	},
@@ -85,7 +85,7 @@ const twistedAncestral: Createable[] = [
 		},
 		outputItems: {
 			[itemID('Ancestral robe hat')]: 1,
-			[itemID('Twisted ancestral colour kit')]: 1	
+			[itemID('Twisted ancestral colour kit')]: 1
 		},
 		noCl: true
 	}

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -842,7 +842,7 @@ export const filterableTypes: Filterable[] = [
 	},
 	{
 		name: 'Secondaries',
-		aliases: ['seconds', 'secondary'],
+		aliases: ['seconds', 'secondary', 'secondaries'],
 		items: secondaries
 	},
 	{

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -842,7 +842,7 @@ export const filterableTypes: Filterable[] = [
 	},
 	{
 		name: 'Secondaries',
-		aliases: ['seconds, secondary'],
+		aliases: ['seconds', 'secondary'],
 		items: secondaries
 	},
 	{

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -58,10 +58,8 @@ const killableBosses: KillableMonster[] = [
 		qpRequired: 205,
 		itemInBankBoosts: [
 			{
-				[itemID('Dragon warhammer')]: 10
-			},
-			{
-				[itemID('Dragon hunter crossbow')]: 20
+				[itemID('Dragon warhammer')]: 20,
+				[itemID('Dragon hunter crossbow')]: 30
 			}
 		],
 		levelRequirements: {

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -58,7 +58,8 @@ const killableBosses: KillableMonster[] = [
 		qpRequired: 205,
 		itemInBankBoosts: [
 			{
-				[itemID('Dragon warhammer')]: 20,
+				[itemID('Bandos godsword')]: 15,
+ 				[itemID('Dragon warhammer')]: 15,
 				[itemID('Dragon hunter crossbow')]: 30
 			}
 		],

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -59,7 +59,7 @@ const killableBosses: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Bandos godsword')]: 15,
- 				[itemID('Dragon warhammer')]: 15,
+				[itemID('Dragon warhammer')]: 15,
 				[itemID('Dragon hunter crossbow')]: 30
 			}
 		],

--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -175,7 +175,7 @@ const killableBosses: KillableMonster[] = [
 		difficultyRating: 6,
 		itemsRequired: deepResolveItems([
 			'Anti-dragon shield',
-			['Armadyl crossbow', 'Rune crossbow', 'Twisted bow'],
+			['Armadyl crossbow', 'Rune crossbow', 'Twisted bow', 'Dragon hunter crossbow'],
 			[
 				"Black d'hide body",
 				"Black d'hide body (g)",


### PR DESCRIPTION
- Added +create revert ancestral, to remove twisted kits
- Fixed —secondaries flag
- Changed Vork boosts to BGS or DWH or DHCB, not stacked
- Allowed DHCB to act as a required item for KBD

checks seem to be stuck pending, no idea why