### PR TITLE
[BSO] Fix small display error on =dice when a gambler's bag is won

### DIFF
--- a/src/commands/Minion/dice.ts
+++ b/src/commands/Minion/dice.ts
@@ -65,7 +65,7 @@ export default class extends BotCommand {
 					`${
 						msg.author.username
 					} rolled **${roll}** on the percentile dice, and you won ${Util.toKMB(
-						amountToAdd - gp
+						amountToAdd
 					)} GP.\n\nYou received a **Gamblers Bag**.`
 				);
 			}


### PR DESCRIPTION
### Description:
Previously, when winning a gamblers bag it would show (winnings - totalGp) as being won, AKA a negative number.

### Changes:
Removed the `- gp` from the display message of a gamblers bag.


### Other checks:

-   [x] I have tested all my changes thoroughly.
