### PR TITLE
Fixed wrong order of Slayer/Dungeoneering capes

### DIFF
--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -1553,8 +1553,8 @@ export const capes: CollectionLogData = {
 		'Defence cape(t)',
 		'Hitpoints cape(t)',
 		'Ranging cape(t)',
-		'Dungeoneering cape(t)',
-		'Slayer cape(t)'
+		'Slayer cape(t)',
+		'Dungeoneering cape(t)'
 	]),
 	'master capes2': resolveItems([
 		'Farming master cape',


### PR DESCRIPTION


### Description:

The Cape collection log had the Dungeoneering cape and Slayer cape mixed up. Has been fixed. 
### Changes:

- Swapped the order of Slayer cape and Dungeoneering cape in the Collection log
### Other checks:

-   [ ] I have tested all my changes thoroughly.
