### PR TITLE
[BSO] Spawnbox Return Message

### DIFF
--- a/src/commands/bso/spawnbox.ts
+++ b/src/commands/bso/spawnbox.ts
@@ -30,7 +30,7 @@ export default class extends BotCommand {
 		}
 
 		if (msg.author.id !== '157797566833098752' && msg.channel.id !== '732207379818479756') {
-			return msg.send(`You can only spawn boxes in #bot-channel-bso in the oldschool.gg server. `);
+			return msg.send(`You can only spawn boxes in #bot-channel-bso in the oldschool.gg server.`);
 		}
 
 		const randomItem = Items.filter(i => (i as Item).tradeable_on_ge).random() as Item;

--- a/src/commands/bso/spawnbox.ts
+++ b/src/commands/bso/spawnbox.ts
@@ -30,7 +30,9 @@ export default class extends BotCommand {
 		}
 
 		if (msg.author.id !== '157797566833098752' && msg.channel.id !== '732207379818479756') {
-			return msg.send(`You can only spawn boxes in #bot-channel-bso in the oldschool.gg server.`);
+			return msg.send(`
+You can only spawn boxes in #bot-channel-bso in the oldschool.gg server.`
+);
 		}
 
 		const randomItem = Items.filter(i => (i as Item).tradeable_on_ge).random() as Item;

--- a/src/commands/bso/spawnbox.ts
+++ b/src/commands/bso/spawnbox.ts
@@ -30,7 +30,7 @@ export default class extends BotCommand {
 		}
 
 		if (msg.author.id !== '157797566833098752' && msg.channel.id !== '732207379818479756') {
-			return msg.send(`You can only use this in the BSO channel.`);
+			return msg.send(`You can only spawn boxes in #bot-channel-bso in the oldschool.gg server. `);
 		}
 
 		const randomItem = Items.filter(i => (i as Item).tradeable_on_ge).random() as Item;

--- a/src/commands/bso/spawnbox.ts
+++ b/src/commands/bso/spawnbox.ts
@@ -31,8 +31,7 @@ export default class extends BotCommand {
 
 		if (msg.author.id !== '157797566833098752' && msg.channel.id !== '732207379818479756') {
 			return msg.send(`
-You can only spawn boxes in #bot-channel-bso in the oldschool.gg server.`
-);
+You can only spawn boxes in #bot-channel-bso in the oldschool.gg server.`);
 		}
 
 		const randomItem = Items.filter(i => (i as Item).tradeable_on_ge).random() as Item;


### PR DESCRIPTION
Changed the return msg when using =spawnbox outside of #bot-channel-bso, as ‘The BSO Channel’ is now a little confusing with #bso-general

also the linter told me to add that return idk why