### PR TITLE
[BSO] Remove Abyssal pouch from umb drops

### DIFF
--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -486,6 +486,7 @@ allItemsIDs = removeDuplicatesFromArray(allItemsIDs);
 const cantBeDropped = [
 	...Object.values(coxLog).flat(Infinity),
 	...Object.values(customBossLog).flat(Infinity),
+	itemID('Abyssal pouch'),
 	itemID('Dwarven crate'),
 	itemID('Halloween mask set'),
 	itemID('Partyhat set'),


### PR DESCRIPTION
### Description:
Does what it says on the tin

### Changes:
Added 'Abyssal pouch' to the cantBeDropped array since it's not on the customBossLog list
