### PR TITLE
LB changes

### DIFF
--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -401,7 +401,7 @@ ORDER BY u.petcount DESC LIMIT 2000;`
 FROM users
 ${msg.flagArgs.im ? 'WHERE "minion.ironman" = true' : ''}
 ORDER BY totalxp
-DESC LIMIT 100;`
+DESC LIMIT 2000;`
 			);
 			overallUsers = res.map(user => {
 				let totalLevel = 0;
@@ -418,6 +418,7 @@ DESC LIMIT 100;`
 			if (!msg.flagArgs.xp) {
 				overallUsers.sort((a, b) => b.totalLevel - a.totalLevel);
 			}
+			overallUsers.slice(0, 100);
 		} else {
 			if (!skill) {
 				return msg.channel.send("That's not a valid skill.");

--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -66,6 +66,11 @@ interface KCUser {
 	minigameScores: ItemBank;
 }
 
+interface contractUser {
+	id: string;
+	contractCount: number;
+}
+
 interface GPLeaderboard {
 	lastUpdated: number;
 	list: GPUser[];
@@ -113,7 +118,7 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			description: 'Shows the bots leaderboards.',
-			usage: '[pets|gp|petrecords|kc|cl|qp|skills|sacrifice|laps|creatures|minigame] [name:...string]',
+			usage: '[pets|gp|petrecords|kc|cl|qp|skills|sacrifice|laps|creatures|minigame|farmingcontracts|xp] [name:...string]',
 			usageDelim: ' ',
 			subcommands: true,
 			aliases: ['lb'],
@@ -166,6 +171,12 @@ export default class extends BotCommand {
 	}
 
 	async run(msg: KlasaMessage) {
+		this.skills(msg, ['overall']);
+		return null;
+	}
+
+	async xp(msg: KlasaMessage) {
+		msg.flagArgs.xp = 'xp';
 		this.skills(msg, ['overall']);
 		return null;
 	}
@@ -243,6 +254,42 @@ DESC LIMIT 2000;`
 					subList.map(({ id, QP }) => `**${this.getUsername(id)}** has ${QP.toLocaleString()} QP`).join('\n')
 				),
 			'QP Leaderboard'
+		);
+	}
+
+	async farmingcontracts(msg: KlasaMessage) {
+		const onlyForGuild = msg.flagArgs.server;
+		const key = 'minion.farmingContract';
+		const value = 'contractsCompleted';
+
+		let list = (
+			await this.query(`SELECT id, "${key}" FROM users WHERE CAST ("${key}"->>'${value}' AS INTEGER) >= 1;`)
+		)
+			.filter(user => typeof user[key][value] === 'number')
+			.sort((a: contractUser, b: contractUser) => {
+				return b.contractCount - a.contractCount;
+			})
+			.slice(0, 2000);
+
+		if (onlyForGuild && msg.guild) {
+			list = list.filter(user => msg.guild!.members.cache.has(user.id));
+		}
+
+		this.doMenu(
+			msg,
+			util
+				.chunk(list, 10)
+				.map(subList =>
+					subList
+						.map(
+							user =>
+								`**${this.getUsername(user.id)}** has ${user[key][
+									value
+								].toLocaleString()} contracts completed`
+						)
+						.join('\n')
+				),
+			'Farming contracts Leaderboard'
 		);
 	}
 
@@ -356,20 +403,21 @@ ${msg.flagArgs.im ? 'WHERE "minion.ironman" = true' : ''}
 ORDER BY totalxp
 DESC LIMIT 100;`
 			);
-			overallUsers = res
-				.map(user => {
-					let totalLevel = 0;
-					for (const skill of skillsVals) {
-						totalLevel += convertXPtoLVL(Number(user[`skills.${skill.id}` as keyof SkillUser]) as any);
-					}
-					return {
-						id: user.id,
-						totalLevel,
-						ironman: user['minion.ironman'],
-						totalXP: Number(user.totalxp!)
-					};
-				})
-				.sort((a, b) => b.totalLevel - a.totalLevel);
+			overallUsers = res.map(user => {
+				let totalLevel = 0;
+				for (const skill of skillsVals) {
+					totalLevel += convertXPtoLVL(Number(user[`skills.${skill.id}` as keyof SkillUser]) as any);
+				}
+				return {
+					id: user.id,
+					totalLevel,
+					ironman: user['minion.ironman'],
+					totalXP: Number(user.totalxp!)
+				};
+			});
+			if (!msg.flagArgs.xp) {
+				overallUsers.sort((a, b) => b.totalLevel - a.totalLevel);
+			}
 		} else {
 			if (!skill) {
 				return msg.channel.send("That's not a valid skill.");
@@ -402,7 +450,7 @@ DESC LIMIT 100;`
 						})
 						.join('\n')
 				),
-				'Overall Leaderboard'
+				`Overall Leaderboard${msg.flagArgs.xp ? ' (XP)' : ''}`
 			);
 			return;
 		}


### PR DESCRIPTION
### Description:

The overall skill LB was changed a while ago to sort by total level. However, it still only fetched the top 100 total XP users to sort by. This meant that users with lower total XP but high total level were excluded from the LB, causing confusion.

This PR fixes the above, but also adds an --xp flagArg to sort by totalXP like before, as well as farmingcontracts LB.

### Changes:

- Overall skills LB fetches 2000 users, sorts it if --xp is not provided, and then keeps removes all but the first 100 users in the array.
- --xp flagarg prevents the sort by total level from occurring in the overall skills LB. 
- xp LB added, functions basically like an alias to the flagArg.
- Farming contracts LB added.

### Other checks:

-   [X] I have tested all my changes thoroughly.
