### PR TITLE
CL cleanup

### DIFF
--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -1582,6 +1582,8 @@ export const miscLog: CollectionLogData = {
 		'Book of darkness',
 		'Book of law'
 	]),
+	MA1: resolveItems(['Saradomin cape', 'Zamorak cape', 'Guthix cape']),
+	MA2: resolveItems(['Imbued saradomin cape', 'Imbued zamorak cape', 'Imbued guthix cape']),
 	Tzhaar: resolveItems(['Fire cape']),
 	evilChickenOutfit,
 	other: resolveItems(['Amulet of eternal glory', 'Crystal grail']),

--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -345,7 +345,6 @@ export const bosses: CollectionLogData = {
 		'Jar of sand',
 		'Kalphite princess'
 	]),
-	'Lizardman shaman': resolveItems(['Dragon warhammer']),
 	Callisto: resolveItems(['Dragon pickaxe', 'Dragon 2h sword', 'Tyrannical ring', 'Callisto cub']),
 	Venenatis: resolveItems(['Dragon pickaxe', 'Dragon 2h sword', 'Treasonous ring', 'Venenatis spiderling']),
 	Vetion: resolveItems(['Dragon pickaxe', 'Dragon 2h sword', 'Ring of the gods', "Vet'ion jr."]),
@@ -1585,7 +1584,8 @@ export const miscLog: CollectionLogData = {
 	]),
 	Tzhaar: resolveItems(['Fire cape']),
 	evilChickenOutfit,
-	other: resolveItems(['Amulet of eternal glory', 'Crystal grail'])
+	other: resolveItems(['Amulet of eternal glory', 'Crystal grail']),
+	'Lizardman shaman': resolveItems(['Dragon warhammer'])
 };
 
 export const slayerLog: CollectionLogData = {

--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -142,25 +142,24 @@ const barbAssaultLog = resolveItems([
 ]);
 
 const agilityArenaLog = resolveItems([
-	'Agility arena ticket',
-	"Pirate's hook",
 	'Brimhaven graceful hood',
 	'Brimhaven graceful top',
 	'Brimhaven graceful legs',
 	'Brimhaven graceful gloves',
 	'Brimhaven graceful boots',
-	'Brimhaven graceful cape'
+	'Brimhaven graceful cape',
+	'Agility arena ticket',
+	"Pirate's hook"
 ]);
 
-const zalcanoLog = resolveItems(['Crystal shard', 'Zalcano shard', 'Smolcano', 'Uncut onyx', 'Crystal tool seed	']);
+const zalcanoLog = resolveItems(['Smolcano', 'Crystal shard', 'Zalcano shard', 'Uncut onyx', 'Crystal tool seed	']);
 
 export const farmersOutfit = resolveItems([
 	"Farmer's strawhat",
 	"Farmer's jacket",
 	"Farmer's shirt",
 	"Farmer's boro trousers",
-	"Farmer's boots",
-	'Tangleroot'
+	"Farmer's boots"
 ]);
 
 export const anglerOutfit = resolveItems(['Angler hat', 'Angler top', 'Angler waders', 'Angler boots']);
@@ -1761,22 +1760,20 @@ const chompyHuntingLog: CollectionLogData = {
 };
 
 export const skillingLog: CollectionLogData = {
-	Mining: resolveItems([
-		'Prospector helmet',
-		'Prospector jacket',
-		'Prospector legs',
-		'Prospector boots',
-		'Mining gloves',
-		'Superior mining gloves',
-		'Expert mining gloves',
-		'Golden nugget',
-		'Unidentified minerals',
-		'Rock golem'
+	Agility: resolveItems([
+		...gracefulItems.filter(i => !i.startsWith('Agility cape')),
+		'Giant squirrel',
+		'Mark of grace'
 	]),
-	Fishing: resolveItems(['Big swordfish', 'Big shark', 'Big bass', 'Heron']),
-	Agility: resolveItems([...gracefulItems.filter(i => i !== 'Agility cape'), 'Mark of grace', 'Giant squirrel']),
-	MonkeyBackpacks: Agility.MonkeyBackpacks.map(i => i.id),
-	Firemaking: wintertodtLog,
+	AgilityArena: agilityArenaLog,
+	Sepulchre2: resolveItems([
+		'Dark graceful hood',
+		'Dark graceful top',
+		'Dark graceful legs',
+		'Dark graceful boots',
+		'Dark graceful gloves',
+		'Dark graceful cape'
+	]),
 	Sepulchre1: resolveItems([
 		'Hallowed mark',
 		'Hallowed token',
@@ -1786,38 +1783,44 @@ export const skillingLog: CollectionLogData = {
 		'Hallowed hammer',
 		'Hallowed ring',
 		'Dark dye',
-		'Dark acorn',
 		'Strange old lockpick',
-		'Ring of endurance (uncharged)'
-	]),
-	Sepulchre2: resolveItems([
-		'Dark graceful hood',
-		'Dark graceful top',
-		'Dark graceful legs',
-		'Dark graceful boots',
-		'Dark graceful gloves',
-		'Dark graceful cape',
+		'Ring of endurance (uncharged)',
+		'Dark acorn',
 		'Dark squirrel'
 	]),
+	MonkeyBackpacks: Agility.MonkeyBackpacks.map(i => i.id),
+	Mining: resolveItems([
+		'Rock golem',
+		'Prospector helmet',
+		'Prospector jacket',
+		'Prospector legs',
+		'Prospector boots',
+		'Mining gloves',
+		'Superior mining gloves',
+		'Expert mining gloves',
+		'Golden nugget',
+		'Unidentified minerals'
+	]),
+	Fishing: resolveItems(['Heron', 'Big swordfish', 'Big shark', 'Big bass']),
 	AerialFishing: Object.values(aerialFishing).flat(Infinity) as number[],
-	Farming: [...farmersOutfit, ...resolveItems(['Bottomless compost bucket'])],
-	Zalcano: zalcanoLog,
-	Plunder: resolveItems(["Pharaoh's sceptre (3)", 'Rocky']),
-	AgilityArena: agilityArenaLog,
+	Firemaking: wintertodtLog,
+	Farming: [...resolveItems(['Tangleroot', 'Bottomless compost bucket']), ...farmersOutfit],
+	Plunder: resolveItems(['Rocky', "Pharaoh's sceptre (3)"]),
+	RogueOutfit: Object.values(rogueOutfit).flat(Infinity) as number[],
 	Hunter: resolveItems([
+		'Baby chinchompa',
+		'Herbi',
 		'Kyatt hat',
 		'Kyatt top',
 		'Kyatt legs',
 		'Spotted cape',
 		'Spottier cape',
-		'Gloves of silence',
-		'Baby chinchompa',
-		'Herbi'
+		'Gloves of silence'
 	]),
 	MahoganyHomes: Object.values(mahoganyHomesLog).flat(Infinity) as number[],
-	Runecraft: resolveItems(['Small pouch', 'Medium pouch', 'Large pouch', 'Giant pouch', 'Rift guardian']),
-	CrystalTools: resolveItems(['Crystal pickaxe', 'Crystal axe', 'Crystal harpoon']),
-	RogueOutfit: Object.values(rogueOutfit).flat(Infinity) as number[]
+	Runecraft: resolveItems(['Rift guardian', 'Small pouch', 'Medium pouch', 'Large pouch', 'Giant pouch']),
+	Zalcano: zalcanoLog,
+	CrystalTools: resolveItems(['Crystal pickaxe', 'Crystal axe', 'Crystal harpoon'])
 };
 
 export type CollectionLogData = Record<string, number[]>;

--- a/src/lib/data/collectionLog.ts
+++ b/src/lib/data/collectionLog.ts
@@ -1582,11 +1582,17 @@ export const miscLog: CollectionLogData = {
 		'Book of darkness',
 		'Book of law'
 	]),
-	MA1: resolveItems(['Saradomin cape', 'Zamorak cape', 'Guthix cape']),
-	MA2: resolveItems(['Imbued saradomin cape', 'Imbued zamorak cape', 'Imbued guthix cape']),
-	Tzhaar: resolveItems(['Fire cape']),
+	MA1: resolveItems([
+		'Saradomin cape',
+		'Zamorak cape',
+		'Guthix cape',
+		'Imbued saradomin cape',
+		'Imbued zamorak cape',
+		'Imbued guthix cape'
+	]),
 	evilChickenOutfit,
 	other: resolveItems(['Amulet of eternal glory', 'Crystal grail']),
+	Tzhaar: resolveItems(['Fire cape']),
 	'Lizardman shaman': resolveItems(['Dragon warhammer'])
 };
 


### PR DESCRIPTION
### Description:

General changes to +cl for better organization and adding new things.

### Changes:

* Added MA1 and MA2 to misc
* Moved DWH from boss to misc
* Reshuffled the order of items in skilling to be more aesthetically pleasing/intuitive. Mainly moved different CL sources for the same skill together and for the most part placed pets at the start of the lines, with the exception of agility to make graceful line up nicely.
* Removed trimmed agi cape from skilling log to align with other skills, still visible in capes log.

### Other checks:

-   [X] I have tested all my changes thoroughly.
