### PR TITLE
Fix Bank / tradeableItemBank --search flag to work case-insensitive. 

### DIFF
--- a/src/arguments/tradeableItemBank.ts
+++ b/src/arguments/tradeableItemBank.ts
@@ -63,7 +63,9 @@ export default class TradeableItemBankArgument extends Argument {
 		if (search) {
 			items = [
 				...items,
-				...userBank.items().filter(i => i[0].name.toLowerCase().includes(search))
+				...userBank
+					.items()
+					.filter(i => i[0].name.toLowerCase().includes(search.toLowerCase()))
 			];
 		}
 

--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -44,7 +44,7 @@ export default class extends BotCommand {
 		if (msg.flagArgs.text) {
 			const textBank = [];
 			for (const [item, qty] of bank.items()) {
-				if (msg.flagArgs.search && !item.name.toLowerCase().includes(msg.flagArgs.search)) {
+				if (msg.flagArgs.search && !item.name.toLowerCase().includes(msg.flagArgs.search.toLowerCase())) {
 					continue;
 				}
 				textBank.push(`${item.name}: ${qty.toLocaleString()}`);

--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -44,7 +44,10 @@ export default class extends BotCommand {
 		if (msg.flagArgs.text) {
 			const textBank = [];
 			for (const [item, qty] of bank.items()) {
-				if (msg.flagArgs.search && !item.name.toLowerCase().includes(msg.flagArgs.search.toLowerCase())) {
+				if (
+					msg.flagArgs.search &&
+					!item.name.toLowerCase().includes(msg.flagArgs.search.toLowerCase())
+				) {
 					continue;
 				}
 				textBank.push(`${item.name}: ${qty.toLocaleString()}`);

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -74,7 +74,7 @@ export function parseBank({ inputBank, inputStr, flags = {} }: ParseBankOptions)
 		if (flagsKeys.includes('tradeables') && !item.tradeable) continue;
 		if (flagsKeys.includes('untradeables') && item.tradeable) continue;
 		if (flagsKeys.includes('equippables') && !item.equipment?.slot) continue;
-		if (flagsKeys.includes('search') && !item.name.toLowerCase().includes(flags.search)) {
+		if (flagsKeys.includes('search') && !item.name.toLowerCase().includes(flags.search.toLowerCase())) {
 			continue;
 		}
 

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -74,7 +74,10 @@ export function parseBank({ inputBank, inputStr, flags = {} }: ParseBankOptions)
 		if (flagsKeys.includes('tradeables') && !item.tradeable) continue;
 		if (flagsKeys.includes('untradeables') && item.tradeable) continue;
 		if (flagsKeys.includes('equippables') && !item.equipment?.slot) continue;
-		if (flagsKeys.includes('search') && !item.name.toLowerCase().includes(flags.search.toLowerCase())) {
+		if (
+			flagsKeys.includes('search') &&
+			!item.name.toLowerCase().includes(flags.search.toLowerCase())
+		) {
 			continue;
 		}
 


### PR DESCRIPTION
### Description:
Now --search=ELY or --search=Elysian will work, whereas previously --search= had to be all lowercase for it to match.

### Changes:
Added .strToLower() on the search variable.

### Other checks:

-   [x] I have tested all my changes thoroughly.
