### PR TITLE
[BSO] Remove twisted kit+metamorphic dust from boss log

### DIFF
--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -414,7 +414,7 @@ export const bosses: CollectionLogData = {
 		'Ancestral robe bottom',
 		'Twisted buckler'
 	]),
-	Cox2: resolveItems(["Dinh's bulwark", 'Dark relic', 'Metamorphic dust', 'Olmlet', 'Twisted ancestral colour kit']),
+	Cox2: resolveItems(["Dinh's bulwark", 'Dark relic', 'Olmlet']),
 	Skotizo: resolveItems([
 		'Dark totem',
 		'Dark claw',


### PR DESCRIPTION

### Description:.
This is for BSO only. Removed Metamorphic dust+twisted kit from log as they were only obtainable from early mboxes, and cannot be obtained anymore. Giving an unfair advantage to those who were lucky enough to pull it from boxes on the boss log leaderboard. Also doesn't make sense for a log to have unobtainable items 


### Changes:

- Deleted Metamorphic dust + Twisted ancestral kit from the "cox2" line in Boss Collection log

### Other checks:

-   [ ] I have tested all my changes thoroughly.
