### PR TITLE
Fix +favorite with no arguments

### DIFF
--- a/src/commands/Minion/favorite.ts
+++ b/src/commands/Minion/favorite.ts
@@ -19,7 +19,7 @@ export default class extends BotCommand {
 	async run(msg: KlasaMessage, [items]: [Item[] | undefined]) {
 		const currentFavorites = msg.author.settings.get(UserSettings.FavoriteItems);
 
-		if (!items) {
+		if (!items || items.length === 0) {
 			const currentFavorites = msg.author.settings.get(UserSettings.FavoriteItems);
 			if (currentFavorites.length === 0) {
 				return msg.channel.send('You have no favorited items.');


### PR DESCRIPTION
### Description:
Fixed +fav bug showing an error has occured

### Changes:
Klasa is returning an empty array instead of undefiend from usage: [item|Item[]]

### Other checks:

-   [x] I have tested all my changes thoroughly.
