### PR TITLE
Slayer fixes: Suqahs extending, better extending method, circular dependency preventing auto reload

### DIFF
--- a/src/commands/Minion/groupkill.ts
+++ b/src/commands/Minion/groupkill.ts
@@ -10,9 +10,10 @@ import { KillableMonster } from '../../lib/minions/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { MakePartyOptions } from '../../lib/types';
 import { GroupMonsterActivityTaskOptions } from '../../lib/types/minions';
-import findMonster, { formatDuration } from '../../lib/util';
+import { formatDuration } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import calcDurQty from '../../lib/util/calcMassDurationQuantity';
+import findMonster from '../../lib/util/findMonster';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -34,7 +34,7 @@ import { SlayerTaskUnlocksEnum } from '../../lib/slayer/slayerUnlocks';
 import { determineBoostChoice, getUsersCurrentSlayerInfo } from '../../lib/slayer/slayerUtil';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { MonsterActivityTaskOptions } from '../../lib/types/minions';
-import findMonster, {
+import {
 	addArrayOfNumbers,
 	formatDuration,
 	isWeekend,
@@ -44,6 +44,7 @@ import findMonster, {
 	updateBankSetting
 } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
+import findMonster from '../../lib/util/findMonster';
 import itemID from '../../lib/util/itemID';
 
 const validMonsters = killableMonsters.map(mon => mon.name).join('\n');

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -7,13 +7,8 @@ import calculateMonsterFood from '../../lib/minions/functions/calculateMonsterFo
 import reducedTimeFromKC from '../../lib/minions/functions/reducedTimeFromKC';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
-import findMonster, {
-	calcWhatPercent,
-	formatDuration,
-	formatItemBoosts,
-	formatItemReqs,
-	itemNameFromID
-} from '../../lib/util';
+import { calcWhatPercent, formatDuration, formatItemBoosts, formatItemReqs, itemNameFromID } from '../../lib/util';
+import findMonster from '../../lib/util/findMonster';
 
 export default class MinionCommand extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -1,3 +1,4 @@
+import { randInt } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Monsters } from 'oldschooljs';
 
@@ -282,9 +283,12 @@ You've done ${totalTasksDone} tasks. Your current streak is ${msg.author.setting
 				return srs.extendID !== undefined;
 			}).forEach(srsf => {
 				if (myUnlocks.includes(srsf.id) && srsf.extendID!.includes(newSlayerTask.currentTask.monsterID)) {
-					newSlayerTask.currentTask.quantity = Math.ceil(
-						newSlayerTask.currentTask.quantity * srsf.extendMult!
-					);
+					newSlayerTask.currentTask.quantity = newSlayerTask.assignedTask.extendedAmount
+						? randInt(
+								newSlayerTask.assignedTask.extendedAmount[0],
+								newSlayerTask.assignedTask.extendedAmount[1]
+						  )
+						: Math.ceil(newSlayerTask.currentTask.quantity * srsf.extendMult!);
 					newSlayerTask.currentTask.quantityRemaining = newSlayerTask.currentTask.quantity;
 					newSlayerTask.currentTask.save();
 				}

--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -77,7 +77,7 @@ const killableBosses: KillableMonster[] = [
 		defaultAttackStyles: [SkillsEnum.Ranged],
 		customMonsterHP: 723,
 		combatXpMultiplier: 1.132,
-		healAmountNeeded: 20 * 5,
+		healAmountNeeded: 18 * 4,
 		attackStyleToUse: GearSetupTypes.Range,
 		attackStylesUsed: [GearStat.AttackRanged, GearStat.AttackMagic]
 	},
@@ -114,7 +114,7 @@ const killableBosses: KillableMonster[] = [
 		disallowedAttackStyles: [SkillsEnum.Attack, SkillsEnum.Strength, SkillsEnum.Magic],
 		customMonsterHP: 641,
 		combatXpMultiplier: 1.159,
-		healAmountNeeded: 20 * 5,
+		healAmountNeeded: 18 * 4,
 		attackStyleToUse: GearSetupTypes.Range,
 		attackStylesUsed: [GearStat.AttackCrush, GearStat.AttackMagic]
 	},
@@ -154,8 +154,8 @@ const killableBosses: KillableMonster[] = [
 		defaultAttackStyles: [SkillsEnum.Attack],
 		customMonsterHP: 708,
 		combatXpMultiplier: 1.135,
-		healAmountNeeded: 20 * 5,
-		attackStyleToUse: GearSetupTypes.Melee,
+		healAmountNeeded: 20 * 3,
+		attackStyleToUse: GearSetupTypes.Range,
 		attackStylesUsed: [GearStat.AttackMagic]
 	}
 ];

--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -84,7 +84,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 			slayer: 58
 		},
 		superior: Monsters.CaveAbomination,
-		healAmountNeeded: 20,
+		healAmountNeeded: 11,
 		attackStyleToUse: GearSetupTypes.Range,
 		attackStylesUsed: [GearStat.AttackMagic],
 		canCannon: true,

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -221,7 +221,7 @@ export const vannakaMonsters: KillableMonster[] = [
 				[itemID('Arclight')]: 15
 			}
 		],
-		healAmountNeeded: 16,
+		healAmountNeeded: 12,
 		attackStyleToUse: GearSetupTypes.Range,
 		attackStylesUsed: [GearStat.AttackMagic],
 		canCannon: true
@@ -932,7 +932,7 @@ export const vannakaMonsters: KillableMonster[] = [
 			}
 		],
 		superior: Monsters.InsatiableMutatedBloodveld,
-		healAmountNeeded: 22,
+		healAmountNeeded: 15,
 		attackStyleToUse: GearSetupTypes.Range,
 		attackStylesUsed: [GearStat.AttackMagic],
 		canCannon: true,

--- a/src/lib/slayer/slayerUnlocks.ts
+++ b/src/lib/slayer/slayerUnlocks.ts
@@ -81,15 +81,6 @@ export enum SlayerTaskUnlocksEnum {
 	BroaderFletching
 }
 export const SlayerRewardsShop: SlayerTaskUnlocks[] = [
-	/* Anything commented won't appear in lists.
-	{
-		id: SlayerTaskUnlocksEnum.GargoyleSmasher,
-		name: 'Gargoyle smasher',
-		desc: 'Allows you to kill gargoyles faster.',
-		slayerPointCost: 120,
-		canBeRemoved: false
-	},
-	 */
 	{
 		id: SlayerTaskUnlocksEnum.MalevolentMasquerade,
 		name: 'Malevolent Masquerade',

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
 
@@ -392,6 +393,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Suqah,
 		amount: [120, 185],
+		extendedAmount: [180, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.SuqANotherOne,
 		weight: 8,
 		monsters: [Monsters.Suqah.id],
 		combatLevel: 85,

--- a/src/lib/slayer/types.ts
+++ b/src/lib/slayer/types.ts
@@ -15,6 +15,8 @@ export interface AssignableSlayerTask {
 	isBoss?: boolean;
 	levelRequirements?: LevelRequirements;
 	dontAssign?: boolean;
+	extendedAmount?: [number, number];
+	extendedUnlockId?: number;
 }
 
 export interface SlayerMaster {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -9,8 +9,6 @@ import { bool, integer, nodeCrypto, real } from 'random-js';
 
 import { CENA_CHARS, continuationChars, Events, PerkTier, skillEmoji, SupportServer, Time } from './constants';
 import { GearSetupTypes } from './gear/types';
-import killableMonsters from './minions/data/killableMonsters';
-import { KillableMonster } from './minions/types';
 import { ArrayItemsResolved, ItemTuple, Skills } from './types';
 import { GroupMonsterActivityTaskOptions } from './types/minions';
 import itemID from './util/itemID';
@@ -398,13 +396,6 @@ export function skillsMeetRequirements(skills: Skills, requirements: Skills) {
 		}
 	}
 	return true;
-}
-
-export default function findMonster(str: string): KillableMonster | undefined {
-	const mon = killableMonsters.find(
-		mon => stringMatches(mon.name, str) || mon.aliases.some(alias => stringMatches(alias, str))
-	);
-	return mon;
 }
 
 export function formatItemReqs(items: ArrayItemsResolved) {

--- a/src/lib/util/findMonster.ts
+++ b/src/lib/util/findMonster.ts
@@ -1,0 +1,10 @@
+import killableMonsters from '../minions/data/killableMonsters';
+import { KillableMonster } from '../minions/types';
+import { stringMatches } from '../util';
+
+export default function findMonster(str: string): KillableMonster | undefined {
+	const mon = killableMonsters.find(
+		mon => stringMatches(mon.name, str) || mon.aliases.some(alias => stringMatches(alias, str))
+	);
+	return mon;
+}


### PR DESCRIPTION
### Description:
Fix Suqah extending because Nieve + Duradel have very different base values.
Added framework to convert all monsters over to 'exact' extensions, however only did Suqah's currently, because I don't want to go thru each monster for every slayer master right now...
Fixed a circular dependency, moved findMonster to it's own file.
Rebalanced a few mobs that deal magic damage so they aren't as hungry.

### Other checks:

-   [x] I have tested all my changes thoroughly.
