### PR TITLE
Fix nonexistent items appearing in +bank bug and Bank aliases

### DIFF
--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -1,10 +1,11 @@
 import { Bank, Items } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
+import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 import { fromKMB } from 'oldschooljs/dist/util';
 
 import { MAX_INT_JAVA } from '../constants';
 import { filterableTypes } from '../data/filterables';
-import { stringMatches } from '../util';
+import { cleanString, stringMatches } from '../util';
 
 const { floor, max, min } = Math;
 
@@ -38,7 +39,11 @@ export function parseQuantityAndItem(str = ''): [Item[], number] | [] {
 		const item = Items.get(nameAsInt);
 		if (item) osItems.push(item);
 	} else {
-		osItems = Array.from(Items.filter(i => stringMatches(i.name, parsedName)).values());
+		osItems = Array.from(
+			Items.filter(
+				i => itemNameMap.get(cleanString(parsedName)) === i.id || stringMatches(i.name, parsedName)
+			).values()
+		);
 	}
 	if (osItems.length === 0) return [];
 

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -11,6 +11,8 @@ const { floor, max, min } = Math;
 export function parseQuantityAndItem(str = ''): [Item[], number] | [] {
 	str = str.trim();
 	if (!str) return [];
+	// Make it so itemIDs aren't interpreted as quantities
+	if (str.match(/^[0-9]+$/)) str = `0 ${str}`;
 	const split = str.split(' ');
 
 	// If we're passed 2 numbers in a row, e.g. '1 1 coal', remove that number and recurse back.
@@ -80,7 +82,7 @@ export function parseBank({ inputBank, inputStr, flags = {} }: ParseBankOptions)
 		for (const [item, quantity] of strItems) {
 			_bank.add(
 				item.id,
-				!quantity ? inputBank.amount(item.id) : Math.max(1, Math.min(quantity, inputBank.amount(item.id)))
+				!quantity ? inputBank.amount(item.id) : Math.max(0, Math.min(quantity, inputBank.amount(item.id)))
 			);
 		}
 		return _bank;

--- a/tests/parseStringBank.test.ts
+++ b/tests/parseStringBank.test.ts
@@ -201,7 +201,7 @@ describe('Bank Parsers', () => {
 		const bank = new Bank().add('Steel arrow').add('Bones').add('Coal', 500).add('Clue scroll (easy)');
 		expect(parseBank({ inputBank: bank, inputStr: '1 Portrait' }).toString()).toEqual('No items');
 		expect(parseBank({ inputBank: bank, inputStr: '1 666' }).toString()).toEqual('No items');
-		expect(parseBank({ inputBank: bank, inputStr: '5 Coal' }).toString()).toEqual('5x Coal');
+		expect(parseBank({ inputBank: bank, inputStr: '526' }).toString()).toEqual('1x Bones');
 		expect(parseBank({ inputBank: bank, inputStr: '0 Coal' }).toString()).toEqual('500x Coal');
 	});
 });

--- a/tests/parseStringBank.test.ts
+++ b/tests/parseStringBank.test.ts
@@ -202,6 +202,13 @@ describe('Bank Parsers', () => {
 		expect(parseBank({ inputBank: bank, inputStr: '1 Portrait' }).toString()).toEqual('No items');
 		expect(parseBank({ inputBank: bank, inputStr: '1 666' }).toString()).toEqual('No items');
 		expect(parseBank({ inputBank: bank, inputStr: '526' }).toString()).toEqual('1x Bones');
-		expect(parseBank({ inputBank: bank, inputStr: '0 Coal' }).toString()).toEqual('500x Coal');
+		expect(parseBank({ inputBank: bank, inputStr: '0 cOaL' }).toString()).toEqual('500x Coal');
+	});
+
+	test('parseBank - check item aliases', async () => {
+		const bank = new Bank().add('Arceuus graceful top', 30).add('Bones');
+		expect(parseBank({ inputBank: bank, inputStr: 'pUrPle gRaceful top' }).toString()).toEqual(
+			'30x Arceuus graceful top'
+		);
 	});
 });

--- a/tests/parseStringBank.test.ts
+++ b/tests/parseStringBank.test.ts
@@ -196,4 +196,12 @@ describe('Bank Parsers', () => {
 		const other = parseBank({ inputBank: bank, inputStr: get('Egg').id.toString() });
 		expect(other.amount('Egg')).toEqual(3);
 	});
+
+	test('parseBank - look for nonexistent items', async () => {
+		const bank = new Bank().add('Steel arrow').add('Bones').add('Coal', 500).add('Clue scroll (easy)');
+		expect(parseBank({ inputBank: bank, inputStr: '1 Portrait' }).toString()).toEqual('No items');
+		expect(parseBank({ inputBank: bank, inputStr: '1 666' }).toString()).toEqual('No items');
+		expect(parseBank({ inputBank: bank, inputStr: '5 Coal' }).toString()).toEqual('5x Coal');
+		expect(parseBank({ inputBank: bank, inputStr: '0 Coal' }).toString()).toEqual('500x Coal');
+	});
 });


### PR DESCRIPTION
### Description:
Currently, specifying a non-zero quantity in a bank query will make +bank ALWAYS show you have 1x of that item.
Example. This will show 1x Portrait even if you don't have any: 
```
+b 1 666
```

You might want to consider going back to this inside the `if (inputStr)` loop, unless you want `+b 5 cannonball` to only show 5 cannonballs.
```
bank.add(item.id, inputBank.amount(item.id))
```
Also fixed bank aliases.

### Changes:

- Added tests to prevent this issue from recurring.
- Changed the code used when parsing a filter string to use Math.max(0, ... instead of Math.max(1, ...)
- Also fixed an issue where item IDs were being interpreted as quantity, which isn't an issue now, but will be if/when ItemArray or parseStringBank is used with things like equip or spawn. It also helps when people are trading.
- Fixed Bank aliases.
- Recommend adding additional alias tests for bso for tmb/emb/hmb


### Other checks:

-   [x] I have tested all my changes thoroughly.
