### PR TITLE
Added Dragonstone armor to cl misc

### DIFF
--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -1586,7 +1586,15 @@ export const miscLog: CollectionLogData = {
 	]),
 	Tzhaar: resolveItems(['Fire cape']),
 	evilChickenOutfit,
-	other: resolveItems(['Amulet of eternal glory', 'Crystal grail'])
+	other: resolveItems(['Amulet of eternal glory', 'Crystal grail']),
+	dragonstoneArmour: resolveItems([
+		'Dragonstone full helm',
+		'Dragonstone platebody',
+		'Dragonstone platelegs',
+		'Dragonstone gauntlets',
+		'Dragonstone boots',
+		'Enhanced crystal key'
+	])	
 };
 
 export const slayerLog: CollectionLogData = {


### PR DESCRIPTION


### Description:
- Dragonstone armour is the perfect fit for a collection log item, so I added it to cl misc. 
- Also added Enhanced key to the log, so you can track amount of elven chests you opened. Can be removed if deemed unnecessary

### Changes:

- Added a new line in miscLog for Dragonstone Armour & Enhanced crystal key


### Other checks:

-   [ ] I have tested all my changes thoroughly.
