### PR TITLE
Add dwarven knife use

### DIFF
--- a/src/commands/Minion/fletch.ts
+++ b/src/commands/Minion/fletch.ts
@@ -12,7 +12,7 @@ import { SlayerTaskUnlocksEnum } from '../../lib/slayer/slayerUnlocks';
 import { hasSlayerUnlock } from '../../lib/slayer/slayerUtil';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { FletchingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, itemID, stringMatches } from '../../lib/util';
+import { formatDuration, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 
 export default class extends BotCommand {
@@ -85,9 +85,16 @@ export default class extends BotCommand {
 		}
 
 		let hasScruffy = false;
-		if (msg.author.equippedPet() === itemID('Scruffy')) {
+		if (msg.author.usingPet('Scruffy')) {
 			timeToFletchSingleItem /= 2;
 			hasScruffy = true;
+		}
+		if (msg.author.hasItemEquippedAnywhere('Dwarven knife')) {
+			if (hasScruffy) {
+				timeToFletchSingleItem *= 0.75;
+			} else {
+				timeToFletchSingleItem /= 2;
+			}
 		}
 
 		// If no quantity provided, set it to the max the player can make by either the items in bank or max time.

--- a/src/commands/Minion/fletch.ts
+++ b/src/commands/Minion/fletch.ts
@@ -91,7 +91,7 @@ export default class extends BotCommand {
 		}
 		if (msg.author.hasItemEquippedAnywhere('Dwarven knife')) {
 			if (hasScruffy) {
-				timeToFletchSingleItem *= 0.75;
+				timeToFletchSingleItem /= 1.5;
 			} else {
 				timeToFletchSingleItem /= 2;
 			}


### PR DESCRIPTION
### Description:

- Add Dwarven Knife use, as requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/126193909-1c63fe4a-b414-4f7e-8d30-6acdcfe8f0e7.png)

### Changes:

- Allows Dwarven knife to make fletching twice as fast (or 50% as fast if using with Scruffy).

### Other checks:

-   [X] I have tested all my changes thoroughly.

No bonus:
![image](https://user-images.githubusercontent.com/19570528/126194897-d9755c7a-a459-4e78-a8e6-4e2f7bf12a92.png)

Scruffy:
![image](https://user-images.githubusercontent.com/19570528/126194914-63500632-acf1-479f-8b50-4cf1775d73fe.png)

Scruffy + Dwarven Knife
![image](https://user-images.githubusercontent.com/19570528/126195008-9902420a-3000-405b-83de-ebcd1e3a4f62.png)

Only Dwarven Knife
![image](https://user-images.githubusercontent.com/19570528/126195064-db7ce81d-ae8f-4a35-b46e-4e5822c9706f.png)
