### PR TITLE
Drop cannonball rate from 60=>50 per minute.

### DIFF
--- a/src/lib/minions/data/combatConstants.ts
+++ b/src/lib/minions/data/combatConstants.ts
@@ -66,7 +66,7 @@ export const cannonSingleConsumables: Consumable = {
 };
 export const cannonMultiConsumables: Consumable = {
 	itemCost: new Bank().add('Cannonball', 1),
-	qtyPerMinute: 60
+	qtyPerMinute: 50
 };
 // 20% less than always casting to lure.
 export const iceBarrageConsumables: Consumable = {


### PR DESCRIPTION
### Description:
Lowered cannonball usage from 60=>50 per minute. This reduces the overall cannonball cost from being ~5% above OSRS rates to about 10% below OSRS rates. This seems fair, especially considering cannonball supply, lack of bots, etc, and the people in #slayer all received the idea well :)
