### PR TITLE
Dinh's now prevents cannon/barrage

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -222,7 +222,15 @@ export default class extends BotCommand {
 			return msg.send(`You need 70 Magic to use Ice Burst. You have ${msg.author.skillLevel(SkillsEnum.Magic)}`);
 		}
 
-		if (boostChoice === 'barrage' && attackStyles.includes(SkillsEnum.Magic) && monster!.canBarrage) {
+		if (msg.author.hasItemEquippedAnywhere("Dinh's bulwark")) {
+			if (boostChoice === 'barrage' && monster!.canBarrage) {
+				boosts.push("Dinh's Bulwark is preventing you from barraging");
+			} else if (boostChoice === 'burst' && monster!.canBarrage) {
+				boosts.push("Dinh's Bulwark is preventing you from bursting");
+			} else if (boostChoice === 'cannon' && monster!.canCannon) {
+				boosts.push("Dinh's Bulwark is preventing you from using your cannon");
+			}
+		} else if (boostChoice === 'barrage' && attackStyles.includes(SkillsEnum.Magic) && monster!.canBarrage) {
 			consumableCosts.push(iceBarrageConsumables);
 			timeToFinish = reduceNumByPercent(timeToFinish, boostIceBarrage);
 			boosts.push(`${boostIceBarrage}% for Ice Barrage`);


### PR DESCRIPTION

### Description:

This is consistent with in game.

"Furthermore, players wielding the bulwark will not be able to cast any combat spells; players attempting to do so will receive the message "Your bulwark gets in the way". When in defensive mode, the dwarf multicannon will not fire, but it will still rotate, with a filterable message stating "Your bulwark shuns your cowardliness; stopping your cannon from firing.""

### Other checks:

-   [X] I have tested all my changes thoroughly.
