### PR TITLE
Fix purple item bank cache

### DIFF
--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -318,12 +318,11 @@ export default class BankImageTask extends Task {
 		const isTransparent = Boolean(bgImage.transparent);
 
 		const isPurple: boolean =
-			bankBackgroundID === 14 &&
 			flags.showNewCL !== undefined &&
 			currentCL !== undefined &&
 			Object.keys(bank.bank).some(i => !currentCL[i] && allCollectionLogItems.includes(parseInt(i)));
 
-		if (isPurple) {
+		if (isPurple && bankBackgroundID === 14) {
 			bgImage = { ...bgImage, image: await canvasImageFromBuffer(coxPurpleBg) };
 		}
 


### PR DESCRIPTION
### Description:

- Having small generated bank (like offering unsired) with purple items, would cache the purple item together, causing it to show multiple times as purple, until the cache is no longer valid.

### Changes:

- Removes the CoXBG condition from checking if there is a purple and move it to check if the BG should be changed.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Before:
![image](https://user-images.githubusercontent.com/19570528/126154883-4925781b-6443-4603-a996-4bee5b19b6f6.png)

After:
![image](https://user-images.githubusercontent.com/19570528/126154892-4eb5e7ce-9bda-4bc7-8617-cef48cf449e3.png)
