### PR TITLE
[BSO] Make box spawns easier to see and say when they've timed out

### DIFF
--- a/src/monitors/boxSpawns.ts
+++ b/src/monitors/boxSpawns.ts
@@ -38,6 +38,7 @@ async function triviaChallenge(msg: KlasaMessage): Promise<KlasaUser | null> {
 		const winner = collected.first()?.author;
 		return winner ?? null;
 	} catch (err) {
+		msg.channel.send("Nobody answered in time, sorry!");
 		return null;
 	}
 }
@@ -47,7 +48,12 @@ async function itemChallenge(msg: KlasaMessage): Promise<KlasaUser | null> {
 		.split(' ')
 		.map(part => shuffleArr([...part]).join(''))
 		.join(' ');
-	await msg.channel.send(`Unscramble this item name for a reward: ${scrambed}`);
+
+	const embed = new MessageEmbed()
+		.setColor(Color.Orange)
+		.setTitle('Answer this for a reward!')
+		.setDescription(`Unscramble this item name for a reward: ${scrambed}`);
+	await msg.channel.send(embed);
 
 	try {
 		const collected = await msg.channel.awaitMessages(
@@ -62,12 +68,17 @@ async function itemChallenge(msg: KlasaMessage): Promise<KlasaUser | null> {
 		const winner = collected.first()?.author;
 		return winner ?? null;
 	} catch (err) {
+		msg.channel.send("Nobody answered in time, sorry!");
 		return null;
 	}
 }
 
 async function reactChallenge(msg: KlasaMessage): Promise<KlasaUser | null> {
-	const message = await msg.channel.send(`React to this message with any emoji for a reward!`);
+	const embed = new MessageEmbed()
+		.setColor(Color.Orange)
+		.setTitle('Answer this for a reward!')
+		.setDescription(`React to this message with any emoji for a reward!`);
+	const message = await msg.channel.send(embed);
 	try {
 		const collected = await message.awaitReactions(() => true, {
 			max: 1,

--- a/src/monitors/boxSpawns.ts
+++ b/src/monitors/boxSpawns.ts
@@ -38,7 +38,7 @@ async function triviaChallenge(msg: KlasaMessage): Promise<KlasaUser | null> {
 		const winner = collected.first()?.author;
 		return winner ?? null;
 	} catch (err) {
-		msg.channel.send("Nobody answered in time, sorry!");
+		msg.channel.send('Nobody answered in time, sorry!');
 		return null;
 	}
 }
@@ -68,7 +68,7 @@ async function itemChallenge(msg: KlasaMessage): Promise<KlasaUser | null> {
 		const winner = collected.first()?.author;
 		return winner ?? null;
 	} catch (err) {
-		msg.channel.send("Nobody answered in time, sorry!");
+		msg.channel.send('Nobody answered in time, sorry!');
 		return null;
 	}
 }
@@ -125,7 +125,7 @@ export default class extends Monitor {
 	async run(msg: KlasaMessage) {
 		if (
 			!msg.guild ||
-			msg.guild.id !== SupportServer ||
+			msg.guild!.id !== SupportServer ||
 			msg.channel.id !== '792691343284764693'
 		) {
 			return;

--- a/src/monitors/boxSpawns.ts
+++ b/src/monitors/boxSpawns.ts
@@ -125,7 +125,7 @@ export default class extends Monitor {
 	async run(msg: KlasaMessage) {
 		if (
 			!msg.guild ||
-			msg.guild!.id !== SupportServer ||
+			msg.guild.id !== SupportServer ||
 			msg.channel.id !== '792691343284764693'
 		) {
 			return;


### PR DESCRIPTION
### Description:
Changed the emojii + unscramble to embeds so they're easier to see, like the trivia.
Added a timeout message for all except the emojii-after 30 seconds its not really needed and obvious because of the nature of the type of challenge.

### Changes:
Changed the msg.channel.send to msg.channel.embed and added a timeout message to the error trap.

### Other checks:

-   [x] I have tested all my changes thoroughly.