### PR TITLE
Silence disabled commands toggle

### DIFF
--- a/src/commands/Configuration/cmd.ts
+++ b/src/commands/Configuration/cmd.ts
@@ -9,11 +9,11 @@ export default class extends BotCommand {
 			runIn: ['text'],
 			cooldown: 2,
 			subcommands: true,
-			usage: '<enable|disable> <command:cmd>',
+			usage: '<enable|disable|silence> <command:cmd>',
 			usageDelim: ' ',
 			permissionLevel: 7,
-			description: 'Allows you to enable or disable commands in your server.',
-			examples: ['+cmd enable casket', '+cmd disable casket'],
+			description: 'Allows you to enable/disable commands in your server, or silence warnings for disabled commands',
+			examples: ['+cmd enable casket', '+cmd disable casket', 'cmd silence enable', 'cmd silence disable'],
 			categoryFlags: ['settings']
 		});
 	}
@@ -23,6 +23,7 @@ export default class extends BotCommand {
 		if (!msg.guild!.settings.get(GuildSettings.DisabledCommands).includes(command.name)) {
 			return msg.send("That command isn't disabled.");
 		}
+		this.store.get(command.name)!.disabled = false;
 		await msg.guild!.settings.update('disabledCommands', command.name, {
 			arrayAction: 'remove'
 		});
@@ -34,9 +35,28 @@ export default class extends BotCommand {
 		if (msg.guild!.settings.get(GuildSettings.DisabledCommands).includes(command.name)) {
 			return msg.send('That command is already disabled.');
 		}
+		this.store.get(command.name)!.disabled = true;
 		await msg.guild!.settings.update(GuildSettings.DisabledCommands, command.name, {
 			arrayAction: 'add'
 		});
 		return msg.send(`Successfully disabled the \`${command.name}\` command.`);
+	}
+
+	// @ts-ignore 2416
+	async silence(msg: KlasaMessage, [command]: [Command]) {
+		if (!msg.guild!.settings.get(GuildSettings.Silenced) && command.name == 'enable') {
+			msg.guild!.settings.set(GuildSettings.Silenced, true);
+			return msg.send(`Successfully silenced disabled commands.`);
+		}
+		else if (msg.guild!.settings.get(GuildSettings.Silenced) && command.name == 'enable') {
+			return msg.send(`Disabled commands are already silenced.`);
+		} 
+		else if (msg.guild!.settings.get(GuildSettings.Silenced) && command.name == 'disable') {
+			msg.guild!.settings.set(GuildSettings.Silenced, false);
+			return msg.send(`Successfully unsilenced disabled commands.`);
+		}
+		else {
+			return msg.send(`Disabled commands are already unsilenced.`);
+		}
 	}
 }

--- a/src/inhibitors/disabledCommand.ts
+++ b/src/inhibitors/disabledCommand.ts
@@ -1,0 +1,16 @@
+import { Command, Inhibitor, InhibitorStore, KlasaMessage } from 'klasa';
+import { GuildSettings } from '../lib/settings/types/GuildSettings';
+
+export default class extends Inhibitor {
+    public constructor(store: InhibitorStore, file: string[], directory: string) {
+		super(store, file, directory);
+	}
+	public async run(msg: KlasaMessage, command: Command) {
+		if (command.disabled && !msg.guild!.settings.get(GuildSettings.Silenced)) {
+			throw "This command has been disabled.";
+		}
+        else if (command.disabled) {
+            return true;
+        }
+	}
+}

--- a/src/lib/settings/types/GuildSettings.ts
+++ b/src/lib/settings/types/GuildSettings.ts
@@ -15,4 +15,5 @@ export namespace GuildSettings {
 	export const StreamerTweets = T<string>('streamertweets');
 	export const PetChannel = T<string>('petchannel');
 	export const JModTweets = T<string>('tweetchannel');
+	export const Silenced = T<string>('silenced');
 }

--- a/src/lib/structures/BotCommand.ts
+++ b/src/lib/structures/BotCommand.ts
@@ -9,6 +9,7 @@ export abstract class BotCommand extends Command {
 	public oneAtTime: boolean;
 	public perkTier?: number;
 	public ironCantUse?: boolean;
+	public disabled?: boolean;
 	public examples: string[];
 	public categoryFlags: CategoryFlag[];
 
@@ -27,7 +28,8 @@ export abstract class BotCommand extends Command {
 					altProtection: false,
 					oneAtTime: false,
 					guildOnly: false,
-					ironCantUse: false
+					ironCantUse: false,
+					disabled: false
 				},
 				options
 			)
@@ -37,6 +39,7 @@ export abstract class BotCommand extends Command {
 		this.guildOnly = options.guildOnly!;
 		this.perkTier = options.perkTier;
 		this.ironCantUse = options.ironCantUse;
+		this.disabled = options.disabled;
 		this.examples = options.examples || [];
 		this.categoryFlags = options.categoryFlags || [];
 		this.bitfieldsRequired = options.bitfieldsRequired || [];
@@ -59,6 +62,7 @@ export interface BotCommandOptions extends CommandOptions {
 	guildOnly?: boolean;
 	perkTier?: number;
 	ironCantUse?: boolean;
+	disabled?: boolean;
 	testingCommand?: boolean;
 	examples?: string[];
 	description?: string;

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -12,13 +12,13 @@ import { MinigameKey, MinigameScore } from '../../extendables/User/Minigame';
 import { BankImageResult } from '../../tasks/bankImage';
 import { Activity as OSBActivity, BitField, PerkTier } from '../constants';
 import { GearSetupType, UserFullGearSetup } from '../gear/types';
-import { AttackStyles } from '../minions/functions';
 import { KillableMonster } from '../minions/types';
 import { CustomGet } from '../settings/types/UserSettings';
 import { Creature, SkillsEnum } from '../skilling/types';
 import { Gear } from '../structures/Gear';
 import { MinigameTable } from '../typeorm/MinigameTable.entity';
 import { PoHTable } from '../typeorm/PoHTable.entity';
+import { AttackStyles } from '../util';
 import { ItemBank, MakePartyOptions, Skills } from '.';
 
 declare module 'klasa' {
@@ -50,6 +50,7 @@ declare module 'klasa' {
 		guildOnly?: boolean;
 		perkTier?: number;
 		ironCantUse?: boolean;
+		disabled?: boolean;
 		testingCommand?: boolean;
 		bitfieldsRequired?: BitField[];
 	}

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -12,13 +12,13 @@ import { MinigameKey, MinigameScore } from '../../extendables/User/Minigame';
 import { BankImageResult } from '../../tasks/bankImage';
 import { Activity as OSBActivity, BitField, PerkTier } from '../constants';
 import { GearSetupType, UserFullGearSetup } from '../gear/types';
+import { AttackStyles } from '../minions/functions';
 import { KillableMonster } from '../minions/types';
 import { CustomGet } from '../settings/types/UserSettings';
 import { Creature, SkillsEnum } from '../skilling/types';
 import { Gear } from '../structures/Gear';
 import { MinigameTable } from '../typeorm/MinigameTable.entity';
 import { PoHTable } from '../typeorm/PoHTable.entity';
-import { AttackStyles } from '../util';
 import { ItemBank, MakePartyOptions, Skills } from '.';
 
 declare module 'klasa' {


### PR DESCRIPTION
### Description:

Add ability to silence the "This command has been disabled by an admin in this guild." message when a user tries to use a disabled command. The specific use-case in mind is when a server uses a different bot for certain commands that overlap with old school bot commands. My server does this, and the error message popping up every time is mildly annoying.

### Changes:

-   Add "silenced" GuildSetting that can be toggled via new command `!cmd silence disable/enable`
-   Add "disabled" flag to BotCommand class.
-   Toggle "disabled" flag for a specific command when an admin uses `!cmd disable/enable <command>`
-   Add new inhibitor that checks for a command's "disabled" status, as well as the current "silenced" GuildSetting state, and short-circuits execution if both are true.

### Other checks:

-   [ X] I have tested all my changes thoroughly.
