### PR TITLE
Favpatch for +af

### DIFF
--- a/src/commands/Minion/favpatch.ts
+++ b/src/commands/Minion/favpatch.ts
@@ -1,0 +1,77 @@
+import { objectValues } from 'e';
+import { ArrayActions, CommandStore, KlasaMessage } from 'klasa';
+
+import { FarmingPatchTypes } from '../../lib/minions/farming/types';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { BotCommand } from '../../lib/structures/BotCommand';
+import { toTitleCase } from '../../lib/util';
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			usage: '[patches:...string]',
+			description: 'Favorites a farming patch.',
+			examples: ['+favpatch herb'],
+			categoryFlags: ['minion', 'skilling']
+		});
+	}
+
+	async run(msg: KlasaMessage, [patches]: [string | undefined]) {
+		const currentFavorites = msg.author.settings.get(UserSettings.FavoritePatches);
+		let newFavorites = [...currentFavorites];
+		const input = patches?.split(', ').map(x => toTitleCase(x).replace(' ', ''));
+
+		if (!patches || patches.length === 0) {
+			if (currentFavorites.length === 0) {
+				return msg.channel.send(
+					`You have no favorited farming patches. Valid options are: ${objectValues(FarmingPatchTypes)}`
+				);
+			}
+			return msg.channel.send(
+				`Your current favorite farming patches are: ${currentFavorites.toString().split(',').join(', ')}.`
+			);
+		}
+
+		if (input![0] === 'clear') {
+			await msg.author.settings.update(UserSettings.FavoritePatches, [], {
+				arrayAction: ArrayActions.Overwrite
+			});
+			return msg.channel.send('Your favorite patches are cleared');
+		}
+
+		const patchesProvided: FarmingPatchTypes[] = input
+			?.map(patch => FarmingPatchTypes[patch as keyof typeof FarmingPatchTypes])
+			.filter(x => x !== undefined) as FarmingPatchTypes[];
+
+		const unrecognized = input?.filter(
+			patch => FarmingPatchTypes[patch as keyof typeof FarmingPatchTypes] === undefined
+		);
+
+		if (patchesProvided.length === 0) {
+			return msg.channel.send('No valid patches provided.');
+		}
+
+		// Removes all specified patches that already exist
+		newFavorites = newFavorites.filter(patch => !patchesProvided.includes(patch));
+
+		// Add all specified patches that weren't already favorites to the new favorites
+		newFavorites.push(...patchesProvided.filter(patch => !currentFavorites.includes(patch)));
+
+		if (newFavorites && newFavorites !== currentFavorites) {
+			const removed = currentFavorites.filter(x => !newFavorites.includes(x));
+			const added = newFavorites.filter(x => !currentFavorites.includes(x));
+			let str = 'Favorite patches modified.\n';
+
+			if (added.length !== 0) str += `You added: ${added.toString().split(',').join(', ')}\n`;
+			if (removed.length !== 0) str += `You removed: ${removed.toString().split(',').join(', ')}\n`;
+			if (unrecognized) str += `Unrecognized patches: ${unrecognized.toString().split(',').join(', ')}\n`;
+
+			await msg.author.settings.update(UserSettings.FavoritePatches, newFavorites, {
+				arrayAction: ArrayActions.Overwrite
+			});
+			return msg.channel.send(str);
+		}
+
+		return msg.channel.send('No change in fav patches detected. Please report this.');
+	}
+}

--- a/src/commands/Minion/favpatch.ts
+++ b/src/commands/Minion/favpatch.ts
@@ -47,7 +47,7 @@ export default class extends BotCommand {
 			patch => FarmingPatchTypes[patch as keyof typeof FarmingPatchTypes] === undefined
 		);
 
-		if (patchesProvided && patchesProvided.length === 0) {
+		if (!patchesProvided || patchesProvided.length === 0) {
 			return msg.channel.send('No valid patches provided.');
 		}
 

--- a/src/commands/Minion/favpatch.ts
+++ b/src/commands/Minion/favpatch.ts
@@ -47,7 +47,7 @@ export default class extends BotCommand {
 			patch => FarmingPatchTypes[patch as keyof typeof FarmingPatchTypes] === undefined
 		);
 
-		if (patchesProvided.length === 0) {
+		if (patchesProvided && patchesProvided.length === 0) {
 			return msg.channel.send('No valid patches provided.');
 		}
 
@@ -57,7 +57,7 @@ export default class extends BotCommand {
 		// Add all specified patches that weren't already favorites to the new favorites
 		newFavorites.push(...patchesProvided.filter(patch => !currentFavorites.includes(patch)));
 
-		if (newFavorites && newFavorites !== currentFavorites) {
+		if (newFavorites !== currentFavorites) {
 			const removed = currentFavorites.filter(x => !newFavorites.includes(x));
 			const added = newFavorites.filter(x => !currentFavorites.includes(x));
 			let str = 'Favorite patches modified.\n';

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -48,6 +48,7 @@ Client.defaultUserSchema
 	)
 
 	.add('favorite_alchables', 'integer', { array: true, default: [] })
+	.add('favorite_patches', 'string', { array: true, default: [] })
 	.add('bank_bg_hex', 'string', { default: null })
 	.add('minion', folder =>
 		folder

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -47,6 +47,7 @@ export namespace UserSettings {
 	export const AttackStyle = T<readonly SkillsEnum[]>('attack_style');
 	export const TotalCoxPoints = T<number>('total_cox_points');
 	export const FavoriteAlchables = T<readonly number[]>('favorite_alchables');
+	export const FavoritePatches = T<readonly FarmingPatchTypes[]>('favorite_patches');
 	export const BankBackgroundHex = T<HexColorString | null>('bank_bg_hex');
 	export const CombatOptions = T<readonly CombatOptionsEnum[]>('combat_options');
 	export const FarmingPatchReminders = T<boolean>('farming_patch_reminders');


### PR DESCRIPTION
### Description:

Added +favpatch command to favorite patch types much like +favalch favorites items to be alched. +autofarm would only plant in patches defined in +favpatch, if any are present.

### Other checks:

-   [X] I have tested all my changes thoroughly.
