### PR TITLE
Add Dagannoth Kings as a group, and the supporting infrastructure.

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -119,6 +119,9 @@ export default class extends BotCommand {
 			return msg.channel.send(`You can't kill ${monster.name}, because you're not on a slayer task.`);
 		}
 
+		// If monster requires a minimum kc (ie. group monsters) use that.
+		if (monster.minimumKC && quantity && quantity < monster.minimumKC) quantity = monster.minimumKC;
+
 		// Set chosen boost based on priority:
 		const myCBOpts = msg.author.settings.get(UserSettings.CombatOptions);
 		const boostChoice = determineBoostChoice({

--- a/src/commands/Testing/spawndks.ts
+++ b/src/commands/Testing/spawndks.ts
@@ -41,6 +41,6 @@ export default class extends BotCommand {
 		}
 
 		await msg.author.addItemsToBank(dksBank.bank);
-		return msg.send(`Gave you gear for Dagannoth Kings.${msg.flagArgs.max ? ' Including max boosts' : ''}`);
+		return msg.channel.send(`Gave you gear for Dagannoth Kings.${msg.flagArgs.max ? ' Including max boosts' : ''}`);
 	}
 }

--- a/src/commands/Testing/spawndks.ts
+++ b/src/commands/Testing/spawndks.ts
@@ -1,0 +1,46 @@
+import { CommandStore, KlasaMessage } from 'klasa';
+import { Bank } from 'oldschooljs';
+
+import { production } from '../../config';
+import { BotCommand } from '../../lib/structures/BotCommand';
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			cooldown: 1,
+			oneAtTime: true,
+			testingCommand: true
+		});
+		this.enabled = !this.client.production;
+	}
+
+	async run(msg: KlasaMessage) {
+		if (production) {
+			return msg.channel.send("Nice try. You shouldn't see this.");
+		}
+		const dksBank = new Bank();
+		dksBank
+			.add("Guthan's warspear")
+			.add("Guthan's chainskirt")
+			.add("Guthan's platebody")
+			.add("Guthan's helm")
+			.add("Torag's platebody")
+			.add("Torag's platelegs")
+			.add("Karil's leatherskirt")
+			.add("Karil's leathertop");
+		if (msg.flagArgs.max) {
+			dksBank
+				.add('Armadyl chestplate')
+				.add('Armadyl chainskirt')
+				.add('Bandos tassets')
+				.add('Bandos chestplate')
+				.add('Dragon claws')
+				.add('Saradomin godsword')
+				.add('Harmonised nightmare staff')
+				.add('Occult necklace');
+		}
+
+		await msg.author.addItemsToBank(dksBank.bank);
+		return msg.send(`Gave you gear for Dagannoth Kings.${msg.flagArgs.max ? ' Including max boosts' : ''}`);
+	}
+}

--- a/src/lib/minions/data/killableMonsters/bosses/dks.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dks.ts
@@ -1,6 +1,6 @@
+import { Time } from 'e';
 import { Monsters } from 'oldschooljs';
 
-import { Time } from '../../../../constants';
 import { GearStat } from '../../../../gear/types';
 import { SkillsEnum } from '../../../../skilling/types';
 import itemID from '../../../../util/itemID';

--- a/src/lib/minions/data/killableMonsters/bosses/dks.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dks.ts
@@ -1,0 +1,176 @@
+import { Monsters } from 'oldschooljs';
+
+import { Time } from '../../../../constants';
+import { GearStat } from '../../../../gear/types';
+import { SkillsEnum } from '../../../../skilling/types';
+import itemID from '../../../../util/itemID';
+import resolveItems, { deepResolveItems } from '../../../../util/resolveItems';
+import { KillableMonster } from '../../../types';
+import DagannothKings, { DagannothKingsMonsterGroup } from './groups/DagannothKings';
+
+const dagannothKingsBosses: KillableMonster[] = [
+	{
+		id: Monsters.DagannothPrime.id,
+		name: Monsters.DagannothPrime.name,
+		aliases: Monsters.DagannothPrime.aliases,
+		timeToFinish: Time.Minute * 1.9,
+		table: Monsters.DagannothPrime,
+		emoji: '<:Pet_dagannoth_prime:324127376877289474>',
+		wildy: false,
+
+		difficultyRating: 5,
+		itemsRequired: deepResolveItems([
+			"Guthan's platebody",
+			"Guthan's chainskirt",
+			"Guthan's helm",
+			"Guthan's warspear",
+			['Armadyl chestplate', "Karil's leathertop"],
+			['Armadyl chainskirt', "Karil's leatherskirt"]
+		]),
+		notifyDrops: resolveItems(['Pet dagannoth prime']),
+		qpRequired: 0,
+		itemInBankBoosts: [
+			{
+				[itemID('Armadyl chestplate')]: 2
+			},
+			{
+				[itemID('Armadyl chainskirt')]: 2
+			},
+			{
+				[itemID('Twisted bow')]: 6
+			}
+		],
+		levelRequirements: {
+			prayer: 43
+		},
+		combatXpMultiplier: 1.3,
+		healAmountNeeded: 100,
+		attackStyleToUse: GearStat.AttackRanged,
+		attackStylesUsed: [GearStat.AttackMagic]
+	},
+	{
+		id: Monsters.DagannothRex.id,
+		name: Monsters.DagannothRex.name,
+		aliases: Monsters.DagannothRex.aliases,
+		timeToFinish: Time.Minute * 1.9,
+		table: Monsters.DagannothRex,
+		emoji: '<:Pet_dagannoth_rex:324127377091330049>',
+		wildy: false,
+
+		difficultyRating: 5,
+		itemsRequired: deepResolveItems([
+			"Guthan's platebody",
+			"Guthan's chainskirt",
+			"Guthan's helm",
+			"Guthan's warspear",
+			['Bandos chestplate', "Torag's platebody"],
+			['Bandos tassets', "Torag's platelegs"]
+		]),
+		notifyDrops: resolveItems(['Pet dagannoth rex']),
+		qpRequired: 0,
+		itemInBankBoosts: [
+			{
+				[itemID("Iban's staff")]: 3,
+				[itemID('Harmonised nightmare staff')]: 5
+			},
+			{
+				[itemID('Occult necklace')]: 5
+			}
+		],
+		levelRequirements: {
+			prayer: 43
+		},
+		combatXpMultiplier: 1.3,
+		healAmountNeeded: 100,
+		attackStyleToUse: GearStat.AttackMagic,
+		attackStylesUsed: [GearStat.AttackSlash]
+	},
+	{
+		id: Monsters.DagannothSupreme.id,
+		name: Monsters.DagannothSupreme.name,
+		aliases: Monsters.DagannothSupreme.aliases,
+		timeToFinish: Time.Minute * 1.9,
+		table: Monsters.DagannothSupreme,
+		emoji: '<:Pet_dagannoth_supreme:324127377066164245>',
+		wildy: false,
+
+		difficultyRating: 5,
+		itemsRequired: deepResolveItems([
+			"Guthan's platebody",
+			"Guthan's chainskirt",
+			"Guthan's helm",
+			"Guthan's warspear",
+			['Bandos chestplate', "Torag's platebody"],
+			['Bandos tassets', "Torag's platelegs"]
+		]),
+		notifyDrops: resolveItems(['Pet dagannoth supreme']),
+		qpRequired: 0,
+		itemInBankBoosts: [
+			{
+				[itemID('Bandos chestplate')]: 2
+			},
+			{
+				[itemID('Bandos tassets')]: 2
+			},
+			{
+				[itemID('Saradomin godsword')]: 4,
+				[itemID('Dragon claws')]: 6
+			}
+		],
+		levelRequirements: {
+			prayer: 43
+		},
+		healAmountNeeded: 100,
+		attackStyleToUse: GearStat.AttackSlash,
+		attackStylesUsed: [GearStat.AttackRanged]
+	}
+];
+const killableBosses: KillableMonster[] = [
+	...dagannothKingsBosses,
+	{
+		id: DagannothKings.id,
+		name: DagannothKings.name,
+		aliases: DagannothKings.aliases,
+		timeToFinish: Time.Minute * 1.75,
+		table: DagannothKings,
+		wildy: false,
+
+		difficultyRating: 6,
+		itemsRequired: deepResolveItems([
+			"Guthan's platebody",
+			"Guthan's chainskirt",
+			"Guthan's helm",
+			"Guthan's warspear",
+			['Armadyl chestplate', "Karil's leathertop"],
+			['Armadyl chainskirt', "Karil's leatherskirt"],
+			['Bandos chestplate', "Torag's platebody"],
+			['Bandos tassets', "Torag's platelegs"]
+		]),
+		notifyDrops: resolveItems(['Pet dagannoth rex', 'Pet dagannoth supreme', 'Pet dagannoth prime']),
+		qpRequired: 0,
+		itemInBankBoosts: [
+			...dagannothKingsBosses.flatMap(dks => dks.itemInBankBoosts!),
+			{
+				[itemID('Saradomin godsword')]: 10
+			}
+		],
+		levelRequirements: {
+			prayer: 43,
+			defence: 70,
+			ranged: 70,
+			attack: 70,
+			strength: 70,
+			magic: 70
+		},
+		healAmountNeeded: 100,
+		attackStyleToUse: GearStat.AttackSlash,
+		attackStylesUsed: [GearStat.AttackStab, GearStat.AttackRanged],
+		defaultAttackStyles: [SkillsEnum.Ranged, SkillsEnum.Magic, SkillsEnum.Attack, SkillsEnum.Strength],
+		combatXpMultiplier: 1.075,
+		isGroupMonster: true,
+		groupMonsters: DagannothKingsMonsterGroup,
+		minimumKC: 3
+	}
+];
+
+export default killableBosses;

--- a/src/lib/minions/data/killableMonsters/bosses/groups/DagannothKings.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/groups/DagannothKings.ts
@@ -1,0 +1,21 @@
+import { Monsters } from 'oldschooljs';
+
+import setMonsterGroup from '../../../../../util/setMonsterGroup';
+
+export const DagannothKingsMonsterGroup = [Monsters.DagannothRex, Monsters.DagannothPrime, Monsters.DagannothSupreme];
+
+setMonsterGroup({
+	id: 632267,
+	name: 'Dagannoth kings',
+	monsters: DagannothKingsMonsterGroup,
+	newItemData: {
+		id: 632267,
+		name: 'Dagannoth kings',
+		aliases: ['dagannoth kings', 'dks', 'dag kings']
+	},
+	randomStart: true
+});
+
+export const DagannothKings = Monsters.find(mon => mon.name === 'Dagannoth kings')!;
+
+export default DagannothKings;

--- a/src/lib/minions/data/killableMonsters/bosses/groups/DagannothKings.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/groups/DagannothKings.ts
@@ -5,11 +5,11 @@ import setMonsterGroup from '../../../../../util/setMonsterGroup';
 export const DagannothKingsMonsterGroup = [Monsters.DagannothRex, Monsters.DagannothPrime, Monsters.DagannothSupreme];
 
 setMonsterGroup({
-	id: 632267,
+	id: 632_267,
 	name: 'Dagannoth kings',
 	monsters: DagannothKingsMonsterGroup,
 	newItemData: {
-		id: 632267,
+		id: 632_267,
 		name: 'Dagannoth kings',
 		aliases: ['dagannoth kings', 'dks', 'dag kings']
 	},

--- a/src/lib/minions/data/killableMonsters/bosses/index.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/index.ts
@@ -1,5 +1,6 @@
+import dksBosses from './dks';
 import gwdBosses from './gwd';
 import miscBosses from './misc';
 import wildyBosses from './wildy';
 
-export default [...gwdBosses, ...miscBosses, ...wildyBosses];
+export default [...dksBosses, ...gwdBosses, ...miscBosses, ...wildyBosses];

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -5,7 +5,7 @@ import { ZALCANO_ID } from '../../../constants';
 import { GearSetupTypes, GearStat } from '../../../gear/types';
 import { SkillsEnum } from '../../../skilling/types';
 import itemID from '../../../util/itemID';
-import resolveItems, { deepResolveItems } from '../../../util/resolveItems';
+import resolveItems from '../../../util/resolveItems';
 import { KillableMonster } from '../../types';
 import { NIGHTMARES_HP } from './../../../constants';
 import bosses from './bosses';
@@ -59,121 +59,6 @@ const killableMonsters: KillableMonster[] = [
 		defaultAttackStyles: [SkillsEnum.Attack, SkillsEnum.Magic, SkillsEnum.Ranged],
 		customMonsterHP: 600,
 		combatXpMultiplier: 1.09
-	},
-	{
-		id: Monsters.DagannothPrime.id,
-		name: Monsters.DagannothPrime.name,
-		aliases: Monsters.DagannothPrime.aliases,
-		timeToFinish: Time.Minute * 1.9,
-		table: Monsters.DagannothPrime,
-		emoji: '<:Pet_dagannoth_prime:324127376877289474>',
-		wildy: false,
-
-		difficultyRating: 5,
-		itemsRequired: deepResolveItems([
-			"Guthan's platebody",
-			"Guthan's chainskirt",
-			"Guthan's helm",
-			"Guthan's warspear",
-			['Armadyl chestplate', "Karil's leathertop"],
-			['Armadyl chainskirt', "Karil's leatherskirt"]
-		]),
-		notifyDrops: resolveItems(['Pet dagannoth prime']),
-		qpRequired: 0,
-		itemInBankBoosts: [
-			{
-				[itemID('Armadyl chestplate')]: 2
-			},
-			{
-				[itemID('Armadyl chainskirt')]: 2
-			},
-			{
-				[itemID('Twisted bow')]: 6
-			}
-		],
-		levelRequirements: {
-			prayer: 43
-		},
-		combatXpMultiplier: 1.3,
-		healAmountNeeded: 100,
-		attackStyleToUse: GearStat.AttackRanged,
-		attackStylesUsed: [GearStat.AttackMagic]
-	},
-	{
-		id: Monsters.DagannothRex.id,
-		name: Monsters.DagannothRex.name,
-		aliases: Monsters.DagannothRex.aliases,
-		timeToFinish: Time.Minute * 1.9,
-		table: Monsters.DagannothRex,
-		emoji: '<:Pet_dagannoth_rex:324127377091330049>',
-		wildy: false,
-
-		difficultyRating: 5,
-		itemsRequired: deepResolveItems([
-			"Guthan's platebody",
-			"Guthan's chainskirt",
-			"Guthan's helm",
-			"Guthan's warspear",
-			['Bandos chestplate', "Torag's platebody"],
-			['Bandos tassets', "Torag's platelegs"]
-		]),
-		notifyDrops: resolveItems(['Pet dagannoth rex']),
-		qpRequired: 0,
-		itemInBankBoosts: [
-			{
-				[itemID("Iban's staff")]: 3,
-				[itemID('Harmonised nightmare staff')]: 5
-			},
-			{
-				[itemID('Occult necklace')]: 5
-			}
-		],
-		levelRequirements: {
-			prayer: 43
-		},
-		combatXpMultiplier: 1.3,
-		healAmountNeeded: 100,
-		attackStyleToUse: GearStat.AttackMagic,
-		attackStylesUsed: [GearStat.AttackSlash]
-	},
-	{
-		id: Monsters.DagannothSupreme.id,
-		name: Monsters.DagannothSupreme.name,
-		aliases: Monsters.DagannothSupreme.aliases,
-		timeToFinish: Time.Minute * 1.9,
-		table: Monsters.DagannothSupreme,
-		emoji: '<:Pet_dagannoth_supreme:324127377066164245>',
-		wildy: false,
-
-		difficultyRating: 5,
-		itemsRequired: deepResolveItems([
-			"Guthan's platebody",
-			"Guthan's chainskirt",
-			"Guthan's helm",
-			"Guthan's warspear",
-			['Bandos chestplate', "Torag's platebody"],
-			['Bandos tassets', "Torag's platelegs"]
-		]),
-		notifyDrops: resolveItems(['Pet dagannoth supreme']),
-		qpRequired: 0,
-		itemInBankBoosts: [
-			{
-				[itemID('Bandos chestplate')]: 2
-			},
-			{
-				[itemID('Bandos tassets')]: 2
-			},
-			{
-				[itemID('Saradomin godsword')]: 4,
-				[itemID('Dragon claws')]: 6
-			}
-		],
-		levelRequirements: {
-			prayer: 43
-		},
-		healAmountNeeded: 100,
-		attackStyleToUse: GearStat.AttackSlash,
-		attackStylesUsed: [GearStat.AttackRanged]
 	},
 	{
 		id: Monsters.Man.id,

--- a/src/lib/minions/functions/index.ts
+++ b/src/lib/minions/functions/index.ts
@@ -41,9 +41,29 @@ export function resolveAttackStyles(
 		SkillsEnum.Defence
 	];
 
-	// If their attack style can't be used on this monster, or they have no selected attack styles selected,
-	// use the monsters default attack style.
-	if (attackStyles.length === 0 || attackStyles.some(s => killableMon?.disallowedAttackStyles?.includes(s))) {
+	if (
+		[SkillsEnum.Attack, SkillsEnum.Strength, SkillsEnum.Magic, SkillsEnum.Ranged].every(s =>
+			monsterStyles.includes(s as AttackStyles)
+		)
+	) {
+		// If the monsterStyles match this array, that means it needs to use all 3 styles
+		attackStyles = [
+			SkillsEnum.Magic,
+			SkillsEnum.Ranged,
+			...attackStyles.filter(s => {
+				if ([SkillsEnum.Attack, SkillsEnum.Strength, SkillsEnum.Defence].includes(s)) return s as AttackStyles;
+			})
+		];
+		if (
+			![SkillsEnum.Attack, SkillsEnum.Strength, SkillsEnum.Defence].some(s =>
+				attackStyles.includes(s as AttackStyles)
+			)
+		) {
+			attackStyles.push(SkillsEnum.Attack as AttackStyles);
+		}
+	} else if (attackStyles.length === 0 || attackStyles.some(s => killableMon?.disallowedAttackStyles?.includes(s))) {
+		// If their attack style can't be used on this monster, or they have no selected attack styles selected,
+		// use the monsters default attack style.
 		attackStyles = monsterStyles;
 	}
 

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -104,6 +104,9 @@ export interface KillableMonster {
 	canBarrage?: boolean;
 	canCannon?: boolean;
 	cannonMulti?: boolean;
+	isGroupMonster?: boolean;
+	groupMonsters?: SimpleMonster[];
+	minimumKC?: number;
 }
 /*
  * Monsters will have an array of Consumables

--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import DagannothKings from '../../minions/data/killableMonsters/bosses/groups/DagannothKings';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
 
@@ -158,7 +159,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 			Monsters.DaganothFledgeling.id,
 			Monsters.DagannothSupreme.id,
 			Monsters.DagannothRex.id,
-			Monsters.DagannothPrime.id
+			Monsters.DagannothPrime.id,
+			DagannothKings.id
 		],
 		combatLevel: 75,
 		questPoints: 2,

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -1,7 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
-import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import DagannothKings from '../../minions/data/killableMonsters/bosses/groups/DagannothKings';
+import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
 

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -1,6 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
+import DagannothKings from '../../minions/data/killableMonsters/bosses/groups/DagannothKings';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
 
@@ -155,7 +156,8 @@ export const duradelTasks: AssignableSlayerTask[] = [
 			Monsters.DaganothFledgeling.id,
 			Monsters.DagannothSupreme.id,
 			Monsters.DagannothRex.id,
-			Monsters.DagannothPrime.id
+			Monsters.DagannothPrime.id,
+			DagannothKings.id
 		],
 		combatLevel: 75,
 		questPoints: 2,

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import DagannothKings from '../../minions/data/killableMonsters/bosses/groups/DagannothKings';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -157,7 +158,8 @@ export const konarTasks: AssignableSlayerTask[] = [
 			Monsters.DaganothFledgeling.id,
 			Monsters.DagannothSupreme.id,
 			Monsters.DagannothRex.id,
-			Monsters.DagannothPrime.id
+			Monsters.DagannothPrime.id,
+			DagannothKings.id
 		],
 		combatLevel: 75,
 		questPoints: 2,

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import DagannothKings from '../../minions/data/killableMonsters/bosses/groups/DagannothKings';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -143,7 +144,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 			Monsters.DaganothFledgeling.id,
 			Monsters.DagannothSupreme.id,
 			Monsters.DagannothRex.id,
-			Monsters.DagannothPrime.id
+			Monsters.DagannothPrime.id,
+			DagannothKings.id
 		],
 		combatLevel: 75,
 		questPoints: 2,

--- a/src/lib/slayer/tasks/vannakaTasks.ts
+++ b/src/lib/slayer/tasks/vannakaTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import DagannothKings from '../../minions/data/killableMonsters/bosses/groups/DagannothKings';
 import { AssignableSlayerTask } from '../types';
 
 export const vannakaTasks: AssignableSlayerTask[] = [
@@ -154,7 +155,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 			Monsters.DaganothFledgeling.id,
 			Monsters.DagannothSupreme.id,
 			Monsters.DagannothRex.id,
-			Monsters.DagannothPrime.id
+			Monsters.DagannothPrime.id,
+			DagannothKings.id
 		],
 		combatLevel: 75,
 		questPoints: 2,

--- a/src/lib/util/setMonsterGroup.ts
+++ b/src/lib/util/setMonsterGroup.ts
@@ -1,0 +1,54 @@
+import { randInt } from 'e';
+import { Bank, MonsterKillOptions, Monsters } from 'oldschooljs';
+import Monster from 'oldschooljs/dist/structures/Monster';
+import SimpleMonster from 'oldschooljs/dist/structures/SimpleMonster';
+
+export interface SetMonsterGroupOptions {
+	id: number;
+	name: string;
+	monsters: SimpleMonster[];
+	newItemData?: Partial<Monster>;
+	randomStart?: boolean;
+}
+
+export function makeGroupMonsterKillTable(tables: SimpleMonster[], randomStart = false) {
+	return (quantity: number, options: MonsterKillOptions) => {
+		const loot = new Bank();
+
+		const randomizer = randomStart ? randInt(1, tables.length) - 1 : 0;
+
+		for (let i = 0; i < quantity; i++) {
+			loot.add(tables[(i + randomizer) % tables.length].kill(1, options));
+		}
+		return loot;
+	};
+}
+// Possibly change monsters to GroupMonsters[] => { weight: %, monster: SimpleMonster }
+export default function setMonsterGroup(options: SetMonsterGroupOptions) {
+	Monsters.set(options.id, {
+		...(options.monsters[0] as Monster),
+		kill: makeGroupMonsterKillTable(options.monsters, options.randomStart),
+		allItems: options.monsters.flatMap(t => t.table!.allItems),
+		...options.newItemData,
+		name: options.name,
+		id: options.id
+	});
+}
+/*
+export default function oldsetMonsterGroup(
+	id: number,
+	name: string,
+	tables: LootTable[],
+	baseItem: Monster,
+	newItemData?: Partial<Monster>
+) {
+	Monsters.set(id, {
+		...baseItem,
+		...newItemData,
+		name,
+		id,
+		kill: makeGropupMonsterKillTable(tables),
+		allItems: tables.flatMap(t => t.allItems)
+	});
+}
+*/

--- a/src/lib/util/setMonsterGroup.ts
+++ b/src/lib/util/setMonsterGroup.ts
@@ -34,21 +34,3 @@ export default function setMonsterGroup(options: SetMonsterGroupOptions) {
 		id: options.id
 	});
 }
-/*
-export default function oldsetMonsterGroup(
-	id: number,
-	name: string,
-	tables: LootTable[],
-	baseItem: Monster,
-	newItemData?: Partial<Monster>
-) {
-	Monsters.set(id, {
-		...baseItem,
-		...newItemData,
-		name,
-		id,
-		kill: makeGropupMonsterKillTable(tables),
-		allItems: tables.flatMap(t => t.allItems)
-	});
-}
-*/

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -64,6 +64,19 @@ export default class extends Task {
 			superiorCount: newSuperiorCount
 		});
 
+		if (monster.isGroupMonster && monster.groupMonsters) {
+			const groupQty = monster.groupMonsters.length;
+			const groupExtraQty = quantity % groupQty;
+			const groupIndividualQty = (quantity - groupExtraQty) / groupQty;
+
+			for (let i = 0; i < groupQty; i++) {
+				await user.incrementMonsterScore(
+					monster.groupMonsters[i].id,
+					groupIndividualQty + (i < groupExtraQty ? 1 : 0)
+				);
+			}
+		}
+
 		announceLoot(this.client, user, monster, loot.bank);
 		if (newSuperiorCount && newSuperiorCount > 0) {
 			const oldSuperiorCount = await user.settings.get(UserSettings.Slayer.SuperiorCount);


### PR DESCRIPTION
### Description:

- Added a way to create groups of mosnters that are killable.
- It's easily extendable, so we could easily add the ability to assign weights to different monsters, for example cannoning Lizardmen also kills 'lizardman brute's.
- Increments the individual KC's of each monster in the group, as well as a KC for the group as a whole.
- Added Dagannoth Kings as the first implemented Monster Group
- Could be used in bso for some cool custom stuff.

### Changes:

- Added spawndks commaand for testing to spawn all the required gear, with --max giving max boosts as well.
- Added function setMonsterGroup to create the Monster entry based on the monsters in the group
- Added 'DagannothKings' as a slayer option to dagannoth tasks.
- Added ability to force all 3 combat styles by specifying all 4 offensive styles in the 'defaultAttackStyles' property.
- monsterActivity.ts checks if the monster if a group monster, and assigns individual kc if so.

### Other checks:

-   [x] I have tested all my changes thoroughly.
