### PR TITLE
Fix Mysterious tree bug

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -476,7 +476,7 @@ export default class extends Task {
 			}
 
 			if (plantToHarvest.name === 'Mysterious tree') {
-				let upper = randInt(quantity, quantity * 6);
+				let upper = randInt(quantity, alivePlants * 6);
 				for (let i = 0; i < upper; i++) {
 					loot = addItemToBank(loot, getRandomMysteryBox());
 				}


### PR DESCRIPTION
### Description:
Mysterious trees using the wrong variable to count # of mystery boxes. Should be using 'alivePlants'


