### PR TITLE
Shows total tithe farm points when using +tfs.

### DIFF
--- a/src/commands/Minion/tithefarmshop.ts
+++ b/src/commands/Minion/tithefarmshop.ts
@@ -31,33 +31,35 @@ export default class extends BotCommand {
 				(item.aliases && item.aliases.some(alias => stringMatches(alias, buyableName)))
 		);
 
+		await msg.author.settings.sync(true);
+        let titheFarmPoints = msg.author.settings.get(UserSettings.Stats.TitheFarmPoints);
+        
 		if (!buyable) {
 			throw `I don't recognize that item, the items you can buy are: ${TitheFarmBuyables.map(
 				item => item.name
-			).join(', ')}.`;
+			).join(', ')}.You have ${titheFarmPoints} points.`;
 		}
-
-		await msg.author.settings.sync(true);
 
 		const outItems = multiplyBank(buyable.outputItems, quantity);
 		const itemString = new Bank(outItems).toString();
 
-		const titheFarmPoints = msg.author.settings.get(UserSettings.Stats.TitheFarmPoints);
-
 		const titheFarmPointsCost = buyable.titheFarmPoints * quantity;
 
 		if (titheFarmPoints < titheFarmPointsCost) {
-			throw `You need ${titheFarmPointsCost} Tithe Farm points to make this purchase.`;
+			throw `You need ${titheFarmPointsCost} Tithe Farm points to make this purchase. You have ${titheFarmPoints}.`;
 		}
 
 		let purchaseMsg = `${itemString} for ${titheFarmPointsCost} Tithe Farm points`;
 
 		await msg.confirm(`${msg.author}, please confirm that you want to purchase ${purchaseMsg}.`);
-
-		await msg.author.settings.update(UserSettings.Stats.TitheFarmPoints, titheFarmPoints - titheFarmPointsCost);
+		titheFarmPoints -= titheFarmPointsCost;
+		
+		await msg.author.settings.update(UserSettings.Stats.TitheFarmPoints, titheFarmPoints);
 
 		await msg.author.addItemsToBank(outItems, true);
 
-		return msg.channel.send(`You purchased ${itemString} for ${titheFarmPointsCost} Tithe Farm points.`);
+		return msg.channel.send(
+			`You purchased ${itemString} for ${titheFarmPointsCost} Tithe Farm points. You have ${titheFarmPoints} remaining.`
+		);
 	}
 }


### PR DESCRIPTION
### Description:

Includes total points in the "i dont recognize this item" message, the "you dont have enough pts" message, the confirmation message, and the message sent after you buy something.
ty to wyatt for giving me a coding lesson (and maybe actually writing most of this)
if its bad blame him :)

### Changes:

adds titheFarmPoints to a few more places, changes how its updated i think
not really sure whats happening there if im honest

### Other checks:

-   [ ] I have tested all my changes thoroughly.
:)
