### PR TITLE
Cerb balancing changes

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -233,8 +233,11 @@ const killableBosses: KillableMonster[] = [
 				[itemID("Inquisitor's plateskirt")]: 8
 			},
 			{
-				[itemID('Arclight')]: 15,
-				[itemID("Inquisitor's mace")]: 8
+				[itemID('Arclight')]: 8,
+				[itemID('Abyssal whip')]: 10,
+				[itemID('Abyssal tentacle')]: 11,
+				[itemID('Abyssal bludgeon')]: 13,
+				[itemID("Inquisitor's mace")]: 15
 			}
 		],
 		levelRequirements: {


### PR DESCRIPTION
### Description:
After discussions in #slayer we rebalanced items on cerb. Inq mace should be BIS, and we also decided ( with house paran/mylife/ and #slayer ) that arclight shouldn't be as strong vs cerb because there's no cost to using it, and it's so easy to obtain.

### Changes:
Cerb: 
- Added boosts for whip/tentacle/bludgeon
- Lowered boost for arclight
- Increased boost for Inquisitor's mace.

### Other checks:

-   [x] I have tested all my changes thoroughly.
