### PR TITLE
Change getAlternateMonsterList return message

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -37,7 +37,7 @@ export default class extends BotCommand {
 	public getAlternateMonsterList(assignedTask: AssignableSlayerTask | null) {
 		if (assignedTask) {
 			const altMobs = assignedTask.monsters;
-			let alternateMonsters = killableMonsters
+			const alternateMonsters = killableMonsters
 				.filter(m => {
 					return altMobs.includes(m.id) && m!.id !== assignedTask.monster.id;
 				})

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -44,8 +44,7 @@ export default class extends BotCommand {
 				.map(m => {
 					return m!.name;
 				});
-			alternateMonsters.unshift(assignedTask.monster.name);
-			return alternateMonsters.length > 1 ? ` (**Possible choices**: ${alternateMonsters.join(', ')})` : '';
+			return alternateMonsters.length > 0 ? ` (**Alternate Monsters**: ${alternateMonsters.join(', ')})` : '';
 		}
 		return '';
 	}

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -45,7 +45,7 @@ export default class extends BotCommand {
 					return m!.name;
 				});
 			alternateMonsters.unshift(assignedTask.monster.name);
-			return alternateMonsters.length > 1 ? ` (**Possible choices**: ${alternateMonsters.join('/')})` : '';
+			return alternateMonsters.length > 1 ? ` (**Possible choices**: ${alternateMonsters.join(', ')})` : '';
 		}
 		return '';
 	}

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -37,14 +37,15 @@ export default class extends BotCommand {
 	public getAlternateMonsterList(assignedTask: AssignableSlayerTask | null) {
 		if (assignedTask) {
 			const altMobs = assignedTask.monsters;
-			const alternateMonsters = killableMonsters
+			let alternateMonsters = killableMonsters
 				.filter(m => {
 					return altMobs.includes(m.id) && m!.id !== assignedTask.monster.id;
 				})
 				.map(m => {
 					return m!.name;
 				});
-			return alternateMonsters.length > 0 ? ` (${alternateMonsters.join('/')})` : '';
+			alternateMonsters.unshift(assignedTask.monster.name);
+			return alternateMonsters.length > 1 ? ` (**Possible choices**: ${alternateMonsters.join('/')})` : '';
 		}
 		return '';
 	}


### PR DESCRIPTION
### Description:

- People complained that they were confused by the message in the parentheses of the +st command. They thought they could only kill the monsters in parenthesis.

### Changes:

- Improves the alternative monsters on the slayertask.ts return, so all possible monsters that can be killed is now shown. The current task selection is also shown as an option, so people can kill anything in the Possible choices list.
- Changes the default monster separator to be comma + space, instead of forward slash. Forward slash wasn't being handled properly on long messages.

### Other checks:

-   [X] I have tested all my changes thoroughly.

The tasked monsters and all its alternatives are shown.
![image](https://user-images.githubusercontent.com/19570528/123343149-94b0fd00-d527-11eb-8c04-f5b18d0f67ef.png)

Message is now shown when no alternatives is found.
![image](https://user-images.githubusercontent.com/19570528/123342978-2bc98500-d527-11eb-81f1-d7efe316ab87.png)

Better line break by using comma and space instead of forward slash.
![image](https://user-images.githubusercontent.com/19570528/123343193-ae524480-d527-11eb-8a85-97c8705d2156.png)