### PR TITLE
[BSO] Fixed - Harvesting Hespori with multiple patches only gives 1 loot.

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -379,12 +379,23 @@ export default class extends Task {
 			let tangleroot = false;
 			if (plantToHarvest.seedType === 'hespori') {
 				await user.incrementMonsterScore(Monsters.Hespori.id);
-				const hesporiLoot = Monsters.Hespori.kill(1, { farmingLevel: currentFarmingLevel });
+				const hesporiLoot = Monsters.Hespori.kill(patchType.lastQuantity, {
+					farmingLevel: currentFarmingLevel
+				});
 				loot = hesporiLoot;
 				for (const hesporiLoot of Object.keys(loot)) {
 					if (itemID(hesporiLoot) === itemID('Tangleroot')) {
 						tangleroot = true;
 					}
+				}
+				if (
+					roll(
+						(plantToHarvest.petChance - currentFarmingLevel * 25) /
+							patchType.lastQuantity /
+							5
+					)
+				) {
+					loot[itemID('Plopper')] = 1;
 				}
 			} else if (
 				patchType.patchPlanted &&


### PR DESCRIPTION
### Description:

Fixed a bug where Harvesting multiple Hespori only gives 1 kill worth of loot. Also added Plopper chance to Hespori at the usual rate.

### Changes:

- Set the Hespori kill() command to use the number of planted Hespori (because they can't die).
- Added chance to get Plopper from Hespori at the usual rate of (petChance - farmLevel * 25) / 5.

### Other checks:

-   [x] I have tested all my changes thoroughly.
