### PR TITLE
AgiAlching now consumes runes and alchables, and doesn't work on ape atoll

### DIFF
--- a/src/commands/Minion/laps.ts
+++ b/src/commands/Minion/laps.ts
@@ -132,8 +132,8 @@ export default class extends BotCommand {
 			course.name
 		} laps, it'll take around ${formatDuration(duration)} to finish.`;
 
-		const alchResult = alching(msg.author, duration, true);
-		if (alchResult !== null && course.name === 'Ape Atoll Agility Course') {
+		const alchResult = course.name === 'Ape Atoll Agility Course' ? null : alching(msg.author, duration, true);
+		if (alchResult !== null) {
 			if (!msg.author.owns(alchResult.bankToRemove)) {
 				return msg.channel.send(`You don't own ${alchResult.bankToRemove}.`);
 			}


### PR DESCRIPTION
### Description:

Corrects BSO to use runes and the alchable item when alching, and doesn't work on ape atoll.

### Other checks:

-   [X] I have tested all my changes thoroughly.
