### PR TITLE
[BSO] Fixed Displayed XP Multiplier in Sepulchre return msg

### DIFF
--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -43,19 +43,13 @@ export default class extends Task {
 		}
 
 		await user.addItemsToBank(loot.bank, true);
-		const currentLevel = user.skillLevel(SkillsEnum.Agility);
-		await user.addXP(SkillsEnum.Agility, agilityXP);
-		const nextLevel = user.skillLevel(SkillsEnum.Agility);
+		const xpStr = await user.addXP(SkillsEnum.Agility, agilityXP);
 
 		let str = `${user}, ${
 			user.minionName
 		} finished doing the Hallowed Sepulchre ${quantity}x times (floor ${floors[0]}-${
 			floors[floors.length - 1]
-		}), you received ${agilityXP.toLocaleString()} Agility XP. ${numCoffinsOpened}x coffins opened.`;
-
-		if (nextLevel > currentLevel) {
-			str += `\n\n${user.minionName}'s Agility level is now ${nextLevel}!`;
-		}
+		}), and opened ${numCoffinsOpened}x coffins.\n\n${xpStr}`;
 
 		const { image } = await this.client.tasks
 			.get('bankImage')!


### PR DESCRIPTION
### Description:
Fixed the sepulchre trip return message so it displays the correct XP for BSO.

This can probably be used as-is in master branch also.

### Changes:
Updated sepulchreActivity to use the string returned from user.addXP instead of it's own custom code.

### Other checks:

-   [x] I have tested all my changes thoroughly.
