### PR TITLE
Remove +m buttons when not interacted after the timeout period

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -122,7 +122,9 @@ export default class MinionCommand extends BotCommand {
 						return lastTrip.continue(msg);
 					}
 					await this.client.commands.get('mclue')?.run(msg, [selection.customID]);
-				} catch {}
+				} catch {
+					await sentMessage.edit({ components: [] });
+				}
 			};
 			handleButtons();
 		}


### PR DESCRIPTION
### Description:

- Button were still showing after the timeout ended, making everyone that clicking on it to receive 'This interaction failed'

### Changes:

- Update the message components when the catch is caught

### Other checks:

-   [X] I have tested all my changes thoroughly.
