### PR TITLE
Allow +st to show current task when minion is busy

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -128,6 +128,13 @@ export default class extends BotCommand {
 			const slayerStreak = msg.author.settings.get(UserSettings.Slayer.TaskStreak);
 			return msg.channel.send(
 				`Your minion is busy, but you can still manage your block list: \`${msg.cmdPrefix}st blocks\`` +
+					`${
+						currentTask
+							? `\nYour current task is to kill **${getCommonTaskName(
+									assignedTask!.monster
+							  )}**. You have ${currentTask.quantity.toLocaleString()} kills remaining.`
+							: ''
+					}` +
 					`\nYou have ${slayerPoints} slayer points, and have completed ${slayerStreak} tasks in a row.`
 			);
 		}

--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -132,10 +132,10 @@ export default class extends BotCommand {
 						currentTask
 							? `\nYour current task is to kill **${getCommonTaskName(
 									assignedTask!.monster
-							  )}**. You have ${currentTask.quantity.toLocaleString()} kills remaining.`
+							  )}**. You have ${currentTask.quantityRemaining.toLocaleString()} kills remaining.`
 							: ''
 					}` +
-					`\nYou have ${slayerPoints} slayer points, and have completed ${slayerStreak} tasks in a row.`
+					`\nYou have ${slayerPoints.toLocaleString()} slayer points, and have completed ${slayerStreak} tasks in a row.`
 			);
 		}
 		if (input && (input === 'skip' || input === 'block')) msg.flagArgs[input] = 'yes';
@@ -152,11 +152,13 @@ export default class extends BotCommand {
 			if (slayerPoints < (toBlock ? 100 : 30)) {
 				return msg.channel.send(
 					`You need ${toBlock ? 100 : 30} points to ${toBlock ? 'block' : 'cancel'},` +
-						` you only have: ${slayerPoints}`
+						` you only have: ${slayerPoints.toLocaleString()}`
 				);
 			}
 			await msg.confirm(
-				`Really ${toBlock ? 'block' : 'skip'} task? You have ${slayerPoints} and this will cost ${
+				`Really ${
+					toBlock ? 'block' : 'skip'
+				} task? You have ${slayerPoints.toLocaleString()} and this will cost ${
 					toBlock ? 100 : 30
 				} slayer points.\n\nPlease confirm you want to ${toBlock ? 'block' : 'skip'}.`
 			);
@@ -168,7 +170,9 @@ export default class extends BotCommand {
 			currentTask!.skipped = true;
 			currentTask!.save();
 			return msg.channel.send(
-				`Your task has been ${toBlock ? 'blocked' : 'skipped'}. You have ${slayerPoints} slayer points.`
+				`Your task has been ${
+					toBlock ? 'blocked' : 'skipped'
+				}. You have ${slayerPoints.toLocaleString()} slayer points.`
 			);
 		}
 


### PR DESCRIPTION
### Description:

- Allow +st to show current task when minion is busy.

### Changes:

- Add the current task to the message returned from +st when the minion is busy.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Before:
![image](https://user-images.githubusercontent.com/19570528/125205696-f5e00c80-e259-11eb-9fe1-c818a572bed9.png)

After:
![image](https://user-images.githubusercontent.com/19570528/125205718-11e3ae00-e25a-11eb-9354-c8fae07dbd11.png)