### PR TITLE
Update to allow multiple stacks of items to be alch'd.

### DIFF
--- a/src/arguments/tradeableItemBank.ts
+++ b/src/arguments/tradeableItemBank.ts
@@ -63,9 +63,7 @@ export default class TradeableItemBankArgument extends Argument {
 		if (search) {
 			items = [
 				...items,
-				...userBank
-					.items()
-					.filter(i => i[0].name.toLowerCase().includes(search.toLowerCase()))
+				...userBank.items().filter(i => i[0].name.toLowerCase().includes(search))
 			];
 		}
 

--- a/src/arguments/tradeableItemBank.ts
+++ b/src/arguments/tradeableItemBank.ts
@@ -63,7 +63,9 @@ export default class TradeableItemBankArgument extends Argument {
 		if (search) {
 			items = [
 				...items,
-				...userBank.items().filter(i => i[0].name.toLowerCase().includes(search.toLowerCase()))
+				...userBank
+					.items()
+					.filter(i => i[0].name.toLowerCase().includes(search.toLowerCase()))
 			];
 		}
 

--- a/src/arguments/tradeableItemBank.ts
+++ b/src/arguments/tradeableItemBank.ts
@@ -63,7 +63,7 @@ export default class TradeableItemBankArgument extends Argument {
 		if (search) {
 			items = [
 				...items,
-				...userBank.items().filter(i => i[0].name.toLowerCase().includes(search))
+				...userBank.items().filter(i => i[0].name.toLowerCase().includes(search.toLowerCase()))
 			];
 		}
 

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -1,17 +1,16 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Bank, Util } from 'oldschooljs';
-import { Item } from 'oldschooljs/dist/meta/types';
 
 import { Activity, Time } from '../../lib/constants';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
-import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, updateBankSetting } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import resolveItems from '../../lib/util/resolveItems';
+import Items from 'oldschooljs/dist/structures/Items';
 
 const unlimitedFireRuneProviders = resolveItems([
 	'Staff of fire',
@@ -30,7 +29,7 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			cooldown: 1,
-			usage: '[quantity:int{1}] <item:...item>',
+			usage: '(items:...TradeableBank)',
 			usageDelim: ' ',
 			oneAtTime: true,
 			description: 'Allows you to send your minion to alch items from your bank',
@@ -41,29 +40,56 @@ export default class extends BotCommand {
 
 	@minionNotBusy
 	@requiresMinion
-	async run(msg: KlasaMessage, [quantity = null, item]: [number | null, Item[]]) {
-		const userBank = msg.author.settings.get(UserSettings.Bank);
-		const osItem = item.find(i => userBank[i.id] && i.highalch && i.tradeable);
-		if (!osItem) {
-			return msg.send(`You don't have any of this item to alch.`);
+	async run(msg: KlasaMessage, [[bankToAlch]]: [[Bank]]) {
+		if (bankToAlch === undefined)
+		{
+			throw "You must specify item[s] to alch.";
 		}
 
-		if (msg.author.skillLevel(SkillsEnum.Magic) < 55) {
-			return msg.send(`You need level 55 Magic to cast High Alchemy`);
+		if (!msg.author.bank().fits(bankToAlch)) {
+			throw "You don't have all of those items.";
 		}
 
 		// 5 tick action
 		const timePerAlch = Time.Second * 3;
 		const maxTripLength = msg.author.maxTripLength(Activity.Alching);
 
-		const maxCasts = Math.min(Math.floor(maxTripLength / timePerAlch), userBank[osItem.id]);
+		let maxRemaining = Math.floor(maxTripLength / timePerAlch);
 
-		if (!quantity) {
-			quantity = maxCasts;
+		let quantity = 0;
+		let alchValue = 0;
+
+		for (const [itemID, qty] of Object.entries(bankToAlch.bank)) {
+			const item = Items.get(parseInt(itemID));
+			if (!(item!.highalch && item!.tradeable)) {
+				throw "Not all selected items are alchable.";
+			}
+
+			// Subtract quantities used until we reach max.
+			let qtyUsable = qty;
+			if (qtyUsable > maxRemaining) {
+				qtyUsable = maxRemaining;
+				bankToAlch.bank[itemID] = qtyUsable;
+			}
+			maxRemaining -= qtyUsable;
+			if (maxRemaining < 0) {
+				maxRemaining = 0;
+			}
+
+			quantity += qtyUsable;
+			alchValue += qtyUsable * item!.highalch;
+		}
+
+		const maxCasts = Math.min(Math.floor(maxTripLength / timePerAlch), quantity);
+
+		if (msg.author.skillLevel(SkillsEnum.Magic) < 55) {
+			return msg.send(`You need level 55 Magic to cast High Alchemy`);
 		}
 
 		if (quantity * timePerAlch > maxTripLength) {
-			return msg.send(`The max number of alchs you can do is ${maxCasts}!`);
+			return msg.send(
+				`The max number of alchs you can do is ${maxCasts}!\nYou've chosen: ${bankToAlch}`
+			);
 		}
 
 		const duration = quantity * timePerAlch;
@@ -76,12 +102,11 @@ export default class extends BotCommand {
 			}
 		}
 
-		const alchValue = quantity * osItem.highalch;
 		const consumedItems = new Bank({
 			...(fireRuneCost > 0 ? { 'Fire rune': fireRuneCost } : {}),
 			'Nature rune': quantity
 		});
-		consumedItems.add(osItem.id, quantity);
+		consumedItems.add(bankToAlch);
 
 		if (!msg.author.owns(consumedItems)) {
 			return msg.send(`You don't have the required items, you need ${consumedItems}`);
@@ -89,7 +114,7 @@ export default class extends BotCommand {
 
 		if (!msg.flagArgs.confirm && !msg.flagArgs.cf) {
 			const alchMessage = await msg.channel.send(
-				`${msg.author}, say \`confirm\` to alch ${quantity} ${osItem.name} (${Util.toKMB(
+				`${msg.author}, say \`confirm\` to alch ${bankToAlch.toString()} (${Util.toKMB(
 					alchValue
 				)}). This will take approximately ${formatDuration(
 					duration
@@ -108,7 +133,7 @@ export default class extends BotCommand {
 					}
 				);
 			} catch (err) {
-				return alchMessage.edit(`Cancelling alch of ${quantity}x ${osItem.name}.`);
+				return alchMessage.edit(`Cancelling alch of ${bankToAlch.toString()}.`);
 			}
 		}
 
@@ -120,7 +145,7 @@ export default class extends BotCommand {
 		);
 
 		await addSubTaskToActivityTask<AlchingActivityTaskOptions>(this.client, {
-			itemID: osItem.id,
+			alchBank: bankToAlch,
 			userID: msg.author.id,
 			channelID: msg.channel.id,
 			quantity,
@@ -129,10 +154,10 @@ export default class extends BotCommand {
 			type: Activity.Alching
 		});
 
-		msg.author.log(`alched Quantity[${quantity}] ItemID[${osItem.id}] for ${alchValue}`);
+		msg.author.log(`alched ${bankToAlch.toString()} for ${alchValue}`);
 
-		const response = `${msg.author.minionName} is now alching ${quantity}x ${
-			osItem.name
+		const response = `${msg.author.minionName} is now alching  ${
+			bankToAlch.toString()
 		}, it'll take around ${formatDuration(duration)} to finish.`;
 
 		return msg.send(response);

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -1,5 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Bank, Util } from 'oldschooljs';
+import Items from 'oldschooljs/dist/structures/Items';
 
 import { Activity, Time } from '../../lib/constants';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
@@ -10,7 +11,6 @@ import { AlchingActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, updateBankSetting } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import resolveItems from '../../lib/util/resolveItems';
-import Items from 'oldschooljs/dist/structures/Items';
 
 const unlimitedFireRuneProviders = resolveItems([
 	'Staff of fire',
@@ -41,9 +41,8 @@ export default class extends BotCommand {
 	@minionNotBusy
 	@requiresMinion
 	async run(msg: KlasaMessage, [[bankToAlch]]: [[Bank]]) {
-		if (bankToAlch === undefined)
-		{
-			throw "You must specify item[s] to alch.";
+		if (bankToAlch === undefined) {
+			throw 'You must specify item[s] to alch.';
 		}
 
 		if (!msg.author.bank().fits(bankToAlch)) {
@@ -62,7 +61,7 @@ export default class extends BotCommand {
 		for (const [itemID, qty] of Object.entries(bankToAlch.bank)) {
 			const item = Items.get(parseInt(itemID));
 			if (!(item!.highalch && item!.tradeable)) {
-				throw "Not all selected items are alchable.";
+				throw 'Not all selected items are alchable.';
 			}
 
 			// Subtract quantities used until we reach max.
@@ -156,9 +155,11 @@ export default class extends BotCommand {
 
 		msg.author.log(`alched ${bankToAlch.toString()} for ${alchValue}`);
 
-		const response = `${msg.author.minionName} is now alching  ${
-			bankToAlch.toString()
-		}, it'll take around ${formatDuration(duration)} to finish.`;
+		const response = `${
+			msg.author.minionName
+		} is now alching  ${bankToAlch.toString()}, it'll take around ${formatDuration(
+			duration
+		)} to finish.`;
 
 		return msg.send(response);
 	}

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -366,9 +366,7 @@ export default class extends Extendable {
 			case Activity.Alching: {
 				const data = currentTask as AlchingActivityTaskOptions;
 
-				return `${this.minionName} is currently alching ${data.quantity}x ${itemNameFromID(
-					data.itemID
-				)}. ${formattedDuration}`;
+				return `${this.minionName} is currently alching ${data.alchBank}. ${formattedDuration}`;
 			}
 
 			case Activity.Farming: {

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -599,8 +599,8 @@ export default class extends Extendable {
 		const kc = mon
 			? this.getKC(((mon as unknown) as Monster).id)
 			: minigame
-				? await this.getMinigameScore(minigame!.key)
-				: this.getCreatureScore(creature!);
+			? await this.getMinigameScore(minigame!.key)
+			: this.getCreatureScore(creature!);
 
 		const name = minigame ? minigame.name : mon ? mon!.name : creature?.name;
 		return [name, kc];
@@ -740,7 +740,7 @@ export default class extends Extendable {
 				{
 					count: string;
 				}[]
-				>(`SELECT COUNT(*) FROM users WHERE "skills.${skillName}" > 13034430;`);
+			>(`SELECT COUNT(*) FROM users WHERE "skills.${skillName}" > 13034430;`);
 
 			let str = `${skill.emoji} **${this.username}'s** minion, ${
 				this.minionName
@@ -753,7 +753,7 @@ export default class extends Extendable {
 					{
 						count: string;
 					}[]
-					>(
+				>(
 					`SELECT COUNT(*) FROM users WHERE "minion.ironman" = true AND "skills.${skillName}" > 13034430;`
 				);
 				str += ` They are the ${formatOrdinal(

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -103,13 +103,13 @@ import {
 import { Minigames } from './Minigame';
 
 const suffixes = new SimpleTable<string>()
-	.add('🎉', 200)
-	.add('🎆', 10)
-	.add('🙌', 10)
-	.add('🎇', 10)
-	.add('🥳', 10)
-	.add('🍻', 10)
-	.add('🎊', 10)
+	.add('ðŸŽ‰', 200)
+	.add('ðŸŽ†', 10)
+	.add('ðŸ™Œ', 10)
+	.add('ðŸŽ‡', 10)
+	.add('ðŸ¥³', 10)
+	.add('ðŸ»', 10)
+	.add('ðŸŽŠ', 10)
 	.add(Emoji.PeepoNoob, 1)
 	.add(Emoji.PeepoRanger, 1)
 	.add(Emoji.PeepoSlayer);
@@ -599,8 +599,8 @@ export default class extends Extendable {
 		const kc = mon
 			? this.getKC(((mon as unknown) as Monster).id)
 			: minigame
-			? await this.getMinigameScore(minigame!.key)
-			: this.getCreatureScore(creature!);
+				? await this.getMinigameScore(minigame!.key)
+				: this.getCreatureScore(creature!);
 
 		const name = minigame ? minigame.name : mon ? mon!.name : creature?.name;
 		return [name, kc];
@@ -740,7 +740,7 @@ export default class extends Extendable {
 				{
 					count: string;
 				}[]
-			>(`SELECT COUNT(*) FROM users WHERE "skills.${skillName}" > 13034430;`);
+				>(`SELECT COUNT(*) FROM users WHERE "skills.${skillName}" > 13034430;`);
 
 			let str = `${skill.emoji} **${this.username}'s** minion, ${
 				this.minionName
@@ -753,7 +753,7 @@ export default class extends Extendable {
 					{
 						count: string;
 					}[]
-				>(
+					>(
 					`SELECT COUNT(*) FROM users WHERE "minion.ironman" = true AND "skills.${skillName}" > 13034430;`
 				);
 				str += ` They are the ${formatOrdinal(

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -103,13 +103,13 @@ import {
 import { Minigames } from './Minigame';
 
 const suffixes = new SimpleTable<string>()
-	.add('ðŸŽ‰', 200)
-	.add('ðŸŽ†', 10)
-	.add('ðŸ™Œ', 10)
-	.add('ðŸŽ‡', 10)
-	.add('ðŸ¥³', 10)
-	.add('ðŸ»', 10)
-	.add('ðŸŽŠ', 10)
+	.add('🎉', 200)
+	.add('🎆', 10)
+	.add('🙌', 10)
+	.add('🎇', 10)
+	.add('🥳', 10)
+	.add('🍻', 10)
+	.add('🎊', 10)
 	.add(Emoji.PeepoNoob, 1)
 	.add(Emoji.PeepoRanger, 1)
 	.add(Emoji.PeepoSlayer);

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -1,9 +1,10 @@
+import { Bank } from 'oldschooljs';
+
 import { MinigameKey } from '../../extendables/User/Minigame';
 import { Peak } from '../../tasks/WildernessPeakInterval';
 import { Activity } from '../constants';
 import { IPatchData } from '../minions/farming/types';
 import { BirdhouseData } from './../skilling/skills/hunter/defaultBirdHouseTrap';
-import { Bank } from 'oldschooljs';
 
 export interface ActivityTaskOptions {
 	type: Activity;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -3,6 +3,7 @@ import { Peak } from '../../tasks/WildernessPeakInterval';
 import { Activity } from '../constants';
 import { IPatchData } from '../minions/farming/types';
 import { BirdhouseData } from './../skilling/skills/hunter/defaultBirdHouseTrap';
+import { Bank } from 'oldschooljs';
 
 export interface ActivityTaskOptions {
 	type: Activity;
@@ -138,7 +139,7 @@ export interface HunterActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface AlchingActivityTaskOptions extends ActivityTaskOptions {
-	itemID: number;
+	alchBank: Bank;
 	quantity: number;
 	alchValue: number;
 }

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -5,7 +5,6 @@ import { resolveNameBank } from 'oldschooljs/dist/util';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
 import { roll } from '../../lib/util';
-import getOSItem from '../../lib/util/getOSItem';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import itemID from '../../lib/util/itemID';
 
@@ -13,11 +12,13 @@ const bryophytasStaffId = itemID("Bryophyta's staff");
 
 export default class extends Task {
 	async run(data: AlchingActivityTaskOptions) {
-		let { itemID, quantity, channelID, alchValue, userID, duration } = data;
+		let { alchBank, quantity, channelID, alchValue, userID, duration } = data;
 		const user = await this.client.users.fetch(userID);
 		const loot = new Bank({ Coins: alchValue });
 
-		const item = getOSItem(itemID);
+		// Loses class/type info so reclass-ify it:
+		// (My guess it that it loads from DB and doesn't 'new')
+		alchBank = new Bank(alchBank.bank);
 
 		// If bryophyta's staff is equipped when starting the alch activity
 		// calculate how many runes have been saved
@@ -43,7 +44,7 @@ export default class extends Task {
 		const saved =
 			savedRunes > 0 ? `Your Bryophyta's staff saved you ${savedRunes} Nature runes.` : '';
 		let responses = [
-			`${user}, ${user.minionName} has finished alching ${quantity}x ${item.name}! ${loot} has been added to your bank. ${xpRes}. ${saved}`
+			`${user}, ${user.minionName} has finished alching ${alchBank}! ${loot} has been added to your bank. ${xpRes}. ${saved}`
 		].join('\n');
 
 		handleTripFinish(
@@ -52,8 +53,8 @@ export default class extends Task {
 			channelID,
 			responses,
 			res => {
-				user.log(`continued trip of alching ${quantity}x ${item.name}`);
-				return this.client.commands.get('alch')!.run(res, [quantity, [item]]);
+				user.log(`continued trip of alching ${alchBank.toString()}`);
+				return this.client.commands.get('alch')!.run(res, [[alchBank]]);
 			},
 			undefined,
 			data,


### PR DESCRIPTION
### Description:
Now you can do: 
```
+alch dragon platelegs, dragon med helm
+alch 10 dragon platelegs, 10 dragon med helm
+alch --search=dragon
```
Be careful with the --cf flag! As always items are deleted from bank immediately and will be lost if you cancel!

Untradeables are automatically removed from the list to be aclh'd if using a filter or search.

### Changes:

- Fixed an issue where --search in tradeableItemBank wouldn't work with capital letters in the search
- Changed the type of AlchActivityTaskOptions to use a Bank object for continuing/status
- Updated alch.ts to use tradeableItemBank, and calculate the required resources accordingly.


### Other checks:

-   [x] I have tested all my changes thoroughly. Anime helped out quite a bit, but because of the major changes under the hood, I would like this to maybe be in testbot first with a few extra testers to try some things maybe we didn't think of.
