### PR TITLE
[BSO] Make the active skill's Master Skillcape take priority

### DIFF
--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -771,10 +771,23 @@ export default class extends Extendable {
 			.map(val => val.cape)
 			.filter(notEmpty)
 			.map(i => i.item);
-		const masterCape = multiplier
+
+		// Get cape object from MasterSkillCapes that matches active skill.
+		const matchingCape = multiplier
+			? MasterSkillcapes.find(cape => skillName === cape.skill)
+			: undefined;
+
+		// If the matching cape is equipped, isMatchingCape = true
+		const isMatchingCape =
+			multiplier && matchingCape ? allCapes.includes(matchingCape.item.id) : false;
+
+		// Get the masterCape object for use in text output
+		const masterCape = isMatchingCape
+			? matchingCape
+			: multiplier
 			? MasterSkillcapes.find(cape => allCapes.includes(cape.item.id))
 			: undefined;
-		const isMatchingCape = masterCape?.skill === skillName;
+
 		if (masterCape) {
 			amount = increaseNumByPercent(amount, isMatchingCape ? 8 : 3);
 		}


### PR DESCRIPTION
### Description:
Currently, Master skillcape priority is based on the order in which they apper in the MasterSkillcapes object.
This means if you have both a Fishing master cape and a Construction master cape equipped, the Fishing cape will always take priority, and you won't get your 8% construction XP unless you remove the fishing cape.

This fixes that issue by always giving priority to the active skill's Master cape, if one is being worn.
This also means if you're wearing Attack, Strength, Defence, and Hitpoints cape and train on shared, you will get 8% bonus XP to all 4 skills :) How about that!

### Changes:

1. Updated the addXP function in src/extendables/User/Minion.ts
2. First we assign `matchingCape` the MasterSkillcape element that corresponds to the active skill.
3. We then check if it's currently equipped, and set `isMatchingCape` accordingly.
4. Lastly we set `masterCape` = `matchingCape` if isMatchingCape, and we fallback to the old priority model to use any cape if the matching cape is not equipped.

### Other checks:

-   [x] I have tested all my changes thoroughly.
