### PR TITLE
Allows flappy to double Temple Trekking loot

### DIFF
--- a/src/tasks/minions/minigames/templeTrekkingActivity.ts
+++ b/src/tasks/minions/minigames/templeTrekkingActivity.ts
@@ -90,9 +90,7 @@ export default class extends Task {
 		let str = `${user}, ${
 			user.minionName
 		} finished Temple Trekking ${quantity}x times. ${totalEncounters}x encounters were defeated. ${
-			user.usingPet('Flappy')
-				? ' \n\n<:flappy:812280578195456002> Flappy helps you in your treekings, granting you 2x rewards.'
-				: ''
+			user.usingPet('Flappy') ? ' <:flappy:812280578195456002>' : ''
 		}`;
 
 		const { image } = await this.client.tasks

--- a/src/tasks/minions/minigames/templeTrekkingActivity.ts
+++ b/src/tasks/minions/minigames/templeTrekkingActivity.ts
@@ -87,7 +87,13 @@ export default class extends Task {
 
 		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true);
 
-		let str = `${user}, ${user.minionName} finished Temple Trekking ${quantity}x times. ${totalEncounters}x encounters were defeated.`;
+		let str = `${user}, ${
+			user.minionName
+		} finished Temple Trekking ${quantity}x times. ${totalEncounters}x encounters were defeated. ${
+			user.usingPet('Flappy')
+				? ' \n\n<:flappy:812280578195456002> Flappy helps you in your treekings, granting you 2x rewards.'
+				: ''
+		}`;
 
 		const { image } = await this.client.tasks
 			.get('bankImage')!

--- a/src/tasks/minions/minigames/templeTrekkingActivity.ts
+++ b/src/tasks/minions/minigames/templeTrekkingActivity.ts
@@ -81,6 +81,10 @@ export default class extends Task {
 			loot.add(rewardToken.id);
 		}
 
+		if (user.usingPet('Flappy')) {
+			loot.multiply(2);
+		}
+
 		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true);
 
 		let str = `${user}, ${user.minionName} finished Temple Trekking ${quantity}x times. ${totalEncounters}x encounters were defeated.`;


### PR DESCRIPTION
### Description:

- Requested by bso-pool:
![image](https://user-images.githubusercontent.com/19570528/126187190-d7c6e6e1-c35e-45f4-bde2-682564e7c373.png)

### Changes:

- Check if Flappy is owned and equipped and double its loot.

### Other checks:

-   [X] I have tested all my changes thoroughly.

No Flappy
![image](https://user-images.githubusercontent.com/19570528/126187829-f208943c-ab6d-412b-9139-a662049a91d7.png)

With Flappy
![image](https://user-images.githubusercontent.com/19570528/126187806-8ff0d41e-75c3-48e3-b669-b4092da044e8.png)
