### PR TITLE
[BSO] Added Hammy tracking and ability to disable confirmations

### DIFF
--- a/src/commands/bso/hammy.ts
+++ b/src/commands/bso/hammy.ts
@@ -2,9 +2,11 @@ import { randArrItem } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Bank } from 'oldschooljs';
 
-import { Emoji } from '../../lib/constants';
+import { BitField, Emoji } from '../../lib/constants';
+import { ClientSettings } from '../../lib/settings/types/ClientSettings';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
-import { itemID, roll } from '../../lib/util';
+import { itemID, roll, updateBankSetting } from '../../lib/util';
 import getOSItem from '../../lib/util/getOSItem';
 
 const options = {
@@ -20,7 +22,7 @@ const chanceToDouble = 100;
 const chanceToSave = 10;
 
 const hammyMessages = [
-	'You try to use a {item} on Hammy, he swiftly eats it.',
+	'You try to use your {item} on Hammy, he swiftly eats it.',
 	"You shove the {item} in Hammy's face; he crushes it with his teeth in rage, barely missing your hand.",
 	'You offer the {item} to Hammy, and he throws it to the floor.',
 	'You gently hand the {item} to Hammy. He squeaks excitedly before tearing it to shreds.',
@@ -36,37 +38,96 @@ const hammyMessages = [
 ];
 
 const hammyFailMessages = [
-	'You gave {item} to Hammy. He hurriedly chokes it down, before spitting it back up in disgust. It seems ok...',
-	"Hammy refused to eat {item} for personal reasons. Don't ask.",
+	'You gave your {item} to Hammy. He hurriedly chokes it down, before spitting it back up in disgust. It seems ok...',
+	"Hammy refused to eat your {item} for personal reasons. Don't ask.",
 	'Hammy will NEVER eat another {item} after what happened last summer...',
 	'You dropped your {item} but Hammy helpfully caught it and slipped it back into your pack.',
-	`${Emoji.MoneyBag} Hammy took your {item} and diced it...\n\nHe won, but ate the profit. At least you didn't lost anything ${Emoji.Joy}`
+	`${Emoji.MoneyBag} Hammy took your {item} and diced it...\n\nHe won, but ate the profit. At least you didn't lose anything ${Emoji.Joy}`
 ];
 
 const hammyDoubleMessages = [
 	`${Emoji.MoneyBag} Hammy took your {item} and diced it...\n\nHe won, and actually brought you the profit! ${Emoji.Joy}`,
-	'You feed {item} to Hammy and he hides it in his cheeks. You go to pull it out and find it doubled. How did that happen?',
-	"You give {item} to Hammy while he's on his hamster wheel. When he stops and the dust settles, you realize there are now two.",
-	"Hammy takes your {item} while you aren't looking and runs to the casino. He comes back rich and hands you an extra {item} for your trouble."
+	'You feed your {item} to Hammy and he hides it in his cheeks. You go to pull it out and find it doubled. How did that happen?',
+	`You give your {item} to Hammy while he's on his hamster wheel. When he stops and the dust settles, you realize there are now two.`,
+	`Hammy takes your {item} while you aren't looking and runs to the casino. He comes back rich and hands you an extra {item} for your trouble.`
 ];
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '<item:string>',
+			usage: '[item:string]',
 			usageDelim: ',',
 			oneAtTime: true,
 			aliases: ['feed', 'feedhammy'],
-			cooldown: 5,
+			cooldown: 2,
 			altProtection: true
 		});
 	}
 
 	async run(msg: KlasaMessage, [firstItemStr]: [string]) {
+		if (msg.flagArgs.help) {
+			return msg.send(
+				`Usage:\n\n\`${msg.cmdPrefix}hammy --warnings [--enable/--disable]\` ` +
+					`Show/enable/disable confirmation\n` +
+					`\`${msg.cmdPrefix}hammy Dragon warhammer --cf\` Feeds item to Hammy without confirmation`
+			);
+		}
+
+		const hammyFeedWarningDisabled = msg.author.settings
+			.get(UserSettings.BitField)
+			.includes(BitField.DisabledHammyFeedConfirm);
+
+		if (msg.flagArgs.warning || msg.flagArgs.warnings) {
+			let nextBool = false;
+			if (msg.flagArgs.disable) {
+				nextBool = true;
+			} else if (msg.flagArgs.enable) {
+				nextBool = false;
+			} else {
+				return msg.send(
+					`Hammy's feed warnings are ${
+						!hammyFeedWarningDisabled ? 'enabled' : 'disabled'
+					} for you.\n\n` +
+						`Use \`${msg.cmdPrefix}hammy --warnings [--enable/--disable]\` to change this`
+				);
+			}
+			if (hammyFeedWarningDisabled === nextBool) {
+				return msg.send(
+					`Hammy's feed warnings are already ${
+						!hammyFeedWarningDisabled ? 'enabled' : 'disabled'
+					} for you.`
+				);
+			}
+			await msg.author.settings.update(
+				UserSettings.BitField,
+				BitField.DisabledHammyFeedConfirm
+			);
+			return msg.send(
+				`Hammy's feed warnings are now ${!nextBool ? 'enabled' : 'disabled'} for you.`
+			);
+		}
+
+		if (firstItemStr === undefined) {
+			return msg.send(`Item name is a required argument.`);
+		}
+
+		// Start the actually Hammy code
 		const bank = msg.author.bank();
 		const firstItem = getOSItem(firstItemStr);
 
-		if (!msg.flagArgs.confirm && !msg.flagArgs.cf && !msg.flagArgs.yes) {
+		if (!bank.has(firstItem.id)) {
+			return msg.send(`You don't have a ${firstItem.name}.`);
+		}
+		if (!bank.has(itemID('Hammy')) && msg.author.equippedPet() !== itemID('Hammy')) {
+			return msg.send(`You don't have a Hammy, so how could you feed it?`);
+		}
+
+		if (
+			!hammyFeedWarningDisabled &&
+			!msg.flagArgs.confirm &&
+			!msg.flagArgs.cf &&
+			!msg.flagArgs.yes
+		) {
 			const dropMsg = await msg.channel.send(
 				`${msg.author}, are you sure you want to give ${firstItem.name} to Hammy? You probably won't get it back... Type \`confirm\` to confirm.`
 			);
@@ -83,22 +144,25 @@ export default class extends BotCommand {
 			}
 		}
 
-		if (!bank.has(firstItem.id)) {
-			return msg.send(`You don't have a ${firstItem.name}.`);
-		}
-		if (!bank.has(itemID('Hammy'))) {
-			return msg.send("You don't have a Hammy, so how could you feed it?");
-		}
-
 		if (roll(chanceToDouble)) {
 			let loot = new Bank();
 			loot.add(firstItem.id);
+			updateBankSetting(this.client, ClientSettings.EconomyStats.HammyDoubled, loot);
 			await msg.author.addItemsToBank(loot, false);
 			return msg.send(randArrItem(hammyDoubleMessages).replace(/\{item\}/g, firstItem.name));
 		}
+
 		if (roll(chanceToSave)) {
+			let spared = new Bank();
+			spared.add(firstItem.id);
+			updateBankSetting(this.client, ClientSettings.EconomyStats.HammySpared, spared);
+			await msg.author.addItemsToBank(spared, false);
 			return msg.send(randArrItem(hammyFailMessages).replace(/\{item\}/g, firstItem.name));
 		}
+
+		let lost = new Bank();
+		lost.add(firstItem.id);
+		updateBankSetting(this.client, ClientSettings.EconomyStats.HammyDestroyed, lost);
 		await msg.author.removeItemFromBank(firstItem.id);
 		return msg.send(randArrItem(hammyMessages).replace(/\{item\}/g, firstItem.name));
 	}

--- a/src/commands/bso/hammy.ts
+++ b/src/commands/bso/hammy.ts
@@ -48,8 +48,8 @@ const hammyFailMessages = [
 const hammyDoubleMessages = [
 	`${Emoji.MoneyBag} Hammy took your {item} and diced it...\n\nHe won, and actually brought you the profit! ${Emoji.Joy}`,
 	'You feed your {item} to Hammy and he hides it in his cheeks. You go to pull it out and find it doubled. How did that happen?',
-	`You give your {item} to Hammy while he's on his hamster wheel. When he stops and the dust settles, you realize there are now two.`,
-	`Hammy takes your {item} while you aren't looking and runs to the casino. He comes back rich and hands you an extra {item} for your trouble.`
+	"You give your {item} to Hammy while he's on his hamster wheel. When he stops and the dust settles, you realize there are now two.",
+	"Hammy takes your {item} while you aren't looking and runs to the casino. He comes back rich and hands you an extra {item} for your trouble."
 ];
 
 export default class extends BotCommand {
@@ -68,7 +68,7 @@ export default class extends BotCommand {
 		if (msg.flagArgs.help) {
 			return msg.send(
 				`Usage:\n\n\`${msg.cmdPrefix}hammy --warnings [--enable/--disable]\` ` +
-					`Show/enable/disable confirmation\n` +
+					'Show/enable/disable confirmation\n' +
 					`\`${msg.cmdPrefix}hammy Dragon warhammer --cf\` Feeds item to Hammy without confirmation`
 			);
 		}
@@ -85,30 +85,21 @@ export default class extends BotCommand {
 				nextBool = false;
 			} else {
 				return msg.send(
-					`Hammy's feed warnings are ${
-						!hammyFeedWarningDisabled ? 'enabled' : 'disabled'
-					} for you.\n\n` +
+					`Hammy's feed warnings are ${!hammyFeedWarningDisabled ? 'enabled' : 'disabled'} for you.\n\n` +
 						`Use \`${msg.cmdPrefix}hammy --warnings [--enable/--disable]\` to change this`
 				);
 			}
 			if (hammyFeedWarningDisabled === nextBool) {
 				return msg.send(
-					`Hammy's feed warnings are already ${
-						!hammyFeedWarningDisabled ? 'enabled' : 'disabled'
-					} for you.`
+					`Hammy's feed warnings are already ${!hammyFeedWarningDisabled ? 'enabled' : 'disabled'} for you.`
 				);
 			}
-			await msg.author.settings.update(
-				UserSettings.BitField,
-				BitField.DisabledHammyFeedConfirm
-			);
-			return msg.send(
-				`Hammy's feed warnings are now ${!nextBool ? 'enabled' : 'disabled'} for you.`
-			);
+			await msg.author.settings.update(UserSettings.BitField, BitField.DisabledHammyFeedConfirm);
+			return msg.send(`Hammy's feed warnings are now ${!nextBool ? 'enabled' : 'disabled'} for you.`);
 		}
 
 		if (firstItemStr === undefined) {
-			return msg.send(`Item name is a required argument.`);
+			return msg.send('Item name is a required argument.');
 		}
 
 		// Start the actually Hammy code
@@ -119,15 +110,10 @@ export default class extends BotCommand {
 			return msg.send(`You don't have a ${firstItem.name}.`);
 		}
 		if (!bank.has(itemID('Hammy')) && msg.author.equippedPet() !== itemID('Hammy')) {
-			return msg.send(`You don't have a Hammy, so how could you feed it?`);
+			return msg.send("You don't have a Hammy, so how could you feed it?");
 		}
 
-		if (
-			!hammyFeedWarningDisabled &&
-			!msg.flagArgs.confirm &&
-			!msg.flagArgs.cf &&
-			!msg.flagArgs.yes
-		) {
+		if (!hammyFeedWarningDisabled && !msg.flagArgs.confirm && !msg.flagArgs.cf && !msg.flagArgs.yes) {
 			const dropMsg = await msg.channel.send(
 				`${msg.author}, are you sure you want to give ${firstItem.name} to Hammy? You probably won't get it back... Type \`confirm\` to confirm.`
 			);

--- a/src/commands/bso/hammystats.ts
+++ b/src/commands/bso/hammystats.ts
@@ -1,0 +1,66 @@
+import { CommandStore, KlasaMessage } from 'klasa';
+
+import { ClientSettings } from '../../lib/settings/types/ClientSettings';
+import { BotCommand } from '../../lib/structures/BotCommand';
+import { ItemBank } from '../../lib/types';
+import { countAllItemsInBank } from '../../lib/util';
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			usage: '[statsType:string]',
+			usageDelim: ',',
+			oneAtTime: true,
+			cooldown: 15,
+			altProtection: true
+		});
+	}
+
+	async run(msg: KlasaMessage, [statsType]: [string]) {
+		if (msg.flagArgs.help || statsType === 'help') {
+			return msg.send(
+				`Usage:\n\n` +
+					`\`${msg.cmdPrefix}hammystats [overall/destroyed/doubled/spared]\` Show Hammy's economy stats`
+			);
+		}
+
+		if (statsType === 'destroyed') {
+			return msg.channel.sendBankImage({
+				bank: this.client.settings.get(ClientSettings.EconomyStats.HammyDestroyed),
+				title: `All items Hammys have destroyed:`,
+				flags: msg.flagArgs
+			});
+		}
+		if (statsType === 'doubled') {
+			return msg.channel.sendBankImage({
+				bank: this.client.settings.get(ClientSettings.EconomyStats.HammyDoubled),
+				title: `All items Hammys have doubled:`,
+				flags: msg.flagArgs
+			});
+		}
+		if (statsType === 'spared') {
+			return msg.channel.sendBankImage({
+				bank: this.client.settings.get(ClientSettings.EconomyStats.HammySpared),
+				title: `All items Hammys have spared:`,
+				flags: msg.flagArgs
+			});
+		}
+
+		const ctDestroyed = countAllItemsInBank(
+			this.client.settings.get(ClientSettings.EconomyStats.HammyDestroyed) as ItemBank
+		);
+		const ctDoubled = countAllItemsInBank(
+			this.client.settings.get(ClientSettings.EconomyStats.HammyDoubled) as ItemBank
+		);
+		const ctSpared = countAllItemsInBank(
+			this.client.settings.get(ClientSettings.EconomyStats.HammySpared) as ItemBank
+		);
+
+		return msg.send(
+			`Overall Hammy economy stats:\n\n` +
+				`Total items destroyed: ${ctDestroyed}\n` +
+				`Total items doubled: ${ctDoubled}\n` +
+				`Total items spared: ${ctSpared}`
+		);
+	}
+}

--- a/src/commands/bso/hammystats.ts
+++ b/src/commands/bso/hammystats.ts
@@ -19,7 +19,7 @@ export default class extends BotCommand {
 	async run(msg: KlasaMessage, [statsType]: [string]) {
 		if (msg.flagArgs.help || statsType === 'help') {
 			return msg.send(
-				`Usage:\n\n` +
+				'Usage:\n\n' +
 					`\`${msg.cmdPrefix}hammystats [overall/destroyed/doubled/spared]\` Show Hammy's economy stats`
 			);
 		}
@@ -27,21 +27,21 @@ export default class extends BotCommand {
 		if (statsType === 'destroyed') {
 			return msg.channel.sendBankImage({
 				bank: this.client.settings.get(ClientSettings.EconomyStats.HammyDestroyed),
-				title: `All items Hammys have destroyed:`,
+				title: 'All items Hammys have destroyed:',
 				flags: msg.flagArgs
 			});
 		}
 		if (statsType === 'doubled') {
 			return msg.channel.sendBankImage({
 				bank: this.client.settings.get(ClientSettings.EconomyStats.HammyDoubled),
-				title: `All items Hammys have doubled:`,
+				title: 'All items Hammys have doubled:',
 				flags: msg.flagArgs
 			});
 		}
 		if (statsType === 'spared') {
 			return msg.channel.sendBankImage({
 				bank: this.client.settings.get(ClientSettings.EconomyStats.HammySpared),
-				title: `All items Hammys have spared:`,
+				title: 'All items Hammys have spared:',
 				flags: msg.flagArgs
 			});
 		}
@@ -57,7 +57,7 @@ export default class extends BotCommand {
 		);
 
 		return msg.send(
-			`Overall Hammy economy stats:\n\n` +
+			'Overall Hammy economy stats:\n\n' +
 				`Total items destroyed: ${ctDestroyed}\n` +
 				`Total items doubled: ${ctDoubled}\n` +
 				`Total items spared: ${ctSpared}`

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -360,12 +360,11 @@ export const enum BitField {
 	HasPermanentTierOne = 12,
 	DisabledRandomEvents = 13,
 	PermanentIronman = 14,
-	DisabledHammyFeedConfirm = 15,
-	PreloadHammyDestroyed = 16,
 	HasGivenBirthdayPack = 200,
 	HasPermanentSpawnLamp = 201,
 	HasScrollOfFarming = 202,
-	HasScrollOfLongevity = 203
+	HasScrollOfLongevity = 203,
+	DisabledHammyFeedConfirm = 204
 }
 
 interface BitFieldData {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -360,6 +360,8 @@ export const enum BitField {
 	HasPermanentTierOne = 12,
 	DisabledRandomEvents = 13,
 	PermanentIronman = 14,
+	DisabledHammyFeedConfirm = 15,
+	PreloadHammyDestroyed = 16,
 	HasGivenBirthdayPack = 200,
 	HasPermanentSpawnLamp = 201,
 	HasScrollOfFarming = 202,

--- a/src/lib/settings/schemas/ClientSchema.ts
+++ b/src/lib/settings/schemas/ClientSchema.ts
@@ -38,6 +38,9 @@ Client.defaultClientSchema
 	.add('mage_arena_cost', 'any', { default: {} })
 	.add('hunter_cost', 'any', { default: {} })
 	.add('hunter_loot', 'any', { default: {} })
+	.add('hammy_destroyed', 'any', { default: {} })
+	.add('hammy_doubled', 'any', { default: {} })
+	.add('hammy_spared', 'any', { default: {} })
 	.add('economyStats', folder =>
 		folder
 			.add('dicingBank', 'number', { default: 0 })

--- a/src/lib/settings/types/ClientSettings.ts
+++ b/src/lib/settings/types/ClientSettings.ts
@@ -86,5 +86,9 @@ export namespace ClientSettings {
 		export const GPSourcePet = T<number>('gp_pet');
 		export const GPSourceDaily = T<number>('gp_daily');
 		export const GPSourceItemContracts = T<number>('gp_ic');
+
+		export const HammyDestroyed = T<O.Readonly<ItemBank>>('hammy_destroyed');
+		export const HammyDoubled = T<O.Readonly<ItemBank>>('hammy_doubled');
+		export const HammySpared = T<O.Readonly<ItemBank>>('hammy_spared');
 	}
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -518,3 +518,17 @@ export async function wipeDBArrayByKey(user: KlasaUser, key: string): Promise<Se
 	const active: any[] = user.settings.get(key) as any[];
 	return user.settings.update(key, active);
 }
+
+/**
+ * Counts the total number of items in the bank. Example 2x Air rune, 1x Dust rune returns 3.
+ * @param bank The ItemBank object we will be counting
+ */
+export function countAllItemsInBank(bank: ItemBank) {
+	let totalQty = 0;
+	for (const [itemID, qty] of Object.entries(bank)) {
+		const item = Items.get(parseInt(itemID));
+		if (!item) continue;
+		totalQty += qty;
+	}
+	return totalQty;
+}


### PR DESCRIPTION
Edit: Updated to resolve conflicts.

### Description:
Added tracking code for Hammy: destroyed, spared, doubled.
```
=hammystats [overall/destroyed/spared/doubled]
=hammy --warnings [--disable/--enable]
```

Please consider running:
`-ev this.client.settings.update('hammy_destroyed',{'12817':1,'24214':1});`
After the schema is loaded to preload the Elysian and Abyssal cape Hammy ate on release.

Also, please check on the cooldowns to make sure we don't overload the database, you definitely know load issues on the DB more than myself :) Considered making =hammystats a Tier[1?]'d Perk

### Changes:

- Created file/command: hammystats.ts
- Added 3 new bank settings to the schema + clientsettings enum.
- Added a `countAllItemsInBank` function to util.ts for counting the total number of items in an Itembank.
- Added a new bitfield for disabling the Hammy confirmation check
- Fixed some minor grammatical errors

### Other checks:

-   [x] I have tested all my changes thoroughly.
