### PR TITLE
Better offensive stats

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -342,7 +342,7 @@ export default class extends BotCommand {
 		// Check food
 		let foodStr: undefined | string = undefined;
 		if (monster.healAmountNeeded && monster.attackStyleToUse && monster.attackStylesUsed) {
-			const [healAmountNeeded, foodMessages] = calculateMonsterFood(monster, msg.author);
+			const [healAmountNeeded, foodMessages] = calculateMonsterFood(monster, msg.author, burstOrBarrage > 0);
 			messages = messages.concat(foodMessages);
 
 			let gearToCheck = GearSetupTypes.Melee;

--- a/src/lib/minions/functions/removeFoodFromUser.ts
+++ b/src/lib/minions/functions/removeFoodFromUser.ts
@@ -59,6 +59,9 @@ export default async function removeFoodFromUser({
 		);
 
 		let reductionsStr = reductions.length > 0 ? ` **Base Food Reductions:** ${reductions.join(', ')}.` : '';
-		return [`${new Bank(foodToRemove)} from ${user.username}${reductionsStr}`, foodToRemove];
+		return [
+			totalHealingNeeded > 0 ? `${new Bank(foodToRemove)} from ${user.username}${reductionsStr}` : '',
+			foodToRemove
+		];
 	}
 }

--- a/src/lib/structures/Gear.ts
+++ b/src/lib/structures/Gear.ts
@@ -144,6 +144,14 @@ export class Gear {
 		return sum;
 	}
 
+	getHighestMeleeStat() {
+		return this.stats.attack_stab >= this.stats.attack_slash && this.stats.attack_stab >= this.stats.attack_crush
+			? 'AttackStab'
+			: this.stats.attack_slash >= this.stats.attack_crush
+			? 'AttackSlash'
+			: 'AttackCrush';
+	}
+
 	meetsStatRequirements(gearRequirements: GearRequirement): [false, keyof GearStats, number] | [true, null, null] {
 		const keys = objectKeys(this.stats as Record<keyof GearStats, number>);
 		for (const key of keys) {


### PR DESCRIPTION
### Description:

Melee was checking slash attack only for food cost reductions. This checks the highest melee stat. Food cost reductions have also been rebalanced to max 50% from defences and 75% total from offensiveAccuracy + (relevantStrength / 2), giving a max total possible food reduction of 87,5%. Additionally, when barraging, mage gear is used for food reduction checks.

### Changes:

* Max melee offensive stat from Gear
* Mage gear used for food when barraging or bursting
* Strength stat check in food calcs, 50% value
* Cap on total stat contribution for food at 87.5%, 50% defensive 75% offensive

### Other checks:

-   [X] I have tested all my changes thoroughly.
