### PR TITLE
Boosts Dungeoneering

### DIFF
--- a/src/commands/Minion/dung.ts
+++ b/src/commands/Minion/dung.ts
@@ -319,8 +319,8 @@ export default class extends BotCommand {
 		duration = reduceNumByPercent(duration, 20);
 
 		if (users.length > 1) {
-			duration = reduceNumByPercent(duration, users.length * 10);
-			boosts.push(`${users.length * 10}% for having a team of ${users.length}`);
+			duration = reduceNumByPercent(duration, users.length * 5);
+			boosts.push(`${users.length * 5}% for having a team of ${users.length}`);
 		}
 
 		// Calculate new number of floors will be done now that it is about to start

--- a/src/commands/Minion/dung.ts
+++ b/src/commands/Minion/dung.ts
@@ -1,4 +1,4 @@
-import { increaseNumByPercent, reduceNumByPercent, Time } from 'e';
+import { reduceNumByPercent, Time } from 'e';
 import { CommandStore, KlasaMessage, KlasaUser } from 'klasa';
 
 import { Activity, Emoji } from '../../lib/constants';
@@ -226,8 +226,8 @@ export default class extends BotCommand {
 			return msg.channel.send(`You need level ${determineDgLevelForFloor(floorToDo)} to do Floor ${floorToDo}.`);
 		}
 
-		const dungeonLength = Time.Minute * 5 * (floorToDo / 2) * 1;
-		const quantity = Math.floor(msg.author.maxTripLength(Activity.Dungeoneering) / dungeonLength);
+		const dungeonLength = Time.Minute * 5 * (floorToDo / 2);
+		let quantity = Math.floor(msg.author.maxTripLength(Activity.Dungeoneering) / dungeonLength);
 		let duration = quantity * dungeonLength;
 
 		let message = `${msg.author.username} has created a Dungeoneering party! Anyone can click the ${
@@ -236,7 +236,7 @@ export default class extends BotCommand {
 
 **Floor:** ${floorToDo}
 **Duration:** ${formatDuration(duration)}
-**Quantity:** ${quantity}
+**Min. Quantity:** ${quantity}
 **Required Stats:** ${formatSkillRequirements(requiredSkills(floorToDo))}`;
 
 		const partyOptions: MakePartyOptions = {
@@ -318,19 +318,21 @@ export default class extends BotCommand {
 
 		duration = reduceNumByPercent(duration, 20);
 
-		if (users.length === 1) {
-			duration = increaseNumByPercent(duration, 20);
-			boosts.push('-20% for not having a team');
-		} else if (users.length === 2) {
-			duration = increaseNumByPercent(duration, 15);
-			boosts.push('-15% for having a small team');
+		if (users.length > 1) {
+			duration = reduceNumByPercent(duration, users.length * 10);
+			boosts.push(`${users.length * 10}% for having a team of ${users.length}`);
 		}
+
+		// Calculate new number of floors will be done now that it is about to start
+		const perFloor = duration / quantity;
+		quantity = Math.floor(msg.author.maxTripLength(Activity.Dungeoneering) / perFloor);
+		duration = quantity * perFloor;
 
 		let str = `${partyOptions.leader.username}'s dungeoneering party (${users
 			.map(u => u.username)
 			.join(', ')}) is now off to do ${quantity}x dungeons of the ${formatOrdinal(
 			floorToDo
-		)} floor. Each dungeon takes ${formatDuration(dungeonLength)} - the total trip will take ${formatDuration(
+		)} floor. Each dungeon takes ${formatDuration(perFloor)} - the total trip will take ${formatDuration(
 			duration
 		)}.`;
 

--- a/src/commands/Minion/dung.ts
+++ b/src/commands/Minion/dung.ts
@@ -242,7 +242,7 @@ export default class extends BotCommand {
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,
 			minSize: 1,
-			maxSize: 12,
+			maxSize: 5,
 			ironmanAllowed: true,
 			message,
 			customDenier: user => {

--- a/src/tasks/minions/dungeoneeringActivity.ts
+++ b/src/tasks/minions/dungeoneeringActivity.ts
@@ -50,7 +50,7 @@ export default class extends Task {
 		const { channelID, duration, userID, floor, quantity, users } = data;
 		const user = await this.client.users.fetch(userID);
 
-		let baseXp = ((Math.log(floor * 16 + 1) * quantity * 1) / (36 - floor * 5)) * 59_000;
+		let baseXp = ((Math.log(floor * 16 + 1) * quantity) / (36 - floor * 5)) * 59_000;
 		baseXp *= 1.5;
 		let str = `<:dungeoneering:828683755198873623> ${user}, your party finished ${quantity}x Floor ${floor} dungeons.\n\n`;
 		const minutes = duration / Time.Minute;
@@ -85,14 +85,20 @@ export default class extends Task {
 			let rawXPHr = (xp / (duration / Time.Minute)) * 60;
 			rawXPHr = Math.floor(xp / 1000) * 1000;
 
-			const gotMysteryBox = u.bank().has('Scroll of mystery') && roll(5);
-			if (gotMysteryBox) {
-				await u.addItemsToBank({ [getRandomMysteryBox()]: 1 });
+			// Allow MBs to roll per floor and not trip
+			// This allows people that wants to farm mbs and not xp to do a lot of small floors
+			let gotMysteryBox = false;
+			for (let i = 0; i < quantity; i++) {
+				if (u.bank().has('Scroll of mystery') && roll(5)) {
+					await u.addItemsToBank({ [getRandomMysteryBox()]: 1 });
+					if (!gotMysteryBox) gotMysteryBox = true;
+				}
 			}
+
 			str += `${gotMysteryBox ? Emoji.MysteryBox : ''} ${u} received: ${xp.toLocaleString()} XP (${toKMB(
 				rawXPHr
 			)}/hr) and <:dungeoneeringToken:829004684685606912> ${tokens.toLocaleString()} Dungeoneering tokens (${toKMB(
-				rawXPHr * 0.1
+				(rawXPHr * 0.1) / 4
 			)}/hr)`;
 			if (gorajanEquipped > 0) {
 				str += ` ${bonusXP.toLocaleString()} Bonus XP`;
@@ -118,6 +124,22 @@ export default class extends Task {
 			str += '\n';
 		}
 
-		handleTripFinish(this.client, user, channelID, str, undefined, undefined, data, null);
+		handleTripFinish(
+			this.client,
+			user,
+			channelID,
+			str,
+			users.length > 1
+				? undefined
+				: res => {
+						user.log(`continued trip of ${quantity}x F${floor} dungeoneering`);
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						return this.client.commands.get('dung')!.start(res, ['solo']);
+				  },
+			undefined,
+			data,
+			null
+		);
 	}
 }


### PR DESCRIPTION
### Description:

Requested by:
![image](https://user-images.githubusercontent.com/19570528/126204876-f1e2a307-4f07-48d9-89f1-51d58b203a01.png)
![image](https://user-images.githubusercontent.com/19570528/126205087-5936d5cb-f858-40a3-9aee-0a2b823f75ab.png)

### Changes:

- Removed negative boost from soloing;
- Adding 10% boost for each player that joins the party;
- Changed the quantity of floors done to do the maximum allowed after all boosts/effects is applied, instead of always doing the minimum possible and returning earlier;
- Changed Scroll of Mystery to roll for every floor done and not once per trip.

### Other checks:

-   [X] I have tested all my changes thoroughly.
