### PR TITLE
[BSO] Give DHCB priority over DHL, while still only allowing one or the other

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -152,9 +152,7 @@ export default class extends BotCommand {
 			if (msg.author.hasItemEquippedAnywhere(itemID('Dragon hunter crossbow'))) {
 				timeToFinish *= 0.7;
 				boosts.push(`30% boost for Dragon hunter crossbow`);
-			}
-		} else if (Monsters.get(monster.id)?.data.attributes.includes(MonsterAttribute.Dragon)) {
-			if (msg.author.hasItemEquippedAnywhere(itemID('Dragon hunter lance'))) {
+			} else if (msg.author.hasItemEquippedAnywhere(itemID('Dragon hunter lance'))) {
 				timeToFinish *= 0.8;
 				boosts.push(`20% boost for Dragon hunter lance`);
 			}

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -147,7 +147,13 @@ export default class extends BotCommand {
 			boosts.push(`40% boost for Dwarven warhammer`);
 		}
 
+		// Give DHCB's 30% boost priority, and then fallback to dhl's 20%
 		if (Monsters.get(monster.id)?.data.attributes.includes(MonsterAttribute.Dragon)) {
+			if (msg.author.hasItemEquippedAnywhere(itemID('Dragon hunter crossbow'))) {
+				timeToFinish *= 0.7;
+				boosts.push(`30% boost for Dragon hunter crossbow`);
+			}
+		} else if (Monsters.get(monster.id)?.data.attributes.includes(MonsterAttribute.Dragon)) {
 			if (msg.author.hasItemEquippedAnywhere(itemID('Dragon hunter lance'))) {
 				timeToFinish *= 0.8;
 				boosts.push(`20% boost for Dragon hunter lance`);

--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -188,7 +188,6 @@ const killableBosses: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Armadyl crossbow')]: 6,
-				[itemID('Dragon hunter crossbow')]: 8,
 				[itemID('Twisted bow')]: 10
 			}
 		],


### PR DESCRIPTION
### Description:
Dragon hunter crossbow once again works on dragons, however the boost will NOT stack with the dragon hunter lance. You will get the greater boost of the two.

### Changes:

- Now handles DHCB the same was DHL does, but only allowing one boost or the other.
- Removed the DHCB boost from KBD, but left the Twisted bow so you can stack Tbow + DHCB.
- (KBD Now only has 2% more boost overall with DHCB)
- Other dragons previously unaffected by DHCB will have an additional 10% above what they had with Lance.

### Other checks:

-   [x] I have tested all my changes thoroughly.
