### PR TITLE
Update slayerBuyables.ts

### DIFF
--- a/src/lib/data/buyables/slayerBuyables.ts
+++ b/src/lib/data/buyables/slayerBuyables.ts
@@ -1,3 +1,4 @@
+import { itemID } from '../../util';
 import { Buyable } from './buyables';
 
 // Most prices >=10k are x10, < 10k = x100
@@ -12,7 +13,10 @@ export const slayerBuyables: Buyable[] = [
 	},
 	{
 		name: 'Broad arrowhead pack',
-		gpCost: 22_500
+		gpCost: 22_500,
+		outputItems: {
+			[itemID('Broad arrowheads')]: 100
+		}
 	},
 	{
 		name: 'Unfinished broad bolts',
@@ -20,7 +24,10 @@ export const slayerBuyables: Buyable[] = [
 	},
 	{
 		name: 'Unfinished broad bolt pack',
-		gpCost: 22_500
+		gpCost: 22_500,
+		outputItems: {
+			[itemID('Unfinished broad bolts')]: 100
+		}
 	},
 	{
 		name: 'Enchanted gem',


### PR DESCRIPTION
### Description:

Fletching supplies in slayer buyables don't currently do anything. Should probably convert existing ones to 100x of their respective item once this is merged.

### Other checks:

-   [X] I have tested all my changes thoroughly.
