### PR TITLE
Fix collection logs adding more clues than the user were receiving

### DIFF
--- a/src/extendables/User/Bank.ts
+++ b/src/extendables/User/Bank.ts
@@ -7,6 +7,7 @@ import { Events } from '../../lib/constants';
 import { similarItems } from '../../lib/data/similarItems';
 import clueTiers from '../../lib/minions/data/clueTiers';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { filterLootReplace } from '../../lib/slayer/slayerUtil';
 import { ItemBank } from '../../lib/types';
 import { bankHasAllItemsFromBank, removeBankFromBank, removeItemFromBank } from '../../lib/util';
 import itemID from '../../lib/util/itemID';
@@ -112,17 +113,18 @@ export default class extends Extendable {
 				}
 			}
 
-			const items = {
+			let items = new Bank({
 				..._items
-			};
-
+			});
+			const { bankLoot, clLoot } = filterLootReplace(user.allItemsOwned(), items);
+			items = bankLoot;
 			if (collectionLog) {
-				await user.addItemsToCollectionLog(items);
+				await user.addItemsToCollectionLog(clLoot.bank);
 			}
 
-			if (items[995]) {
-				await user.addGP(items[995]);
-				delete items[995];
+			if (items.has(995)) {
+				await user.addGP(items.amount(995));
+				items.remove(995);
 			}
 
 			this.log(`Had items added to bank - ${JSON.stringify(items)}`);
@@ -130,7 +132,7 @@ export default class extends Extendable {
 
 			return {
 				previousCL,
-				itemsAdded: _items
+				itemsAdded: items.bank
 			};
 		});
 	}

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -1,6 +1,7 @@
 import { Task } from 'klasa';
 import { MonsterKillOptions, Monsters } from 'oldschooljs';
 
+import clueTiers from '../../lib/minions/data/clueTiers';
 import { SlayerActivityConstants } from '../../lib/minions/data/combatConstants';
 import killableMonsters from '../../lib/minions/data/killableMonsters';
 import { addMonsterXP } from '../../lib/minions/functions';
@@ -121,9 +122,13 @@ export default class extends Task {
 			await usersTask.currentTask!.save();
 		}
 
+		// This will alter the loot variable by reference, changing its content
 		const { clLoot } = filterLootReplace(user.allItemsOwned(), loot);
-
+		// Remove all the clues from the CL loot
+		for (const { scrollID } of clueTiers) clLoot.removeItem(scrollID, clLoot.amount(scrollID));
 		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, false);
+		// Re-add to the CL loot only the clues that were added to the user bank
+		for (const { scrollID } of clueTiers) if (itemsAdded[scrollID]) clLoot.add(scrollID, itemsAdded[scrollID]);
 		await user.addItemsToCollectionLog(clLoot.bank);
 
 		const { image } = await this.client.tasks

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -1,7 +1,6 @@
 import { Task } from 'klasa';
 import { MonsterKillOptions, Monsters } from 'oldschooljs';
 
-import clueTiers from '../../lib/minions/data/clueTiers';
 import { SlayerActivityConstants } from '../../lib/minions/data/combatConstants';
 import killableMonsters from '../../lib/minions/data/killableMonsters';
 import { addMonsterXP } from '../../lib/minions/functions';
@@ -9,12 +8,7 @@ import announceLoot from '../../lib/minions/functions/announceLoot';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { SlayerTaskUnlocksEnum } from '../../lib/slayer/slayerUnlocks';
-import {
-	calculateSlayerPoints,
-	filterLootReplace,
-	getSlayerMasterOSJSbyID,
-	getUsersCurrentSlayerInfo
-} from '../../lib/slayer/slayerUtil';
+import { calculateSlayerPoints, getSlayerMasterOSJSbyID, getUsersCurrentSlayerInfo } from '../../lib/slayer/slayerUtil';
 import { MonsterActivityTaskOptions } from '../../lib/types/minions';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
@@ -122,14 +116,7 @@ export default class extends Task {
 			await usersTask.currentTask!.save();
 		}
 
-		// This will alter the loot variable by reference, changing its content
-		const { clLoot } = filterLootReplace(user.allItemsOwned(), loot);
-		// Remove all the clues from the CL loot
-		for (const { scrollID } of clueTiers) clLoot.removeItem(scrollID, clLoot.amount(scrollID));
-		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, false);
-		// Re-add to the CL loot only the clues that were added to the user bank
-		for (const { scrollID } of clueTiers) if (itemsAdded[scrollID]) clLoot.add(scrollID, itemsAdded[scrollID]);
-		await user.addItemsToCollectionLog(clLoot.bank);
+		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true);
 
 		const { image } = await this.client.tasks
 			.get('bankImage')!


### PR DESCRIPTION
### Description:

- This is a problem for OSB only.
- Clue Scrolls that were being filtered by addItemsToBank were still being added to the collection log, making users having more clues in the CL than they actually had received.

### Changes:

- Moves the filterLootReplace into addItemsToBank and only calls it after the clue filtering is done.

### Other checks:

-   [X] I have tested all my changes thoroughly.
