### PR TITLE
Sepulchre/Plunder XP Changes

### DIFF
--- a/src/lib/minions/data/plunder.ts
+++ b/src/lib/minions/data/plunder.ts
@@ -109,7 +109,7 @@ export const plunderRooms = [
 		number: 8,
 		petChance: 2000,
 		thievingLevel: 91,
-		xp: 12_423,
+		xp: 12_665,
 		rockyChance: 6893,
 		roomTable: Room8Table
 	}

--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -93,7 +93,7 @@ export const sepulchreFloors = [
 		petChance: 2000,
 		agilityLevel: 92,
 		xp: 5850,
-		time: Time.Minute * 4.3,
+		time: Time.Minute * 3.75,
 		lockpickCoffinChance: 600,
 		coffinTable: new LootTable().add(MidTierCoffin, 1, 20).add(HighTierCoffin, 1, 80),
 		numCoffins: 3,


### PR DESCRIPTION
Changed XP given slightly for Plunder room 8 and Sepulchre floor 5, these will now match consistent XP rates on OSRS a little more, 

graphs provided by Fishy below to show proposed XP rates

![](https://media.discordapp.net/attachments/731961112899223672/855155216822042654/unknown.png)

![](https://media.discordapp.net/attachments/731961112899223672/855151636385497088/unknown.png)
