### PR TITLE
Kill inCatacombs

### DIFF
--- a/src/commands/OSRS_Fun/kill.ts
+++ b/src/commands/OSRS_Fun/kill.ts
@@ -13,7 +13,7 @@ export default class extends BotCommand {
 			cooldown: 1,
 			oneAtTime: true,
 			description: 'Simulate killing OSRS monsters and shows the loot.',
-			usage: '<quantity:int{1}> <BossName:...str>',
+			usage: '<quantity:int{1}> <BossName:...str> [inCatacombs:boolean]',
 			usageDelim: ' ',
 			requiredPermissions: ['ATTACH_FILES'],
 			examples: ['+kill 100 vorkath', 'kill 100k bandos'],
@@ -59,7 +59,8 @@ export default class extends BotCommand {
 		const result = await Workers.kill({
 			quantity,
 			bossName,
-			limit: this.determineKillLimit(msg.author)
+			limit: this.determineKillLimit(msg.author),
+			inCatacombs: msg.flagArgs.cannon === undefined ? true : false
 		});
 
 		if (typeof result === 'string') {

--- a/src/lib/workers/index.ts
+++ b/src/lib/workers/index.ts
@@ -11,7 +11,8 @@ export interface KillWorkerArgs {
 	bossName: string;
 	quantity: number;
 	limit: number;
-	inCatacombs: boolean;
+	onTask: boolean;
+	catacombs: boolean;
 }
 
 export const piscinaPool = new Piscina();

--- a/src/lib/workers/index.ts
+++ b/src/lib/workers/index.ts
@@ -11,6 +11,7 @@ export interface KillWorkerArgs {
 	bossName: string;
 	quantity: number;
 	limit: number;
+	inCatacombs: boolean;
 }
 
 export const piscinaPool = new Piscina();

--- a/src/lib/workers/kill.worker.ts
+++ b/src/lib/workers/kill.worker.ts
@@ -11,7 +11,7 @@ export function stringMatches(str: string, str2: string) {
 	return cleanString(str) === cleanString(str2);
 }
 
-export default ({ quantity, bossName, limit }: KillWorkerArgs): Bank | string => {
+export default ({ quantity, bossName, limit, inCatacombs }: KillWorkerArgs): Bank | string => {
 	const osjsMonster = Monsters.find(mon => mon.aliases.some(alias => stringMatches(alias, bossName)));
 
 	if (osjsMonster) {
@@ -23,7 +23,7 @@ export default ({ quantity, bossName, limit }: KillWorkerArgs): Bank | string =>
 			);
 		}
 
-		return osjsMonster.kill(quantity, {});
+		return osjsMonster.kill(quantity, { inCatacombs });
 	}
 
 	if (['nightmare', 'the nightmare'].some(alias => stringMatches(alias, bossName))) {

--- a/src/lib/workers/kill.worker.ts
+++ b/src/lib/workers/kill.worker.ts
@@ -11,7 +11,7 @@ export function stringMatches(str: string, str2: string) {
 	return cleanString(str) === cleanString(str2);
 }
 
-export default ({ quantity, bossName, limit, inCatacombs }: KillWorkerArgs): Bank | string => {
+export default ({ quantity, bossName, limit, catacombs, onTask }: KillWorkerArgs): Bank | string => {
 	const osjsMonster = Monsters.find(mon => mon.aliases.some(alias => stringMatches(alias, bossName)));
 
 	if (osjsMonster) {
@@ -23,7 +23,7 @@ export default ({ quantity, bossName, limit, inCatacombs }: KillWorkerArgs): Ban
 			);
 		}
 
-		return osjsMonster.kill(quantity, { inCatacombs });
+		return osjsMonster.kill(quantity, { inCatacombs: catacombs, onSlayerTask: onTask });
 	}
 
 	if (['nightmare', 'the nightmare'].some(alias => stringMatches(alias, bossName))) {


### PR DESCRIPTION
### Description:

Unlike +k, +kill did not pass whether or not it kills in catacombs or not to the worker, leading to never getting catacombs drops. 

### Changes:

By adding the cannon flagArg, you get a +kill outside of catacombs. Without it, you get inside catacombs.
`+kill 100k ankou --cannon` - no catacombs drops
`+kill 100k ankou` - catacombs drops

### Other checks:

-   [X] I have tested all my changes thoroughly.
