### PR TITLE
Fix Abyssal Sire Coll Log

### DIFF
--- a/src/commands/Minion/collectionlog.ts
+++ b/src/commands/Minion/collectionlog.ts
@@ -55,13 +55,16 @@ Go collect these items! ${notOwned.map(itemNameFromID).join(', ')}.`
 			new Set(Object.values(type?.items ?? Monsters.get(monster!.id)!.allItems!).flat(100))
 		) as number[];
 		const log = msg.author.settings.get(UserSettings.CollectionLogBank);
-		const num = items.filter(item => log[item] > 0).length;
 		const { name } = type || monster!;
 
+		// Add Sire uniques that come from Unsired.
 		if (stringMatches('abyssal sire', name)) {
 			items.unshift(...bosses['Abyssal Sire']);
 			items = [...new Set(items)];
 		}
+
+		// Count number of items the player owns in CL.
+		const num = items.filter(item => log[item] > 0).length;
 
 		const chunkedMonsterItems: Record<number, number[]> = {};
 		let i = 0;


### PR DESCRIPTION
### Description:
After Unsired drops were added to Sire CL, those newly added drops weren't being counted in the total count at the top: 'Owned/Total'.

### Changes:
Moved the code that counts number of 'CL owned' items to after the custom exception for Sire.

### Other checks:

-   [x] I have tested all my changes thoroughly.
