### PR TITLE
Update fire rune providers when agility-alching

### DIFF
--- a/src/commands/Minion/laps.ts
+++ b/src/commands/Minion/laps.ts
@@ -13,6 +13,19 @@ import { formatDuration, stringMatches, updateBankSetting } from '../../lib/util
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import getOSItem from '../../lib/util/getOSItem';
 
+const unlimitedFireRuneProviders = [
+	'Staff of fire',
+	'Fire battlestaff',
+	'Mystic fire staff',
+	'Lava battlestaff',
+	'Mystic lava staff',
+	'Steam battlestaff',
+	'Mystic steam staff',
+	'Smoke battlestaff',
+	'Mystic smoke staff',
+	'Tome of fire'
+];
+
 function alching(msg: KlasaMessage, tripLength: number) {
 	if (msg.author.skillLevel(SkillsEnum.Magic) < 55) return null;
 	const bank = msg.author.bank();
@@ -36,7 +49,7 @@ function alching(msg: KlasaMessage, tripLength: number) {
 	const nats = bank.amount('Nature rune');
 	const fireRunes = bank.amount('Fire rune');
 
-	const hasInfiniteFireRunes = msg.author.hasItemEquippedAnywhere('Staff of fire');
+	const hasInfiniteFireRunes = msg.author.hasItemEquippedAnywhere(unlimitedFireRuneProviders);
 
 	let maxCasts = Math.floor(tripLength / (Time.Second * (3 + 10)));
 	maxCasts = Math.min(alchItemQty, maxCasts);


### PR DESCRIPTION
### Description:

Fixes an issue where fire rune providers were ignored and fire runes were still consumed when agility alching.

### Changes:

Copied fire rune provider list from `alching` command into `laps` command, and used that to check if the user has unlimited fire rune provider. I did not re-use the list because I see there's a chance these lists may differ at some point or in some situations (also, I don't know where you would want that list to live).

### Other checks:

-   [ ] I have tested all my changes thoroughly.

I haven't tested the changes thoroughly - just put this fix together quickly, I'm sure you'll be able to tell if it works or not.
