### PR TITLE
[BSO] Add purple square emoji to igne uniques.

### DIFF
--- a/src/lib/minions/data/killableMonsters/custom/Ignecarus.ts
+++ b/src/lib/minions/data/killableMonsters/custom/Ignecarus.ts
@@ -2,6 +2,7 @@ import { Monsters } from 'oldschooljs';
 import LootTable from 'oldschooljs/dist/structures/LootTable';
 
 import { runeAlchablesTable } from '../../../../simulation/sharedTables';
+import resolveItems from '../../../../util/resolveItems';
 import setCustomMonster from '../../../../util/setCustomMonster';
 
 const barTable = new LootTable()
@@ -35,6 +36,8 @@ export const IgnecarusLootTable = new LootTable()
 	.add(barTable, 5)
 	.add(runeAlchablesTable, 5)
 	.add(gemTable, 5);
+
+export const IgnecarusNotifyDrops = resolveItems(['Ignis ring', 'Ignecarus dragonclaw', 'Dragon egg']);
 
 setCustomMonster(69_420, 'Ignecarus', IgnecarusLootTable, Monsters.GeneralGraardor, {
 	id: 69_420,

--- a/src/tasks/minions/minigames/ignecarusActivity.ts
+++ b/src/tasks/minions/minigames/ignecarusActivity.ts
@@ -3,7 +3,11 @@ import { KlasaUser, Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
 import { DOUBLE_LOOT_ACTIVE, Emoji } from '../../../lib/constants';
-import { Ignecarus, IgnecarusLootTable } from '../../../lib/minions/data/killableMonsters/custom/Ignecarus';
+import {
+	Ignecarus,
+	IgnecarusLootTable,
+	IgnecarusNotifyDrops
+} from '../../../lib/minions/data/killableMonsters/custom/Ignecarus';
 import { addMonsterXP } from '../../../lib/minions/functions';
 import { ClientSettings } from '../../../lib/settings/types/ClientSettings';
 import { BossUser } from '../../../lib/structures/Boss';
@@ -74,7 +78,8 @@ export default class extends Task {
 				taskQuantity: null
 			});
 			await user.addItemsToBank(loot, true);
-			resultStr += `\n${user} received ${loot}.`;
+			const purple = Object.keys(loot.bank).some(itemID => IgnecarusNotifyDrops.includes(parseInt(itemID)));
+			resultStr += `\n${purple ? Emoji.Purple : ''}${user} received ${loot}.`;
 		}
 		updateBankSetting(this.client, ClientSettings.EconomyStats.IgnecarusLoot, totalLoot);
 


### PR DESCRIPTION
### Description:
Added Purple Square emoji prefix to player names when a unique is rolled in their name.

### Changes:
Added IgnecarusNotifyDrops variable, and compare loot against it when generating resultStr.

### Other checks:

-   [x] I have tested all my changes thoroughly.
