### PR TITLE
[BSO] Tames fix adult stage. Trip lengths are infinite and won't send.

### DIFF
--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -141,11 +141,12 @@ ${allTames
 		if (!monster) {
 			return msg.channel.send("That's not a valid monster.");
 		}
+		const growthDifference = selectedTame.maxCombatLevel - selectedTame.combatLvl;
 		let speed = monster.timeToFinish * selectedTame.growthLevel;
-		speed = increaseNumByPercent(
-			speed,
-			calcWhatPercent(selectedTame.combatLvl, selectedTame.maxCombatLevel - selectedTame.combatLvl)
-		);
+		speed =
+			growthDifference === 0
+				? speed
+				: increaseNumByPercent(speed, calcWhatPercent(selectedTame.combatLvl, growthDifference));
 		const quantity = Math.floor(Time.Hour / speed);
 		if (quantity < 1) {
 			return msg.channel.send("Your tame can't kill this monster fast enough.");


### PR DESCRIPTION
### Description:
Fixed some code that resulting in a timeToKill length of Infinity, preventing any tame pvm trips from sending.

### Changes:
calcWhatPercent returns Infinity instead of 0% as expected when the 2nd argument is zero.
Changed the code to use the pre-calculated speed if the increase percentage would be zero, and fallback to the original formula otherwise.

### Other checks:

-   [x] I have tested all my changes thoroughly.
