### PR TITLE
[BSO] Fixed bug where =spawn would update defaultGear.

### DIFF
--- a/src/commands/Testing/spawn.ts
+++ b/src/commands/Testing/spawn.ts
@@ -97,11 +97,16 @@ export default class extends BotCommand {
 		for (const setup of ['range', 'melee', 'mage', 'skilling'] as const) {
 			if (msg.flagArgs[setup]) {
 				let newGear: GearSetup = msg.author.settings.get(`gear.${setup}`) as GearSetup;
+				const returnToBank = new Bank();
 				for (const [item] of items) {
 					if (!item.equipable_by_player || !item.equipment) continue;
+					if (newGear[item.equipment.slot] !== null) {
+						returnToBank.add(newGear[item.equipment.slot]!.item, newGear[item.equipment.slot]!.quantity);
+					}
 					newGear[item.equipment.slot] = { item: item.id, quantity: 1 };
 				}
 				await msg.author.settings.update(`gear.${setup}`, newGear);
+				await msg.author.addItemsToBank(returnToBank);
 				res += `\n\nEquipped these items: ${new Gear(newGear).toString()}`;
 			}
 		}

--- a/src/commands/Testing/spawn.ts
+++ b/src/commands/Testing/spawn.ts
@@ -3,7 +3,7 @@ import { Bank, Items, Openables } from 'oldschooljs';
 
 import { customItems } from '../../lib/customItems';
 import { maxMageGear, maxMeleeGear, maxRangeGear } from '../../lib/data/cox';
-import { defaultGear, GearSetup } from '../../lib/gear';
+import { GearSetup } from '../../lib/gear';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { Gear } from '../../lib/structures/Gear';
@@ -96,7 +96,7 @@ export default class extends BotCommand {
 		let res = `Gave you ${loot}.`;
 		for (const setup of ['range', 'melee', 'mage', 'skilling'] as const) {
 			if (msg.flagArgs[setup]) {
-				let newGear: GearSetup = defaultGear;
+				let newGear: GearSetup = msg.author.settings.get(`gear.${setup}`) as GearSetup;
 				for (const [item] of items) {
 					if (!item.equipable_by_player || !item.equipment) continue;
 					newGear[item.equipment.slot] = { item: item.id, quantity: 1 };


### PR DESCRIPTION
### Description:
In BSO's spawn command, spawn can take a list of items and update all the gear at once. It was using 'defaultGear' (all nulls) as the base, and assigning `newGear = defaultGear`.

The problem is this a by-reference assignment, so when newGear is updated, so is defaultGear. (defaultGear is const, but that just means it's assignment to the object cannot change. The contents of the object itself are mutable).

### Changes:
Was originally going to change it `newGear = { ...defaultGear }`, but decided it was better if it used the players actual gear in that slot as a base, so that you didn't have to spawn everything at once, but you still can if you want to.

### Other checks:

-   [x] I have tested all my changes thoroughly.
