### PR TITLE
Craft bank usage and fletching filter

### DIFF
--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -3,12 +3,13 @@ import { CommandStore, KlasaMessage } from 'klasa';
 import { Activity, Time } from '../../lib/constants';
 import { FaladorDiary, userhasDiaryTier } from '../../lib/diaries';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
+import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Crafting from '../../lib/skilling/skills/crafting';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { CraftingActivityTaskOptions } from '../../lib/types/minions';
-import { bankHasItem, formatDuration, itemNameFromID, removeItemFromBank, stringMatches } from '../../lib/util';
+import { addBanks, formatDuration, itemNameFromID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 
 export default class extends BotCommand {
@@ -48,28 +49,25 @@ export default class extends BotCommand {
 			quantity = null;
 		}
 
-		const Craft = Crafting.Craftables.find(item => stringMatches(item.name, craftName));
+		const craftable = Crafting.Craftables.find(item => stringMatches(item.name, craftName));
 
-		if (!Craft) {
+		if (!craftable) {
 			return msg.send(
 				`That is not a valid craftable item, to see the items available do \`${msg.cmdPrefix}craft --items\``
 			);
 		}
 
-		if (msg.author.skillLevel(SkillsEnum.Crafting) < Craft.level) {
-			return msg.send(`${msg.author.minionName} needs ${Craft.level} Crafting to craft ${Craft.name}.`);
+		if (msg.author.skillLevel(SkillsEnum.Crafting) < craftable.level) {
+			return msg.send(`${msg.author.minionName} needs ${craftable.level} Crafting to craft ${craftable.name}.`);
 		}
 
 		await msg.author.settings.sync(true);
-		const userBank = msg.author.settings.get(UserSettings.Bank);
-		const requiredItems: [string, number][] = Object.entries(Craft.inputItems);
+		const userBank = msg.author.bank();
 
 		// Get the base time to craft the item then add on quarter of a second per item to account for banking/etc.
-
-		let timeToCraftSingleItem = Craft.tickRate * Time.Second * 0.6 + Time.Second / 4;
-
+		let timeToCraftSingleItem = craftable.tickRate * Time.Second * 0.6 + Time.Second / 4;
 		const [hasFallyHard] = await userhasDiaryTier(msg.author, FaladorDiary.hard);
-		if (Craft.bankChest && (hasFallyHard || msg.author.skillLevel(SkillsEnum.Crafting) >= 99)) {
+		if (craftable.bankChest && (hasFallyHard || msg.author.skillLevel(SkillsEnum.Crafting) >= 99)) {
 			timeToCraftSingleItem /= 3.25;
 		}
 
@@ -78,64 +76,58 @@ export default class extends BotCommand {
 		// If no quantity provided, set it to the max the player can make by either the items in bank or max time.
 		if (quantity === null) {
 			quantity = Math.floor(maxTripLength / timeToCraftSingleItem);
-			for (const [itemID, qty] of requiredItems) {
-				const id = parseInt(itemID);
-				if (id === 995) {
-					const userGP = msg.author.settings.get(UserSettings.GP);
-					if (userGP < qty) {
-						return msg.send('You do not have enough GP.');
-					}
-					quantity = Math.min(quantity, Math.floor(userGP / qty));
-					continue;
-				}
-				const itemsOwned = userBank[parseInt(itemID)];
-				if (itemsOwned < qty) {
-					return msg.send(`You dont have enough ${itemNameFromID(parseInt(itemID))}.`);
-				}
-				quantity = Math.min(quantity, Math.floor(itemsOwned / qty));
-			}
+			const max = userBank.fits(craftable.inputItems);
+			if (max < quantity && max !== 0) quantity = max;
 		}
 
 		const duration = quantity * timeToCraftSingleItem;
-
 		if (duration > maxTripLength) {
 			return msg.send(
 				`${msg.author.minionName} can't go on trips longer than ${formatDuration(
 					maxTripLength
-				)}, try a lower quantity. The highest amount of ${Craft.name}s you can craft is ${Math.floor(
+				)}, try a lower quantity. The highest amount of ${craftable.name}s you can craft is ${Math.floor(
 					maxTripLength / timeToCraftSingleItem
 				)}.`
 			);
 		}
 
-		// Check the user has add the required items to craft.
-		for (const [itemID, qty] of requiredItems) {
-			const id = parseInt(itemID);
-			if (id === 995) {
-				const userGP = msg.author.settings.get(UserSettings.GP);
-				if (userGP < qty * quantity) {
-					return msg.send(`You don't have enough ${itemNameFromID(id)}.`);
-				}
-				continue;
-			}
-			if (!bankHasItem(userBank, id, qty * quantity)) {
-				return msg.send(`You don't have enough ${itemNameFromID(id)}.`);
-			}
+		const itemsNeeded = craftable.inputItems.clone().multiply(quantity);
+		let gpNeeded = 0;
+		const currentGP = msg.author.settings.get(UserSettings.GP);
+		if (itemsNeeded.has('Coins')) {
+			gpNeeded = itemsNeeded.amount('Coins');
+			itemsNeeded.remove('Coins');
 		}
 
-		// Remove the required items from their bank.
-		let newBank = { ...userBank };
-		for (const [itemID, qty] of requiredItems) {
-			if (parseInt(itemID) === 995) {
-				await msg.author.removeGP(qty * quantity);
-				continue;
-			}
-			newBank = removeItemFromBank(newBank, parseInt(itemID), qty * quantity);
+		// Check the user has all the required items to craft.
+		if (!userBank.has(itemsNeeded.bank)) {
+			return msg.send(
+				`You don't have enough items. For ${quantity}x ${craftable.name}, you're missing **${itemsNeeded
+					.clone()
+					.remove(userBank)}**.`
+			);
 		}
-		await msg.author.settings.update(UserSettings.Bank, newBank);
+
+		// Check the user has the GP to craft.
+		if (gpNeeded > currentGP) {
+			return msg.send(
+				`You don't have enough GP. For ${quantity}x ${craftable.name}, you're missing **${
+					gpNeeded - currentGP
+				}**.`
+			);
+		}
+
+		await msg.author.removeItemsFromBank(itemsNeeded);
+
+		if (gpNeeded > 0) await msg.author.removeGP(gpNeeded);
+
+		await this.client.settings.update(
+			ClientSettings.EconomyStats.CraftingCostBank,
+			addBanks([this.client.settings.get(ClientSettings.EconomyStats.CraftingCostBank), itemsNeeded.bank])
+		);
 
 		await addSubTaskToActivityTask<CraftingActivityTaskOptions>({
-			craftableID: Craft.id,
+			craftableID: craftable.id,
 			userID: msg.author.id,
 			channelID: msg.channel.id,
 			quantity,
@@ -143,10 +135,18 @@ export default class extends BotCommand {
 			type: Activity.Crafting
 		});
 
+		let gpUsedString = '';
+
+		if (gpNeeded > 0) {
+			gpUsedString += ` and ${gpNeeded} GP`;
+		}
+
 		return msg.send(
-			`${msg.author.minionName} is now crafting ${quantity}x ${Craft.name}, it'll take around ${formatDuration(
+			`${msg.author.minionName} is now crafting ${quantity}x ${
+				craftable.name
+			}, it'll take around ${formatDuration(
 				duration
-			)} to finish.`
+			)} to finish. Removed ${itemsNeeded}${gpUsedString} from your bank.`
 		);
 	}
 }

--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -9,7 +9,7 @@ import Crafting from '../../lib/skilling/skills/crafting';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { CraftingActivityTaskOptions } from '../../lib/types/minions';
-import { addBanks, formatDuration, itemNameFromID, stringMatches } from '../../lib/util';
+import { updateBankSetting, addBanks, formatDuration, itemNameFromID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 
 export default class extends BotCommand {
@@ -121,10 +121,7 @@ export default class extends BotCommand {
 
 		if (gpNeeded > 0) await msg.author.removeGP(gpNeeded);
 
-		await this.client.settings.update(
-			ClientSettings.EconomyStats.CraftingCostBank,
-			addBanks([this.client.settings.get(ClientSettings.EconomyStats.CraftingCostBank), itemsNeeded.bank])
-		);
+		updateBankSetting(this.client, ClientSettings.EconomyStats.CraftingCost, itemsNeeded.bank)
 
 		await addSubTaskToActivityTask<CraftingActivityTaskOptions>({
 			craftableID: craftable.id,

--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -9,7 +9,7 @@ import Crafting from '../../lib/skilling/skills/crafting';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { CraftingActivityTaskOptions } from '../../lib/types/minions';
-import { updateBankSetting, addBanks, formatDuration, itemNameFromID, stringMatches } from '../../lib/util';
+import { updateBankSetting, formatDuration, itemNameFromID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 
 export default class extends BotCommand {

--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -91,8 +91,6 @@ export default class extends BotCommand {
 		}
 
 		const itemsNeeded = craftable.inputItems.clone().multiply(quantity);
-		let gpNeeded = 0;
-		if (itemsNeeded.has('Coins')) gpNeeded = itemsNeeded.amount('Coins');
 
 		// Check the user has all the required items to craft.
 		if (!userBank.has(itemsNeeded.bank)) {
@@ -116,18 +114,10 @@ export default class extends BotCommand {
 			type: Activity.Crafting
 		});
 
-		let gpUsedString = '';
-
-		if (gpNeeded > 0) {
-			gpUsedString += ` and ${gpNeeded} GP`;
-		}
-
 		return msg.send(
 			`${msg.author.minionName} is now crafting ${quantity}x ${
 				craftable.name
-			}, it'll take around ${formatDuration(
-				duration
-			)} to finish. Removed ${itemsNeeded}${gpUsedString} from your bank.`
+			}, it'll take around ${formatDuration(duration)} to finish. Removed ${itemsNeeded} from your bank.`
 		);
 	}
 }

--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -4,7 +4,6 @@ import { Activity, Time } from '../../lib/constants';
 import { FaladorDiary, userhasDiaryTier } from '../../lib/diaries';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
-import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Crafting from '../../lib/skilling/skills/crafting';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
@@ -93,7 +92,6 @@ export default class extends BotCommand {
 
 		const itemsNeeded = craftable.inputItems.clone().multiply(quantity);
 		let gpNeeded = 0;
-		const currentGP = msg.author.settings.get(UserSettings.GP);
 		if (itemsNeeded.has('Coins')) gpNeeded = itemsNeeded.amount('Coins');
 
 		// Check the user has all the required items to craft.
@@ -102,15 +100,6 @@ export default class extends BotCommand {
 				`You don't have enough items. For ${quantity}x ${craftable.name}, you're missing **${itemsNeeded
 					.clone()
 					.remove(userBank)}**.`
-			);
-		}
-
-		// Check the user has the GP to craft.
-		if (gpNeeded > currentGP) {
-			return msg.send(
-				`You don't have enough GP. For ${quantity}x ${craftable.name}, you're missing **${
-					gpNeeded - currentGP
-				}**.`
 			);
 		}
 

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -146,7 +146,7 @@ const gems = resolveItems([
 	'Zenyte shard'
 ]);
 
-const craftingItems = Craftables.flatMap(item => Object.keys(item.inputItems).map(key => parseInt(key)));
+const craftingItems = Craftables.flatMap(item => Object.keys(item.inputItems.bank).map(key => parseInt(key)));
 
 const craftingItemsSet = [...new Set(craftingItems)];
 
@@ -347,7 +347,7 @@ const bones = resolveItems([
 	'Zogre bones'
 ]);
 
-const fletchingItems = Fletchables.flatMap(item => Object.keys(item.inputItems).map(key => parseInt(key)));
+const fletchingItems = Fletchables.flatMap(item => Object.keys(item.inputItems.bank).map(key => parseInt(key)));
 
 const fletchingItemsSet = [...new Set(fletchingItems)];
 

--- a/src/lib/settings/schemas/ClientSchema.ts
+++ b/src/lib/settings/schemas/ClientSchema.ts
@@ -11,6 +11,7 @@ Client.defaultClientSchema
 	.add('farming_loot_bank', 'any', { default: {} })
 	.add('buy_cost_bank', 'any', { default: {} })
 	.add('magic_cost_bank', 'any', { default: {} })
+	.add('crafting_cost_bank', 'any', { default: {} })
 	.add('gnome_res_cost', 'any', { default: {} })
 	.add('gnome_res_loot', 'any', { default: {} })
 	.add('rogues_den_cost', 'any', { default: {} })

--- a/src/lib/settings/schemas/ClientSchema.ts
+++ b/src/lib/settings/schemas/ClientSchema.ts
@@ -11,7 +11,7 @@ Client.defaultClientSchema
 	.add('farming_loot_bank', 'any', { default: {} })
 	.add('buy_cost_bank', 'any', { default: {} })
 	.add('magic_cost_bank', 'any', { default: {} })
-	.add('crafting_cost_bank', 'any', { default: {} })
+	.add('crafting_cost', 'any', { default: {} })
 	.add('gnome_res_cost', 'any', { default: {} })
 	.add('gnome_res_loot', 'any', { default: {} })
 	.add('rogues_den_cost', 'any', { default: {} })

--- a/src/lib/settings/types/ClientSettings.ts
+++ b/src/lib/settings/types/ClientSettings.ts
@@ -36,6 +36,7 @@ export namespace ClientSettings {
 		export const FarmingLootBank = T<O.Readonly<ItemBank>>('farming_loot_bank');
 		export const BuyCostBank = T<O.Readonly<ItemBank>>('buy_cost_bank');
 		export const MagicCostBank = T<O.Readonly<ItemBank>>('magic_cost_bank');
+		export const CraftingCostBank = T<O.Readonly<ItemBank>>('crafting_cost_bank');
 
 		export const GnomeRestaurantCostBank = T<O.Readonly<ItemBank>>('gnome_res_cost');
 		export const GnomeRestaurantLootBank = T<O.Readonly<ItemBank>>('gnome_res_loot');

--- a/src/lib/settings/types/ClientSettings.ts
+++ b/src/lib/settings/types/ClientSettings.ts
@@ -36,7 +36,7 @@ export namespace ClientSettings {
 		export const FarmingLootBank = T<O.Readonly<ItemBank>>('farming_loot_bank');
 		export const BuyCostBank = T<O.Readonly<ItemBank>>('buy_cost_bank');
 		export const MagicCostBank = T<O.Readonly<ItemBank>>('magic_cost_bank');
-		export const CraftingCostBank = T<O.Readonly<ItemBank>>('crafting_cost_bank');
+		export const CraftingCost = T<O.Readonly<ItemBank>>('crafting_cost');
 
 		export const GnomeRestaurantCostBank = T<O.Readonly<ItemBank>>('gnome_res_cost');
 		export const GnomeRestaurantLootBank = T<O.Readonly<ItemBank>>('gnome_res_loot');

--- a/src/lib/skilling/skills/crafting/craftables/birdhouse.ts
+++ b/src/lib/skilling/skills/crafting/craftables/birdhouse.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Bird house'),
 		level: 5,
 		xp: 15,
-		inputItems: resolveNameBank({ Logs: 1, Clockwork: 1 }),
+		inputItems: new Bank({ Logs: 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -16,7 +17,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Oak bird house'),
 		level: 15,
 		xp: 20,
-		inputItems: resolveNameBank({ 'Oak logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Oak logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -24,7 +25,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Willow bird house'),
 		level: 25,
 		xp: 25,
-		inputItems: resolveNameBank({ 'Willow logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Willow logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -32,7 +33,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Teak bird house'),
 		level: 35,
 		xp: 30,
-		inputItems: resolveNameBank({ 'Teak logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Teak logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -40,7 +41,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Maple bird house'),
 		level: 45,
 		xp: 35,
-		inputItems: resolveNameBank({ 'Maple logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Maple logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -48,7 +49,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Mahogany bird house'),
 		level: 50,
 		xp: 40,
-		inputItems: resolveNameBank({ 'Mahogany logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Mahogany logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -56,7 +57,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Yew bird house'),
 		level: 60,
 		xp: 45,
-		inputItems: resolveNameBank({ 'Yew logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Yew logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -64,7 +65,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Magic bird house'),
 		level: 75,
 		xp: 50,
-		inputItems: resolveNameBank({ 'Magic logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Magic logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	},
 	{
@@ -72,7 +73,7 @@ const Birdhouse: Craftable[] = [
 		id: itemID('Redwood bird house'),
 		level: 90,
 		xp: 55,
-		inputItems: resolveNameBank({ 'Redwood logs': 1, Clockwork: 1 }),
+		inputItems: new Bank({ 'Redwood logs': 1, Clockwork: 1 }),
 		tickRate: 2
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/built.ts
+++ b/src/lib/skilling/skills/crafting/craftables/built.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Built: Craftable[] = [
 		id: itemID('Serpentine helm (uncharged)'),
 		level: 52,
 		xp: 120,
-		inputItems: resolveNameBank({ 'Serpentine visage': 1 }),
+		inputItems: new Bank({ 'Serpentine visage': 1 }),
 		tickRate: 3
 	},
 	{
@@ -16,7 +17,7 @@ const Built: Craftable[] = [
 		id: itemID('Toxic staff (uncharged)'),
 		level: 59,
 		xp: 0,
-		inputItems: resolveNameBank({ 'Staff of the dead': 1, 'Magic fang': 1 }),
+		inputItems: new Bank({ 'Staff of the dead': 1, 'Magic fang': 1 }),
 		tickRate: 3
 	},
 	{
@@ -24,7 +25,7 @@ const Built: Craftable[] = [
 		id: itemID('Uncharged toxic trident'),
 		level: 59,
 		xp: 0,
-		inputItems: resolveNameBank({ 'Uncharged trident': 1, 'Magic fang': 1 }),
+		inputItems: new Bank({ 'Uncharged trident': 1, 'Magic fang': 1 }),
 		tickRate: 3
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/dragonhide.ts
+++ b/src/lib/skilling/skills/crafting/craftables/dragonhide.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Green d'hide vambraces"),
 		level: 57,
 		xp: 62,
-		inputItems: resolveNameBank({ 'Green dragon leather': 1 }),
+		inputItems: new Bank({ 'Green dragon leather': 1 }),
 		tickRate: 3
 	},
 	{
@@ -16,7 +17,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Green d'hide chaps"),
 		level: 60,
 		xp: 124,
-		inputItems: resolveNameBank({ 'Green dragon leather': 2 }),
+		inputItems: new Bank({ 'Green dragon leather': 2 }),
 		tickRate: 3.5
 	},
 	{
@@ -24,7 +25,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Green d'hide shield"),
 		level: 62,
 		xp: 124,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Green dragon leather': 2,
 			'Maple shield': 1,
 			'Steel nails': 15
@@ -36,7 +37,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Green d'hide body"),
 		level: 63,
 		xp: 186,
-		inputItems: resolveNameBank({ 'Green dragon leather': 3 }),
+		inputItems: new Bank({ 'Green dragon leather': 3 }),
 		tickRate: 3.5
 	},
 	{
@@ -44,7 +45,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Blue d'hide vambraces"),
 		level: 66,
 		xp: 70,
-		inputItems: resolveNameBank({ 'Blue dragon leather': 1 }),
+		inputItems: new Bank({ 'Blue dragon leather': 1 }),
 		tickRate: 3
 	},
 	{
@@ -52,7 +53,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Blue d'hide chaps"),
 		level: 68,
 		xp: 140,
-		inputItems: resolveNameBank({ 'Blue dragon leather': 2 }),
+		inputItems: new Bank({ 'Blue dragon leather': 2 }),
 		tickRate: 3.5
 	},
 	{
@@ -60,7 +61,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Blue d'hide shield"),
 		level: 69,
 		xp: 140,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Blue dragon leather': 2,
 			'Yew shield': 1,
 			'Mithril nails': 15
@@ -72,7 +73,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Blue d'hide body"),
 		level: 71,
 		xp: 210,
-		inputItems: resolveNameBank({ 'Blue dragon leather': 3 }),
+		inputItems: new Bank({ 'Blue dragon leather': 3 }),
 		tickRate: 3.5
 	},
 	{
@@ -80,7 +81,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Red d'hide vambraces"),
 		level: 73,
 		xp: 78,
-		inputItems: resolveNameBank({ 'Red dragon leather': 1 }),
+		inputItems: new Bank({ 'Red dragon leather': 1 }),
 		tickRate: 3
 	},
 	{
@@ -88,7 +89,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Red d'hide chaps"),
 		level: 75,
 		xp: 156,
-		inputItems: resolveNameBank({ 'Red dragon leather': 2 }),
+		inputItems: new Bank({ 'Red dragon leather': 2 }),
 		tickRate: 3.5
 	},
 	{
@@ -96,7 +97,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Red d'hide shield"),
 		level: 76,
 		xp: 156,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Red dragon leather': 2,
 			'Magic shield': 1,
 			'Adamantite nails': 15
@@ -108,7 +109,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Red d'hide body"),
 		level: 77,
 		xp: 234,
-		inputItems: resolveNameBank({ 'Red dragon leather': 3 }),
+		inputItems: new Bank({ 'Red dragon leather': 3 }),
 		tickRate: 3.5
 	},
 	{
@@ -116,7 +117,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Black d'hide vambraces"),
 		level: 79,
 		xp: 86,
-		inputItems: resolveNameBank({ 'Black dragon leather': 1 }),
+		inputItems: new Bank({ 'Black dragon leather': 1 }),
 		tickRate: 3
 	},
 	{
@@ -124,7 +125,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Black d'hide chaps"),
 		level: 82,
 		xp: 172,
-		inputItems: resolveNameBank({ 'Black dragon leather': 2 }),
+		inputItems: new Bank({ 'Black dragon leather': 2 }),
 		tickRate: 3.5
 	},
 	{
@@ -132,7 +133,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Black d'hide shield"),
 		level: 83,
 		xp: 172,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Black dragon leather': 2,
 			'Redwood shield': 1,
 			'Rune nails': 15
@@ -144,7 +145,7 @@ const Dragonhide: Craftable[] = [
 		id: itemID("Black d'hide body"),
 		level: 84,
 		xp: 258,
-		inputItems: resolveNameBank({ 'Black dragon leather': 3 }),
+		inputItems: new Bank({ 'Black dragon leather': 3 }),
 		tickRate: 3.5
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/gems.ts
+++ b/src/lib/skilling/skills/crafting/craftables/gems.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Gems: Craftable[] = [
 		id: itemID('Opal'),
 		level: 1,
 		xp: 15,
-		inputItems: resolveNameBank({ 'Uncut opal': 1 }),
+		inputItems: new Bank({ 'Uncut opal': 1 }),
 		tickRate: 2,
 		crushChance: [122 / (98 * 256), 129 / 256]
 	},
@@ -17,7 +18,7 @@ const Gems: Craftable[] = [
 		id: itemID('Jade'),
 		level: 13,
 		xp: 20,
-		inputItems: resolveNameBank({ 'Uncut Jade': 1 }),
+		inputItems: new Bank({ 'Uncut Jade': 1 }),
 		tickRate: 2,
 		crushChance: [145 / (98 * 256), 101 / 256]
 	},
@@ -26,7 +27,7 @@ const Gems: Craftable[] = [
 		id: itemID('Red topaz'),
 		level: 16,
 		xp: 25,
-		inputItems: resolveNameBank({ 'Uncut red topaz': 1 }),
+		inputItems: new Bank({ 'Uncut red topaz': 1 }),
 		tickRate: 2,
 		crushChance: [150 / (98 * 256), 91 / 256]
 	},
@@ -35,7 +36,7 @@ const Gems: Craftable[] = [
 		id: itemID('Sapphire'),
 		level: 20,
 		xp: 50,
-		inputItems: resolveNameBank({ 'Uncut sapphire': 1 }),
+		inputItems: new Bank({ 'Uncut sapphire': 1 }),
 		tickRate: 2
 	},
 	{
@@ -43,7 +44,7 @@ const Gems: Craftable[] = [
 		id: itemID('Emerald'),
 		level: 27,
 		xp: 67.5,
-		inputItems: resolveNameBank({ 'Uncut Emerald': 1 }),
+		inputItems: new Bank({ 'Uncut Emerald': 1 }),
 		tickRate: 2
 	},
 	{
@@ -51,7 +52,7 @@ const Gems: Craftable[] = [
 		id: itemID('Ruby'),
 		level: 34,
 		xp: 85,
-		inputItems: resolveNameBank({ 'Uncut ruby': 1 }),
+		inputItems: new Bank({ 'Uncut ruby': 1 }),
 		tickRate: 2
 	},
 	{
@@ -59,7 +60,7 @@ const Gems: Craftable[] = [
 		id: itemID('Diamond'),
 		level: 43,
 		xp: 107.5,
-		inputItems: resolveNameBank({ 'Uncut Diamond': 1 }),
+		inputItems: new Bank({ 'Uncut Diamond': 1 }),
 		tickRate: 2
 	},
 	{
@@ -67,7 +68,7 @@ const Gems: Craftable[] = [
 		id: itemID('Dragonstone'),
 		level: 55,
 		xp: 137.5,
-		inputItems: resolveNameBank({ 'Uncut dragonstone': 1 }),
+		inputItems: new Bank({ 'Uncut dragonstone': 1 }),
 		tickRate: 2
 	},
 	{
@@ -75,7 +76,7 @@ const Gems: Craftable[] = [
 		id: itemID('Onyx'),
 		level: 67,
 		xp: 167.5,
-		inputItems: resolveNameBank({ 'Uncut onyx': 1 }),
+		inputItems: new Bank({ 'Uncut onyx': 1 }),
 		tickRate: 2
 	},
 	{
@@ -83,7 +84,7 @@ const Gems: Craftable[] = [
 		id: itemID('Zenyte'),
 		level: 89,
 		xp: 200,
-		inputItems: resolveNameBank({ 'Uncut zenyte': 1 }),
+		inputItems: new Bank({ 'Uncut zenyte': 1 }),
 		tickRate: 2
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/glassblowing.ts
+++ b/src/lib/skilling/skills/crafting/craftables/glassblowing.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Beer glass'),
 		level: 1,
 		xp: 17.5,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	},
 	{
@@ -16,7 +17,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Empty candle lantern'),
 		level: 4,
 		xp: 19,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	},
 	{
@@ -24,7 +25,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Empty oil lamp'),
 		level: 12,
 		xp: 25,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	},
 	{
@@ -32,7 +33,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Vial'),
 		level: 33,
 		xp: 35,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	},
 	{
@@ -40,7 +41,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Fishbowl'),
 		level: 42,
 		xp: 42.5,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	},
 	{
@@ -48,7 +49,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Unpowered orb'),
 		level: 46,
 		xp: 52.5,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	},
 	{
@@ -56,7 +57,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Lantern lens'),
 		level: 49,
 		xp: 55,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	},
 	{
@@ -64,7 +65,7 @@ const Glassblowing: Craftable[] = [
 		id: itemID('Empty light orb'),
 		level: 87,
 		xp: 70,
-		inputItems: resolveNameBank({ 'Molten glass': 1 }),
+		inputItems: new Bank({ 'Molten glass': 1 }),
 		tickRate: 3
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/gold.ts
+++ b/src/lib/skilling/skills/crafting/craftables/gold.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Gold: Craftable[] = [
 		id: itemID('Gold ring'),
 		level: 5,
 		xp: 15,
-		inputItems: resolveNameBank({ 'Gold bar': 1 }),
+		inputItems: new Bank({ 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -16,7 +17,7 @@ const Gold: Craftable[] = [
 		id: itemID('Gold necklace'),
 		level: 6,
 		xp: 20,
-		inputItems: resolveNameBank({ 'Gold bar': 1 }),
+		inputItems: new Bank({ 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -24,7 +25,7 @@ const Gold: Craftable[] = [
 		id: itemID('Gold bracelet'),
 		level: 7,
 		xp: 25,
-		inputItems: resolveNameBank({ 'Gold bar': 1 }),
+		inputItems: new Bank({ 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -32,7 +33,7 @@ const Gold: Craftable[] = [
 		id: itemID('Gold amulet (u)'),
 		level: 8,
 		xp: 30,
-		inputItems: resolveNameBank({ 'Gold bar': 1 }),
+		inputItems: new Bank({ 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -40,7 +41,7 @@ const Gold: Craftable[] = [
 		id: itemID('Gold amulet'),
 		level: 8,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Gold amulet (u)': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Gold amulet (u)': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	},
 	{
@@ -48,7 +49,7 @@ const Gold: Craftable[] = [
 		id: itemID('Sapphire ring'),
 		level: 20,
 		xp: 40,
-		inputItems: resolveNameBank({ Sapphire: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Sapphire: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -56,7 +57,7 @@ const Gold: Craftable[] = [
 		id: itemID('Sapphire necklace'),
 		level: 22,
 		xp: 55,
-		inputItems: resolveNameBank({ Sapphire: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Sapphire: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -64,7 +65,7 @@ const Gold: Craftable[] = [
 		id: itemID('Sapphire bracelet'),
 		level: 23,
 		xp: 60,
-		inputItems: resolveNameBank({ Sapphire: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Sapphire: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -72,7 +73,7 @@ const Gold: Craftable[] = [
 		id: itemID('Sapphire amulet (u)'),
 		level: 24,
 		xp: 65,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			Sapphire: 1,
 			'Gold bar': 1
 		}),
@@ -83,7 +84,7 @@ const Gold: Craftable[] = [
 		id: itemID('Sapphire amulet'),
 		level: 24,
 		xp: 4,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Sapphire amulet (u)': 1,
 			'Ball of wool': 1
 		}),
@@ -94,7 +95,7 @@ const Gold: Craftable[] = [
 		id: itemID('Emerald ring'),
 		level: 27,
 		xp: 55,
-		inputItems: resolveNameBank({ Emerald: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Emerald: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -102,7 +103,7 @@ const Gold: Craftable[] = [
 		id: itemID('Emerald necklace'),
 		level: 29,
 		xp: 60,
-		inputItems: resolveNameBank({ Emerald: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Emerald: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -110,7 +111,7 @@ const Gold: Craftable[] = [
 		id: itemID('Emerald bracelet'),
 		level: 30,
 		xp: 65,
-		inputItems: resolveNameBank({ Emerald: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Emerald: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -118,7 +119,7 @@ const Gold: Craftable[] = [
 		id: itemID('Emerald amulet (u)'),
 		level: 31,
 		xp: 70,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			Emerald: 1,
 			'Gold bar': 1
 		}),
@@ -129,7 +130,7 @@ const Gold: Craftable[] = [
 		id: itemID('Emerald amulet'),
 		level: 31,
 		xp: 4,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Emerald amulet (u)': 1,
 			'Ball of wool': 1
 		}),
@@ -140,7 +141,7 @@ const Gold: Craftable[] = [
 		id: itemID('Ruby ring'),
 		level: 34,
 		xp: 70,
-		inputItems: resolveNameBank({ Ruby: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Ruby: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -148,7 +149,7 @@ const Gold: Craftable[] = [
 		id: itemID('Ruby necklace'),
 		level: 40,
 		xp: 75,
-		inputItems: resolveNameBank({ Ruby: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Ruby: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -156,7 +157,7 @@ const Gold: Craftable[] = [
 		id: itemID('Ruby bracelet'),
 		level: 42,
 		xp: 80,
-		inputItems: resolveNameBank({ Ruby: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Ruby: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -164,7 +165,7 @@ const Gold: Craftable[] = [
 		id: itemID('Ruby amulet (u)'),
 		level: 50,
 		xp: 85,
-		inputItems: resolveNameBank({ Ruby: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Ruby: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -172,7 +173,7 @@ const Gold: Craftable[] = [
 		id: itemID('Ruby amulet'),
 		level: 50,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Ruby amulet (u)': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Ruby amulet (u)': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	},
 	{
@@ -180,7 +181,7 @@ const Gold: Craftable[] = [
 		id: itemID('Diamond ring'),
 		level: 43,
 		xp: 85,
-		inputItems: resolveNameBank({ Diamond: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Diamond: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -188,7 +189,7 @@ const Gold: Craftable[] = [
 		id: itemID('Diamond necklace'),
 		level: 56,
 		xp: 90,
-		inputItems: resolveNameBank({ Diamond: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Diamond: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -196,7 +197,7 @@ const Gold: Craftable[] = [
 		id: itemID('Diamond bracelet'),
 		level: 58,
 		xp: 95,
-		inputItems: resolveNameBank({ Diamond: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Diamond: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -204,7 +205,7 @@ const Gold: Craftable[] = [
 		id: itemID('Diamond amulet (u)'),
 		level: 70,
 		xp: 100,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			Diamond: 1,
 			'Gold bar': 1
 		}),
@@ -215,7 +216,7 @@ const Gold: Craftable[] = [
 		id: itemID('Diamond amulet'),
 		level: 70,
 		xp: 4,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Diamond amulet (u)': 1,
 			'Ball of wool': 1
 		}),
@@ -226,7 +227,7 @@ const Gold: Craftable[] = [
 		id: itemID('Dragonstone ring'),
 		level: 55,
 		xp: 100,
-		inputItems: resolveNameBank({ Dragonstone: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Dragonstone: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -234,7 +235,7 @@ const Gold: Craftable[] = [
 		id: itemID('Dragon necklace'),
 		level: 72,
 		xp: 105,
-		inputItems: resolveNameBank({ Dragonstone: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Dragonstone: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -242,7 +243,7 @@ const Gold: Craftable[] = [
 		id: itemID('Dragonstone bracelet'),
 		level: 74,
 		xp: 110,
-		inputItems: resolveNameBank({ Dragonstone: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Dragonstone: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -250,7 +251,7 @@ const Gold: Craftable[] = [
 		id: itemID('Dragonstone amulet (u)'),
 		level: 80,
 		xp: 150,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			Dragonstone: 1,
 			'Gold bar': 1
 		}),
@@ -261,7 +262,7 @@ const Gold: Craftable[] = [
 		id: itemID('Dragonstone amulet'),
 		level: 80,
 		xp: 4,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Dragonstone amulet (u)': 1,
 			'Ball of wool': 1
 		}),
@@ -272,7 +273,7 @@ const Gold: Craftable[] = [
 		id: itemID('Onyx ring'),
 		level: 67,
 		xp: 115,
-		inputItems: resolveNameBank({ Onyx: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Onyx: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -280,7 +281,7 @@ const Gold: Craftable[] = [
 		id: itemID('Onyx necklace'),
 		level: 82,
 		xp: 120,
-		inputItems: resolveNameBank({ Onyx: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Onyx: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -288,7 +289,7 @@ const Gold: Craftable[] = [
 		id: itemID('Onyx bracelet'),
 		level: 84,
 		xp: 125,
-		inputItems: resolveNameBank({ Onyx: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Onyx: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -296,7 +297,7 @@ const Gold: Craftable[] = [
 		id: itemID('Onyx amulet (u)'),
 		level: 90,
 		xp: 165,
-		inputItems: resolveNameBank({ Onyx: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Onyx: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -304,7 +305,7 @@ const Gold: Craftable[] = [
 		id: itemID('Onyx amulet'),
 		level: 90,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Onyx amulet (u)': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Onyx amulet (u)': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	},
 	{
@@ -312,7 +313,7 @@ const Gold: Craftable[] = [
 		id: itemID('Zenyte ring'),
 		level: 89,
 		xp: 150,
-		inputItems: resolveNameBank({ Zenyte: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Zenyte: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -320,7 +321,7 @@ const Gold: Craftable[] = [
 		id: itemID('Zenyte necklace'),
 		level: 92,
 		xp: 165,
-		inputItems: resolveNameBank({ Zenyte: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Zenyte: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -328,7 +329,7 @@ const Gold: Craftable[] = [
 		id: itemID('Zenyte bracelet'),
 		level: 95,
 		xp: 180,
-		inputItems: resolveNameBank({ Zenyte: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Zenyte: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -336,7 +337,7 @@ const Gold: Craftable[] = [
 		id: itemID('Zenyte amulet (u)'),
 		level: 98,
 		xp: 200,
-		inputItems: resolveNameBank({ Zenyte: 1, 'Gold bar': 1 }),
+		inputItems: new Bank({ Zenyte: 1, 'Gold bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -344,7 +345,7 @@ const Gold: Craftable[] = [
 		id: itemID('Zenyte amulet'),
 		level: 98,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Zenyte amulet (u)': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Zenyte amulet (u)': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/leather.ts
+++ b/src/lib/skilling/skills/crafting/craftables/leather.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Leather: Craftable[] = [
 		id: itemID('Leather gloves'),
 		level: 1,
 		xp: 13.8,
-		inputItems: resolveNameBank({ Leather: 1 }),
+		inputItems: new Bank({ Leather: 1 }),
 		tickRate: 3
 	},
 	{
@@ -16,7 +17,7 @@ const Leather: Craftable[] = [
 		id: itemID('Leather boots'),
 		level: 7,
 		xp: 16.2,
-		inputItems: resolveNameBank({ Leather: 1 }),
+		inputItems: new Bank({ Leather: 1 }),
 		tickRate: 3
 	},
 	{
@@ -24,7 +25,7 @@ const Leather: Craftable[] = [
 		id: itemID('Leather cowl'),
 		level: 9,
 		xp: 18.5,
-		inputItems: resolveNameBank({ Leather: 1 }),
+		inputItems: new Bank({ Leather: 1 }),
 		tickRate: 3
 	},
 	{
@@ -32,7 +33,7 @@ const Leather: Craftable[] = [
 		id: itemID('Leather vambraces'),
 		level: 11,
 		xp: 22,
-		inputItems: resolveNameBank({ Leather: 1 }),
+		inputItems: new Bank({ Leather: 1 }),
 		tickRate: 3
 	},
 	{
@@ -40,7 +41,7 @@ const Leather: Craftable[] = [
 		id: itemID('Leather body'),
 		level: 14,
 		xp: 25,
-		inputItems: resolveNameBank({ Leather: 1 }),
+		inputItems: new Bank({ Leather: 1 }),
 		tickRate: 3
 	},
 	{
@@ -48,7 +49,7 @@ const Leather: Craftable[] = [
 		id: itemID('Leather chaps'),
 		level: 18,
 		xp: 27,
-		inputItems: resolveNameBank({ Leather: 1 }),
+		inputItems: new Bank({ Leather: 1 }),
 		tickRate: 3
 	},
 	{
@@ -56,7 +57,7 @@ const Leather: Craftable[] = [
 		id: itemID('Hardleather body'),
 		level: 28,
 		xp: 35,
-		inputItems: resolveNameBank({ 'Hard leather': 1 }),
+		inputItems: new Bank({ 'Hard leather': 1 }),
 		tickRate: 3
 	},
 	{
@@ -64,7 +65,7 @@ const Leather: Craftable[] = [
 		id: itemID('Coif'),
 		level: 38,
 		xp: 37,
-		inputItems: resolveNameBank({ Leather: 1 }),
+		inputItems: new Bank({ Leather: 1 }),
 		tickRate: 3
 	},
 	{
@@ -72,7 +73,7 @@ const Leather: Craftable[] = [
 		id: itemID('Hardleather shield'),
 		level: 41,
 		xp: 70,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Hard leather': 2,
 			'Oak shield': 1,
 			'Bronze nails': 15
@@ -84,7 +85,7 @@ const Leather: Craftable[] = [
 		id: itemID('Studded body'),
 		level: 41,
 		xp: 40,
-		inputItems: resolveNameBank({ 'Leather body': 1, 'Steel studs': 1 }),
+		inputItems: new Bank({ 'Leather body': 1, 'Steel studs': 1 }),
 		tickRate: 3
 	},
 	{
@@ -92,7 +93,7 @@ const Leather: Craftable[] = [
 		id: itemID('Studded chaps'),
 		level: 44,
 		xp: 42,
-		inputItems: resolveNameBank({ 'Leather chaps': 1, 'Steel studs': 1 }),
+		inputItems: new Bank({ 'Leather chaps': 1, 'Steel studs': 1 }),
 		tickRate: 3
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/misc.ts
+++ b/src/lib/skilling/skills/crafting/craftables/misc.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Misc: Craftable[] = [
 		id: itemID('Drift net'),
 		level: 26,
 		xp: 55,
-		inputItems: resolveNameBank({ 'Jute fibre': 2 }),
+		inputItems: new Bank({ 'Jute fibre': 2 }),
 		tickRate: 3
 	},
 	{
@@ -16,7 +17,7 @@ const Misc: Craftable[] = [
 		id: itemID('Snakeskin boots'),
 		level: 45,
 		xp: 30,
-		inputItems: resolveNameBank({ Snakeskin: 6 }),
+		inputItems: new Bank({ Snakeskin: 6 }),
 		tickRate: 3
 	},
 	{
@@ -24,7 +25,7 @@ const Misc: Craftable[] = [
 		id: itemID('Snakeskin vambraces'),
 		level: 47,
 		xp: 35,
-		inputItems: resolveNameBank({ Snakeskin: 8 }),
+		inputItems: new Bank({ Snakeskin: 8 }),
 		tickRate: 3
 	},
 	{
@@ -32,7 +33,7 @@ const Misc: Craftable[] = [
 		id: itemID('Snakeskin bandana'),
 		level: 48,
 		xp: 45,
-		inputItems: resolveNameBank({ Snakeskin: 5 }),
+		inputItems: new Bank({ Snakeskin: 5 }),
 		tickRate: 3
 	},
 	{
@@ -40,7 +41,7 @@ const Misc: Craftable[] = [
 		id: itemID('Snakeskin chaps'),
 		level: 51,
 		xp: 50,
-		inputItems: resolveNameBank({ Snakeskin: 12 }),
+		inputItems: new Bank({ Snakeskin: 12 }),
 		tickRate: 3
 	},
 	{
@@ -48,7 +49,7 @@ const Misc: Craftable[] = [
 		id: itemID('Snakeskin body'),
 		level: 53,
 		xp: 55,
-		inputItems: resolveNameBank({ Snakeskin: 15 }),
+		inputItems: new Bank({ Snakeskin: 15 }),
 		tickRate: 3
 	},
 	{
@@ -56,7 +57,7 @@ const Misc: Craftable[] = [
 		id: itemID('Snakeskin shield'),
 		level: 56,
 		xp: 100,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			Snakeskin: 2,
 			'Willow shield': 1,
 			'Iron nails': 15
@@ -68,7 +69,7 @@ const Misc: Craftable[] = [
 		id: itemID('Xerician hat'),
 		level: 14,
 		xp: 66,
-		inputItems: resolveNameBank({ 'Xerician fabric': 3 }),
+		inputItems: new Bank({ 'Xerician fabric': 3 }),
 		tickRate: 3
 	},
 	{
@@ -76,7 +77,7 @@ const Misc: Craftable[] = [
 		id: itemID('Xerician robe'),
 		level: 17,
 		xp: 88,
-		inputItems: resolveNameBank({ 'Xerician fabric': 4 }),
+		inputItems: new Bank({ 'Xerician fabric': 4 }),
 		tickRate: 3
 	},
 	{
@@ -84,7 +85,7 @@ const Misc: Craftable[] = [
 		id: itemID('Xerician top'),
 		level: 22,
 		xp: 110,
-		inputItems: resolveNameBank({ 'Xerician fabric': 5 }),
+		inputItems: new Bank({ 'Xerician fabric': 5 }),
 		tickRate: 3
 	},
 	{
@@ -92,7 +93,7 @@ const Misc: Craftable[] = [
 		id: itemID('Water battlestaff'),
 		level: 54,
 		xp: 100,
-		inputItems: resolveNameBank({ Battlestaff: 1, 'Water orb': 1 }),
+		inputItems: new Bank({ Battlestaff: 1, 'Water orb': 1 }),
 		tickRate: 2
 	},
 	{
@@ -100,7 +101,7 @@ const Misc: Craftable[] = [
 		id: itemID('Earth battlestaff'),
 		level: 58,
 		xp: 112.5,
-		inputItems: resolveNameBank({ Battlestaff: 1, 'Earth orb': 1 }),
+		inputItems: new Bank({ Battlestaff: 1, 'Earth orb': 1 }),
 		tickRate: 2
 	},
 	{
@@ -108,7 +109,7 @@ const Misc: Craftable[] = [
 		id: itemID('Fire battlestaff'),
 		level: 62,
 		xp: 125,
-		inputItems: resolveNameBank({ Battlestaff: 1, 'Fire orb': 1 }),
+		inputItems: new Bank({ Battlestaff: 1, 'Fire orb': 1 }),
 		tickRate: 2
 	},
 	{
@@ -116,7 +117,7 @@ const Misc: Craftable[] = [
 		id: itemID('Air battlestaff'),
 		level: 66,
 		xp: 137.5,
-		inputItems: resolveNameBank({ Battlestaff: 1, 'Air orb': 1 }),
+		inputItems: new Bank({ Battlestaff: 1, 'Air orb': 1 }),
 		tickRate: 2
 	},
 	{
@@ -124,7 +125,7 @@ const Misc: Craftable[] = [
 		id: itemID('Ball of wool'),
 		level: 1,
 		xp: 2.5,
-		inputItems: resolveNameBank({ Wool: 1 }),
+		inputItems: new Bank({ Wool: 1 }),
 		tickRate: 3
 	},
 	{
@@ -132,7 +133,7 @@ const Misc: Craftable[] = [
 		id: itemID('Bow string'),
 		level: 10,
 		xp: 15,
-		inputItems: resolveNameBank({ Flax: 1 }),
+		inputItems: new Bank({ Flax: 1 }),
 		tickRate: 3
 	},
 	{
@@ -140,7 +141,7 @@ const Misc: Craftable[] = [
 		id: itemID('Crossbow string'),
 		level: 10,
 		xp: 15,
-		inputItems: resolveNameBank({ Sinew: 1 }),
+		inputItems: new Bank({ Sinew: 1 }),
 		tickRate: 3
 	},
 	{
@@ -148,7 +149,7 @@ const Misc: Craftable[] = [
 		id: itemID('Crossbow string'),
 		level: 10,
 		xp: 15,
-		inputItems: resolveNameBank({ Sinew: 1 }),
+		inputItems: new Bank({ Sinew: 1 }),
 		tickRate: 3
 	},
 	{
@@ -156,7 +157,7 @@ const Misc: Craftable[] = [
 		id: itemID('Clockwork'),
 		level: 8,
 		xp: 15,
-		inputItems: resolveNameBank({ 'Steel bar': 1 }),
+		inputItems: new Bank({ 'Steel bar': 1 }),
 		tickRate: 3
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/silver.ts
+++ b/src/lib/skilling/skills/crafting/craftables/silver.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Silver: Craftable[] = [
 		id: itemID('Opal ring'),
 		level: 1,
 		xp: 10,
-		inputItems: resolveNameBank({ Opal: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Opal: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -16,7 +17,7 @@ const Silver: Craftable[] = [
 		id: itemID('Opal necklace'),
 		level: 16,
 		xp: 35,
-		inputItems: resolveNameBank({ Opal: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Opal: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -24,7 +25,7 @@ const Silver: Craftable[] = [
 		id: itemID('Opal bracelet'),
 		level: 22,
 		xp: 45,
-		inputItems: resolveNameBank({ Opal: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Opal: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -32,7 +33,7 @@ const Silver: Craftable[] = [
 		id: itemID('Opal amulet (u)'),
 		level: 27,
 		xp: 59,
-		inputItems: resolveNameBank({ Opal: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Opal: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -40,7 +41,7 @@ const Silver: Craftable[] = [
 		id: itemID('Opal amulet'),
 		level: 1,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Opal amulet (u)': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Opal amulet (u)': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	},
 	{
@@ -48,7 +49,7 @@ const Silver: Craftable[] = [
 		id: itemID('Jade ring'),
 		level: 13,
 		xp: 32,
-		inputItems: resolveNameBank({ Jade: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Jade: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -56,7 +57,7 @@ const Silver: Craftable[] = [
 		id: itemID('Jade necklace'),
 		level: 25,
 		xp: 54,
-		inputItems: resolveNameBank({ Jade: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Jade: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -64,7 +65,7 @@ const Silver: Craftable[] = [
 		id: itemID('Jade bracelet'),
 		level: 29,
 		xp: 60,
-		inputItems: resolveNameBank({ Jade: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Jade: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -72,7 +73,7 @@ const Silver: Craftable[] = [
 		id: itemID('Jade amulet (u)'),
 		level: 34,
 		xp: 74,
-		inputItems: resolveNameBank({ Jade: 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ Jade: 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -80,7 +81,7 @@ const Silver: Craftable[] = [
 		id: itemID('Jade amulet'),
 		level: 1,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Jade amulet (u)': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Jade amulet (u)': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	},
 	{
@@ -88,7 +89,7 @@ const Silver: Craftable[] = [
 		id: itemID('Topaz ring'),
 		level: 16,
 		xp: 35,
-		inputItems: resolveNameBank({ 'Red topaz': 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ 'Red topaz': 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -96,7 +97,7 @@ const Silver: Craftable[] = [
 		id: itemID('Topaz necklace'),
 		level: 32,
 		xp: 70,
-		inputItems: resolveNameBank({ 'Red topaz': 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ 'Red topaz': 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -104,7 +105,7 @@ const Silver: Craftable[] = [
 		id: itemID('Topaz bracelet'),
 		level: 18,
 		xp: 75,
-		inputItems: resolveNameBank({ 'Red topaz': 1, 'Silver bar': 1 }),
+		inputItems: new Bank({ 'Red topaz': 1, 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -112,7 +113,7 @@ const Silver: Craftable[] = [
 		id: itemID('Topaz amulet (u)'),
 		level: 45,
 		xp: 84,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Red topaz': 1,
 			'Silver bar': 1
 		}),
@@ -123,7 +124,7 @@ const Silver: Craftable[] = [
 		id: itemID('Topaz amulet'),
 		level: 1,
 		xp: 4,
-		inputItems: resolveNameBank({
+		inputItems: new Bank({
 			'Topaz amulet (u)': 1,
 			'Ball of wool': 1
 		}),
@@ -134,7 +135,7 @@ const Silver: Craftable[] = [
 		id: itemID('Unstrung symbol'),
 		level: 16,
 		xp: 50,
-		inputItems: resolveNameBank({ 'Silver bar': 1 }),
+		inputItems: new Bank({ 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -142,7 +143,7 @@ const Silver: Craftable[] = [
 		id: itemID('Unblessed symbol'),
 		level: 16,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Unstrung symbol': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Unstrung symbol': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	},
 	{
@@ -150,7 +151,7 @@ const Silver: Craftable[] = [
 		id: itemID('Unstrung emblem'),
 		level: 17,
 		xp: 50,
-		inputItems: resolveNameBank({ 'Silver bar': 1 }),
+		inputItems: new Bank({ 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -158,7 +159,7 @@ const Silver: Craftable[] = [
 		id: itemID('Unpowered symbol'),
 		level: 17,
 		xp: 4,
-		inputItems: resolveNameBank({ 'Unstrung emblem': 1, 'Ball of wool': 1 }),
+		inputItems: new Bank({ 'Unstrung emblem': 1, 'Ball of wool': 1 }),
 		tickRate: 2
 	},
 	{
@@ -166,7 +167,7 @@ const Silver: Craftable[] = [
 		id: itemID('Silver sickle'),
 		level: 18,
 		xp: 50,
-		inputItems: resolveNameBank({ 'Silver bar': 1 }),
+		inputItems: new Bank({ 'Silver bar': 1 }),
 		tickRate: 3
 	},
 	{
@@ -174,7 +175,7 @@ const Silver: Craftable[] = [
 		id: itemID('Tiara'),
 		level: 23,
 		xp: 52.5,
-		inputItems: resolveNameBank({ 'Silver bar': 1 }),
+		inputItems: new Bank({ 'Silver bar': 1 }),
 		tickRate: 3
 	}
 ];

--- a/src/lib/skilling/skills/crafting/craftables/tanning.ts
+++ b/src/lib/skilling/skills/crafting/craftables/tanning.ts
@@ -1,4 +1,5 @@
-import { resolveNameBank } from '../../../../util';
+import { Bank } from 'oldschooljs';
+
 import itemID from '../../../../util/itemID';
 import { Craftable } from '../../../types';
 
@@ -8,7 +9,7 @@ const Tanning: Craftable[] = [
 		id: itemID('Leather'),
 		level: 1,
 		xp: 0,
-		inputItems: resolveNameBank({ Cowhide: 1, Coins: 1 }),
+		inputItems: new Bank({ Cowhide: 1, Coins: 1 }),
 		tickRate: 1,
 		bankChest: true
 	},
@@ -17,7 +18,7 @@ const Tanning: Craftable[] = [
 		id: itemID('Hard leather'),
 		level: 1,
 		xp: 0,
-		inputItems: resolveNameBank({ Cowhide: 1, Coins: 3 }),
+		inputItems: new Bank({ Cowhide: 1, Coins: 3 }),
 		tickRate: 1,
 		bankChest: true
 	},
@@ -26,7 +27,7 @@ const Tanning: Craftable[] = [
 		id: itemID('Green dragon leather'),
 		level: 1,
 		xp: 0,
-		inputItems: resolveNameBank({ 'Green dragonhide': 1, Coins: 20 }),
+		inputItems: new Bank({ 'Green dragonhide': 1, Coins: 20 }),
 		tickRate: 1,
 		bankChest: true
 	},
@@ -35,7 +36,7 @@ const Tanning: Craftable[] = [
 		id: itemID('Blue dragon leather'),
 		level: 1,
 		xp: 0,
-		inputItems: resolveNameBank({ 'Blue dragonhide': 1, Coins: 20 }),
+		inputItems: new Bank({ 'Blue dragonhide': 1, Coins: 20 }),
 		tickRate: 1,
 		bankChest: true
 	},
@@ -44,7 +45,7 @@ const Tanning: Craftable[] = [
 		id: itemID('Red dragon leather'),
 		level: 1,
 		xp: 0,
-		inputItems: resolveNameBank({ 'Red dragonhide': 1, Coins: 20 }),
+		inputItems: new Bank({ 'Red dragonhide': 1, Coins: 20 }),
 		tickRate: 1,
 		bankChest: true
 	},
@@ -53,7 +54,7 @@ const Tanning: Craftable[] = [
 		id: itemID('Black dragon leather'),
 		level: 1,
 		xp: 0,
-		inputItems: resolveNameBank({ 'Black dragonhide': 1, Coins: 20 }),
+		inputItems: new Bank({ 'Black dragonhide': 1, Coins: 20 }),
 		tickRate: 1,
 		bankChest: true
 	}

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -143,7 +143,7 @@ export interface Craftable {
 	id: number;
 	level: number;
 	xp: number;
-	inputItems: ItemBank;
+	inputItems: Bank;
 	tickRate: number;
 	crushChance?: number[];
 	bankChest?: boolean;


### PR DESCRIPTION
### Description:

+craft properly uses the Bank class to handle items.
+craft tells you what items it uses when leaving for a trip
Craftables filter now uses Bank class for its items
Fletching filter now works

### Changes:

Changed both +craft and Craftables to work very similar to +fletch and Fletchables. The main difference is in GP handling, due to tanning costs and the like.

### Other checks:

-   [X] I have tested all my changes thoroughly.
