### PR TITLE
Jad pet chance on task

### DIFF
--- a/src/tasks/minions/minigames/fightCavesActivity.ts
+++ b/src/tasks/minions/minigames/fightCavesActivity.ts
@@ -110,7 +110,7 @@ export default class extends Task {
 		}
 
 		await user.incrementMonsterScore(Monsters.TzTokJad.id);
-		const loot = Monsters.TzTokJad.kill();
+		const loot = Monsters.TzTokJad.kill(1, { onSlayerTask: isOnTask });
 
 		if (loot.has('Tzrek-jad')) {
 			this.client.emit(


### PR DESCRIPTION
### Description:

Jad is set to double the drop rate of the pet if you do him on task. We never passed whether or not you're on task to the kill.

### Changes:

Passing isOnTask to the kill.

### Other checks:

-   [X] I have tested all my changes thoroughly.
