### PR TITLE
[BSO] Maxcape requires 2760 total level to buy on BSO.

### DIFF
--- a/src/lib/data/buyables/capes.ts
+++ b/src/lib/data/buyables/capes.ts
@@ -31,7 +31,7 @@ export const capeBuyables: Buyable[] = [
 		}),
 		gpCost: 150_000_000,
 		customReq: async user => {
-			if (user.totalLevel() < 2277) {
+			if (user.totalLevel() < 2760) {
 				return [false, "You can't buy this because you aren't maxed!"];
 			}
 			return [true];


### PR DESCRIPTION
### Description:
BSO now requires 2760 total instead of 2277

### Changes:
Update custom requirement on buyables/capes.ts to 2760 for max cape.

