### PR TITLE
Adds --as to +slayertask and shows alternate monsters on receiving a task

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -14,6 +14,7 @@ import {
 	getUsersCurrentSlayerInfo,
 	userCanUseMaster
 } from '../../lib/slayer/slayerUtil';
+import { AssignableSlayerTask } from '../../lib/slayer/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { stringMatches } from '../../lib/util';
 import itemID from '../../lib/util/itemID';
@@ -32,13 +33,41 @@ export default class extends BotCommand {
 		});
 	}
 
+	public getAlternateMonsterList(assignedTask: AssignableSlayerTask | null) {
+		if (assignedTask) {
+			const altMobs = assignedTask.monsters;
+			const alternateMonsters = killableMonsters
+				.filter(m => {
+					return altMobs.includes(m.id) && m!.id !== assignedTask.monster.id;
+				})
+				.map(m => {
+					return m!.name;
+				});
+			return alternateMonsters.length > 0 ? ` (${alternateMonsters.join('/')})` : '';
+		}
+		return '';
+	}
+
+	public async returnSuccess(msg: KlasaMessage, message: string, autoslay: boolean) {
+		if (autoslay) {
+			try {
+				return this.client.commands.get('autoslay')!.run(msg, ['']);
+			} catch (e) {
+				return msg.channel.send('It was not possible to auto-slay this task. Please, try again.');
+			}
+		}
+		return msg.channel.send(message);
+	}
+
 	@requiresMinion
 	async run(msg: KlasaMessage, [input]: [string | undefined]) {
 		const { currentTask, totalTasksDone, assignedTask } = await getUsersCurrentSlayerInfo(msg.author.id);
 		const myBlockList = msg.author.settings.get(UserSettings.Slayer.BlockedTasks);
 		const myQPs = msg.author.settings.get(UserSettings.QP);
-
 		const maxBlocks = calcMaxBlockedTasks(myQPs);
+
+		let returnMessage = '';
+
 		if (
 			msg.flagArgs.listblocks ||
 			msg.flagArgs.blocks ||
@@ -221,10 +250,12 @@ export default class extends BotCommand {
 			msg.author.settings.update(UserSettings.Slayer.TaskStreak, 0);
 			const newSlayerTask = await assignNewSlayerTask(msg.author, slayerMaster);
 			let commonName = getCommonTaskName(newSlayerTask.assignedTask!.monster);
-			return msg.channel.send(
+			returnMessage =
 				`Your task has been skipped.\n\n ${slayerMaster.name}` +
-					` has assigned you to kill ${newSlayerTask.currentTask.quantity}x ${commonName}.`
-			);
+				` has assigned you to kill ${
+					newSlayerTask.currentTask.quantity
+				}x ${commonName}${this.getAlternateMonsterList(newSlayerTask.assignedTask)}.`;
+			return this.returnSuccess(msg, returnMessage, Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay));
 		}
 
 		if (currentTask || !slayerMaster) {
@@ -239,33 +270,29 @@ export default class extends BotCommand {
 				if (aRequirements.length) warningInfo += `**Requires**:\n${aRequirements.join('\n')}\n\n`;
 			}
 
-			let monsterList = '';
-			if (currentTask && assignedTask) {
-				const altMobs = assignedTask.monsters;
-
-				const alternateMonsters = killableMonsters
-					.filter(m => {
-						return altMobs.includes(m.id) && m!.id !== assignedTask.monster.id;
-					})
-					.map(m => {
-						return m!.name;
-					});
-
-				monsterList = alternateMonsters.length > 0 ? ` (${alternateMonsters.join('/')})` : '';
-			}
 			let baseInfo = currentTask
 				? `Your current task is to kill ${currentTask.quantity}x ${getCommonTaskName(
 						assignedTask!.monster
-				  )}${monsterList}, you have ${currentTask.quantityRemaining} kills remaining.`
+				  )}${this.getAlternateMonsterList(assignedTask)}, you have ${
+						currentTask.quantityRemaining
+				  } kills remaining.`
 				: `You have no task at the moment, you can get a task using \`${msg.cmdPrefix}slayertask ${slayerMasters
 						.map(i => i.name)
 						.join('/')}\``;
 
-			return msg.channel.send(`${warningInfo}${baseInfo}
-	
+			returnMessage = `${warningInfo}${baseInfo}
+
 You've done ${totalTasksDone} tasks. Your current streak is ${msg.author.settings.get(
 				UserSettings.Slayer.TaskStreak
-			)}.`);
+			)}.`;
+			if (currentTask && !warningInfo) {
+				return this.returnSuccess(
+					msg,
+					returnMessage,
+					Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay)
+				);
+			}
+			return msg.channel.send(returnMessage);
 		}
 
 		// Store favorite slayer master if requested:
@@ -297,8 +324,10 @@ You've done ${totalTasksDone} tasks. Your current streak is ${msg.author.setting
 				`. You can choose to kill TzTok-Jad with ${msg.cmdPrefix}fightcaves as long as you ` +
 				"don't kill any regular TzHaar first.";
 		}
-		return msg.channel.send(
-			`${slayerMaster.name} has assigned you to kill ${newSlayerTask.currentTask.quantity}x ${commonName}.${updateMsg}`
-		);
+
+		returnMessage = `${slayerMaster.name} has assigned you to kill ${
+			newSlayerTask.currentTask.quantity
+		}x ${commonName}${this.getAlternateMonsterList(newSlayerTask.assignedTask)}.${updateMsg}`;
+		return this.returnSuccess(msg, returnMessage, Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay));
 	}
 }

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -50,6 +50,7 @@ export default class extends BotCommand {
 
 	public async returnSuccess(msg: KlasaMessage, message: string, autoslay: boolean) {
 		if (autoslay) {
+			await msg.channel.send(message);
 			try {
 				return this.client.commands.get('autoslay')!.run(msg, ['']);
 			} catch (e) {


### PR DESCRIPTION
### Description:

- I noticed that whenever we got a new task, the alternated monsters available to kill didn't appeared on the return message. When issuing +st again, it would appear.
- Also, I found that a good QoL would be the addition of the parameter --as to the +st command. That way, we could just say "Minion, go do a new slayer task, I don't care what monster I get".

### Changes:

- Add getAlternateMonsterList and returnSuccess methods to slayertask.ts;
- Add flag --as/--autoslay to slayertask.ts, to allow autoslayer from a single command (+st --as is the same as +st then +as);
- Change de result message of a new task to include the alternate monster;
- When issuing --as/--autoslay to the slayertask.ts, the default output will be ignored for sucessfull comands (when a task is received/already in execution).

### Other checks:

-   [X] I have tested all my changes thoroughly.

Default behavior
![image](https://user-images.githubusercontent.com/19570528/123089142-f4f75000-d3fc-11eb-8306-423046a66a6a.png)

Skipping task
![image](https://user-images.githubusercontent.com/19570528/123089201-03de0280-d3fd-11eb-89fe-458e19a21fcd.png)

Only killing the correct amount
![image](https://user-images.githubusercontent.com/19570528/123089247-15bfa580-d3fd-11eb-9013-8e3c4b28dffd.png)

Alternate Monsters being show on a new task being assigned
![image](https://user-images.githubusercontent.com/19570528/122975537-d3995400-d369-11eb-8707-0ca251ab7491.png)
