### PR TITLE
[BSO] Lower Goldemar time to get max KC boost to 100-150hrs [+?]

### DIFF
--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -241,7 +241,7 @@ export class BossInstance {
 		let speedReductionForBoosts = sumArr(this.itemBoosts.map(i => i[1]));
 		const totalSpeedReduction =
 			speedReductionForGear + speedReductionForKC + speedReductionForBoosts;
-		const kcCap = 100;
+		const kcCap = 125;
 
 		const bossUsers: BossUser[] = [];
 		let totalPercent = 0;

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -241,7 +241,7 @@ export class BossInstance {
 		let speedReductionForBoosts = sumArr(this.itemBoosts.map(i => i[1]));
 		const totalSpeedReduction =
 			speedReductionForGear + speedReductionForKC + speedReductionForBoosts;
-		const kcCap = 250;
+		const kcCap = 100;
 
 		const bossUsers: BossUser[] = [];
 		let totalPercent = 0;


### PR DESCRIPTION
### Description:
Most monsters boosts are around 40hr/2xBSOboost = 20hrs to get max boost.
This obviously isnt the same, but Nex/KK are also around 100 hours for max boost.
Goldy is 200-350hrs to get max kc boost currently, depending on gear & team.

This changes goldy to be more in line with other end game bosses.
100 hours is roughly 1/4 the time to get a hammer on average, and that feels about right.

This is something the new people to goldy have really been asking for as they barely see their boost improve over days.

### Changes:
Set kcCap = 125

