### PR TITLE
Fix zalcano purple items

### DIFF
--- a/src/tasks/minions/minigames/zalcanoActivity.ts
+++ b/src/tasks/minions/minigames/zalcanoActivity.ts
@@ -49,11 +49,11 @@ export default class extends Task {
 			);
 		}
 
-		await user.addItemsToBank(loot, true);
+		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true);
 
 		const { image } = await this.client.tasks
 			.get('bankImage')!
-			.generateBankImage(loot.bank, `Loot From ${quantity}x Zalcano`, true, { showNewCL: 1 }, user);
+			.generateBankImage(itemsAdded, `Loot From ${quantity}x Zalcano`, true, { showNewCL: 1 }, user, previousCL);
 
 		handleTripFinish(
 			this.client,

--- a/src/tasks/minions/minigames/zalcanoActivity.ts
+++ b/src/tasks/minions/minigames/zalcanoActivity.ts
@@ -68,7 +68,7 @@ export default class extends Task {
 			},
 			image!,
 			data,
-			loot.bank
+			itemsAdded
 		);
 	}
 }


### PR DESCRIPTION
### Description:

- Zalcano CL items were never shown as purple;

### Changes:

- Fix it by using the itemsAdded and previousCL from addItemsToBank.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/126157658-e876d6f4-7e78-4a6a-bc1d-55581a64aef8.png)
