### PR TITLE
Fix graceful check, simple switch

### DIFF
--- a/src/lib/gear/functions/hasGracefulEquipped.ts
+++ b/src/lib/gear/functions/hasGracefulEquipped.ts
@@ -84,6 +84,6 @@ export const gracefulCapes = [
 export function hasGracefulEquipped(setup: Gear) {
 	return setup.hasEquipped(
 		['Graceful hood', 'Graceful top', 'Graceful legs', 'Graceful boots', 'Graceful boots', 'Graceful cape'],
-		false
+		true
 	);
 }

--- a/tests/hasGracefulEquipped.test.ts
+++ b/tests/hasGracefulEquipped.test.ts
@@ -30,11 +30,8 @@ describe('hasGracefulEquipped', () => {
 			legs: 'Hosidius graceful legs'
 		};
 		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Agility cape' }))).toEqual(true);
-		expect(
-			hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Agility cape', head: 'Agility hood' }))
-		).toEqual(false);
 		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Agility cape(t)' }))).toEqual(true);
 		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Max cape' }))).toEqual(true);
-		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Max cape', head: 'Max hood' }))).toEqual(false);
+		expect(hasGracefulEquipped(constructGearSetup({ ...base }))).toEqual(false);
 	});
 });

--- a/tests/hasGracefulEquipped.test.ts
+++ b/tests/hasGracefulEquipped.test.ts
@@ -32,9 +32,9 @@ describe('hasGracefulEquipped', () => {
 		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Agility cape' }))).toEqual(true);
 		expect(
 			hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Agility cape', head: 'Agility hood' }))
-		).toEqual(true);
+		).toEqual(false);
 		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Agility cape(t)' }))).toEqual(true);
 		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Max cape' }))).toEqual(true);
-		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Max cape', head: 'Max hood' }))).toEqual(true);
+		expect(hasGracefulEquipped(constructGearSetup({ ...base, cape: 'Max cape', head: 'Max hood' }))).toEqual(false);
 	});
 });


### PR DESCRIPTION
### Description:
Graceful boost is applied if any one piece is worn.
New hasGracefulEquipped check didn't use every=true, so now it does, and it works fine.

**/update:** Max hood + 99 Agility hood do Not count as graceful, so I had to alter the tests accordingly.

### Changes:
Change hasGracefulEquipped: 
```                
.hasEquipped(..., false) 
```
 to : 
```
.hasEquipped(..., true) 
```

### Other checks:
-   [x] I have tested all my changes thoroughly. Even though it was a simple change, I still tested to make sure it worked as expected.
