### PR TITLE
Collectionlog now also checks the name not just aliases.

### DIFF
--- a/src/commands/Minion/collectionlog.ts
+++ b/src/commands/Minion/collectionlog.ts
@@ -35,9 +35,13 @@ Go collect these items! ${notOwned.map(itemNameFromID).join(', ')}.`
 
 		await msg.author.settings.sync(true);
 
-		const monster = killableMonsters.find(_type => _type.aliases.some(name => stringMatches(name, inputType)));
+		const monster = killableMonsters.find(
+			_type => stringMatches(_type.name, inputType) || _type.aliases.some(name => stringMatches(name, inputType))
+		);
 
-		const type = slicedCollectionLogTypes.find(_type => _type.aliases.some(name => stringMatches(name, inputType)));
+		const type = slicedCollectionLogTypes.find(
+			_type => stringMatches(_type.name, inputType) || _type.aliases.some(name => stringMatches(name, inputType))
+		);
 
 		if (!type && !monster) {
 			return msg.send(


### PR DESCRIPTION
### Description:
This is really needed for BSO for 'malygos,' but the change should also be made to master, even though I am not immediately aware of any instances where it doesn't work.

Note: In BSO you also have to import killableMonsters because it currently uses Monsters.

### Changes:
Make collectionlog.ts also check the name (not just aliases) for string matches.

### Other checks:

-   [x] I have tested all my changes thoroughly.
