### PR TITLE
[BSO] Remove TGB's and Dwarven gauntlets from UMBs

### DIFF
--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -501,6 +501,7 @@ const cantBeDropped = [
 	itemID('Dwarven pickaxe'),
 	itemID('Dwarven greataxe'),
 	itemID('Dwarven greathammer'),
+	itemID('Dwarven gauntlets'),
 	itemID('Dwarven knife'),
 	itemID('Dwarven blessing'),
 	itemID('Helm of raedwald'),
@@ -510,6 +511,7 @@ const cantBeDropped = [
 	itemID('Clue hunter boots'),
 	itemID('Clue hunter cloak'),
 	itemID('Cob'),
+	itemID('Tester gift box'),
 	22664, // JMOD Scythe of Vitur,
 	...resolveItems([
 		'Red Partyhat',


### PR DESCRIPTION
### Description:
Removed TGBs and Dwarven Gauntlets from tgb table.

I'm pretty sure 'Cob' can be removed from the 'master' list, because it's also on the linked 'allPetIDs' table, but I don't want to be responsible for bringing more Cobs into the game incase there's a reason its on their twice haha.

### Changes:
Added 'Dwarven gauntlets' and 'Tester gift box' to the cantBeDropped[] array.
