### PR TITLE
Change EHP on spectres to cannon abberant

### DIFF
--- a/src/commands/Minion/autoslay.ts
+++ b/src/commands/Minion/autoslay.ts
@@ -68,9 +68,9 @@ const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 	},
 	{
 		monsterID: Monsters.AberrantSpectre.id,
-		efficientName: Monsters.DeviantSpectre.name,
-		efficientMonster: Monsters.DeviantSpectre.id,
-		efficientMethod: AutoSlayMethod.None
+		efficientName: Monsters.AberrantSpectre.name,
+		efficientMonster: Monsters.AberrantSpectre.id,
+		efficientMethod: AutoSlayMethod.Cannon
 	},
 	{
 		monsterID: Monsters.MountainTroll.id,


### PR DESCRIPTION
### Description:

After the recent change for Aberrant Spectres to reduce the kill time, it's now more efficient to kill regular spectres with a cannon than deviants without.

### Other checks:

-   [X] I have tested all my changes thoroughly.
