### PR TITLE
[BSO] Give 2x tokens for Flappy at ODS [a minigame].

### DIFF
--- a/src/tasks/minions/minigames/ouraniaDeliveryServiceActivity.ts
+++ b/src/tasks/minions/minigames/ouraniaDeliveryServiceActivity.ts
@@ -7,7 +7,7 @@ import { UserSettings } from '../../../lib/settings/types/UserSettings';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import { MinigameActivityTaskOptions } from '../../../lib/types/minions';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
-import itemID from "../../../lib/util/itemID";
+import itemID from '../../../lib/util/itemID';
 
 export default class extends Task {
 	async run(data: MinigameActivityTaskOptions) {
@@ -18,7 +18,7 @@ export default class extends Task {
 		const user = await this.client.users.fetch(userID);
 		const level = user.skillLevel(SkillsEnum.Magic);
 		let tokens = Math.floor((quantity / 2) * 3.235 * (level / 25 + 1));
-		if(user.equippedPet() === itemID('Flappy')) {
+		if (user.equippedPet() === itemID('Flappy')) {
 			tokens *= 2;
 		}
 

--- a/src/tasks/minions/minigames/ouraniaDeliveryServiceActivity.ts
+++ b/src/tasks/minions/minigames/ouraniaDeliveryServiceActivity.ts
@@ -7,6 +7,7 @@ import { UserSettings } from '../../../lib/settings/types/UserSettings';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import { MinigameActivityTaskOptions } from '../../../lib/types/minions';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
+import itemID from "../../../lib/util/itemID";
 
 export default class extends Task {
 	async run(data: MinigameActivityTaskOptions) {
@@ -16,7 +17,10 @@ export default class extends Task {
 
 		const user = await this.client.users.fetch(userID);
 		const level = user.skillLevel(SkillsEnum.Magic);
-		const tokens = Math.floor((quantity / 2) * 3.235 * (level / 25 + 1));
+		let tokens = Math.floor((quantity / 2) * 3.235 * (level / 25 + 1));
+		if(user.equippedPet() === itemID('Flappy')) {
+			tokens *= 2;
+		}
 
 		await user.settings.update(
 			UserSettings.OuraniaTokens,


### PR DESCRIPTION
### Description:
Doubles tokens if Flappy is equipped.

- **PS. This got 100% upvotes in the poll channel** and seems reasonable. 
- Obis doesn't have any effect here either, and it's definitely a minigame.
- Rewards are untradeable, anyway

### Changes:
Multiples tokens by 2 if user.equippedPet() === itemID('Flappy');

### Other checks:

-   [x] I have tested all my changes thoroughly.
