### PR TITLE
[BSO] Add --id flag to =bank to show item IDs

### DIFF
--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -521,6 +521,10 @@ export default class BankImageTask extends Task {
 				bottomItemText = (item.highalch ?? 0) * quantity;
 			}
 
+			if (flags.id) {
+				bottomItemText = item.id.toString();
+			}
+
 			if (flags.names) {
 				bottomItemText = `${item.name!.replace('Grimy', 'Grmy').slice(0, 7)}..`;
 			}


### PR DESCRIPTION
### Description:
Does what it says on the tin.

### Changes:
Updated bankImage.ts to support the --id flag, and then had to disable toKMB when the id flag is enabled, and convert the number to a string

### Other checks:

-   [x] I have tested all my changes thoroughly.
