### PR TITLE
Removed extraneous tab from Harmonised nightmare staff Creatable.

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1291,7 +1291,7 @@ const Createables: Createable[] = [
 		})
 	},
 	{
-		name: '	Harmonised nightmare staff',
+		name: 'Harmonised nightmare staff',
 		inputItems: resolveNameBank({
 			'Nightmare staff': 1,
 			'Harmonised orb': 1


### PR DESCRIPTION
### Description:
Removed extra \t from the beginning of the ' Harmonised nightmare staff' in the name key.

Also needs to be merged with BSO.

### Other checks:

-   [x] I have tested all my changes thoroughly.
