### PR TITLE
[BSO] Add minimum trip length requirement for pet roll.

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -407,6 +407,7 @@ export const RAZOR_KEBBIT_ID = 35;
 export const BLACK_CHIN_ID = 9;
 export const ZALCANO_ID = 9049;
 export const NIGHTMARE_ID = 9415;
+export const MIN_LENGTH_FOR_PET = Time.Minute * 5;
 
 /**
  * Map<user_id, PromiseQueue>

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -2,7 +2,7 @@ import { randInt, roll } from 'e';
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Activity, Emoji, Events, Time } from '../../lib/constants';
+import { Activity, Emoji, Events, Time, MIN_LENGTH_FOR_PET } from '../../lib/constants';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Agility from '../../lib/skilling/skills/agility';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -80,38 +80,38 @@ export default class extends Task {
 				}
 			}
 		}
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const minutes = duration / Time.Minute;
+			if (course.id === 4) {
+				for (let i = 0; i < minutes; i++) {
+					if (roll(4000)) {
+						loot.add('Scruffy');
+						str += `\n\n<:scruffy:749945071146762301> As you jump off the rooftop in Varrock, a stray dog covered in flies approaches you. You decide to adopt the dog, and name him 'Scruffy'.`;
+						break;
+					}
+				}
+			}
 
-		const minutes = duration / Time.Minute;
-		if (course.id === 4) {
-			for (let i = 0; i < minutes; i++) {
-				if (roll(4000)) {
-					loot.add('Scruffy');
-					str += `\n\n<:scruffy:749945071146762301> As you jump off the rooftop in Varrock, a stray dog covered in flies approaches you. You decide to adopt the dog, and name him 'Scruffy'.`;
-					break;
+			if (course.id === 11) {
+				for (let i = 0; i < minutes; i++) {
+					if (roll(1600)) {
+						loot.add('Harry');
+						str += `\n\n<:harry:749945071104819292> As you jump across a rooftop, you notice a monkey perched on the roof - which has escaped from the Ardougne Zoo! You decide to adopt the monkey, and call him Harry.`;
+						break;
+					}
+				}
+			}
+
+			if (course.id === 12) {
+				for (let i = 0; i < minutes; i++) {
+					if (roll(1600)) {
+						loot.add('Skipper');
+						str += `\n\n<:skipper:755853421801766912> As you finish the Penguin agility course, a lone penguin asks if you'd like to hire it as your accountant, you accept.`;
+						break;
+					}
 				}
 			}
 		}
-
-		if (course.id === 11) {
-			for (let i = 0; i < minutes; i++) {
-				if (roll(1600)) {
-					loot.add('Harry');
-					str += `\n\n<:harry:749945071104819292> As you jump across a rooftop, you notice a monkey perched on the roof - which has escaped from the Ardougne Zoo! You decide to adopt the monkey, and call him Harry.`;
-					break;
-				}
-			}
-		}
-
-		if (course.id === 12) {
-			for (let i = 0; i < minutes; i++) {
-				if (roll(1600)) {
-					loot.add('Skipper');
-					str += `\n\n<:skipper:755853421801766912> As you finish the Penguin agility course, a lone penguin asks if you'd like to hire it as your accountant, you accept.`;
-					break;
-				}
-			}
-		}
-
 		// Roll for pet
 		if (
 			course.petChance &&

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -2,6 +2,7 @@ import { Time } from 'e';
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 import { resolveNameBank } from 'oldschooljs/dist/util';
+import { MIN_LENGTH_FOR_PET } from '../../lib/constants';
 
 import { SkillsEnum } from '../../lib/skilling/types';
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
@@ -36,7 +37,7 @@ export default class extends Task {
 			}
 		}
 
-		if (duration > Time.Minute * 20 && roll(Math.ceil(8000 / (duration / Time.Minute)))) {
+		if (duration > MIN_LENGTH_FOR_PET && roll(Math.ceil(8000 / (duration / Time.Minute)))) {
 			loot.add('Lil lamb');
 		}
 

--- a/src/tasks/minions/cookingActivity.ts
+++ b/src/tasks/minions/cookingActivity.ts
@@ -7,6 +7,7 @@ import { SkillsEnum } from '../../lib/skilling/types';
 import { CookingActivityTaskOptions } from '../../lib/types/minions';
 import { roll } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
+import { MIN_LENGTH_FOR_PET } from "../../lib/constants";
 
 export default class extends Task {
 	async run(data: CookingActivityTaskOptions) {
@@ -44,12 +45,14 @@ export default class extends Task {
 		loot.remove(cookable.id, burnedAmount);
 		loot.add(cookable.burntCookable, burnedAmount);
 
-		const minutesInTrip = Math.ceil(duration / 1000 / 60);
-		for (let i = 0; i < minutesInTrip; i++) {
-			if (roll(5000)) {
-				loot.add('Remy');
-				str += `\n<:remy:748491189925183638> A small rat notices you cooking, and tells you you're cooking it all wrong! He crawls into your bank to help you with your cooking. You can equip Remy for a boost to your cooking skills.`;
-				break;
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const minutesInTrip = Math.ceil(duration / 1000 / 60);
+			for (let i = 0; i < minutesInTrip; i++) {
+				if (roll(5000)) {
+					loot.add('Remy');
+					str += `\n<:remy:748491189925183638> A small rat notices you cooking, and tells you you're cooking it all wrong! He crawls into your bank to help you with your cooking. You can equip Remy for a boost to your cooking skills.`;
+					break;
+				}
 			}
 		}
 

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -1,7 +1,7 @@
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Emoji, Events } from '../../lib/constants';
+import { Emoji, Events, Time, MIN_LENGTH_FOR_PET} from '../../lib/constants';
 import { hasArrayOfItemsEquipped } from '../../lib/gear';
 import addSkillingClueToLoot from '../../lib/minions/functions/addSkillingClueToLoot';
 import { Cookables } from '../../lib/skilling/skills/cooking';
@@ -153,12 +153,14 @@ export default class extends Task {
 			}
 		}
 
-		const minutesInTrip = Math.ceil(duration / 1000 / 60);
-		for (let i = 0; i < minutesInTrip; i++) {
-			if (roll(8000)) {
-				loot.add('Shelldon');
-				str += `\n<:shelldon:748496988407988244> A crab steals your fish just as you catch it! After some talking, the crab, called Sheldon, decides to join you on your fishing adventures. You can equip Shelldon and he will help you fish!`;
-				break;
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const minutesInTrip = Math.ceil(duration / 1000 / 60);
+			for (let i = 0; i < minutesInTrip; i++) {
+				if (roll(8000)) {
+					loot.add('Shelldon');
+					str += `\n<:shelldon:748496988407988244> A crab steals your fish just as you catch it! After some talking, the crab, called Sheldon, decides to join you on your fishing adventures. You can equip Shelldon and he will help you fish!`;
+					break;
+				}
 			}
 		}
 

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -1,7 +1,7 @@
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Emoji, Events, Time, MIN_LENGTH_FOR_PET} from '../../lib/constants';
+import { Emoji, Events, MIN_LENGTH_FOR_PET} from '../../lib/constants';
 import { hasArrayOfItemsEquipped } from '../../lib/gear';
 import addSkillingClueToLoot from '../../lib/minions/functions/addSkillingClueToLoot';
 import { Cookables } from '../../lib/skilling/skills/cooking';

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -2,7 +2,7 @@ import { roll } from 'e';
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Emoji, Events, Time } from '../../lib/constants';
+import { Emoji, Events, Time, MIN_LENGTH_FOR_PET } from '../../lib/constants';
 import { getRandomMysteryBox } from '../../lib/data/openables';
 import { hasArrayOfItemsEquipped } from '../../lib/gear';
 import addSkillingClueToLoot from '../../lib/minions/functions/addSkillingClueToLoot';
@@ -88,12 +88,14 @@ export default class extends Task {
 			}
 		}
 
-		const minutesInTrip = Math.ceil(duration / Time.Minute);
-		for (let i = 0; i < minutesInTrip; i++) {
-			if (roll(12_000)) {
-				loot.add('Doug');
-				str += `\n<:doug:748892864813203591> A pink-colored mole emerges from where you're mining, and decides to join you on your adventures after seeing your groundbreaking new methods of mining.`;
-				break;
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const minutesInTrip = Math.ceil(duration / Time.Minute);
+			for (let i = 0; i < minutesInTrip; i++) {
+				if (roll(12_000)) {
+					loot.add('Doug');
+					str += `\n<:doug:748892864813203591> A pink-colored mole emerges from where you're mining, and decides to join you on your adventures after seeing your groundbreaking new methods of mining.`;
+					break;
+				}
 			}
 		}
 

--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -100,9 +100,9 @@ export default class extends Task {
 			}
 		}
 
+		let gotWil = false;
 		if(duration >= MIN_LENGTH_FOR_PET) {
 			const minutes = duration / Time.Minute;
-			let gotWil = false;
 			if (roll(Math.floor(4000 / minutes))) {
 				loot.add('Wilvus');
 				gotWil = true;

--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -10,6 +10,7 @@ import { roll, rollRogueOutfitDoubleLoot } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import itemID from '../../lib/util/itemID';
 import { multiplyBankNotClues } from '../../lib/util/mbnc';
+import { MIN_LENGTH_FOR_PET } from '../../lib/constants';
 
 export function calcLootXPPickpocketing(
 	currentLevel: number,
@@ -99,11 +100,13 @@ export default class extends Task {
 			}
 		}
 
-		const minutes = duration / Time.Minute;
-		let gotWil = false;
-		if (roll(Math.floor(4000 / minutes))) {
-			loot.add('Wilvus');
-			gotWil = true;
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const minutes = duration / Time.Minute;
+			let gotWil = false;
+			if (roll(Math.floor(4000 / minutes))) {
+				loot.add('Wilvus');
+				gotWil = true;
+			}
 		}
 
 		await user.addItemsToBank(loot.values(), true);

--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -1,7 +1,7 @@
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Emoji, Events, Time } from '../../lib/constants';
+import { Emoji, Events, Time, MIN_LENGTH_FOR_PET } from '../../lib/constants';
 import { calcMaxRCQuantity } from '../../lib/skilling/functions/calcMaxRCQuantity';
 import Runecraft, { RunecraftActivityTaskOptions } from '../../lib/skilling/skills/runecraft';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -28,9 +28,11 @@ export default class extends Task {
 			[rune.id]: runeQuantity
 		});
 
-		const minutes = duration / Time.Minute;
-		if (roll(Math.floor(5000 / minutes)) && !user.hasItemEquippedOrInBank('Obis')) {
-			loot.add('Obis');
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const minutes = duration / Time.Minute;
+			if (roll(Math.floor(5000 / minutes)) && !user.hasItemEquippedOrInBank('Obis')) {
+				loot.add('Obis');
+			}
 		}
 
 		if (roll((1_795_758 - user.skillLevel(SkillsEnum.Runecraft) * 25) / essenceQuantity)) {

--- a/src/tasks/minions/smeltingActivity.ts
+++ b/src/tasks/minions/smeltingActivity.ts
@@ -2,7 +2,7 @@ import { randInt } from 'e';
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Time } from '../../lib/constants';
+import { Time, MIN_LENGTH_FOR_PET } from '../../lib/constants';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Smithing from '../../lib/skilling/skills/smithing';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -48,13 +48,15 @@ export default class extends Task {
 			[bar.id]: quantity
 		});
 
-		const numMinutes = duration / Time.Minute;
-		if (user.settings.get(UserSettings.QP) > 10) {
-			for (let i = 0; i < numMinutes; i++) {
-				if (roll(6500)) {
-					str += `\n\n<:zak:751035589952012298> While Smelting ores on Neitiznot, a Yak approaches you and says "Moooo". and is now following you around. You decide to name him 'Zak'.`;
-					loot.add('Zak');
-					break;
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const numMinutes = duration / Time.Minute;
+			if (user.settings.get(UserSettings.QP) > 10) {
+				for (let i = 0; i < numMinutes; i++) {
+					if (roll(6500)) {
+						str += `\n\n<:zak:751035589952012298> While Smelting ores on Neitiznot, a Yak approaches you and says "Moooo". and is now following you around. You decide to name him 'Zak'.`;
+						loot.add('Zak');
+						break;
+					}
 				}
 			}
 		}

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -1,7 +1,7 @@
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Emoji, Events, Time } from '../../lib/constants';
+import { Emoji, Events, Time, MIN_LENGTH_FOR_PET } from '../../lib/constants';
 import addSkillingClueToLoot from '../../lib/minions/functions/addSkillingClueToLoot';
 import Woodcutting from '../../lib/skilling/skills/woodcutting';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -42,10 +42,12 @@ export default class extends Task {
 
 		let str = `${user}, ${user.minionName} finished woodcutting, you received ${loot}. ${xpRes}`;
 
-		const minutes = duration / Time.Minute;
-		if (roll(Math.floor(4000 / minutes))) {
-			loot.add('Peky');
-			str += `<:peky:787028037031559168> A small pigeon has taken a liking to you, and hides itself in your bank.`;
+		if(duration >= MIN_LENGTH_FOR_PET) {
+			const minutes = duration / Time.Minute;
+			if (roll(Math.floor(4000 / minutes))) {
+				loot.add('Peky');
+				str += `<:peky:787028037031559168> A small pigeon has taken a liking to you, and hides itself in your bank.`;
+			}
 		}
 
 		// Roll for pet


### PR DESCRIPTION
### Description:
Adds minimum trip length before a pet roll occurs
Currently set to 5 minutes, this is set in constants.ts. 

Note: A value of `1 * Time.Minute` would be similar to current behavior but wouldn't allow any rolls for trips under 1 minute.

### Changes:
Updated the following pets to use this limit:
Scruffy, Harry, Skipper, Lil Lamb, Peky, Wilvus, Doug, Zak, Remy, Obis and Shelldon.

### Other checks:

-   [x] I have tested all my changes thoroughly.
