### PR TITLE
[BSO] Fix size matters and longevity scrolls

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -1,4 +1,3 @@
-import { randInt } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Monsters } from 'oldschooljs';
 
@@ -7,7 +6,6 @@ import { requiresMinion } from '../../lib/minions/decorators';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { slayerMasters } from '../../lib/slayer/slayerMasters';
-import { SlayerRewardsShop } from '../../lib/slayer/slayerUnlocks';
 import {
 	assignNewSlayerTask,
 	calcMaxBlockedTasks,
@@ -302,23 +300,6 @@ You've done ${totalTasksDone} tasks. Your current streak is ${msg.author.setting
 		}
 
 		const newSlayerTask = await assignNewSlayerTask(msg.author, slayerMaster);
-		const myUnlocks = (await msg.author.settings.get(UserSettings.Slayer.SlayerUnlocks)) ?? undefined;
-		if (myUnlocks) {
-			SlayerRewardsShop.filter(srs => {
-				return srs.extendID !== undefined;
-			}).forEach(srsf => {
-				if (myUnlocks.includes(srsf.id) && srsf.extendID!.includes(newSlayerTask.currentTask.monsterID)) {
-					newSlayerTask.currentTask.quantity = newSlayerTask.assignedTask.extendedAmount
-						? randInt(
-								newSlayerTask.assignedTask.extendedAmount[0],
-								newSlayerTask.assignedTask.extendedAmount[1]
-						  )
-						: Math.ceil(newSlayerTask.currentTask.quantity * srsf.extendMult!);
-					newSlayerTask.currentTask.quantityRemaining = newSlayerTask.currentTask.quantity;
-					newSlayerTask.currentTask.save();
-				}
-			});
-		}
 
 		let commonName = getCommonTaskName(newSlayerTask.assignedTask!.monster);
 		if (commonName === 'TzHaar') {

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -186,6 +186,27 @@ export async function assignNewSlayerTask(_user: KlasaUser, master: SlayerMaster
 
 	let messages: string[] = [];
 	let quantity = randInt(assignedTask!.amount[0], assignedTask!.amount[1]);
+
+	if (unlocks) {
+		if (
+			assignedTask!.extendedUnlockId &&
+			assignedTask!.extendedAmount &&
+			unlocks.includes(assignedTask!.extendedUnlockId)
+		) {
+			quantity = randInt(assignedTask!.extendedAmount[0], assignedTask!.extendedAmount[1]);
+		} else {
+			SlayerRewardsShop.filter(srs => {
+				return srs.extendID !== undefined;
+			}).forEach(srsf => {
+				if (unlocks.includes(srsf.id) && srsf.extendID!.includes(assignedTask!.monster.id)) {
+					quantity = assignedTask!.extendedAmount
+						? randInt(assignedTask!.extendedAmount[0], assignedTask!.extendedAmount[1])
+						: Math.ceil(quantity * srsf.extendMult!);
+				}
+			});
+		}
+	}
+
 	if (unlocks.includes(SlayerTaskUnlocksEnum.SizeMatters)) {
 		quantity *= 2;
 		messages.push('2x qty for unlock');


### PR DESCRIPTION
### Description:

Moves task extension calculation into slayerUtil, before the doubling from longevity and size matters.

### Other checks:

-   [X] I have tested all my changes thoroughly.
