### PR TITLE
(BSO) Fixed a =ping typo

### DIFF
--- a/src/commands/Owner/ping.ts
+++ b/src/commands/Owner/ping.ts
@@ -24,7 +24,7 @@ export default class extends BotCommand {
 			return;
 		}
 		return message.channel.send(
-			`<@&${roleToPing.roleID}> You were pinged because you have this role, you can remove it using \`+role ${roleToPing.name}\`.`
+			`<@&${roleToPing.roleID}> You were pinged because you have this role, you can remove it using \`=roles ${roleToPing.name}\`.`
 		);
 	}
 }


### PR DESCRIPTION
ping cmd was saying to use ‘+role name’ to add/remove rather than ‘=roles name’

Changed on BSO as OSB has no +roles yet, not sure if this will need changing again in the future if OSB code needs updating to follow suit