### PR TITLE
EHP level requirements

### DIFF
--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -313,8 +313,9 @@ export default class extends BotCommand {
 			if (
 				ehpKillable?.levelRequirements !== undefined &&
 				!msg.author.hasSkillReqs(ehpKillable.levelRequirements)[0]
-			)
+			) {
 				return this.client.commands.get('k')?.run(msg, [null, usersTask.assignedTask!.monster.name]);
+			}
 
 			if (ehpMonster && ehpMonster.efficientName) {
 				if (ehpMonster.efficientMethod) msg.flagArgs[ehpMonster.efficientMethod] = 'force';

--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -318,9 +318,8 @@ export default class extends BotCommand {
 				}
 			});
 
-			//If we don't have the requirements for the efficient monster, revert to default monster
-			if (cantEHP)
-				return this.client.commands.get('k')?.run(msg, [null, usersTask.assignedTask!.monster.name]);
+			// If we don't have the requirements for the efficient monster, revert to default monster
+			if (cantEHP) return this.client.commands.get('k')?.run(msg, [null, usersTask.assignedTask!.monster.name]);
 
 			if (ehpMonster && ehpMonster.efficientName) {
 				if (ehpMonster.efficientMethod) msg.flagArgs[ehpMonster.efficientMethod] = 'force';

--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -307,19 +307,14 @@ export default class extends BotCommand {
 				return masterMatch && e.monsterID === usersTask.assignedTask!.monster.id;
 			});
 
-			const allMonsters = killableMonsters.filter(m => {
-				return usersTask.assignedTask!.monsters.includes(m.id);
-			});
-
-			const cantEHP = allMonsters.some(m => {
-				if (m.levelRequirements !== undefined) {
-					const [hasSkillReqs] = msg.author.hasSkillReqs(m.levelRequirements);
-					return m.id === ehpMonster?.efficientMonster && !hasSkillReqs;
-				}
-			});
+			const ehpKillable = killableMonsters.find(m => m.id === ehpMonster?.efficientMonster);
 
 			// If we don't have the requirements for the efficient monster, revert to default monster
-			if (cantEHP) return this.client.commands.get('k')?.run(msg, [null, usersTask.assignedTask!.monster.name]);
+			if (
+				ehpKillable?.levelRequirements !== undefined &&
+				!msg.author.hasSkillReqs(ehpKillable.levelRequirements)[0]
+			)
+				return this.client.commands.get('k')?.run(msg, [null, usersTask.assignedTask!.monster.name]);
 
 			if (ehpMonster && ehpMonster.efficientName) {
 				if (ehpMonster.efficientMethod) msg.flagArgs[ehpMonster.efficientMethod] = 'force';

--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -307,6 +307,21 @@ export default class extends BotCommand {
 				return masterMatch && e.monsterID === usersTask.assignedTask!.monster.id;
 			});
 
+			const allMonsters = killableMonsters.filter(m => {
+				return usersTask.assignedTask!.monsters.includes(m.id);
+			});
+
+			const cantEHP = allMonsters.some(m => {
+				if (m.levelRequirements !== undefined) {
+					const [hasSkillReqs] = msg.author.hasSkillReqs(m.levelRequirements);
+					return m.id === ehpMonster?.efficientMonster && !hasSkillReqs;
+				}
+			});
+
+			//If we don't have the requirements for the efficient monster, revert to default monster
+			if (cantEHP)
+				return this.client.commands.get('k')?.run(msg, [null, usersTask.assignedTask!.monster.name]);
+
 			if (ehpMonster && ehpMonster.efficientName) {
 				if (ehpMonster.efficientMethod) msg.flagArgs[ehpMonster.efficientMethod] = 'force';
 				return this.client.commands


### PR DESCRIPTION
### Description:

+as --ehp no longer selects monsters you lack requirements for.

### Changes:

Added a check to --ehp for level requirements. Probably only affects spiritual creatures right now, but still.

### Other checks:

-   [ x ] I have tested all my changes thoroughly.
