### PR TITLE
[BSO] Allow Obis to be rolled even if you already have one.

### DIFF
--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -48,7 +48,7 @@ export default class extends Task {
 
 		if (duration >= MIN_LENGTH_FOR_PET) {
 			const minutes = duration / Time.Minute;
-			if (roll(Math.floor(5000 / minutes)) && !user.hasItemEquippedOrInBank('Obis')) {
+			if (roll(Math.floor(5000 / minutes))) {
 				loot.add('Obis');
 			}
 		}


### PR DESCRIPTION
### Description:
Allows Obis to be obtained even if you have one equipped or in bank.

Reasoning:
- No other pets have this restriction, and with Obis's heavy 3x rune cost, it should still be obtainable.
- This also encourages rather than discourages loans, which leads to more essence being removed from the game.

### Changes:
Removed the check that looks for Obis equipped or in bank, and allows it to be obtained.