### PR TITLE
Chop trips under 5

### DIFF
--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -69,56 +69,42 @@ export default class extends Task {
 				str +=
 					'<:peky:787028037031559168> A small pigeon has taken a liking to you, and hides itself in your bank.';
 			}
-			if (bonusXP > 0) {
-				str += `. **Bonus XP:** ${bonusXP.toLocaleString()}`;
-			}
+		}
+		if (bonusXP > 0) {
+			str += `. **Bonus XP:** ${bonusXP.toLocaleString()}`;
+		}
 
-			// Roll for pet
-			if (log.petChance && roll((log.petChance - user.skillLevel(SkillsEnum.Woodcutting) * 25) / quantity)) {
-				loot.add('Beaver');
-				str += "\nYou have a funny feeling you're being followed...";
-				this.client.emit(
-					Events.ServerNotification,
-					`${Emoji.Woodcutting} **${user.username}'s** minion, ${
-						user.minionName
-					}, just received a Beaver while cutting ${log.name} at level ${user.skillLevel(
-						SkillsEnum.Woodcutting
-					)} Woodcutting!`
-				);
-			}
-			if (bonusXP > 0) {
-				str += `. **Bonus XP:** ${bonusXP.toLocaleString()}`;
-			}
-
-			// Roll for pet
-			if (log.petChance && roll((log.petChance - user.skillLevel(SkillsEnum.Woodcutting) * 25) / quantity)) {
-				loot.add('Beaver');
-				str += "\nYou have a funny feeling you're being followed...";
-				this.client.emit(
-					Events.ServerNotification,
-					`${Emoji.Woodcutting} **${user.username}'s** minion, ${
-						user.minionName
-					}, just received a Beaver while cutting ${log.name} at level ${user.skillLevel(
-						SkillsEnum.Woodcutting
-					)} Woodcutting!`
-				);
-			}
-
-			await user.addItemsToBank(loot, true);
-
-			handleTripFinish(
-				this.client,
-				user,
-				channelID,
-				str,
-				res => {
-					user.log(`continued trip of ${quantity}x ${log.name}[${log.id}]`);
-					return this.client.commands.get('chop')!.run(res, [quantity, log.name]);
-				},
-				undefined,
-				data,
-				loot.bank
+		// Roll for pet
+		if (log.petChance && roll((log.petChance - user.skillLevel(SkillsEnum.Woodcutting) * 25) / quantity)) {
+			loot.add('Beaver');
+			str += "\nYou have a funny feeling you're being followed...";
+			this.client.emit(
+				Events.ServerNotification,
+				`${Emoji.Woodcutting} **${user.username}'s** minion, ${
+					user.minionName
+				}, just received a Beaver while cutting ${log.name} at level ${user.skillLevel(
+					SkillsEnum.Woodcutting
+				)} Woodcutting!`
 			);
 		}
+		if (bonusXP > 0) {
+			str += `. **Bonus XP:** ${bonusXP.toLocaleString()}`;
+		}
+
+		await user.addItemsToBank(loot, true);
+
+		handleTripFinish(
+			this.client,
+			user,
+			channelID,
+			str,
+			res => {
+				user.log(`continued trip of ${quantity}x ${log.name}[${log.id}]`);
+				return this.client.commands.get('chop')!.run(res, [quantity, log.name]);
+			},
+			undefined,
+			data,
+			loot.bank
+		);
 	}
 }

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -67,7 +67,7 @@ export default class extends Task {
 			if (roll(Math.floor(4000 / minutes))) {
 				loot.add('Peky');
 				str +=
-					'<:peky:787028037031559168> A small pigeon has taken a liking to you, and hides itself in your bank.';
+					'\n<:peky:787028037031559168> A small pigeon has taken a liking to you, and hides itself in your bank.';
 			}
 		}
 

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -70,9 +70,6 @@ export default class extends Task {
 					'<:peky:787028037031559168> A small pigeon has taken a liking to you, and hides itself in your bank.';
 			}
 		}
-		if (bonusXP > 0) {
-			str += `. **Bonus XP:** ${bonusXP.toLocaleString()}`;
-		}
 
 		// Roll for pet
 		if (log.petChance && roll((log.petChance - user.skillLevel(SkillsEnum.Woodcutting) * 25) / quantity)) {


### PR DESCRIPTION
### Description:

Peky can only drop if the chop trip duration is above a constant. Due to incorrect brackets, this condition also applied to everything after it. Trips shorter than minPetDuration never gave loot and never handled the trip finish properly.

Also beaver drop code was in there twice, removed that.

### Other checks:

-   [X] I have tested all my changes thoroughly.
