### PR TITLE
Change how max is calculated for Max cape

### DIFF
--- a/src/lib/data/buyables/capes.ts
+++ b/src/lib/data/buyables/capes.ts
@@ -30,7 +30,7 @@ export const capeBuyables: Buyable[] = [
 		}),
 		gpCost: 150_000_000,
 		customReq: async user => {
-			if (user.totalLevel() < 2277) {
+			if (Object.values(user.rawSkills).filter(s => s < 13034431).length > 0) {
 				return [false, "You can't buy this because you aren't maxed!"];
 			}
 			return [true];


### PR DESCRIPTION
### Description:
Changes Max cape buyable to see if any skills are < 99 instead of a hardcoded total level. This will fix BSO, as well as future-proof against any possible future skills.

### Changes:
Updated the custom requirement to count total number of skills with less than 13034431 XP and if any exist, block the purchase.

### Other checks:

-   [x] I have tested all my changes thoroughly.
