### PR TITLE
Fixed hasEquipped and added a bunch of tests.

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -180,8 +180,11 @@ const source: [string, (string | number)[]][] = [
 	[
 		'Black mask',
 		[
+			...blackMaskISimilar,
+			...slayerHelmSimilarI,
 			...slayerHelmSimilar,
 			...[
+				'Black mask (i)',
 				'Black mask (1)',
 				'Black mask (2)',
 				'Black mask (3)',
@@ -213,7 +216,8 @@ const source: [string, (string | number)[]][] = [
 			'Steam battlestaff',
 			'Mystic steam staff',
 			'Mud battlestaff',
-			'Mystic mud staff'
+			'Mystic mud staff',
+			'Kodai wand'
 		]
 	]
 ];
@@ -224,11 +228,13 @@ export const similarItems: Map<number, number[]> = new Map(
 
 export const inverseSimilarItems: Map<number, number> = new Map();
 for (const group of similarItems.entries()) {
+	inverseSimilarItems.set(group[0], group[0]);
 	for (const item of group[1]) {
 		inverseSimilarItems.set(item, group[0]);
 	}
 }
 
 export function getSimilarItems(itemID: number): number[] {
-	return similarItems.get(itemID) ?? [];
+	const similars = similarItems.get(itemID);
+	return similars ? [itemID, ...similars] : [itemID];
 }

--- a/tests/Gear.test.ts
+++ b/tests/Gear.test.ts
@@ -51,7 +51,7 @@ describe('Gear', () => {
 		// Single items
 		expect(testGear.hasEquipped('Twisted bow')).toEqual(true);
 		expect(testGear.hasEquipped('Dragon full helm')).toEqual(true);
-		expect(testGear.hasEquipped('Dragon full helm(g)')).toEqual(true);
+
 		expect(testGear.hasEquipped('3rd age platebody')).toEqual(true);
 		expect(testGear.hasEquipped('3rd age platelegs')).toEqual(true);
 		expect(testGear.hasEquipped('Dragon dagger')).toEqual(false);

--- a/tests/similarItems.test.ts
+++ b/tests/similarItems.test.ts
@@ -27,7 +27,7 @@ describe('Gear', () => {
 
 	test('', () => {
 		expect(testGear2.allItems().includes(itemID('Mist battlestaff'))).toBeTruthy();
-		expect(testGear2.allItems().includes(itemID('Staff of water'))).toBeTruthy();
+		expect(testGear2.allItems(true).includes(itemID('Staff of water'))).toBeTruthy();
 		expect(testGear2.hasEquipped('Staff of water')).toBeTruthy();
 		expect(testGear2.hasEquipped('Staff of water', false, false)).toBeFalsy();
 	});
@@ -38,5 +38,42 @@ describe('Gear', () => {
 
 	test('', () => {
 		expect(testGear3.hasEquipped('Kodai wand')).toBeFalsy();
+	});
+
+	const testGear4 = new Gear({
+		weapon: 'Kodai wand',
+		head: 'Slayer helmet (i)',
+		hands: 'Barrows gloves'
+	});
+	test('', () => {
+		expect(testGear4.hasEquipped(['Staff of water', 'Black mask (i)'], true)).toBeTruthy();
+	});
+
+	const testGear5 = new Gear({
+		weapon: 'Mist battlestaff',
+		head: 'Purple slayer helmet (i)',
+		hands: 'Barrows gloves'
+	});
+	test('', () => {
+		expect(testGear5.hasEquipped(['Staff of water', 'Black mask', 'Barrows gloves'], true)).toBeTruthy();
+		expect(testGear5.hasEquipped(['Staff of water', 'Black mask', 'Pufferfish'], false)).toBeTruthy();
+	});
+
+	const testGear6 = new Gear({
+		weapon: 'Mist battlestaff',
+		head: 'Red slayer helmet',
+		hands: 'Barrows gloves'
+	});
+	test('', () => {
+		expect(testGear6.hasEquipped(['Staff of water', 'Black mask', 'Barrows gloves'], true)).toBeTruthy();
+		expect(testGear6.hasEquipped('Black mask (i)')).toBeFalsy();
+		expect(testGear6.hasEquipped('Kodai wand')).toBeFalsy();
+		expect(testGear6.hasEquipped('Staff of water')).toBeTruthy();
+		expect(testGear6.hasEquipped('Black mask')).toBeTruthy();
+		expect(testGear6.hasEquipped(['Staff of water', 'Black mask (i)', 'Pufferfish'], false)).toBeTruthy();
+		expect(
+			testGear6.hasEquipped(['Mist battlestaff', 'Barrows gloves', 'Red slayer helmet'], true, false)
+		).toBeTruthy();
+		expect(testGear6.hasEquipped(['Staff of water', 'Barrows gloves', 'Slayer helmet'], true, false)).toBeFalsy();
 	});
 });


### PR DESCRIPTION
### Description:
Fixed the hasEquipped logic, while still maintaining all existing functionality.
One concession: We can't have it both ways, you cannot do `this.hasEquipped('Dragon full helm(or)')`
The similarItems lists are one-way.

### Changes:
Fixed the logic and wrote a bunch of tests.
SimilarItems and InverseSimilarItems maps now contain their root-item, which is required for the other functions to work.

### Other checks:

-   [x] I have tested all my changes thoroughly.
