### PR TITLE
Minor fightcaves change

### DIFF
--- a/src/commands/Minion/fightcaves.ts
+++ b/src/commands/Minion/fightcaves.ts
@@ -98,7 +98,7 @@ export default class extends BotCommand {
 			!equippedWeapon.weapon ||
 			!['crossbow', 'bow'].includes(equippedWeapon.weapon.weapon_type)
 		) {
-			throw 'JalYt, you not wearing ranged weapon?! TzTok-Jad stomp you to death if you get close, come back with range weapon.';
+			throw 'JalYt, you not wearing ranged weapon?! TzTok-Jad stomp you to death if you get close, come back with a bow or a crossbow.';
 		}
 
 		if (usersRangeStats.attack_ranged < 160) {


### PR DESCRIPTION
Changed the chat msg when attempting fight caves with incorrect range weapons, as it checks specifically for a bow or a crossbow, not any ranged weapon