### PR TITLE
Allow values above 51_530_000 to properly roll for hammy

### DIFF
--- a/src/commands/Minion/sacrifice.ts
+++ b/src/commands/Minion/sacrifice.ts
@@ -47,7 +47,13 @@ export default class extends BotCommand {
 			await msg.author.addItemsToBank({ 742: 1 }, true);
 		}
 
-		const gotHammy = totalPrice >= 51_530_000 && roll(140);
+		let gotHammy = false;
+		for (let i = 0; i < Math.floor(totalPrice / 51_530_000); i++) {
+			if (roll(140)) {
+				gotHammy = true;
+				break;
+			}
+		}
 		if (gotHammy) {
 			await msg.author.addItemsToBank({ [itemID('Hammy')]: 1 }, true);
 		}


### PR DESCRIPTION
### Description:

- People were having to become math teachers to find out the exact number of items to optimally sacrifice to try and roll hammy. Not anymore!

### Changes:

- Divides the sacrificed value by the number required for hammy and rolls that amount of times. It it rolls, it rolls.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Still took me around 35b to roll for it...
![image](https://user-images.githubusercontent.com/19570528/126015529-ed4f469b-5419-4247-a34c-419f6f8419dd.png)
