### PR TITLE
Slayer BSO fixes and qol

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -165,14 +165,14 @@ export default class extends BotCommand {
 				!attackStyles.includes(SkillsEnum.Ranged) &&
 				!attackStyles.includes(SkillsEnum.Magic)
 			) {
-				timeToFinish = reduceNumByPercent(timeToFinish, 15);
-				boosts.push('15% for Dragon hunter lance');
+				timeToFinish = reduceNumByPercent(timeToFinish, 20);
+				boosts.push('20% for Dragon hunter lance');
 			} else if (
 				msg.author.hasItemEquippedOrInBank('Dragon hunter crossbow') &&
 				attackStyles.includes(SkillsEnum.Ranged)
 			) {
-				timeToFinish = reduceNumByPercent(timeToFinish, 15);
-				boosts.push('15% for Dragon hunter crossbow');
+				timeToFinish = reduceNumByPercent(timeToFinish, 20);
+				boosts.push('20% for Dragon hunter crossbow');
 			}
 		}
 		// Add 15% slayer boost on task if they have black mask or similar

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -159,7 +159,8 @@ const killableBosses: KillableMonster[] = [
 			pool: {
 				'Rejuvenation pool': 10,
 				'Fancy rejuvenation pool': 10,
-				'Ornate rejuvenation pool': 10
+				'Ornate rejuvenation pool': 10,
+				'Ancient rejuvenation pool': 20
 			}
 		},
 		defaultAttackStyles: [SkillsEnum.Strength],

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -227,7 +227,7 @@ const killableMonsters: KillableMonster[] = [
 		notifyDrops: resolveItems(['Fish sack', 'Fishing trophy', 'Pufferfish']),
 		wildy: false,
 
-		difficultyRating: 0,
+		difficultyRating: 7,
 		qpRequired: 0,
 		healAmountNeeded: 20 * 20,
 		attackStyleToUse: GearSetupTypes.Range,

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -78,7 +78,8 @@ export const vannakaMonsters: KillableMonster[] = [
 			pool: {
 				'Rejuvenation pool': 10,
 				'Fancy rejuvenation pool': 10,
-				'Ornate rejuvenation pool': 10
+				'Ornate rejuvenation pool': 10,
+				'Ancient rejuvenation pool': 20
 			}
 		},
 		slayerOnly: true,


### PR DESCRIPTION
### Description:
Small fixes. All of the big stuff is in master.

### Changes:
Added malygos + sea kraken to their respective slayer tasks
Added the Ancient pool benefit so players don't get 0 boost for having the big pool.
Restored dragon hunter lance's 20% boost (for bso only. osb will only get 15%)


### Other checks:

-   [x] I have tested all my changes thoroughly.
