### PR TITLE
monster command update and nightmare food

### DIFF
--- a/src/commands/Minion/nightmare.ts
+++ b/src/commands/Minion/nightmare.ts
@@ -21,7 +21,7 @@ import resolveItems from '../../lib/util/resolveItems';
 import { ZAM_HASTA_CRUSH } from './../../lib/constants';
 import { NightmareMonster } from './../../lib/minions/data/killableMonsters/index';
 
-function soloMessage(user: KlasaUser, duration: number, quantity: number) {
+function soloMessage(user: KlasaUser, duration: number, quantity: number, costs: Bank) {
 	const kc = user.settings.get(UserSettings.MonsterScores)[NightmareMonster.id] ?? 0;
 	let str = `${user.minionName} is now off to kill The Nightmare ${quantity} times.`;
 	if (kc < 5) {
@@ -34,7 +34,7 @@ function soloMessage(user: KlasaUser, duration: number, quantity: number) {
 		str += ' They are not scared of The Nightmare anymore, and ready to fight!';
 	}
 
-	return `${str} The trip will take approximately ${formatDuration(duration)}.`;
+	return `${str} The trip will take approximately ${formatDuration(duration)}. Removed ${costs} from your bank`;
 }
 
 const inquisitorItems = resolveItems([
@@ -227,7 +227,7 @@ export default class extends BotCommand {
 
 		const str =
 			type === 'solo'
-				? `${soloMessage(msg.author, duration, quantity)}`
+				? `${soloMessage(msg.author, duration, quantity, totalCost)}`
 				: `${partyOptions.leader.username}'s party (${users
 						.map(u => u.username)
 						.join(', ')}) is now off to kill ${quantity}x ${

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -9,6 +9,7 @@ import { bool, integer, nodeCrypto, real } from 'random-js';
 
 import { CENA_CHARS, continuationChars, Events, PerkTier, skillEmoji, SupportServer, Time } from './constants';
 import { GearSetupTypes } from './gear/types';
+import { POHBoosts } from './poh';
 import { ArrayItemsResolved, ItemTuple, Skills } from './types';
 import { GroupMonsterActivityTaskOptions } from './types/minions';
 import itemID from './util/itemID';
@@ -438,6 +439,22 @@ export function formatItemBoosts(items: ItemBank[]) {
 		}
 	}
 	return str.join(', ');
+}
+
+export function formatPohBoosts(boosts: POHBoosts) {
+	const bonusStr = [];
+	const slotStr = [];
+
+	for (const [slot, objBoosts] of objectEntries(boosts)) {
+		if (objBoosts === undefined) continue;
+		for (const [name, boostPercent] of objectEntries(objBoosts)) {
+			bonusStr.push(`${boostPercent}% for ${name}`);
+		}
+
+		slotStr.push(`${slot.replace(/\b\S/g, t => t.toUpperCase())}: (${bonusStr.join(' or ')})\n`);
+	}
+
+	return slotStr.join(', ');
 }
 
 export function filterItemTupleByQuery(query: string, items: ItemTuple[]) {


### PR DESCRIPTION
### Description:

+monster is now up to date with relevant information.
+nightmare solo now shows food costs.

Closes #757
Closes #1226
Closes #1381 


### Changes:

* Updated +monster with global boosts, barrage/cannon info, and POH boosts
* Re-enabled health cost display in +monster
* Added information about food used in +nightmare solo
* Added function to format boosts from POH

### Other checks:

-   [X] I have tested all my changes thoroughly.
