### PR TITLE
Slayer balancing

### DIFF
--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -12,7 +12,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		id: Monsters.AncientZygomite.id,
 		name: Monsters.AncientZygomite.name,
 		aliases: Monsters.AncientZygomite.aliases,
-		timeToFinish: Time.Second * 15,
+		timeToFinish: Time.Second * 25,
 		table: Monsters.AncientZygomite,
 
 		wildy: false,
@@ -439,7 +439,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		id: Monsters.Zygomite.id,
 		name: Monsters.Zygomite.name,
 		aliases: Monsters.Zygomite.aliases,
-		timeToFinish: Time.Second * 25,
+		timeToFinish: Time.Second * 15,
 		table: Monsters.Zygomite,
 		wildy: false,
 

--- a/src/lib/minions/data/killableMonsters/konarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/konarMonsters.ts
@@ -11,7 +11,7 @@ export const konarMonsters: KillableMonster[] = [
 		id: Monsters.AdamantDragon.id,
 		name: Monsters.AdamantDragon.name,
 		aliases: Monsters.AdamantDragon.aliases,
-		timeToFinish: Time.Second * 144,
+		timeToFinish: Time.Second * 80,
 		table: Monsters.AdamantDragon,
 
 		wildy: false,

--- a/src/lib/minions/data/killableMonsters/mazchnaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/mazchnaMonsters.ts
@@ -162,7 +162,7 @@ export const mazchnaMonsters: KillableMonster[] = [
 		id: Monsters.HillGiant.id,
 		name: Monsters.HillGiant.name,
 		aliases: Monsters.HillGiant.aliases,
-		timeToFinish: Time.Second * 24,
+		timeToFinish: Time.Second * 10,
 		table: Monsters.HillGiant,
 		wildy: false,
 

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -246,7 +246,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.BrineRat.id,
 		name: Monsters.BrineRat.name,
 		aliases: Monsters.BrineRat.aliases,
-		timeToFinish: Time.Second * 38,
+		timeToFinish: Time.Second * 13,
 		table: Monsters.BrineRat,
 
 		wildy: false,
@@ -390,7 +390,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.DeviantSpectre.id,
 		name: Monsters.DeviantSpectre.name,
 		aliases: Monsters.DeviantSpectre.aliases,
-		timeToFinish: Time.Second * 37,
+		timeToFinish: Time.Second * 45,
 		table: Monsters.DeviantSpectre,
 
 		wildy: false,
@@ -657,7 +657,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.IceGiant.id,
 		name: Monsters.IceGiant.name,
 		aliases: Monsters.IceGiant.aliases,
-		timeToFinish: Time.Second * 27,
+		timeToFinish: Time.Second * 16,
 		table: Monsters.IceGiant,
 		wildy: true,
 
@@ -845,7 +845,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		id: Monsters.MossGiant.id,
 		name: Monsters.MossGiant.name,
 		aliases: Monsters.MossGiant.aliases,
-		timeToFinish: Time.Second * 30,
+		timeToFinish: Time.Second * 14,
 		table: Monsters.MossGiant,
 
 		wildy: true,


### PR DESCRIPTION
### Description:

* Rebalances the various giants, as well as addy dragons, to make more sense in comparison to similar counterparts. Fire giants/rune dragons were used as baselines. Fire giants remain the king of early combat training.
* Swaps ancient zygomite and zygomite time to finish. Ancients shouldn't be easier than regulars. Ancients are still higher XP/hour.
* Also nerfs deviant spectres a bit (37 to 45 seconds) to better reflect in game values.

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

-   [X] I have tested all my changes thoroughly.
