### PR TITLE
[BSO] Fix Merge issues

### DIFF
--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -59,7 +59,7 @@ export default class extends Task {
 			: undefined;
 
 		const superiorTable = superiorsUnlocked && monster.superior ? monster.superior : undefined;
-		const isInCatacombs = 1 > 2 && !usingCannon ? monster.existsInCatacombs ?? undefined : undefined;
+		const isInCatacombs = !usingCannon ? monster.existsInCatacombs ?? undefined : undefined;
 
 		const killOptions: MonsterKillOptions = {
 			onSlayerTask: isOnTask,
@@ -85,7 +85,8 @@ export default class extends Task {
 			taskQuantity: quantitySlayed,
 			minimal: false,
 			usingCannon,
-			cannonMulti
+			cannonMulti,
+			burstOrBarrage
 		});
 
 		const superiorMessage = newSuperiorCount ? `, including **${newSuperiorCount} superiors**` : '';


### PR DESCRIPTION
### Description:
Fixed BSO merging bugs:
1) Not receiving totem drops
2) Barrage giving melee/ranged XP

### Changes:
1) Undid the OSB override for BSO
2) Put back the 'burstOfBarrage' variable in monsterActivitiy.ts


### Other checks:

-   [x] I have tested all my changes thoroughly.
