### PR TITLE
Level up messages and minor crafting message error

### DIFF
--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -704,7 +704,7 @@ export default class extends Extendable {
 
 		const newXP = Math.min(200_000_000, currentXP + params.amount);
 		const totalXPAdded = newXP - currentXP;
-		const newLevel = convertXPtoLVL(newXP);
+		const newLevel = convertXPtoLVL(Math.floor(newXP));
 
 		if (totalXPAdded > 0) {
 			XPGainsTable.insert({

--- a/src/tasks/minions/craftingActivity.ts
+++ b/src/tasks/minions/craftingActivity.ts
@@ -32,8 +32,8 @@ export default class extends Task {
 
 		const xpRes = await user.addXP({ skillName: SkillsEnum.Crafting, amount: xpReceived });
 
-		let str = `${user}, ${user.minionName} finished crafting ${quantity} ${item.name}, ${
-			crushed ? `crushing ${crushed} of them` : ''
+		let str = `${user}, ${user.minionName} finished crafting ${quantity} ${item.name}${
+			crushed ? `, crushing ${crushed} of them` : ''
 		}. ${xpRes}`;
 
 		await user.addItemsToBank(loot.values(), true);


### PR DESCRIPTION
### Description:

The code for a levelup message checked an unfloored value. The XP then sent into the DB is floored first. This led to a mismatch between levelup messages and the actual minion level when the XP barely didn't reach the threshold to level up.

Also moved a comma in the +craft finish message to not produce a trailing comma space when a minion doesn't crush gems.

### Other checks:

-   [X] I have tested all my changes thoroughly.
