### PR TITLE
Fix Gearpresets "an error has occured" error with long lists.

### DIFF
--- a/src/commands/Minion/gearpresets.ts
+++ b/src/commands/Minion/gearpresets.ts
@@ -1,8 +1,9 @@
-import { MessageAttachment } from 'discord.js';
+import { MessageAttachment, MessageEmbed } from 'discord.js';
 import { CommandStore, KlasaMessage, KlasaUser } from 'klasa';
 import { Bank } from 'oldschooljs';
 import { cleanString } from 'oldschooljs/dist/util';
 
+import { Color } from '../../lib/constants';
 import { defaultGear, resolveGearTypeSetting } from '../../lib/gear';
 import { gearPresetToStr, globalPresets } from '../../lib/gear/functions/gearPresets';
 import { generateGearImage } from '../../lib/gear/functions/generateGearImage';
@@ -39,11 +40,20 @@ export default class extends BotCommand {
 		if (presets.length === 0) {
 			return msg.send(`You have no presets.`);
 		}
-		let str = '**Your presets:**\n';
+		let title = '**Your presets:**';
+		let str = '';
 		for (const pre of presets) {
 			str += `**${pre.name}:** ${gearPresetToStr(pre)}\n`;
 		}
-		return msg.send(str);
+		if (str.length > 2048) {
+			const attachment = new MessageAttachment(
+				Buffer.from(`${title}\n${str}`),
+				`${msg.author.username}s-GearPresets.txt`
+			);
+			return msg.channel.send('Here are your gear presets...', attachment);
+		}
+		const embed = new MessageEmbed().setColor(Color.Orange).setTitle(title).setDescription(str);
+		return msg.channel.send(embed);
 	}
 
 	async equip(msg: KlasaMessage, [name, setup]: [string, string]) {

--- a/src/commands/Minion/gearpresets.ts
+++ b/src/commands/Minion/gearpresets.ts
@@ -45,7 +45,7 @@ export default class extends BotCommand {
 		for (const pre of presets) {
 			str += `**${pre.name}:** ${gearPresetToStr(pre)}\n`;
 		}
-		if (str.length > 2048) {
+		if (str.length > 2000) {
 			const attachment = new MessageAttachment(
 				Buffer.from(`${title}\n${str}`),
 				`${msg.author.username}s-GearPresets.txt`


### PR DESCRIPTION
### Description:
+gearpresets will error out with, 'An error has occured :sad:' if the content is too big ( > 2048 characters ).


### Changes:
- This fixing the problem by sending an attachment if the content is > 2000 characters long.
- It also changes lists <= 2000 characters to use an embed to make it a little easier to read.

### Other checks:

-   [x] I have tested all my changes thoroughly.
