### PR TITLE
Slayer - Auto-magic when barraging, last minute balancing, & CL Updates

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -57,7 +57,7 @@ export default class extends BotCommand {
 			});
 			outstr += `${myBlockedMonsters
 				.map(mbm => {
-					return `${mbm.id}: ${getCommonTaskName(mbm)}`;
+					return `${getCommonTaskName(mbm)}`;
 				})
 				.join('\n')}`;
 			return msg.channel.send(`${outstr}\n\nTry: \`${msg.cmdPrefix}st --block\` to block a task.`);
@@ -111,7 +111,7 @@ export default class extends BotCommand {
 			const slayerStreak = msg.author.settings.get(UserSettings.Slayer.TaskStreak);
 			return msg.channel.send(
 				`Your minion is busy, but you can still manage your block list: \`${msg.cmdPrefix}st blocks\`` +
-					`You have ${slayerPoints} slayer points, and have completed ${slayerStreak} tasks in a row.`
+					`\nYou have ${slayerPoints} slayer points, and have completed ${slayerStreak} tasks in a row.`
 			);
 		}
 		if (input && (input === 'skip' || input === 'block')) msg.flagArgs[input] = 'yes';

--- a/src/commands/Testing/slayersim.ts
+++ b/src/commands/Testing/slayersim.ts
@@ -75,7 +75,9 @@ export default class extends BotCommand {
 		slayerMasters.forEach(master => {
 			master.tasks.forEach(task => {
 				task.monsters.forEach(tmon => {
-					const [, osjsMon, attackStyles] = resolveAttackStyles(msg.author, tmon);
+					const [, osjsMon, attackStyles] = resolveAttackStyles(msg.author, {
+						monsterID: tmon
+					});
 					const kMonster = killableMonsters.find(km => {
 						return km.id === tmon;
 					});

--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -1586,52 +1586,39 @@ export const miscLog: CollectionLogData = {
 	]),
 	Tzhaar: resolveItems(['Fire cape']),
 	evilChickenOutfit,
-	other: resolveItems(['Amulet of eternal glory', 'Crystal grail']),
+	other: resolveItems(['Amulet of eternal glory', 'Crystal grail'])
+};
+
+export const slayerLog: CollectionLogData = {
 	Slayer1: resolveItems([
 		'Imbued heart',
 		'Eternal gem',
 		'Mist battlestaff',
 		'Dust battlestaff',
+		'Basilisk jaw',
 		"Hydra's eye",
 		"Hydra's fang",
 		"Hydra's heart",
 		'Hydra tail',
 		"Drake's tooth",
 		"Drake's claw",
-		'Dragon harpoon',
-		'Dragon sword'
+		'Dragon harpoon'
 	]),
 	Slayer2: resolveItems([
+		'Dragon sword',
 		'Dragon thrownaxe',
 		'Dragon knife',
+		'Black mask',
+		'Granite maul',
 		'Abyssal whip',
 		'Abyssal dagger',
-		'Abyssal head',
-		'Dragon boots',
-		'Granite maul',
 		'Uncharged trident',
 		'Kraken tentacle',
 		'Dark bow',
 		'Death talisman',
 		'Occult necklace'
 	]),
-	Slayer3: resolveItems([
-		'Herb sack',
-		'Rune pouch',
-		'Basilisk jaw',
-		'Brine sabre',
-		'Leaf-bladed battleaxe',
-		'Leaf-bladed sword',
-		'Black mask'
-	]),
-	'Demonic Gorillas': resolveItems([
-		'Zenyte shard',
-		'Heavy frame',
-		'Light frame',
-		'Monkey tail',
-		'Ballista limbs',
-		'Ballista spring'
-	]),
+	Slayer3: resolveItems(['Herb sack', 'Rune pouch', 'Brine sabre', 'Leaf-bladed battleaxe', 'Leaf-bladed sword']),
 	'Mystic Sets': resolveItems([
 		'Mystic hat (light)',
 		'Mystic robe top (light)',
@@ -1654,17 +1641,70 @@ export const miscLog: CollectionLogData = {
 		'Brimstone key'
 	]),
 	Misc1: resolveItems([
+		'Dragon boots',
+		'Dragon platelegs',
+		'Dragon plateskirt',
 		'Dragon full helm',
+		'Chewed bones',
 		'Dragon limbs',
 		'Dragon metal slice',
 		'Dragon metal lump',
 		'Draconic visage',
-		'Skeletal visage',
 		'Wyvern visage'
 	]),
-	Misc2: resolveItems(['Giant key', 'Hill giant club', 'Mossy key', "Bryophyta's essence"])
+	Misc2: resolveItems([
+		'Mudskipper hat',
+		'Flippers',
+		'Granite boots',
+		'Granite helm',
+		'Granite legs',
+		'Granite shield',
+		'Right skull half',
+		'Left skull half',
+		'Bottom of sceptre',
+		'Top of sceptre'
+	]),
+	Misc3: resolveItems([
+		'Dark totem base',
+		'Dark totem middle',
+		'Dark totem top',
+		'Dark totem',
+		'Ancient shard',
+		'Brittle key',
+		'Giant key',
+		'Hill giant club',
+		'Mossy key',
+		"Bryophyta's essence",
+		'Blood shard',
+		'Enhanced crystal teleport seed'
+	]),
+	Heads: resolveItems([
+		// Crawling hand
+		7975,
+		'Basilisk head',
+		'Cockatrice head',
+		'Kurask head',
+		'Abyssal head'
+	]),
+	Boots: resolveItems([
+		'Bronze boots',
+		'Iron boots',
+		'Steel boots',
+		'Black boots',
+		'Mithril boots',
+		'Adamant boots',
+		'Rune boots',
+		'Dragon boots'
+	]),
+	'Demonic Gorillas': resolveItems([
+		'Zenyte shard',
+		'Heavy frame',
+		'Light frame',
+		'Monkey tail',
+		'Ballista limbs',
+		'Ballista spring'
+	])
 };
-
 export const sepulchreLog: CollectionLogData = {
 	Misc: resolveItems([
 		'Hallowed mark',
@@ -2030,6 +2070,11 @@ export const collectionLogTypes: CollectionLogType[] = [
 		name: 'Big Chompy Hunting',
 		aliases: ['chompy', 'bgc', 'big chompy hunting'],
 		items: chompyHuntingLog
+	},
+	{
+		name: 'Slayer',
+		aliases: ['slayer', 'slay'],
+		items: slayerLog
 	}
 ];
 export const allCollectionLogItems = uniqueArr(

--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -30,7 +30,8 @@ const killableBosses: KillableMonster[] = [
 		groupKillable: true,
 		respawnTime: Time.Minute * 1.5,
 		levelRequirements: {
-			prayer: 43
+			prayer: 43,
+			strength: 70
 		},
 		uniques: [...resolveItems(['Rune sword']), ...bosses.Bandos, ...bosses.Shards],
 		defaultAttackStyles: [SkillsEnum.Attack],
@@ -101,7 +102,8 @@ const killableBosses: KillableMonster[] = [
 		groupKillable: true,
 		respawnTime: Time.Minute * 1.5,
 		levelRequirements: {
-			prayer: 43
+			prayer: 40,
+			ranged: 70
 		},
 		uniques: [...bosses.Arma, ...bosses.Shards],
 		itemsRequired: deepResolveItems([
@@ -141,7 +143,8 @@ const killableBosses: KillableMonster[] = [
 		groupKillable: true,
 		respawnTime: Time.Minute * 1.5,
 		levelRequirements: {
-			prayer: 43
+			prayer: 43,
+			hitpoints: 70
 		},
 		uniques: [...bosses.Zammy, ...bosses.Shards],
 		itemsRequired: deepResolveItems([

--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -365,7 +365,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		id: Monsters.SkeletalWyvern.id,
 		name: Monsters.SkeletalWyvern.name,
 		aliases: Monsters.SkeletalWyvern.aliases,
-		timeToFinish: Time.Second * 88,
+		timeToFinish: Time.Second * 84,
 		table: Monsters.SkeletalWyvern,
 
 		wildy: false,
@@ -423,7 +423,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		id: Monsters.Wyrm.id,
 		name: Monsters.Wyrm.name,
 		aliases: Monsters.Wyrm.aliases,
-		timeToFinish: Time.Second * 24,
+		timeToFinish: Time.Second * 27,
 		table: Monsters.Wyrm,
 
 		wildy: false,

--- a/src/lib/minions/data/killableMonsters/konarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/konarMonsters.ts
@@ -82,7 +82,7 @@ export const konarMonsters: KillableMonster[] = [
 		id: Monsters.Drake.id,
 		name: Monsters.Drake.name,
 		aliases: Monsters.Drake.aliases,
-		timeToFinish: Time.Second * 45,
+		timeToFinish: Time.Second * 49,
 		table: Monsters.Drake,
 
 		wildy: false,

--- a/src/lib/minions/data/killableMonsters/nieveMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/nieveMonsters.ts
@@ -134,7 +134,7 @@ export const nieveMonsters: KillableMonster[] = [
 		id: Monsters.Suqah.id,
 		name: Monsters.Suqah.name,
 		aliases: Monsters.Suqah.aliases,
-		timeToFinish: Time.Second * 21,
+		timeToFinish: Time.Second * 23,
 		table: Monsters.Suqah,
 		wildy: false,
 

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -34,7 +34,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.AbyssalDemon.id,
 		name: Monsters.AbyssalDemon.name,
 		aliases: Monsters.AbyssalDemon.aliases,
-		timeToFinish: Time.Second * 26,
+		timeToFinish: Time.Second * 29,
 		table: Monsters.AbyssalDemon,
 
 		wildy: false,
@@ -338,7 +338,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.Dagannoth.id,
 		name: Monsters.Dagannoth.name,
 		aliases: Monsters.Dagannoth.aliases,
-		timeToFinish: Time.Second * 16,
+		timeToFinish: Time.Second * 15,
 		table: Monsters.Dagannoth,
 
 		wildy: false,
@@ -568,7 +568,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.GreaterNechryael.id,
 		name: Monsters.GreaterNechryael.name,
 		aliases: Monsters.GreaterNechryael.aliases,
-		timeToFinish: Time.Second * 40,
+		timeToFinish: Time.Second * 37.2,
 		table: Monsters.GreaterNechryael,
 
 		wildy: false,

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -135,13 +135,18 @@ export interface AddMonsterXpParams {
 	minimal?: boolean;
 	usingCannon?: boolean;
 	cannonMulti?: boolean;
+	burstOrBarrage?: number;
 }
 
 export interface DetermineBoostParams {
 	cbOpts: CombatOptionsEnum[];
-	atkStyles: AttackStyles[];
 	msg: KlasaMessage;
 	monster: KillableMonster;
 	method?: string | null;
 	isOnTask?: boolean;
+}
+
+export interface ResolveAttackStylesParams {
+	monsterID: number;
+	boostMethod?: string;
 }

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -48,17 +48,9 @@ export function determineBoostChoice(params: DetermineBoostParams) {
 		boostChoice = 'burst';
 	} else if (params.msg.flagArgs.cannon || (params.method && params.method === 'cannon')) {
 		boostChoice = 'cannon';
-	} else if (
-		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
-		params.atkStyles.includes(SkillsEnum.Magic) &&
-		params.monster!.canBarrage
-	) {
+	} else if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) && params.monster!.canBarrage) {
 		boostChoice = 'barrage';
-	} else if (
-		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
-		params.atkStyles.includes(SkillsEnum.Magic) &&
-		params.monster!.canBarrage
-	) {
+	} else if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) && params.monster!.canBarrage) {
 		boostChoice = 'burst';
 	} else if (params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)) {
 		boostChoice = 'cannon';

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -214,6 +214,7 @@ export function getCommonTaskName(task: Monster) {
 		case Monsters.ElfWarrior.id:
 			commonName = 'Elves';
 			break;
+		case Monsters.SpiritualRanger.id:
 		case Monsters.SpiritualMage.id:
 			commonName = 'Spiritual Creature';
 			break;

--- a/src/lib/slayer/tasks/bossTasks.ts
+++ b/src/lib/slayer/tasks/bossTasks.ts
@@ -23,6 +23,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Barrows,
 		amount: [1, 6],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.Barrows.id],
 		isBoss: true
 	},
@@ -37,6 +40,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Cerberus,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.Cerberus.id],
 		slayerLevel: 91,
 		isBoss: true
@@ -59,6 +65,10 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.CommanderZilyana,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			agility: 70,
+			prayer: 43
+		},
 		monsters: [Monsters.CommanderZilyana.id],
 		isBoss: true
 	},
@@ -73,6 +83,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.DagannothPrime,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.DagannothPrime.id],
 		isBoss: true
 	},
@@ -80,6 +93,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.DagannothSupreme,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.DagannothSupreme.id],
 		isBoss: true
 	},
@@ -87,6 +103,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.DagannothRex,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.DagannothRex.id],
 		isBoss: true
 	},
@@ -94,6 +113,10 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.GeneralGraardor,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			strength: 70,
+			prayer: 43
+		},
 		monsters: [Monsters.GeneralGraardor.id],
 		isBoss: true
 	},
@@ -101,6 +124,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.GiantMole,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.GiantMole.id],
 		isBoss: true
 	},
@@ -116,6 +142,10 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.KrilTsutsaroth,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			hitpoints: 70,
+			prayer: 43
+		},
 		monsters: [Monsters.KrilTsutsaroth.id],
 		isBoss: true
 	},
@@ -123,6 +153,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.KalphiteQueen,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.KalphiteQueen.id],
 		isBoss: true
 	},
@@ -145,6 +178,10 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Kreearra,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			ranged: 70,
+			prayer: 40
+		},
 		monsters: [Monsters.Kreearra.id],
 		isBoss: true
 	},
@@ -152,6 +189,9 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Sarachnis,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
 		monsters: [Monsters.Sarachnis.id],
 		isBoss: true
 	},
@@ -188,6 +228,10 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Vorkath,
 		amount: [3, 35],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
+		questPoints: 205,
 		monsters: [Monsters.Vorkath.id],
 		isBoss: true
 	},
@@ -195,6 +239,10 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Zulrah,
 		amount: [3, 15],
 		weight: 1,
+		levelRequirements: {
+			prayer: 43
+		},
+		questPoints: 75,
 		monsters: [Monsters.Zulrah.id],
 		isBoss: true
 	}

--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -28,6 +28,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Aviansie,
 		amount: [110, 170],
 		weight: 9,
+		levelRequirements: {
+			agility: 60
+		},
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
 		unlocked: false
 	},

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -44,6 +44,9 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Aviansie,
 		amount: [120, 200],
 		weight: 8,
+		levelRequirements: {
+			agility: 60
+		},
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
 		unlocked: false
 	},

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -42,6 +42,9 @@ export const konarTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Aviansie,
 		amount: [120, 170],
 		weight: 6,
+		levelRequirements: {
+			agility: 60
+		},
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
 		unlocked: false
 	},

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -44,6 +44,9 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Aviansie,
 		amount: [120, 185],
 		weight: 6,
+		levelRequirements: {
+			agility: 60
+		},
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
 		unlocked: false
 	},

--- a/src/lib/slayer/tasks/turaelTasks.ts
+++ b/src/lib/slayer/tasks/turaelTasks.ts
@@ -123,7 +123,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Goblin,
 		amount: [15, 50],
 		weight: 7,
-		monsters: [Monsters.Goblin.id, Monsters.CaveGoblinGuard.id, Monsters.GeneralGraardor.id],
+		monsters: [Monsters.Goblin.id, Monsters.CaveGoblinGuard.id],
 		unlocked: true
 	},
 	{

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -37,7 +37,8 @@ export default class extends Task {
 			taskQuantity: quantitySlayed,
 			minimal: false,
 			usingCannon,
-			cannonMulti
+			cannonMulti,
+			burstOrBarrage
 		});
 
 		const mySlayerUnlocks = user.settings.get(UserSettings.Slayer.SlayerUnlocks);


### PR DESCRIPTION
### Description:

- Automatically use Magic for barrage tasks, this avoids having to switch combat styles between each task, and people were really asking for this feature.
- Last minute balancing changes from House Paran
- Rewrote collection log for slayer with helm from mylife212
- Fixed aviainsies + gwd bosses, + other bosses so can't be assigned without requirements.

### Changes:

- Changed resolveAttackStyles to use a parameter object
- Removed the code restricting Magic from determining boost, and used it to determine attack style instead.
- Tweaked a few more monsters by +/- 5-10%
- Moved slayer log into it's own +cl slayer, and organised it better.

### Other checks:

-   [x] I have tested all my changes thoroughly.
