### PR TITLE
Master slayer release-day fixes

### DIFF
--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -25,6 +25,12 @@ enum AutoSlayMethod {
 
 const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 	{
+		monsterID: Monsters.Jelly.id,
+		efficientName: Monsters.WarpedJelly.name,
+		efficientMonster: Monsters.WarpedJelly.id,
+		efficientMethod: AutoSlayMethod.Barrage
+	},
+	{
 		monsterID: Monsters.SpiritualMage.id,
 		efficientName: Monsters.SpiritualMage.name,
 		efficientMonster: Monsters.SpiritualMage.id,

--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -4,7 +4,7 @@ import { Monsters } from 'oldschooljs';
 import killableMonsters from '../../lib/minions/data/killableMonsters';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
-import { AutoslayOptionsEnum, getUsersCurrentSlayerInfo } from '../../lib/slayer/slayerUtil';
+import { AutoslayOptionsEnum, getUsersCurrentSlayerInfo, SlayerMasterEnum } from '../../lib/slayer/slayerUtil';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { wipeDBArrayByKey } from '../../lib/util';
 
@@ -14,6 +14,7 @@ interface AutoslayLink {
 	efficientName?: string;
 	efficientMonster?: number;
 	efficientMethod?: string;
+	slayerMasters?: SlayerMasterEnum[];
 }
 enum AutoSlayMethod {
 	None = 'none',
@@ -21,6 +22,7 @@ enum AutoSlayMethod {
 	Barrage = 'barrage',
 	Burst = 'burst'
 }
+
 const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 	{
 		monsterID: Monsters.KalphiteWorker.id,
@@ -54,9 +56,22 @@ const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 	},
 	{
 		monsterID: Monsters.MountainTroll.id,
+		efficientName: Monsters.MountainTroll.name,
+		efficientMonster: Monsters.MountainTroll.id,
+		efficientMethod: AutoSlayMethod.Cannon,
+		slayerMasters: [SlayerMasterEnum.Konar]
+	},
+	{
+		monsterID: Monsters.MountainTroll.id,
 		efficientName: Monsters.IceTroll.name,
 		efficientMonster: Monsters.IceTroll.id,
-		efficientMethod: AutoSlayMethod.Cannon
+		efficientMethod: AutoSlayMethod.Cannon,
+		slayerMasters: [
+			SlayerMasterEnum.Chaeldar,
+			SlayerMasterEnum.Vannaka,
+			SlayerMasterEnum.Nieve,
+			SlayerMasterEnum.Duradel
+		]
 	},
 	{
 		monsterID: Monsters.Zygomite.id,
@@ -237,7 +252,8 @@ export default class extends BotCommand {
 				);
 			}
 			const ehpMonster = AutoSlayMaxEfficiencyTable.find(e => {
-				return e.monsterID === usersTask.assignedTask!.monster.id;
+				const masterMatch = !e.slayerMasters || e.slayerMasters.includes(usersTask.currentTask!.slayerMasterID);
+				return masterMatch && e.monsterID === usersTask.assignedTask!.monster.id;
 			});
 
 			if (ehpMonster && ehpMonster.efficientName) {

--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -275,8 +275,10 @@ export default class extends BotCommand {
 			});
 
 			if (ehpMonster && ehpMonster.efficientName) {
-				if (ehpMonster.efficientMethod) msg.flagArgs[ehpMonster.efficientMethod] = 'yes';
-				return this.client.commands.get('k')?.run(msg, [null, ehpMonster.efficientName]);
+				if (ehpMonster.efficientMethod) msg.flagArgs[ehpMonster.efficientMethod] = 'force';
+				return this.client.commands
+					.get('k')
+					?.run(msg, [null, ehpMonster.efficientName, ehpMonster.efficientMethod]);
 			}
 			return this.client.commands.get('k')?.run(msg, [null, usersTask.assignedTask!.monster.name]);
 		}

--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -25,6 +25,18 @@ enum AutoSlayMethod {
 
 const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 	{
+		monsterID: Monsters.SpiritualMage.id,
+		efficientName: Monsters.SpiritualMage.name,
+		efficientMonster: Monsters.SpiritualMage.id,
+		efficientMethod: AutoSlayMethod.None
+	},
+	{
+		monsterID: Monsters.SpiritualRanger.id,
+		efficientName: Monsters.SpiritualMage.name,
+		efficientMonster: Monsters.SpiritualMage.id,
+		efficientMethod: AutoSlayMethod.None
+	},
+	{
 		monsterID: Monsters.KalphiteWorker.id,
 		efficientName: Monsters.KalphiteSoldier.name,
 		efficientMonster: Monsters.KalphiteSoldier.id,

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -186,7 +186,6 @@ export default class extends BotCommand {
 			method: method ?? 'none',
 			isOnTask
 		});
-
 		// Calculate Cannon and Barrage boosts + costs:
 		let usingCannon = false;
 		let cannonMulti = false;

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -161,11 +161,14 @@ export default class extends BotCommand {
 		}
 		// Add 15% slayer boost on task if they have black mask or similar
 		if (attackStyles.includes(SkillsEnum.Ranged) || attackStyles.includes(SkillsEnum.Magic)) {
-			if (isOnTask && msg.author.hasItemEquippedOrInBank(itemID('Black mask (i)'))) {
+			if (isOnTask && msg.author.hasItemEquippedOrInBank('Black mask (i)')) {
 				timeToFinish = reduceNumByPercent(timeToFinish, 15);
 				boosts.push('15% for Black mask (i) on non-melee task');
 			}
-		} else if (isOnTask && msg.author.hasItemEquippedOrInBank(itemID('Black mask'))) {
+		} else if (
+			isOnTask &&
+			(msg.author.hasItemEquippedOrInBank('Black mask') || msg.author.hasItemEquippedOrInBank('Black mask (i)'))
+		) {
 			timeToFinish = reduceNumByPercent(timeToFinish, 15);
 			boosts.push('15% for Black mask on melee task');
 		}

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -193,7 +193,7 @@ export default class extends BotCommand {
 		let burstOrBarrage = 0;
 		const hasCannon = msg.author.owns(CombatCannonItemBank);
 		if ((msg.flagArgs.burst || msg.flagArgs.barrage) && !monster!.canBarrage) {
-			return msg.send(`${monster!.name} cannot be barraged or bursted.`);
+			return msg.send(`${monster!.name} cannot be barraged or burst.`);
 		}
 		if ((msg.flagArgs.burst || msg.flagArgs.barrage) && !attackStyles.includes(SkillsEnum.Magic)) {
 			return msg.send("You can only barrage/burst when you're using magic!");
@@ -203,6 +203,14 @@ export default class extends BotCommand {
 		}
 		if (msg.flagArgs.cannon && !monster!.canCannon) {
 			return msg.send(`${monster!.name} cannot be killed with a cannon.`);
+		}
+		if (boostChoice === 'barrage' && msg.author.skillLevel(SkillsEnum.Magic) < 94) {
+			return msg.send(
+				`You need 94 Magic to use Ice Barrage. You have ${msg.author.skillLevel(SkillsEnum.Magic)}`
+			);
+		}
+		if (boostChoice === 'burst' && msg.author.skillLevel(SkillsEnum.Magic) < 70) {
+			return msg.send(`You need 70 Magic to use Ice Burst. You have ${msg.author.skillLevel(SkillsEnum.Magic)}`);
 		}
 
 		if (boostChoice === 'barrage' && attackStyles.includes(SkillsEnum.Magic) && monster!.canBarrage) {

--- a/src/commands/Minion/slayershop.ts
+++ b/src/commands/Minion/slayershop.ts
@@ -43,14 +43,15 @@ export default class extends BotCommand {
 		const myUnlocks = await msg.author.settings.get(UserSettings.Slayer.SlayerUnlocks);
 		const myPoints = await msg.author.settings.get(UserSettings.Slayer.SlayerPoints);
 
-		const unlocksStr = myUnlocks
+		let unlocksStr = myUnlocks
 			.map(mu => {
 				return getSlayerReward(mu);
 			})
 			.join('\n');
+		if (unlocksStr !== '') unlocksStr = `\`${unlocksStr}\``;
 		const defaultMsg =
 			`Current points: ${myPoints}\nYou currently have the following ` +
-			`rewards unlocked:\n\`${unlocksStr}\`\n\n` +
+			`rewards unlocked:\n${unlocksStr}\n\n` +
 			`Usage:\n\`${msg.cmdPrefix}slayershop [unlock|lock|buy] Reward\`\nExample:` +
 			`\n\`${msg.cmdPrefix}slayershop unlock Malevolent Masquerade\``;
 		if (defaultMsg.length > 2000) {

--- a/src/commands/Minion/slayershop.ts
+++ b/src/commands/Minion/slayershop.ts
@@ -101,7 +101,7 @@ export default class extends BotCommand {
 
 		if (curSlayerPoints < slayerPointCost) {
 			return msg.channel.send(
-				`You need ${slayerPointCost} Slayer points to make this purchase.\n` + `You have: ${curSlayerPoints}`
+				`You need ${slayerPointCost} Slayer points to make this purchase.\nYou have: ${curSlayerPoints}`
 			);
 		}
 
@@ -182,7 +182,7 @@ export default class extends BotCommand {
 
 		if (curSlayerPoints < slayerPointCost) {
 			return msg.channel.send(
-				`You need ${slayerPointCost} Slayer points to make this purchase.\n` + `You have: ${curSlayerPoints}`
+				`You need ${slayerPointCost} Slayer points to make this purchase.\nYou have: ${curSlayerPoints}`
 			);
 		}
 

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -107,7 +107,12 @@ export default class extends BotCommand {
 
 		// Prevent any actions that affect the layer task list when minion is busy.
 		if (msg.author.minionIsBusy) {
-			return msg.channel.send('You can only manage your block list while your minion is busy.');
+			const slayerPoints = msg.author.settings.get(UserSettings.Slayer.SlayerPoints);
+			const slayerStreak = msg.author.settings.get(UserSettings.Slayer.TaskStreak);
+			return msg.channel.send(
+				`Your minion is busy. But you can still manage your block list: \`${msg.cmdPrefix}st blocks\`` +
+					`You have ${slayerPoints} slayer points, and have completed ${slayerStreak} tasks in a row.`
+			);
 		}
 		if (input && (input === 'skip' || input === 'block')) msg.flagArgs[input] = 'yes';
 		if (currentTask && (msg.flagArgs.skip || msg.flagArgs.block)) {
@@ -215,7 +220,7 @@ export default class extends BotCommand {
 			currentTask!.save();
 			msg.author.settings.update(UserSettings.Slayer.TaskStreak, 0);
 			const newSlayerTask = await assignNewSlayerTask(msg.author, slayerMaster);
-			let commonName = getCommonTaskName(newSlayerTask.assignedTask.monster);
+			let commonName = getCommonTaskName(newSlayerTask.assignedTask!.monster);
 			return msg.channel.send(
 				`Your task has been skipped.\n\n ${slayerMaster.name}` +
 					` has assigned you to kill ${newSlayerTask.currentTask.quantity}x ${commonName}.`
@@ -286,7 +291,7 @@ You've done ${totalTasksDone} tasks. Your current streak is ${msg.author.setting
 			});
 		}
 
-		let commonName = getCommonTaskName(newSlayerTask.assignedTask.monster);
+		let commonName = getCommonTaskName(newSlayerTask.assignedTask!.monster);
 		if (commonName === 'TzHaar') {
 			commonName +=
 				`. You can choose to kill TzTok-Jad with ${msg.cmdPrefix}fightcaves as long as you ` +

--- a/src/extendables/User/Gear.ts
+++ b/src/extendables/User/Gear.ts
@@ -40,10 +40,7 @@ export default class extends Extendable {
 
 	public hasItemEquippedOrInBank(this: User, item: number | string) {
 		const id = typeof item === 'string' ? itemID(item) : item;
-		if (SimilarItems[id] === undefined) {
-			return this.hasItemEquippedAnywhere(id, false) || this.numItemsInBankSync(id, true) > 0;
-		}
-		return this.hasItemEquippedAnywhere(SimilarItems[id], false) || this.numItemsInBankSync(id, true) > 0;
+		return this.hasItemEquippedAnywhere(id, false) || this.numItemsInBankSync(id, true) > 0;
 	}
 
 	public getGear(this: User, setup: 'melee' | 'mage' | 'range' | 'misc' | 'skilling'): GearSetup {

--- a/src/extendables/User/Gear.ts
+++ b/src/extendables/User/Gear.ts
@@ -2,7 +2,6 @@ import { User } from 'discord.js';
 import { Extendable, ExtendableStore } from 'klasa';
 import { itemID } from 'oldschooljs/dist/util';
 
-import SimilarItems from '../../lib/data/similarItems';
 import { defaultGear, resolveGearTypeSetting } from '../../lib/gear';
 import { GearSetup, UserFullGearSetup } from '../../lib/gear/types';
 import { Gear } from '../../lib/structures/Gear';

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -1,15 +1,19 @@
 import itemID from '../util/itemID';
 import resolveItems from '../util/resolveItems';
 
+const blackMaskISimilar = resolveItems([
+	'Black mask (10) (i)',
+	'Black mask (9) (i)',
+	'Black mask (8) (i)',
+	'Black mask (7) (i)',
+	'Black mask (6) (i)',
+	'Black mask (5) (i)',
+	'Black mask (4) (i)',
+	'Black mask (3) (i)',
+	'Black mask (2) (i)',
+	'Black mask (1) (i)'
+]);
 const slayerHelmSimilar = resolveItems([
-	'Black slayer helmet (i)',
-	'Green slayer helmet (i)',
-	'Red slayer helmet (i)',
-	'Purple slayer helmet (i)',
-	'Turquoise slayer helmet (i)',
-	'Hydra slayer helmet (i)',
-	'Twisted slayer helmet (i)',
-	'Slayer helmet (i)',
 	'Slayer helmet',
 	'Black slayer helmet',
 	'Green slayer helmet',
@@ -219,7 +223,7 @@ const SimilarItems: Record<number, number[]> = {
 	[itemID('Trident of the swamp')]: resolveItems(['Trident of the swamp (e)']),
 	[itemID('Slayer helmet')]: slayerHelmSimilar,
 	[itemID('Slayer helmet (i)')]: slayerHelmSimilarI,
-	[itemID('Black mask (i)')]: slayerHelmSimilarI,
+	[itemID('Black mask (i)')]: [...slayerHelmSimilarI, ...blackMaskISimilar],
 	[itemID('Black mask')]: [
 		...slayerHelmSimilar,
 		...resolveItems([

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -210,6 +210,9 @@ const SimilarItems: Record<number, number[]> = {
 		'Saradomin max cape',
 		'Zamorak max cape'
 	]),
+	[itemID('Dragonfire ward')]: resolveItems([22003]),
+	[itemID('Dragonfire shield')]: resolveItems([11284]),
+	[itemID('Ancient wyvern shield')]: resolveItems([21634]),
 	[itemID('Avernic defender')]: resolveItems(['Avernic defender (l)']),
 	[itemID('Void melee helm')]: resolveItems(['Void melee helm (l)']),
 	[itemID('Void mage helm')]: resolveItems(['Void mage helm (l)']),

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -227,7 +227,6 @@ const SimilarItems: Record<number, number[]> = {
 	[itemID('Black mask')]: [
 		...slayerHelmSimilar,
 		...resolveItems([
-			'Black mask (i)',
 			'Black mask (1)',
 			'Black mask (2)',
 			'Black mask (3)',

--- a/src/lib/minions/data/combatConstants.ts
+++ b/src/lib/minions/data/combatConstants.ts
@@ -29,7 +29,8 @@ export enum CombatOptionsEnum {
 export enum SlayerActivityConstants {
 	None,
 	IceBarrage,
-	IceBurst
+	IceBurst,
+	Cannon
 }
 export const CombatCannonItemBank = {
 	[itemID('Cannon barrels')]: 1,

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -60,6 +60,9 @@ export function determineBoostChoice(params: DetermineBoostParams) {
 		boostChoice = 'cannon';
 	}
 
+	if (boostChoice === 'barrage' && params.msg.author.skillLevel(SkillsEnum.Magic) < 94) {
+		boostChoice = 'burst';
+	}
 	return boostChoice;
 }
 

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -24,6 +24,17 @@ export enum AutoslayOptionsEnum {
 	MaxEfficiency
 }
 
+export enum SlayerMasterEnum {
+	Reserved,
+	Turael,
+	Mazchna,
+	Vannaka,
+	Chaeldar,
+	Konar,
+	Nieve,
+	Duradel
+}
+
 export function determineBoostChoice(params: DetermineBoostParams) {
 	let boostChoice = 'none';
 
@@ -162,6 +173,8 @@ export async function assignNewSlayerTask(_user: KlasaUser, master: SlayerMaster
 		} else {
 			assignedTask = weightedPick(baseTasks);
 		}
+	} else {
+		assignedTask = weightedPick(baseTasks);
 	}
 
 	const newUser = await getNewUser(_user.id);

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -152,7 +152,7 @@ export function userCanUseTask(
 
 export async function assignNewSlayerTask(_user: KlasaUser, master: SlayerMaster) {
 	// assignedTask is the task object, currentTask is the database row.
-	const baseTasks = [...master.tasks].filter(t => userCanUseTask(_user, t, master));
+	const baseTasks = [...master.tasks].filter(t => userCanUseTask(_user, t, master, true));
 	let bossTask = false;
 	if (
 		_user.settings.get(UserSettings.Slayer.SlayerUnlocks).includes(SlayerTaskUnlocksEnum.LikeABoss) &&
@@ -167,7 +167,7 @@ export async function assignNewSlayerTask(_user: KlasaUser, master: SlayerMaster
 
 	let assignedTask: AssignableSlayerTask | null = null;
 	if (bossTask) {
-		const baseBossTasks = bossTasks.filter(t => userCanUseTask(_user, t, master));
+		const baseBossTasks = bossTasks.filter(t => userCanUseTask(_user, t, master, true));
 		if (baseBossTasks.length) {
 			assignedTask = weightedPick(baseBossTasks);
 		} else {

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -98,8 +98,14 @@ export function userCanUseMaster(user: KlasaUser, master: SlayerMaster) {
 	);
 }
 
-export function userCanUseTask(user: KlasaUser, task: AssignableSlayerTask, master: SlayerMaster) {
-	if (task.isBoss) return false;
+export function userCanUseTask(
+	user: KlasaUser,
+	task: AssignableSlayerTask,
+	master: SlayerMaster,
+	allowBossTasks: boolean = false
+) {
+	if (task.isBoss && !allowBossTasks) return false;
+	if (task.dontAssign) return false;
 	const myLastTask = user.settings.get(UserSettings.Slayer.LastTask);
 	if (myLastTask === task.monster.id) return false;
 	if (task.combatLevel && task.combatLevel > user.combatLevel) return false;
@@ -133,7 +139,6 @@ export function userCanUseTask(user: KlasaUser, task: AssignableSlayerTask, mast
 	return true;
 }
 
-// boss tasks
 export async function assignNewSlayerTask(_user: KlasaUser, master: SlayerMaster) {
 	// assignedTask is the task object, currentTask is the database row.
 	const baseTasks = [...master.tasks].filter(t => userCanUseTask(_user, t, master));
@@ -149,21 +154,31 @@ export async function assignNewSlayerTask(_user: KlasaUser, master: SlayerMaster
 		bossTask = true;
 	}
 
-	const assignedTask = bossTask ? weightedPick(bossTasks) : weightedPick(baseTasks);
+	let assignedTask: AssignableSlayerTask | null = null;
+	if (bossTask) {
+		const baseBossTasks = bossTasks.filter(t => userCanUseTask(_user, t, master));
+		if (baseBossTasks.length) {
+			assignedTask = weightedPick(baseBossTasks);
+		} else {
+			assignedTask = weightedPick(baseTasks);
+		}
+	}
+
 	const newUser = await getNewUser(_user.id);
 
 	const currentTask = new SlayerTaskTable();
 	currentTask.user = newUser;
-	currentTask.quantity = randInt(assignedTask.amount[0], assignedTask.amount[1]);
+	currentTask.quantity = randInt(assignedTask!.amount[0], assignedTask!.amount[1]);
 	currentTask.quantityRemaining = currentTask.quantity;
 	currentTask.slayerMasterID = master.id;
-	currentTask.monsterID = assignedTask.monster.id;
+	currentTask.monsterID = assignedTask!.monster.id;
 	currentTask.skipped = false;
 	await currentTask.save();
-	await _user.settings.update(UserSettings.Slayer.LastTask, assignedTask.monster.id);
+	await _user.settings.update(UserSettings.Slayer.LastTask, assignedTask!.monster.id);
 
 	return { currentTask, assignedTask };
 }
+
 export function calcMaxBlockedTasks(qps: number) {
 	// 6 Blocks total 5 for 250 qps, + 1 for lumby.
 	// For now we're do 1 free + 1 for every 50 qps.

--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -435,6 +435,21 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
+		unlocked: true,
+		dontAssign: true
+	},
+	{
+		monster: Monsters.SpiritualRanger,
+		amount: [110, 170],
+
+		weight: 12,
+		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
+		levelRequirements: {
+			slayer: 60
+		},
+		combatLevel: 60,
+		slayerLevel: 63,
+		questPoints: 3,
 		unlocked: true
 	},
 	{

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -333,6 +333,21 @@ export const duradelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.SpiritualMage,
+		amount: [110, 170],
+
+		weight: 12,
+		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
+		levelRequirements: {
+			slayer: 60
+		},
+		combatLevel: 60,
+		slayerLevel: 63,
+		questPoints: 3,
+		unlocked: true,
+		dontAssign: true
+	},
+	{
+		monster: Monsters.SpiritualRanger,
 		amount: [130, 200],
 		weight: 7,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -354,6 +354,21 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.SpiritualMage,
+		amount: [110, 170],
+
+		weight: 12,
+		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
+		levelRequirements: {
+			slayer: 60
+		},
+		combatLevel: 60,
+		slayerLevel: 63,
+		questPoints: 3,
+		unlocked: true,
+		dontAssign: true
+	},
+	{
+		monster: Monsters.SpiritualRanger,
 		amount: [120, 185],
 		weight: 6,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],

--- a/src/lib/slayer/tasks/vannakaTasks.ts
+++ b/src/lib/slayer/tasks/vannakaTasks.ts
@@ -477,6 +477,21 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.SpiritualMage,
+		amount: [110, 170],
+
+		weight: 12,
+		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
+		levelRequirements: {
+			slayer: 60
+		},
+		combatLevel: 60,
+		slayerLevel: 63,
+		questPoints: 3,
+		unlocked: true,
+		dontAssign: true
+	},
+	{
+		monster: Monsters.SpiritualRanger,
 		amount: [60, 120],
 		weight: 8,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],

--- a/src/lib/slayer/types.ts
+++ b/src/lib/slayer/types.ts
@@ -14,6 +14,7 @@ export interface AssignableSlayerTask {
 	unlocked?: boolean;
 	isBoss?: boolean;
 	levelRequirements?: LevelRequirements;
+	dontAssign?: boolean;
 }
 
 export interface SlayerMaster {

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -1,7 +1,7 @@
 import { Task } from 'klasa';
 import { MonsterKillOptions, Monsters } from 'oldschooljs';
 
-import { CombatOptionsEnum } from '../../lib/minions/data/combatConstants';
+import { SlayerActivityConstants } from '../../lib/minions/data/combatConstants';
 import killableMonsters from '../../lib/minions/data/killableMonsters';
 import { addMonsterXP } from '../../lib/minions/functions';
 import announceLoot from '../../lib/minions/functions/announceLoot';
@@ -136,8 +136,8 @@ export default class extends Task {
 				user.log(`continued trip of killing ${monster.name}`);
 				let method = 'none';
 				if (usingCannon) method = 'cannon';
-				else if (burstOrBarrage === CombatOptionsEnum.AlwaysIceBarrage) method = 'barrage';
-				else if (burstOrBarrage === CombatOptionsEnum.AlwaysIceBurst) method = 'burst';
+				else if (burstOrBarrage === SlayerActivityConstants.IceBarrage) method = 'barrage';
+				else if (burstOrBarrage === SlayerActivityConstants.IceBurst) method = 'burst';
 				return this.client.commands.get('k')!.run(res, [quantity, monster.name, method]);
 			},
 			image!,


### PR DESCRIPTION
### Description:
Fixed boss tasks, made them  unable to assign tasks you don't have the reqs for.
Reverted default spiritual to ranger.
Fixed some autoslay issues
Fixed continue using cannon/barrage
EHP now works with jellys + trolls w/ konar
Some grammar / better response messaging.

### Other checks:

-   [x] I have tested all my changes thoroughly.
