### PR TITLE
Zenyte quantity override

### DIFF
--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -54,6 +54,8 @@ export default class extends BotCommand {
 			quantity = null;
 		}
 
+		if (craftName.toLowerCase().includes('zenyte')) quantity = 1;
+
 		const craftable = Crafting.Craftables.find(item => stringMatches(item.name, craftName));
 
 		if (!craftable) {

--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -54,7 +54,7 @@ export default class extends BotCommand {
 			quantity = null;
 		}
 
-		if (craftName.toLowerCase().includes('zenyte')) quantity = 1;
+		if (craftName.toLowerCase().includes('zenyte') && quantity === null) quantity = 1;
 
 		const craftable = Crafting.Craftables.find(item => stringMatches(item.name, craftName));
 


### PR DESCRIPTION
### Description:

Zenyte item crafting is a case where you more often than not only want to make 1 at a time, to avoid making multiple of the same item.

### Changes:

If the word zenyte is included in the provided name and no quantity is provided, set quantity to 1 instead of max.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Closes #2344
