### PR TITLE
Fix alternate slayer monster list

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -44,6 +44,14 @@ export default class extends BotCommand {
 				.map(m => {
 					return m!.name;
 				});
+			const cname = getCommonTaskName(assignedTask!.monster);
+			if (
+				cname !== assignedTask!.monster.name &&
+				cname.substr(0, cname.length - 1) !== assignedTask!.monster.name
+			) {
+				alternateMonsters.unshift(assignedTask!.monster.name);
+			}
+
 			return alternateMonsters.length > 0 ? ` (**Alternate Monsters**: ${alternateMonsters.join(', ')})` : '';
 		}
 		return '';


### PR DESCRIPTION
### Description:

- Add to the alternate monster list, the default monster, when the task common name is not the same as the assigned monster (aka: spiritual creatures, fossil island wyverms, elves...)

### Changes:

- Check if the commonName is the same as the assigned monster. If not, add the assigned monster to the first position of the array.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/124665566-3f5be080-de83-11eb-9bd7-9ef9b26f5bce.png)
![image](https://user-images.githubusercontent.com/19570528/124665406-0f144200-de83-11eb-90eb-c82421f211dd.png)
![image](https://user-images.githubusercontent.com/19570528/124665311-f3a93700-de82-11eb-99e0-9300b6a8ae13.png)
Doesn't show when not needed
![image](https://user-images.githubusercontent.com/19570528/124665336-fb68db80-de82-11eb-9d65-5a3d529f3fb9.png)
![image](https://user-images.githubusercontent.com/19570528/124665367-0459ad00-de83-11eb-9f69-f52af10a6f3c.png)
