### PR TITLE
Rogues den and Trekking top minigamers role

### DIFF
--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -19,7 +19,9 @@ const minigames = [
 	'castle_wars',
 	'raids',
 	'raids_challenge_mode',
-	'big_chompy_bird_hunting'
+	'big_chompy_bird_hunting',
+	'rogues_den',
+	'temple_trekking'
 ];
 
 const collections = ['Overall', 'Pets', 'Skilling', 'Clue all', 'Boss', 'Minigames', 'Chambers of Xeric', 'Slayer'];


### PR DESCRIPTION
### Description:

Rogues den and Temple Trekking can now give top minigamer role. Double checked the added names, they're correct.
