### PR TITLE
Fix multiple mysterious tree bugs, 1 major one

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -476,7 +476,7 @@ export default class extends Task {
 			}
 
 			if (plantToHarvest.name === 'Mysterious tree') {
-				let upper = randInt(quantity, quantity * 6);
+				let upper = randInt(quantity, alivePlants * 6);
 				for (let i = 0; i < upper; i++) {
 					loot = addItemToBank(loot, getRandomMysteryBox());
 				}

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -150,10 +150,13 @@ export default class extends Task {
 				loot = multiplyBank(loot, 4);
 			}
 
+			// This code gives the boxes for planing when ONLY planting.
 			if (plant.name === 'Mysterious tree') {
-				let upper = randInt(quantity, quantity * 4);
-				for (let i = 0; i < upper; i++) {
-					loot = addItemToBank(loot, getRandomMysteryBox());
+				for (let j = 0; j < quantity; j++) {
+					let upper = randInt(1, 4);
+					for (let i = 0; i < upper; i++) {
+						loot = addItemToBank(loot, getRandomMysteryBox());
+					}
 				}
 			}
 
@@ -474,11 +477,22 @@ export default class extends Task {
 			if (user.hasItemEquippedAnywhere(itemID('Farming master cape'))) {
 				loot = addItemToBank(loot, getRandomMysteryBox());
 			}
-
-			if (plantToHarvest.name === 'Mysterious tree') {
-				let upper = randInt(quantity, alivePlants * 6);
-				for (let i = 0; i < upper; i++) {
-					loot = addItemToBank(loot, getRandomMysteryBox());
+			// Give boxes for planting when harvesting
+			if (planting && plant.name === 'Mysterious tree') {
+				for (let j = 0; j < quantity; j++) {
+					let upper = randInt(1, 4);
+					for (let i = 0; i < upper; i++) {
+						loot = addItemToBank(loot, getRandomMysteryBox());
+					}
+				}
+			}
+			// Give the boxes for harvesting during a harvest
+			if (alivePlants && plantToHarvest.name === 'Mysterious tree') {
+				for (let j = 0; j < alivePlants; j++) {
+					let upper = randInt(1, 6);
+					for (let i = 0; i < upper; i++) {
+						loot = addItemToBank(loot, getRandomMysteryBox());
+					}
 				}
 			}
 


### PR DESCRIPTION
### Description:
Fixed bug where harvesting 1 mysterious tree while planting 10 magic trees gives up to 10x the loot it should
Fixed bug where you wouldn't get the 'planting loot' from mysterious seeds when you are harvesting another plant
Fixed the statistical distribution of boxes, so it rolls 1 to 6 'X' times instead of 'x to 6 * x' one time.
---This is how it would normally work if harvesting multiple plants, and the implications are it's very unlikely to hit the minimum or maximum numbers, but the mode will in the middle of the range.

### Changes:
The major bug was solved by changing 'quantity' to 'alivePlants' in the last relevant section of code.

### Other checks:

-   [x] I have tested all my changes thoroughly. I did test this :)
