### PR TITLE
Change how max is calculated for Max cape

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -459,6 +459,7 @@ export const skillEmoji = {
 	dungeoneering: '<:dungeoneering:828683755198873623>'
 };
 
+export const LEVEL_99_XP = convertLVLtoXP(99);
 export const LEVEL_120_XP = convertLVLtoXP(120);
 export const MAX_LEVEL = 120;
 export const MAX_TOTAL_LEVEL = Object.values(SkillsEnum).length * MAX_LEVEL;

--- a/src/lib/data/buyables/capes.ts
+++ b/src/lib/data/buyables/capes.ts
@@ -1,5 +1,6 @@
 import { Bank } from 'oldschooljs';
 
+import { LEVEL_99_XP } from '../../constants';
 import { diaries, userhasDiaryTier } from '../../diaries';
 import { SkillsEnum } from '../../skilling/types';
 import { Buyable } from './buyables';
@@ -31,7 +32,7 @@ export const capeBuyables: Buyable[] = [
 		}),
 		gpCost: 150_000_000,
 		customReq: async user => {
-			if (user.totalLevel() < 2277) {
+			if (Object.values(user.rawSkills).filter(s => s < LEVEL_99_XP).length > 0) {
 				return [false, "You can't buy this because you aren't maxed!"];
 			}
 			return [true];


### PR DESCRIPTION
### Description:
Changes Max cape buyable to see if any skills are < 99 instead of a hardcoded total level. 

### Changes:
Updated the custom requirement to count total number of skills with less than 13034431 XP and if any exist, block the purchase.

### Other checks:

-   [x] I have tested all my changes thoroughly.
