### PR TITLE
boosts for lower tier axes & pickaxes

### DIFF
--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -42,6 +42,41 @@ const axes = [
 		id: itemID('Dragon axe'),
 		reductionPercent: 9,
 		wcLvl: 61
+	},
+	{
+		id: itemID('Rune axe'),
+		reductionPercent: 8,
+		wcLvl: 41
+	},
+	{
+		id: itemID('Adamant axe'),
+		reductionPercent: 7,
+		wcLvl: 31
+	},
+	{
+		id: itemID('Mithril axe'),
+		reductionPercent: 6,
+		wcLvl: 21
+	},
+	{
+		id: itemID('Black axe'),
+		reductionPercent: 5,
+		wcLvl: 11
+	},
+	{
+		id: itemID('Steel axe'),
+		reductionPercent: 4,
+		wcLvl: 6
+	},
+	{
+		id: itemID('Iron axe'),
+		reductionPercent: 3,
+		wcLvl: 1
+	},
+	{
+		id: itemID('Bronze axe'),
+		reductionPercent: 2,
+		wcLvl: 1
 	}
 ];
 

--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -45,37 +45,37 @@ const axes = [
 	},
 	{
 		id: itemID('Rune axe'),
-		reductionPercent: 8,
+		reductionPercent: 7,
 		wcLvl: 41
 	},
 	{
 		id: itemID('Adamant axe'),
-		reductionPercent: 7,
+		reductionPercent: 6,
 		wcLvl: 31
 	},
 	{
 		id: itemID('Mithril axe'),
-		reductionPercent: 6,
+		reductionPercent: 5,
 		wcLvl: 21
 	},
 	{
 		id: itemID('Black axe'),
-		reductionPercent: 5,
+		reductionPercent: 4,
 		wcLvl: 11
 	},
 	{
 		id: itemID('Steel axe'),
-		reductionPercent: 4,
+		reductionPercent: 3,
 		wcLvl: 6
 	},
 	{
 		id: itemID('Iron axe'),
-		reductionPercent: 3,
+		reductionPercent: 2,
 		wcLvl: 1
 	},
 	{
 		id: itemID('Bronze axe'),
-		reductionPercent: 2,
+		reductionPercent: 1,
 		wcLvl: 1
 	}
 ];

--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -19,19 +19,9 @@ import itemID from '../../lib/util/itemID';
 
 const axes = [
 	{
-		id: itemID('3rd age axe'),
-		reductionPercent: 12,
-		wcLvl: 61
-	},
-	{
 		id: itemID('Crystal axe'),
 		reductionPercent: 12,
-		wcLvl: 61
-	},
-	{
-		id: itemID('Gilded axe'),
-		reductionPercent: 12,
-		wcLvl: 41
+		wcLvl: 71
 	},
 	{
 		id: itemID('Infernal axe'),
@@ -39,9 +29,19 @@ const axes = [
 		wcLvl: 61
 	},
 	{
+		id: itemID('3rd age axe'),
+		reductionPercent: 9,
+		wcLvl: 61
+	},
+	{
 		id: itemID('Dragon axe'),
 		reductionPercent: 9,
 		wcLvl: 61
+	},
+	{
+		id: itemID('Gilded axe'),
+		reductionPercent: 7,
+		wcLvl: 41
 	},
 	{
 		id: itemID('Rune axe'),

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -42,6 +42,41 @@ const pickaxes = [
 		id: itemID('Dragon pickaxe'),
 		reductionPercent: 6,
 		miningLvl: 61
+	},
+	{
+		id: itemID('Rune pickaxe'),
+		reductionPercent: 5,
+		miningLvl: 41
+	},
+	{
+		id: itemID('Adamant pickaxe'),
+		reductionPercent: 4,
+		miningLvl: 31
+	},
+	{
+		id: itemID('Mithril pickaxe'),
+		reductionPercent: 3,
+		miningLvl: 21
+	},
+	{
+		id: itemID('Black pickaxe'),
+		reductionPercent: 3,
+		miningLvl: 11
+	},
+	{
+		id: itemID('Steel pickaxe'),
+		reductionPercent: 2,
+		miningLvl: 6
+	},
+	{
+		id: itemID('Iron pickaxe'),
+		reductionPercent: 1,
+		miningLvl: 1
+	},
+	{
+		id: itemID('Bronze pickaxe'),
+		reductionPercent: 1,
+		miningLvl: 1
 	}
 ];
 

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -19,29 +19,29 @@ import resolveItems from '../../lib/util/resolveItems';
 
 const pickaxes = [
 	{
-		id: itemID('3rd age pickaxe'),
-		reductionPercent: 11,
-		miningLvl: 61
-	},
-	{
 		id: itemID('Crystal pickaxe'),
-		reductionPercent: 11,
+		reductionPercent: 12,
 		miningLvl: 71
 	},
 	{
-		id: itemID('Gilded pickaxe'),
+		id: itemID('Infernal pickaxe'),
 		reductionPercent: 11,
+		miningLvl: 61
+	},
+	{
+		id: itemID('3rd age pickaxe'),
+		reductionPercent: 9,
 		miningLvl: 41
 	},
 	{
-		id: itemID('Infernal pickaxe'),
-		reductionPercent: 10,
+		id: itemID('Dragon pickaxe'),
+		reductionPercent: 9,
 		miningLvl: 61
 	},
 	{
-		id: itemID('Dragon pickaxe'),
-		reductionPercent: 6,
-		miningLvl: 61
+		id: itemID('Gilded pickaxe'),
+		reductionPercent: 5,
+		miningLvl: 41
 	},
 	{
 		id: itemID('Rune pickaxe'),


### PR DESCRIPTION
Added smaller boosts for each of the lower tier axes for woodcutting and pickaxes for mining

will update on wiki if merged