### PR TITLE
Rearranged KK & Cape collection log

### DIFF
--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -1567,8 +1567,8 @@ export const capes: CollectionLogData = {
 		'Defence master cape',
 		'Hitpoints master cape',
 		'Ranged master cape',
-		'Dungeoneering master cape',
-		'Slayer master cape'
+		'Slayer master cape',
+		'Dungeoneering master cape'
 	]),
 	expert: resolveItems(['Support cape', "Gatherer's cape", "Combatant's cape", "Artisan's cape"]),
 	otherCapes: resolveItems(['Quest point hood', 'Achievement diary hood', 'Max hood']),

--- a/src/lib/kalphiteking.ts
+++ b/src/lib/kalphiteking.ts
@@ -9,14 +9,14 @@ import resolveItems from './util/resolveItems';
 import { makeKillTable } from './util/setCustomMonster';
 
 export const allKalphiteKingItems = resolveItems([
-	'Drygore rapier',
-	'Drygore longsword',
 	'Drygore mace',
-	'Offhand drygore rapier',
-	'Offhand drygore longsword',
 	'Offhand drygore mace',
-	'Baby kalphite king',
-	'Perfect chitin'
+	'Drygore longsword',
+	'Offhand drygore longsword',
+	'Drygore rapier',
+	'Offhand drygore rapier',
+	'Perfect chitin',
+	'Baby kalphite king'
 ]);
 
 export const KalphiteKingMonster: KillableMonster = {


### PR DESCRIPTION
### Description:

The cape log had the Slayer/Dungeoneering master capes in wrong order. The Kalphite King log is now cleaner, having weapons being in sets within the log, pet+chitin switched orders to indicate increasing rarity.

### Changes:
- Switched order of Slayer+Dungeoneering master capes
- KK log is now: MH+OH Mace, MH+OH Longsword, MH+OH rapier, chitin, pet

### Other checks:

-   [ ] I have tested all my changes thoroughly.
