### PR TITLE
Fix Black Mask CL and enhanced the loot filter

### DIFF
--- a/src/commands/Minion/slayershop.ts
+++ b/src/commands/Minion/slayershop.ts
@@ -48,14 +48,14 @@ export default class extends BotCommand {
 				return getSlayerReward(mu);
 			})
 			.join('\n');
-		if (unlocksStr !== '') unlocksStr = `\`${unlocksStr}\``;
+		if (unlocksStr !== '') unlocksStr = `${unlocksStr}`;
 		const defaultMsg =
-			`Current points: ${myPoints}\nYou currently have the following ` +
-			`rewards unlocked:\n${unlocksStr}\n\n` +
+			`Current points: ${myPoints}\n**You currently have the following ` +
+			`rewards unlocked:**\n${unlocksStr}\n\n` +
 			`Usage:\n\`${msg.cmdPrefix}slayershop [unlock|lock|buy] Reward\`\nExample:` +
 			`\n\`${msg.cmdPrefix}slayershop unlock Malevolent Masquerade\``;
 		if (defaultMsg.length > 2000) {
-			return msg.channel.sendFile(Buffer.from(defaultMsg), 'currentUnlocks.txt');
+			return msg.channel.sendFile(Buffer.from(defaultMsg.replace(/`/g, '')), 'currentUnlocks.txt');
 		}
 		return msg.channel.send(defaultMsg);
 	}

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -51,7 +51,7 @@ export default class extends BotCommand {
 		) {
 			let outstr =
 				`You have a maximum of ${maxBlocks} task blocks. You are using ${myBlockList.length}` +
-				` and have ${maxBlocks - myBlockList.length} remaining\n\nBlocked Tasks:\n`;
+				` and have ${maxBlocks - myBlockList.length} remaining\n\n**Blocked Tasks:**\n`;
 			const myBlockedMonsters = Monsters.filter(m => {
 				return myBlockList.includes(m.id);
 			});

--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -1608,7 +1608,7 @@ export const slayerLog: CollectionLogData = {
 		'Dragon sword',
 		'Dragon thrownaxe',
 		'Dragon knife',
-		'Black mask',
+		'Black mask (10)',
 		'Granite maul',
 		'Abyssal whip',
 		'Abyssal dagger',

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -11,7 +11,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.AberrantSpectre.id,
 		name: Monsters.AberrantSpectre.name,
 		aliases: Monsters.AberrantSpectre.aliases,
-		timeToFinish: Time.Second * 35,
+		timeToFinish: Time.Second * 24,
 		table: Monsters.AberrantSpectre,
 
 		wildy: false,

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -337,9 +337,12 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 		);
 	}, true);
 
+	const myClLoot = new Bank(myLoot.bank);
+
 	if (numBlackMask) {
 		for (let x = 0; x < numBlackMask; x++) {
 			myLoot.add('Black mask');
+			myClLoot.add('Black mask (10)');
 		}
 	}
 	if (numBludgeonPieces) {
@@ -353,6 +356,7 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 			for (let i = 0; i < bank.length; i++) {
 				if (bank[i] === minBank) {
 					myLoot.add(bludgeonPieces[i]);
+					myClLoot.add(bludgeonPieces[i]);
 					break;
 				}
 			}
@@ -369,6 +373,7 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 			for (let i = 0; i < bank.length; i++) {
 				if (bank[i] === minBank) {
 					myLoot.add(totemPieces[i]);
+					myClLoot.add(totemPieces[i]);
 					break;
 				}
 			}
@@ -385,9 +390,14 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 			for (let i = 0; i < bank.length; i++) {
 				if (bank[i] === minBank) {
 					myLoot.add(ringPieces[i]);
+					myClLoot.add(ringPieces[i]);
 					break;
 				}
 			}
 		}
 	}
+	return {
+		bankLoot: myLoot,
+		clLoot: myClLoot
+	};
 }

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -119,9 +119,10 @@ export default class extends Task {
 			await usersTask.currentTask!.save();
 		}
 
-		filterLootReplace(user.allItemsOwned(), loot);
+		const { clLoot } = filterLootReplace(user.allItemsOwned(), loot);
 
-		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true);
+		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, false);
+		await user.addItemsToCollectionLog(clLoot.bank);
 
 		const { image } = await this.client.tasks
 			.get('bankImage')!


### PR DESCRIPTION
### Description:
Fix black mask so it appears on the CL

### Changes:
The slayer loot filter now also returns a 'CL Bank' variable, which contains entries that should be on the CL.
The only current use is: Black mask (10) is converted to Black mask, but the CL Bank version is 'Black mask (10)'
This allows us to keep OSJS pure, while still avoiding forcing players to needlessly convert Black mask (10) into 'Black mask' and/or handling the multiple variations in creating slayer masks, imbues, etc.
Increased speed of regular abby specs to remain a viable faster but lower xp task

### Other checks:

-   [x] I have tested all my changes thoroughly.
