### PR TITLE
Fix dev mode instant trips

### DIFF
--- a/src/tasks/minionTicker.ts
+++ b/src/tasks/minionTicker.ts
@@ -16,7 +16,7 @@ export default class extends Task {
 				if (production) {
 					query.andWhere('finish_date < now()');
 				} else {
-					query.andWhere("start_date + interval '5 seconds' > now()");
+					query.andWhere("start_date + interval '5 seconds' < now()");
 				}
 
 				const result = await query.getMany();


### PR DESCRIPTION
### Description:

Trips were not being instant on development mode (Production = false)

### Changes:

- Changes `>` for `<`

### Other checks:

-   [X] I have tested all my changes thoroughly.
