### PR TITLE
Fix BSO =create when no outputItems? is specified.

### DIFF
--- a/src/commands/Minion/create.ts
+++ b/src/commands/Minion/create.ts
@@ -96,7 +96,7 @@ export default class extends BotCommand {
 			}
 		}
 
-		const outItems = new Bank(createableItem.outputItems).multiply(quantity);
+		const outItems = new Bank(output).multiply(quantity);
 		const inItems = new Bank(createableItem.inputItems).multiply(quantity);
 
 		console.log(outItems, createableItem.outputItems);

--- a/src/lib/data/dyedCreatables.ts
+++ b/src/lib/data/dyedCreatables.ts
@@ -99,7 +99,7 @@ export const dyedCreatables: Createable[] = [
 	{
 		name: 'Offhand drygore mace (blood)',
 		inputItems: {
-			[itemID('Offhand drygore longsword')]: 1,
+			[itemID('Offhand drygore mace')]: 1,
 			[itemID('Blood dye')]: 1
 		}
 	},


### PR DESCRIPTION
### Description:
Fixed bug where if outputItems? wasn't specified on the creatable, it would result in 'No items' being created, destroying the input items.

Also Offhand Drygore mace (blood) creatable was using oh drygore longsword.

### Other checks
  [x] - Yes i tested this, thank god!