### PR TITLE
[BSO] Tame fixes

### DIFF
--- a/src/lib/typeorm/TamesTable.entity.ts
+++ b/src/lib/typeorm/TamesTable.entity.ts
@@ -100,7 +100,7 @@ export class TamesTable extends BaseEntity {
 	}
 
 	get species() {
-		return tameSpecies.find(s => s.id === this.speciesID, 2)!;
+		return tameSpecies.find(s => s.id === this.speciesID)!;
 	}
 
 	get name() {


### PR DESCRIPTION
### Description:
General tame fixes. Fixed up the description, examples, removed some extraneous code, and fixed the combat level scaling.

### Changes:

- Fixed logic to properly scale trip kill times based on growth stage and combat level.
- Removed extraneous, ", 2" from get species().
- Fixed descriptions and examples.

### Important Note:
For an adult tame with low combat stats, they will still kill the same amount as they did before this update. Highly rolled tames will get a small buff from this update.

### Detailed examples of the old/broken logic:
Basically the code I'm replacing always gave the same trip length for each growth stage, no matter the combat level. It also didn't scale properly. The new code in this PR scales correctly for growth stages and gives the correct boost for combat level. I have thoroughly tested it in all stages.

```ts
/*** Original code simulation: ***/
// **Baby:**:
// Set constants
monsterKillTime = 30;
growthStage = 3;
myTame.maxCombatLevel = 90;
curCombatLevel = 30;

// Calculate
growthDiff = myTame.maxCombatLevel - myTame.maxCombatLevel / growthStage;
    // 90 - 90 / 3 // = 60
duration = monsterKillTime * growthStage; 
    // 30 * 3 = 90
duration = increaseByPercent(duration, curCombatLevel / growthStage); // 30 / 60
    // 90 * (1 + 30/60) = 135
// 135 second kills - this is the same no matter what combat level is rolled for the tame.

// **Juvenile:**
// Set constants
monsterKillTime = 30;
growthStage = 2;
myTame.maxCombatLevel = 90;
curCombatLevel = 45;

// Calculate
growthDiff = myTame.maxCombatLevel - myTame.maxCombatLevel / growthStage;
    // 90 - 90 / 2 = 45
duration = monsterKillTime * growthStage; 
    // 30 * 2 = 60
duration = increaseByPercent(duration, curCombatLevel / growthStage); // 45 / 45
    // 60 * (1 + 45/45) = 120
// 120 second kills - this is the same no matter what combat level is rolled for the tame.
```

**Adult**
Using this same formula results in infinite trip length, which is the bug I already fixed.
However this entire logic is incorrect, I believe, and this replacement is better.
This replacement more accurately scales the kill time based on growth stage AND gives an actual benefit to rolling higher combat stats.

### Other checks:

-   [x] I have tested all my changes thoroughly.
