### PR TITLE
Fix not enough item error

### DIFF
--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -89,7 +89,7 @@ export default class extends BotCommand {
 					continue;
 				}
 				const itemsOwned = userBank[parseInt(itemID)];
-				if (itemsOwned < qty) {
+				if (itemsOwned === undefined || itemsOwned < qty) {
 					return msg.send(`You dont have enough ${itemNameFromID(parseInt(itemID))}.`);
 				}
 				quantity = Math.min(quantity, Math.floor(itemsOwned / qty));


### PR DESCRIPTION
### Description:

If you had 0 of an item in your bank, +craft was unable to produce an error message stating you were missing that item. Instead it'd send an error for an item you had at least 1 of.

### Changes:

Added an undefined check.

### Other checks:

-   [X] I have tested all my changes thoroughly.
