### PR TITLE
[BSO] Fixed =create --items on BSO because of broken creatable

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1552,26 +1552,6 @@ const Createables: Createable[] = [
 		noCl: true
 	},
 	{
-		name: 'Eldritch nightmare staff',
-		inputItems: resolveNameBank({
-			'Nightmare staff': 1,
-			'Eldritch orb': 1
-		}),
-		outputItems: resolveNameBank({
-			'Eldritch nightmare staff': 1
-		})
-	},
-	{
-		name: 'Harmonised nightmare staff',
-		inputItems: resolveNameBank({
-			'Nightmare staff': 1,
-			'Harmonised orb': 1
-		}),
-		outputItems: resolveNameBank({
-			'Harmonised nightmare staff': 1
-		})
-	},
-	{
 		name: 'Bronze set (lg)',
 		inputItems: {
 			[itemID('Bronze full helm')]: 1,
@@ -4206,7 +4186,7 @@ const Createables: Createable[] = [
 		})
 	},
 	{
-		name: '	Harmonised nightmare staff',
+		name: 'Harmonised nightmare staff',
 		inputItems: resolveNameBank({
 			'Nightmare staff': 1,
 			'Harmonised orb': 1


### PR DESCRIPTION
### Description:
Fixed =create --items

### Changes:

- Removed duplicated Nightmare + Elditch staff creatables.
- Fixed the extraneous \t in a copied version of Harmonised Nightmare Staff in the BSO version.

### Other checks:

-   [x] I have tested all my changes thoroughly.
