### PR TITLE
Change DetermineBoostChoice fn to use object param

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -175,13 +175,14 @@ export default class extends BotCommand {
 
 		// Set chosen boost based on priority:
 		const myCBOpts = msg.author.settings.get(UserSettings.CombatOptions);
-		const boostChoice = determineBoostChoice(
-			myCBOpts as CombatOptionsEnum[],
-			attackStyles,
+		const boostChoice = determineBoostChoice({
+			cbOpts: myCBOpts as CombatOptionsEnum[],
+			atkStyles: attackStyles,
 			msg,
 			monster,
-			method ?? 'none'
-		);
+			method: method ?? 'none',
+			isOnTask
+		});
 
 		// Calculate Cannon and Barrage boosts + costs:
 		let usingCannon = false;

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -1,4 +1,5 @@
 import { Image } from 'canvas';
+import { KlasaMessage } from 'klasa';
 import { Bank, MonsterKillOptions } from 'oldschooljs';
 import { BeginnerCasket } from 'oldschooljs/dist/simulation/clues/Beginner';
 import { EasyCasket } from 'oldschooljs/dist/simulation/clues/Easy';
@@ -13,6 +14,7 @@ import { GearSetupTypes, GearStat, OffenceGearStat } from '../gear/types';
 import { POHBoosts } from '../poh';
 import { LevelRequirements, SkillsEnum } from '../skilling/types';
 import { ArrayItemsResolved, ItemBank, Skills } from '../types';
+import { CombatOptionsEnum } from './data/combatConstants';
 import { AttackStyles } from './functions';
 
 export interface BankBackground {
@@ -134,4 +136,13 @@ export interface AddMonsterXpParams {
 	minimal?: boolean;
 	usingCannon?: boolean;
 	cannonMulti?: boolean;
+}
+
+export interface DetermineBoostParams {
+	cbOpts: CombatOptionsEnum[];
+	atkStyles: AttackStyles[];
+	msg: KlasaMessage;
+	monster: KillableMonster;
+	method?: string | null;
+	isOnTask?: boolean;
 }

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -1,12 +1,11 @@
 import { randFloat, randInt } from 'e';
-import { KlasaMessage, KlasaUser } from 'klasa';
+import { KlasaUser } from 'klasa';
 import { Bank, Monsters, MonsterSlayerMaster } from 'oldschooljs';
 import Monster from 'oldschooljs/dist/structures/Monster';
 import { MoreThan } from 'typeorm';
 
 import { CombatOptionsEnum } from '../minions/data/combatConstants';
-import { AttackStyles } from '../minions/functions';
-import { KillableMonster } from '../minions/types';
+import { DetermineBoostParams } from '../minions/types';
 import { getNewUser } from '../settings/settings';
 import { UserSettings } from '../settings/types/UserSettings';
 import { SkillsEnum } from '../skilling/types';
@@ -25,34 +24,28 @@ export enum AutoslayOptionsEnum {
 	MaxEfficiency
 }
 
-export function determineBoostChoice(
-	cbOpts: CombatOptionsEnum[],
-	atkStyles: AttackStyles[],
-	msg: KlasaMessage,
-	monster: KillableMonster,
-	method?: string
-) {
+export function determineBoostChoice(params: DetermineBoostParams) {
 	let boostChoice = 'none';
 
-	if (msg.flagArgs.barrage || (method && method === 'barrage')) {
+	if (params.msg.flagArgs.barrage || (params.method && params.method === 'barrage')) {
 		boostChoice = 'barrage';
-	} else if (msg.flagArgs.burst || (method && method === 'burst')) {
+	} else if (params.msg.flagArgs.burst || (params.method && params.method === 'burst')) {
 		boostChoice = 'burst';
-	} else if (msg.flagArgs.cannon || (method && method === 'cannon')) {
+	} else if (params.msg.flagArgs.cannon || (params.method && params.method === 'cannon')) {
 		boostChoice = 'cannon';
 	} else if (
-		cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
-		atkStyles.includes(SkillsEnum.Magic) &&
-		monster!.canBarrage
+		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
+		params.atkStyles.includes(SkillsEnum.Magic) &&
+		params.monster!.canBarrage
 	) {
 		boostChoice = 'barrage';
 	} else if (
-		cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
-		atkStyles.includes(SkillsEnum.Magic) &&
-		monster!.canBarrage
+		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
+		params.atkStyles.includes(SkillsEnum.Magic) &&
+		params.monster!.canBarrage
 	) {
 		boostChoice = 'burst';
-	} else if (cbOpts.includes(CombatOptionsEnum.AlwaysCannon)) {
+	} else if (params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)) {
 		boostChoice = 'cannon';
 	}
 


### PR DESCRIPTION
### Description:
Change determineboostchoice  function to use an object parameter to avoid messy situations.

### Changes:
Same as the BSO patch except without the return if !nottask line.

### Other checks:

-   [x] I have tested all my changes thoroughly.
