### PR TITLE
[BSO] Add EMB-only tradeables to TMBs

### DIFF
--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -582,9 +582,7 @@ for (const item of Items.values()) {
 	}
 }
 
-const preFilteredAllMbTables = [...tmbTable, ...umbTable, ...embTable];
-
-export const allMbTables = [...new Set([...preFilteredAllMbTables])];
+export const allMbTables = [...new Set([...tmbTable, ...umbTable, ...embTable])];
 
 function randomEquippable(): number {
 	const res = randArrItem(embTable);

--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -581,7 +581,10 @@ for (const item of Items.values()) {
 		embTable.push(item.id);
 	}
 }
-export const allMbTables = [...tmbTable, ...umbTable, ...embTable];
+
+const preFilteredAllMbTables = [...tmbTable, ...umbTable, ...embTable];
+
+export const allMbTables = [...new Set([...preFilteredAllMbTables])];
 
 function randomEquippable(): number {
 	const res = randArrItem(embTable);

--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -568,7 +568,11 @@ for (const item of Items.values()) {
 	) {
 		continue;
 	}
-	if (item.tradeable_on_ge) {
+
+	if (
+		item.tradeable_on_ge ||
+		(Boolean(item.tradeable) && Boolean(item.equipable_by_player) && Boolean(item.equipment?.slot))
+	) {
 		tmbTable.push(item.id);
 	} else if (!item.tradeable) {
 		umbTable.push(item.id);


### PR DESCRIPTION
### Description:
Currently, itemcontracts can give items that only come from EMBs. This makes it incredibly hard to track down items. 
**Examples:**

- Bronze fire arrow (lit)
- Pharaoh's sceptre (2)
- Vesta's chainbody
- ... their variants, and etc.
**Note:** This items do not come from UMB's either, only EMBs currently.

### Changes:
Added an additional check to the tmbTable generation to:
Add item to tmbTable if its tradeable on ge OR if it's tradable AND would also be added to the embTable.

### Other checks:

-   [x] I have tested all my changes thoroughly.
