### PR TITLE
Apply some fixes to the new Collection Log

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -159,7 +159,7 @@ export const allCollectionLogs: ICollection = {
 				alias: Monsters.Barrows.aliases,
 				kcActivity: Monsters.Barrows.name,
 				items: barrowsChestCL,
-				roleCategory: []
+				roleCategory: ['bosses']
 			},
 			Bryophyta: {
 				alias: Monsters.Bryophyta.aliases,
@@ -393,42 +393,50 @@ export const allCollectionLogs: ICollection = {
 			'King Goldemar': {
 				alias: KingGoldemar.aliases,
 				allItems: KingGoldemar.allItems,
-				items: kingGoldemarCL
+				items: kingGoldemarCL,
+				roleCategory: ['bosses']
 			},
 			Malygos: {
 				alias: AbyssalDragon.aliases,
 				allItems: AbyssalDragon.allItems,
-				items: abyssalDragonCL
+				items: abyssalDragonCL,
+				roleCategory: ['bosses']
 			},
 			'Kalphite King': {
 				alias: KalphiteKingMonster.aliases,
 				allItems: kalphiteKingLootTable.allItems,
-				items: kalphiteKingCL
+				items: kalphiteKingCL,
+				roleCategory: ['bosses']
 			},
 			Nex: {
 				alias: NexMonster.aliases,
 				allItems: nexLootTable.allItems,
-				items: nexCL
+				items: nexCL,
+				roleCategory: ['bosses']
 			},
 			'Vasa Magus': {
 				alias: VasaMagus.aliases,
 				allItems: VasaMagus.allItems,
-				items: vasaMagusCL
+				items: vasaMagusCL,
+				roleCategory: ['bosses']
 			},
 			Ignecarus: {
 				alias: Ignecarus.aliases,
 				allItems: Ignecarus.allItems,
-				items: ignecarusCL
+				items: ignecarusCL,
+				roleCategory: ['bosses']
 			},
 			Treebeard: {
 				alias: Treebeard.aliases,
 				allItems: Treebeard.allItems,
-				items: treeBeardCL
+				items: treeBeardCL,
+				roleCategory: ['bosses']
 			},
 			'Sea Kraken': {
 				alias: SeaKraken.aliases,
 				allItems: SeaKraken.allItems,
-				items: seaKrakenCL
+				items: seaKrakenCL,
+				roleCategory: ['bosses']
 			}
 		}
 	},

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -869,7 +869,8 @@ export const allCollectionLogs: ICollection = {
 			},
 			'Custom Pets': {
 				alias: ['cpets', 'custom pet', 'cpet', 'custom pet'],
-				items: customPetsCL
+				items: customPetsCL,
+				roleCategory: ['pets']
 			},
 			'Custom Pets (Discontinued)': {
 				alias: ['dcpets', 'disc custom pet', 'dcpet', 'dcp', 'discontinued custom pet'],

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -8,7 +8,10 @@ import { table } from 'table';
 import { kalphiteKingLootTable, KalphiteKingMonster } from '../kalphiteking';
 import killableMonsters, { effectiveMonsters, NightmareMonster } from '../minions/data/killableMonsters';
 import AbyssalDragon from '../minions/data/killableMonsters/custom/AbyssalDragon';
+import { Ignecarus } from '../minions/data/killableMonsters/custom/Ignecarus';
 import KingGoldemar from '../minions/data/killableMonsters/custom/KingGoldemar';
+import SeaKraken from '../minions/data/killableMonsters/custom/SeaKraken';
+import Treebeard from '../minions/data/killableMonsters/custom/Treebeard';
 import { VasaMagus } from '../minions/data/killableMonsters/custom/VasaMagus';
 import { sepulchreFloors } from '../minions/data/sepulchre';
 import {
@@ -80,6 +83,7 @@ import {
 	hesporiCL,
 	holidayCL,
 	ICollection,
+	ignecarusCL,
 	ILeftListStatus,
 	IToReturnCollection,
 	kalphiteKingCL,
@@ -105,6 +109,7 @@ import {
 	rooftopAgilityCL,
 	sarachnisCL,
 	scorpiaCL,
+	seaKrakenCL,
 	shadesOfMorttonCL,
 	shayzienArmourCL,
 	skillingPetsCL,
@@ -120,6 +125,7 @@ import {
 	theNightmareCL,
 	thermonuclearSmokeDevilCL,
 	titheFarmCL,
+	treeBeardCL,
 	TRoleCategories,
 	troubleBrewingCL,
 	tzHaarCL,
@@ -135,805 +141,833 @@ import {
 
 export const allCollectionLogs: ICollection = {
 	Bosses: {
-		'Abyssal Sire': {
-			alias: Monsters.AbyssalSire.aliases,
-			allItems: Monsters.AbyssalSire.allItems,
-			items: abyssalSireCL,
-			roleCategory: ['bosses']
-		},
-		'Alchemical Hydra': {
-			alias: [...Monsters.AlchemicalHydra.aliases, 'ahydra', 'alchhydra'],
-			allItems: Monsters.AlchemicalHydra.allItems,
-			items: alchemicalHydraCL,
-			roleCategory: ['bosses']
-		},
-		'Barrows Chests': {
-			alias: Monsters.Barrows.aliases,
-			kcActivity: Monsters.Barrows.name,
-			items: barrowsChestCL,
-			roleCategory: []
-		},
-		Bryophyta: {
-			alias: Monsters.Bryophyta.aliases,
-			allItems: Monsters.Bryophyta.allItems,
-			items: bryophytaCL,
-			roleCategory: ['bosses']
-		},
-		Callisto: {
-			alias: Monsters.Callisto.aliases,
-			allItems: Monsters.Callisto.allItems,
-			items: callistoCL,
-			roleCategory: ['bosses']
-		},
-		Cerberus: {
-			alias: Monsters.Cerberus.aliases,
-			allItems: Monsters.Cerberus.allItems,
-			items: cerberusCL,
-			roleCategory: ['bosses']
-		},
-		'Chaos Elemental': {
-			alias: Monsters.ChaosElemental.aliases,
-			allItems: Monsters.ChaosElemental.allItems,
-			items: chaosElementalCL,
-			roleCategory: ['bosses']
-		},
-		'Chaos Fanatic': {
-			alias: Monsters.ChaosFanatic.aliases,
-			allItems: Monsters.ChaosFanatic.allItems,
-			items: chaosFanaticCL,
-			roleCategory: ['bosses']
-		},
-		'Corporeal Beast': {
-			alias: Monsters.CorporealBeast.aliases,
-			allItems: Monsters.CorporealBeast.allItems,
-			items: corporealBeastCL,
-			roleCategory: ['bosses']
-		},
-		'Crazy archaeologist': {
-			alias: Monsters.CrazyArchaeologist.aliases,
-			allItems: Monsters.CrazyArchaeologist.allItems,
-			items: crazyArchaeologistCL,
-			roleCategory: ['bosses']
-		},
-		'Dagannoth Kings': {
-			alias: ['dagannoth kings', 'kings', 'dagga', 'dks'],
-			kcActivity: {
-				Default: [Monsters.DagannothSupreme.name, Monsters.DagannothRex.name, Monsters.DagannothPrime.name]
+		alias: ['boss'],
+		activities: {
+			'Abyssal Sire': {
+				alias: Monsters.AbyssalSire.aliases,
+				allItems: Monsters.AbyssalSire.allItems,
+				items: abyssalSireCL,
+				roleCategory: ['bosses']
 			},
-			allItems: (() => {
-				return [
-					...new Set(
-						...[
-							Monsters.DagannothPrime.allItems,
-							Monsters.DagannothSupreme.allItems,
-							Monsters.DagannothRex.allItems
-						]
-					)
-				];
-			})(),
-			items: dagannothKingsCL,
-			roleCategory: ['bosses']
-		},
-		'Dagannoth Rex': {
-			hidden: true,
-			alias: Monsters.DagannothRex.aliases,
-			allItems: Monsters.DagannothRex.allItems,
-			items: dagannothRexCL
-		},
-		'Dagannoth Prime': {
-			hidden: true,
-			alias: Monsters.DagannothPrime.aliases,
-			allItems: Monsters.DagannothPrime.allItems,
-			items: dagannothPrimeCL
-		},
-		'Dagannoth Supreme': {
-			hidden: true,
-			alias: Monsters.DagannothSupreme.aliases,
-			allItems: Monsters.DagannothSupreme.allItems,
-			items: dagannothSupremeCL
-		},
-		'The Fight Caves': {
-			kcActivity: Monsters.TzTokJad.name,
-			alias: ['firecape', 'jad', 'fightcave'],
-			items: fightCavesCL,
-			roleCategory: ['bosses']
-		},
-		'The Gauntlet': {
-			alias: ['gauntlet', 'crystalline hunllef', 'hunllef'],
-			kcActivity: {
-				Default: user => user.getMinigameScore('Gauntlet'),
-				Corrupted: user => user.getMinigameScore('CorruptedGauntlet')
+			'Alchemical Hydra': {
+				alias: [...Monsters.AlchemicalHydra.aliases, 'ahydra', 'alchhydra'],
+				allItems: Monsters.AlchemicalHydra.allItems,
+				items: alchemicalHydraCL,
+				roleCategory: ['bosses']
 			},
-			items: theGauntletCL,
-			roleCategory: ['bosses']
-		},
-		'Giant Mole': {
-			alias: Monsters.GiantMole.aliases,
-			allItems: Monsters.GiantMole.allItems,
-			items: giantMoleCL,
-			roleCategory: ['bosses']
-		},
-		'Grotesque Guardians': {
-			alias: Monsters.GrotesqueGuardians.aliases,
-			allItems: Monsters.GrotesqueGuardians.allItems,
-			items: grotesqueGuardiansCL,
-			roleCategory: ['bosses']
-		},
-		Hespori: {
-			alias: Monsters.Hespori.aliases,
-			allItems: Monsters.Hespori.allItems,
-			items: hesporiCL,
-			roleCategory: ['bosses']
-		},
-		'The Inferno': {
-			enabled: false,
-			alias: ['zuk', 'inferno'],
-			items: theInfernoCL
-		},
-		'Kalphite Queen': {
-			alias: Monsters.KalphiteQueen.aliases,
-			allItems: Monsters.KalphiteQueen.allItems,
-			items: kalphiteQueenCL,
-			roleCategory: ['bosses']
-		},
-		'King Black Dragon': {
-			alias: Monsters.KingBlackDragon.aliases,
-			allItems: Monsters.KingBlackDragon.allItems,
-			items: kingBlackDragonCL,
-			roleCategory: ['bosses']
-		},
-		Kraken: {
-			alias: Monsters.Kraken.aliases,
-			allItems: Monsters.Kraken.allItems,
-			items: krakenCL,
-			roleCategory: ['bosses']
-		},
-		'General Graardor': {
-			alias: Monsters.GeneralGraardor.aliases,
-			allItems: Monsters.GeneralGraardor.allItems,
-			items: generalGraardorCL,
-			roleCategory: ['bosses']
-		},
-		"Kree'arra": {
-			alias: Monsters.Kreearra.aliases,
-			allItems: Monsters.Kreearra.allItems,
-			items: kreeArraCL,
-			roleCategory: ['bosses']
-		},
-		"K'ril Tsutsaroth": {
-			alias: Monsters.KrilTsutsaroth.aliases,
-			allItems: Monsters.KrilTsutsaroth.allItems,
-			items: krilTsutsarothCL,
-			roleCategory: ['bosses']
-		},
-		'Commander Zilyana': {
-			alias: Monsters.CommanderZilyana.aliases,
-			allItems: Monsters.CommanderZilyana.allItems,
-			items: commanderZilyanaCL,
-			roleCategory: ['bosses']
-		},
-		'The Nightmare': {
-			alias: NightmareMonster.aliases,
-			items: theNightmareCL,
-			roleCategory: ['bosses']
-		},
-		Obor: {
-			alias: Monsters.Obor.aliases,
-			allItems: Monsters.Obor.allItems,
-			items: oborCL,
-			roleCategory: ['bosses']
-		},
-		Sarachnis: {
-			alias: Monsters.Sarachnis.aliases,
-			allItems: Monsters.Sarachnis.allItems,
-			items: sarachnisCL,
-			roleCategory: ['bosses']
-		},
-		Scorpia: {
-			alias: Monsters.Scorpia.aliases,
-			allItems: Monsters.Scorpia.allItems,
-			items: scorpiaCL,
-			roleCategory: ['bosses']
-		},
-		Skotizo: {
-			alias: Monsters.Skotizo.aliases,
-			allItems: Monsters.Skotizo.allItems,
-			items: skotizoCL,
-			roleCategory: ['bosses']
-		},
-		Tempoross: {
-			items: temporossCL,
-			allItems: resolveItems([...spiritAnglerOutfit, 'Spirit flakes']),
-			roleCategory: ['bosses']
-		},
-		'Thermonuclear smoke devil': {
-			alias: Monsters.ThermonuclearSmokeDevil.aliases,
-			allItems: Monsters.ThermonuclearSmokeDevil.allItems,
-			items: thermonuclearSmokeDevilCL,
-			roleCategory: ['bosses']
-		},
-		Venenatis: {
-			alias: Monsters.Venenatis.aliases,
-			allItems: Monsters.Venenatis.allItems,
-			items: venenatisCL,
-			roleCategory: ['bosses']
-		},
-		"Vet'ion": {
-			alias: Monsters.Vetion.aliases,
-			allItems: Monsters.Vetion.allItems,
-			items: vetionCL,
-			roleCategory: ['bosses']
-		},
-		Vorkath: {
-			alias: Monsters.Vorkath.aliases,
-			allItems: Monsters.Vorkath.allItems,
-			items: vorkathCL,
-			roleCategory: ['bosses']
-		},
-		Wintertodt: {
-			alias: ['todt', 'wintertodt', 'wt'],
-			items: wintertodtCL,
-			roleCategory: ['bosses', 'skilling']
-		},
-		Zalcano: { items: zalcanoCL, roleCategory: ['bosses', 'skilling'] },
-		Zulrah: {
-			alias: Monsters.Zulrah.aliases,
-			allItems: Monsters.Zulrah.allItems,
-			items: zulrahCL,
-			roleCategory: ['bosses']
-		},
-		'King Goldemar': {
-			alias: KingGoldemar.aliases,
-			allItems: KingGoldemar.allItems,
-			items: kingGoldemarCL
-		},
-		Malygos: {
-			alias: AbyssalDragon.aliases,
-			allItems: AbyssalDragon.allItems,
-			items: abyssalDragonCL
-		},
-		'Kalphite King': {
-			alias: KalphiteKingMonster.aliases,
-			allItems: kalphiteKingLootTable.allItems,
-			items: kalphiteKingCL
-		},
-		Nex: {
-			alias: NexMonster.aliases,
-			allItems: nexLootTable.allItems,
-			items: nexCL
-		},
-		'Vasa Magus': {
-			alias: VasaMagus.aliases,
-			allItems: VasaMagus.allItems,
-			items: vasaMagusCL
+			'Barrows Chests': {
+				alias: Monsters.Barrows.aliases,
+				kcActivity: Monsters.Barrows.name,
+				items: barrowsChestCL,
+				roleCategory: []
+			},
+			Bryophyta: {
+				alias: Monsters.Bryophyta.aliases,
+				allItems: Monsters.Bryophyta.allItems,
+				items: bryophytaCL,
+				roleCategory: ['bosses']
+			},
+			Callisto: {
+				alias: Monsters.Callisto.aliases,
+				allItems: Monsters.Callisto.allItems,
+				items: callistoCL,
+				roleCategory: ['bosses']
+			},
+			Cerberus: {
+				alias: Monsters.Cerberus.aliases,
+				allItems: Monsters.Cerberus.allItems,
+				items: cerberusCL,
+				roleCategory: ['bosses']
+			},
+			'Chaos Elemental': {
+				alias: Monsters.ChaosElemental.aliases,
+				allItems: Monsters.ChaosElemental.allItems,
+				items: chaosElementalCL,
+				roleCategory: ['bosses']
+			},
+			'Chaos Fanatic': {
+				alias: Monsters.ChaosFanatic.aliases,
+				allItems: Monsters.ChaosFanatic.allItems,
+				items: chaosFanaticCL,
+				roleCategory: ['bosses']
+			},
+			'Corporeal Beast': {
+				alias: Monsters.CorporealBeast.aliases,
+				allItems: Monsters.CorporealBeast.allItems,
+				items: corporealBeastCL,
+				roleCategory: ['bosses']
+			},
+			'Crazy archaeologist': {
+				alias: Monsters.CrazyArchaeologist.aliases,
+				allItems: Monsters.CrazyArchaeologist.allItems,
+				items: crazyArchaeologistCL,
+				roleCategory: ['bosses']
+			},
+			'Dagannoth Kings': {
+				alias: ['dagannoth kings', 'kings', 'dagga', 'dks'],
+				kcActivity: {
+					Default: [Monsters.DagannothSupreme.name, Monsters.DagannothRex.name, Monsters.DagannothPrime.name]
+				},
+				allItems: (() => {
+					return [
+						...new Set(
+							...[
+								Monsters.DagannothPrime.allItems,
+								Monsters.DagannothSupreme.allItems,
+								Monsters.DagannothRex.allItems
+							]
+						)
+					];
+				})(),
+				items: dagannothKingsCL,
+				roleCategory: ['bosses']
+			},
+			'Dagannoth Rex': {
+				hidden: true,
+				alias: Monsters.DagannothRex.aliases,
+				allItems: Monsters.DagannothRex.allItems,
+				items: dagannothRexCL
+			},
+			'Dagannoth Prime': {
+				hidden: true,
+				alias: Monsters.DagannothPrime.aliases,
+				allItems: Monsters.DagannothPrime.allItems,
+				items: dagannothPrimeCL
+			},
+			'Dagannoth Supreme': {
+				hidden: true,
+				alias: Monsters.DagannothSupreme.aliases,
+				allItems: Monsters.DagannothSupreme.allItems,
+				items: dagannothSupremeCL
+			},
+			'The Fight Caves': {
+				kcActivity: Monsters.TzTokJad.name,
+				alias: ['firecape', 'jad', 'fightcave'],
+				items: fightCavesCL,
+				roleCategory: ['bosses']
+			},
+			'The Gauntlet': {
+				alias: ['gauntlet', 'crystalline hunllef', 'hunllef'],
+				kcActivity: {
+					Default: user => user.getMinigameScore('Gauntlet'),
+					Corrupted: user => user.getMinigameScore('CorruptedGauntlet')
+				},
+				items: theGauntletCL,
+				roleCategory: ['bosses']
+			},
+			'Giant Mole': {
+				alias: Monsters.GiantMole.aliases,
+				allItems: Monsters.GiantMole.allItems,
+				items: giantMoleCL,
+				roleCategory: ['bosses']
+			},
+			'Grotesque Guardians': {
+				alias: Monsters.GrotesqueGuardians.aliases,
+				allItems: Monsters.GrotesqueGuardians.allItems,
+				items: grotesqueGuardiansCL,
+				roleCategory: ['bosses']
+			},
+			Hespori: {
+				alias: Monsters.Hespori.aliases,
+				allItems: Monsters.Hespori.allItems,
+				items: hesporiCL,
+				roleCategory: ['bosses']
+			},
+			'The Inferno': {
+				enabled: false,
+				alias: ['zuk', 'inferno'],
+				items: theInfernoCL
+			},
+			'Kalphite Queen': {
+				alias: Monsters.KalphiteQueen.aliases,
+				allItems: Monsters.KalphiteQueen.allItems,
+				items: kalphiteQueenCL,
+				roleCategory: ['bosses']
+			},
+			'King Black Dragon': {
+				alias: Monsters.KingBlackDragon.aliases,
+				allItems: Monsters.KingBlackDragon.allItems,
+				items: kingBlackDragonCL,
+				roleCategory: ['bosses']
+			},
+			Kraken: {
+				alias: Monsters.Kraken.aliases,
+				allItems: Monsters.Kraken.allItems,
+				items: krakenCL,
+				roleCategory: ['bosses']
+			},
+			'General Graardor': {
+				alias: Monsters.GeneralGraardor.aliases,
+				allItems: Monsters.GeneralGraardor.allItems,
+				items: generalGraardorCL,
+				roleCategory: ['bosses']
+			},
+			"Kree'arra": {
+				alias: Monsters.Kreearra.aliases,
+				allItems: Monsters.Kreearra.allItems,
+				items: kreeArraCL,
+				roleCategory: ['bosses']
+			},
+			"K'ril Tsutsaroth": {
+				alias: Monsters.KrilTsutsaroth.aliases,
+				allItems: Monsters.KrilTsutsaroth.allItems,
+				items: krilTsutsarothCL,
+				roleCategory: ['bosses']
+			},
+			'Commander Zilyana': {
+				alias: Monsters.CommanderZilyana.aliases,
+				allItems: Monsters.CommanderZilyana.allItems,
+				items: commanderZilyanaCL,
+				roleCategory: ['bosses']
+			},
+			'The Nightmare': {
+				alias: NightmareMonster.aliases,
+				items: theNightmareCL,
+				roleCategory: ['bosses']
+			},
+			Obor: {
+				alias: Monsters.Obor.aliases,
+				allItems: Monsters.Obor.allItems,
+				items: oborCL,
+				roleCategory: ['bosses']
+			},
+			Sarachnis: {
+				alias: Monsters.Sarachnis.aliases,
+				allItems: Monsters.Sarachnis.allItems,
+				items: sarachnisCL,
+				roleCategory: ['bosses']
+			},
+			Scorpia: {
+				alias: Monsters.Scorpia.aliases,
+				allItems: Monsters.Scorpia.allItems,
+				items: scorpiaCL,
+				roleCategory: ['bosses']
+			},
+			Skotizo: {
+				alias: Monsters.Skotizo.aliases,
+				allItems: Monsters.Skotizo.allItems,
+				items: skotizoCL,
+				roleCategory: ['bosses']
+			},
+			Tempoross: {
+				items: temporossCL,
+				allItems: resolveItems([...spiritAnglerOutfit, 'Spirit flakes']),
+				roleCategory: ['bosses']
+			},
+			'Thermonuclear smoke devil': {
+				alias: Monsters.ThermonuclearSmokeDevil.aliases,
+				allItems: Monsters.ThermonuclearSmokeDevil.allItems,
+				items: thermonuclearSmokeDevilCL,
+				roleCategory: ['bosses']
+			},
+			Venenatis: {
+				alias: Monsters.Venenatis.aliases,
+				allItems: Monsters.Venenatis.allItems,
+				items: venenatisCL,
+				roleCategory: ['bosses']
+			},
+			"Vet'ion": {
+				alias: Monsters.Vetion.aliases,
+				allItems: Monsters.Vetion.allItems,
+				items: vetionCL,
+				roleCategory: ['bosses']
+			},
+			Vorkath: {
+				alias: Monsters.Vorkath.aliases,
+				allItems: Monsters.Vorkath.allItems,
+				items: vorkathCL,
+				roleCategory: ['bosses']
+			},
+			Wintertodt: {
+				alias: ['todt', 'wintertodt', 'wt'],
+				items: wintertodtCL,
+				roleCategory: ['bosses', 'skilling']
+			},
+			Zalcano: { items: zalcanoCL, roleCategory: ['bosses', 'skilling'] },
+			Zulrah: {
+				alias: Monsters.Zulrah.aliases,
+				allItems: Monsters.Zulrah.allItems,
+				items: zulrahCL,
+				roleCategory: ['bosses']
+			},
+			'King Goldemar': {
+				alias: KingGoldemar.aliases,
+				allItems: KingGoldemar.allItems,
+				items: kingGoldemarCL
+			},
+			Malygos: {
+				alias: AbyssalDragon.aliases,
+				allItems: AbyssalDragon.allItems,
+				items: abyssalDragonCL
+			},
+			'Kalphite King': {
+				alias: KalphiteKingMonster.aliases,
+				allItems: kalphiteKingLootTable.allItems,
+				items: kalphiteKingCL
+			},
+			Nex: {
+				alias: NexMonster.aliases,
+				allItems: nexLootTable.allItems,
+				items: nexCL
+			},
+			'Vasa Magus': {
+				alias: VasaMagus.aliases,
+				allItems: VasaMagus.allItems,
+				items: vasaMagusCL
+			},
+			Ignecarus: {
+				alias: Ignecarus.aliases,
+				allItems: Ignecarus.allItems,
+				items: ignecarusCL
+			},
+			Treebeard: {
+				alias: Treebeard.aliases,
+				allItems: Treebeard.allItems,
+				items: treeBeardCL
+			},
+			'Sea Kraken': {
+				alias: SeaKraken.aliases,
+				allItems: SeaKraken.allItems,
+				items: seaKrakenCL
+			}
 		}
 	},
 	Raids: {
-		"Chamber's of Xeric": {
-			alias: ChambersOfXeric.aliases,
-			kcActivity: {
-				Default: user => user.getMinigameScore('Raids'),
-				Challenge: user => user.getMinigameScore('RaidsChallengeMode')
+		activities: {
+			"Chamber's of Xeric": {
+				alias: ChambersOfXeric.aliases,
+				kcActivity: {
+					Default: user => user.getMinigameScore('Raids'),
+					Challenge: user => user.getMinigameScore('RaidsChallengeMode')
+				},
+				items: chambersOfXericCl,
+				roleCategory: ['raids'],
+				isActivity: true
 			},
-			items: chambersOfXericCl,
-			roleCategory: ['raids'],
-			isActivity: true
-		},
-		'Theatre of Blood': {
-			enabled: false,
-			alias: ['tob'],
-			items: theatreOfBLoodCL,
-			roleCategory: ['raids'],
-			isActivity: true
+			'Theatre of Blood': {
+				enabled: false,
+				alias: ['tob'],
+				items: theatreOfBLoodCL,
+				roleCategory: ['raids'],
+				isActivity: true
+			}
 		}
 	},
 	Clues: {
-		'Beginner Treasure Trails': {
-			alias: ['beginner', 'clues beginner', 'clue beginner'],
-			allItems: Clues.Beginner.allItems,
-			kcActivity: {
-				Default: async user => user.getOpenableScore(23_245)
+		activities: {
+			'Beginner Treasure Trails': {
+				alias: ['beginner', 'clues beginner', 'clue beginner'],
+				allItems: Clues.Beginner.allItems,
+				kcActivity: {
+					Default: async user => user.getOpenableScore(23_245)
+				},
+				items: cluesBeginnerCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesBeginnerCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Easy Treasure Trails': {
-			alias: ['easy', 'clues easy', 'clue easy'],
-			allItems: Clues.Easy.allItems,
-			kcActivity: {
-				Default: async user => user.getOpenableScore(20_546)
+			'Easy Treasure Trails': {
+				alias: ['easy', 'clues easy', 'clue easy'],
+				allItems: Clues.Easy.allItems,
+				kcActivity: {
+					Default: async user => user.getOpenableScore(20_546)
+				},
+				items: cluesEasyCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesEasyCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Medium Treasure Trails': {
-			alias: ['medium', 'clues medium', 'clue medium'],
-			allItems: Clues.Medium.allItems,
-			kcActivity: {
-				Default: async user => user.getOpenableScore(20_545)
+			'Medium Treasure Trails': {
+				alias: ['medium', 'clues medium', 'clue medium'],
+				allItems: Clues.Medium.allItems,
+				kcActivity: {
+					Default: async user => user.getOpenableScore(20_545)
+				},
+				items: cluesMediumCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesMediumCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Hard Treasure Trails': {
-			alias: ['hard', 'clues hard', 'clue hard'],
-			allItems: Clues.Hard.allItems,
-			kcActivity: {
-				Default: async user => user.getOpenableScore(20_544)
+			'Hard Treasure Trails': {
+				alias: ['hard', 'clues hard', 'clue hard'],
+				allItems: Clues.Hard.allItems,
+				kcActivity: {
+					Default: async user => user.getOpenableScore(20_544)
+				},
+				items: cluesHardCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesHardCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Elite Treasure Trails': {
-			alias: ['elite', 'clues elite', 'clue elite'],
-			allItems: Clues.Elite.allItems,
-			kcActivity: {
-				Default: async user => user.getOpenableScore(20_543)
+			'Elite Treasure Trails': {
+				alias: ['elite', 'clues elite', 'clue elite'],
+				allItems: Clues.Elite.allItems,
+				kcActivity: {
+					Default: async user => user.getOpenableScore(20_543)
+				},
+				items: cluesEliteCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesEliteCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Master Treasure Trails': {
-			alias: ['master', 'clues master', 'clue master'],
-			allItems: Clues.Master.allItems,
-			kcActivity: {
-				Default: async user => user.getOpenableScore(19_836)
+			'Master Treasure Trails': {
+				alias: ['master', 'clues master', 'clue master'],
+				allItems: Clues.Master.allItems,
+				kcActivity: {
+					Default: async user => user.getOpenableScore(19_836)
+				},
+				items: cluesMasterCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesMasterCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Grandmaster Treasure Trails': {
-			alias: ['grandmaster', 'clues grandmaster', 'clue grandmaster', 'clue gm', 'gm'],
-			allItems: GrandmasterClueTable.allItems,
-			kcActivity: {
-				Default: async user => user.getOpenableScore(19_838)
+			'Grandmaster Treasure Trails': {
+				alias: ['grandmaster', 'clues grandmaster', 'clue grandmaster', 'clue gm', 'gm'],
+				allItems: GrandmasterClueTable.allItems,
+				kcActivity: {
+					Default: async user => user.getOpenableScore(19_838)
+				},
+				items: cluesGrandmasterCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesGrandmasterCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Hard Treasure Trail Rewards (Rare)': {
-			alias: [
-				'hard rares',
-				'clues hard rares',
-				'clue hard rares',
-				'clue rare hard',
-				'clue rares hard',
-				'clues rares hard',
-				'clues rare hard'
-			],
-			kcActivity: {
-				Default: async user => user.getOpenableScore(20_544)
+			'Hard Treasure Trail Rewards (Rare)': {
+				alias: [
+					'hard rares',
+					'clues hard rares',
+					'clue hard rares',
+					'clue rare hard',
+					'clue rares hard',
+					'clues rares hard',
+					'clues rare hard'
+				],
+				kcActivity: {
+					Default: async user => user.getOpenableScore(20_544)
+				},
+				items: cluesHardRareCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesHardRareCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Elite Treasure Trail Rewards (Rare)': {
-			alias: [
-				'elite rares',
-				'clues elite rares',
-				'clue elite rares',
-				'clue rare elite',
-				'clue rares elite',
-				'clues rares elite',
-				'clues rare elite'
-			],
-			kcActivity: {
-				Default: async user => user.getOpenableScore(20_543)
+			'Elite Treasure Trail Rewards (Rare)': {
+				alias: [
+					'elite rares',
+					'clues elite rares',
+					'clue elite rares',
+					'clue rare elite',
+					'clue rares elite',
+					'clues rares elite',
+					'clues rare elite'
+				],
+				kcActivity: {
+					Default: async user => user.getOpenableScore(20_543)
+				},
+				items: cluesEliteRareCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesEliteRareCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Master Treasure Trail Rewards (Rare)': {
-			alias: [
-				'master rares',
-				'clues master rares',
-				'clue master rares',
-				'clue rare master',
-				'clue rares master',
-				'clues rares master',
-				'clues rare master'
-			],
-			kcActivity: {
-				Default: async user => user.getOpenableScore(19_836)
+			'Master Treasure Trail Rewards (Rare)': {
+				alias: [
+					'master rares',
+					'clues master rares',
+					'clue master rares',
+					'clue rare master',
+					'clue rares master',
+					'clues rares master',
+					'clues rare master'
+				],
+				kcActivity: {
+					Default: async user => user.getOpenableScore(19_836)
+				},
+				items: cluesMasterRareCL,
+				roleCategory: ['clues'],
+				isActivity: true
 			},
-			items: cluesMasterRareCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Shared Treasure Trail Rewards': {
-			alias: ['shared', 'clues shared', 'clue shared'],
-			items: cluesSharedCL,
-			roleCategory: ['clues'],
-			isActivity: true
-		},
-		'Rare Treasure Trail Rewards': {
-			alias: ['clues rare', 'rares'],
-			items: [...cluesHardRareCL, ...cluesEliteRareCL, ...cluesMasterRareCL],
-			roleCategory: ['clues'],
-			isActivity: true
+			'Shared Treasure Trail Rewards': {
+				alias: ['shared', 'clues shared', 'clue shared'],
+				items: cluesSharedCL,
+				roleCategory: ['clues'],
+				isActivity: true
+			},
+			'Rare Treasure Trail Rewards': {
+				alias: ['clues rare', 'rares'],
+				items: [...cluesHardRareCL, ...cluesEliteRareCL, ...cluesMasterRareCL],
+				roleCategory: ['clues'],
+				isActivity: true
+			}
 		}
 	},
 	Minigames: {
-		'Barbarian Assault': {
-			alias: ['ba', 'barb assault', 'barbarian assault'],
-			items: barbarianAssaultCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Brimhaven Agility Arena': {
-			alias: ['aa', 'agility arena'],
-			items: brimhavenAgilityArenaCL,
-			roleCategory: ['minigames', 'skilling'],
-			isActivity: true
-		},
-		'Castle Wars': {
-			alias: ['cw', 'castle wars'],
-			items: castleWarsCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Fishing Trawler': {
-			alias: ['trawler', 'ft', 'fishing trawler'],
-			allItems: resolveItems([
-				'Broken arrow',
-				'Broken glass',
-				'Broken staff',
-				'Buttons',
-				'Damaged armour',
-				'Old boot',
-				'Oyster',
-				'Pot',
-				'Rusty sword',
-				'Raw shrimps',
-				'Raw sardine',
-				'Raw anchovies',
-				'Raw tuna',
-				'Raw lobster',
-				'Raw swordfish',
-				'Raw shark',
-				'Raw sea turtle',
-				'Raw manta ray'
-			]),
-			items: fishingTrawlerCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Gnome Restaurant': {
-			alias: ['gnome', 'restaurant'],
-			allItems: resolveItems(['Snake charm', 'Gnomeball']),
-			items: gnomeRestaurantCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Hallowed Sepulchre': {
-			alias: ['sepulchre', 'hallowed sepulchre'],
-			allItems: sepulchreFloors.map(f => f.coffinTable.allItems).flat(100),
-			items: hallowedSepulchreCL,
-			roleCategory: ['minigames', 'skilling'],
-			isActivity: true
-		},
-		'Last Man Standing': {
-			enabled: false,
-			items: lastManStandingCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Magic Training Arena': {
-			alias: ['mta'],
-			items: magicTrainingArenaCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Mahogany Homes': {
-			items: mahoganyHomesCL,
-			roleCategory: ['minigames', 'skilling'],
-			isActivity: true
-		},
-		'Pest Control': {
-			enabled: false,
-			items: pestControlCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		"Rogues' Den": {
-			alias: ['rogues den', 'rd'],
-			items: roguesDenCL,
-			roleCategory: ['minigames', 'skilling'],
-			isActivity: true
-		},
-		"Shades of Mort'ton": {
-			enabled: false,
-			items: shadesOfMorttonCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Soul Wars': {
-			alias: ['soul wars', 'sw'],
-			items: soulWarsCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Temple Trekking': {
-			allItems: [
-				...HardEncounterLoot.allItems,
-				...EasyEncounterLoot.allItems,
-				...MediumEncounterLoot.allItems,
-				...[rewardTokens.hard, rewardTokens.medium, rewardTokens.easy]
-			],
-			alias: ['temple trekking', 'tt', 'temple', 'trek', 'trekking'],
-			items: templeTrekkingCL,
-			roleCategory: ['minigames', 'skilling'],
-			isActivity: true
-		},
-		'Tithe Farm': {
-			alias: ['tithe'],
-			kcActivity: {
-				Default: async user => user.settings.get(UserSettings.Stats.TitheFarmsCompleted)
+		activities: {
+			'Barbarian Assault': {
+				alias: ['ba', 'barb assault', 'barbarian assault'],
+				items: barbarianAssaultCL,
+				roleCategory: ['minigames'],
+				isActivity: true
 			},
-			items: titheFarmCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Trouble Brewing': {
-			enabled: false,
-			items: troubleBrewingCL,
-			roleCategory: ['minigames'],
-			isActivity: true
-		},
-		'Volcanic Mine': {
-			enabled: false,
-			items: volcanicMineCL,
-			roleCategory: ['minigames'],
-			isActivity: true
+			'Brimhaven Agility Arena': {
+				alias: ['aa', 'agility arena'],
+				items: brimhavenAgilityArenaCL,
+				roleCategory: ['minigames', 'skilling'],
+				isActivity: true
+			},
+			'Castle Wars': {
+				alias: ['cw', 'castle wars'],
+				items: castleWarsCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Fishing Trawler': {
+				alias: ['trawler', 'ft', 'fishing trawler'],
+				allItems: resolveItems([
+					'Broken arrow',
+					'Broken glass',
+					'Broken staff',
+					'Buttons',
+					'Damaged armour',
+					'Old boot',
+					'Oyster',
+					'Pot',
+					'Rusty sword',
+					'Raw shrimps',
+					'Raw sardine',
+					'Raw anchovies',
+					'Raw tuna',
+					'Raw lobster',
+					'Raw swordfish',
+					'Raw shark',
+					'Raw sea turtle',
+					'Raw manta ray'
+				]),
+				items: fishingTrawlerCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Gnome Restaurant': {
+				alias: ['gnome', 'restaurant'],
+				allItems: resolveItems(['Snake charm', 'Gnomeball']),
+				items: gnomeRestaurantCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Hallowed Sepulchre': {
+				alias: ['sepulchre', 'hallowed sepulchre'],
+				allItems: sepulchreFloors.map(f => f.coffinTable.allItems).flat(100),
+				items: hallowedSepulchreCL,
+				roleCategory: ['minigames', 'skilling'],
+				isActivity: true
+			},
+			'Last Man Standing': {
+				enabled: false,
+				items: lastManStandingCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Magic Training Arena': {
+				alias: ['mta'],
+				items: magicTrainingArenaCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Mahogany Homes': {
+				items: mahoganyHomesCL,
+				roleCategory: ['minigames', 'skilling'],
+				isActivity: true
+			},
+			'Pest Control': {
+				enabled: false,
+				items: pestControlCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			"Rogues' Den": {
+				alias: ['rogues den', 'rd'],
+				items: roguesDenCL,
+				roleCategory: ['minigames', 'skilling'],
+				isActivity: true
+			},
+			"Shades of Mort'ton": {
+				enabled: false,
+				items: shadesOfMorttonCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Soul Wars': {
+				alias: ['soul wars', 'sw'],
+				items: soulWarsCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Temple Trekking': {
+				allItems: [
+					...HardEncounterLoot.allItems,
+					...EasyEncounterLoot.allItems,
+					...MediumEncounterLoot.allItems,
+					...[rewardTokens.hard, rewardTokens.medium, rewardTokens.easy]
+				],
+				alias: ['temple trekking', 'tt', 'temple', 'trek', 'trekking'],
+				items: templeTrekkingCL,
+				roleCategory: ['minigames', 'skilling'],
+				isActivity: true
+			},
+			'Tithe Farm': {
+				alias: ['tithe'],
+				kcActivity: {
+					Default: async user => user.settings.get(UserSettings.Stats.TitheFarmsCompleted)
+				},
+				items: titheFarmCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Trouble Brewing': {
+				enabled: false,
+				items: troubleBrewingCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			},
+			'Volcanic Mine': {
+				enabled: false,
+				items: volcanicMineCL,
+				roleCategory: ['minigames'],
+				isActivity: true
+			}
 		}
 	},
 	Other: {
-		'Aerial Fishing': {
-			alias: ['af', 'aerial fishing'],
-			items: aerialFishingCL,
-			roleCategory: ['skilling']
-		},
-		'All Pets': {
-			alias: ['pet', 'pets'],
-			items: allPetsCL,
-			roleCategory: ['pets']
-		},
-		Camdozaal: {
-			enabled: false,
-			items: camdozaalCL
-		},
-		"Champion's Challenge": {
-			alias: ['champion', 'champion scrolls', 'champion scroll', 'scroll', 'scrolls'],
-			items: championsChallengeCL,
-			isActivity: true
-		},
-		'Chaos Druids': {
-			allItems: Monsters.ChaosDruid.allItems,
-			kcActivity: Monsters.ChaosDruid.name,
-			items: chaosDruisCL
-		},
-		'Chompy Birds': {
-			alias: ['chompy', 'bgc', 'big chompy hunting'],
-			kcActivity: 'BigChompyBirdHunting',
-			items: chompyBirdsCL
-		},
-		'Creature Creation': {
-			enabled: false,
-			items: creatureCreationCL
-		},
-		Cyclopes: {
-			alias: ['cyclops', 'wg', 'warriors guild', 'warrior guild'],
-			kcActivity: Monsters.Cyclops.name,
-			allItems: Monsters.Cyclops.allItems,
-			items: cyclopsCL
-		},
-		'Fossil Island Notes': {
-			enabled: false,
-			items: fossilIslandNotesCL
-		},
-		"Glough's Experiments": {
-			alias: Monsters.DemonicGorilla.aliases,
-			allItems: Monsters.DemonicGorilla.allItems,
-			kcActivity: Monsters.DemonicGorilla.name,
-			items: demonicGorillaCL
-		},
-		'Monkey Backpacks': {
-			alias: ['monkey', 'monkey bps', 'backpacks'],
-			kcActivity: {
-				Default: async user => user.settings.get(UserSettings.LapsScores)[6]
+		activities: {
+			'Aerial Fishing': {
+				alias: ['af', 'aerial fishing'],
+				items: aerialFishingCL,
+				roleCategory: ['skilling']
 			},
-			items: monkeyBackpacksCL,
-			roleCategory: ['skilling'],
-			isActivity: true
-		},
-		'Motherlode Mine': {
-			enabled: false,
-			items: motherlodeMineCL
-		},
-		'Random Events': {
-			alias: ['random'],
-			items: randomEventsCL
-		},
-		Revenants: {
-			enabled: false,
-			items: revenantsCL
-		},
-		'Rooftop Agility': {
-			alias: ['rooftop', 'laps', 'agility', 'agil'],
-			items: rooftopAgilityCL,
-			roleCategory: ['skilling'],
-			isActivity: true
-		},
-		'Shayzien Armour': {
-			enabled: false,
-			items: shayzienArmourCL
-		},
-		'Shooting Stars': { enabled: false, items: resolveItems(['Celestial ring (uncharged)', 'Star fragment']) },
-		'Skilling Pets': {
-			alias: ['skill pets'],
-			items: skillingPetsCL
-		},
-		Slayer: {
-			alias: ['slay'],
-			items: slayerCL,
-			roleCategory: ['slayer']
-		},
-		TzHaar: {
-			kcActivity: Monsters.TzHaarKet.name,
-			allItems: Monsters.TzHaarKet.allItems,
-			items: tzHaarCL
-		},
-		Miscellaneous: {
-			alias: ['misc'],
-			items: miscellaneousCL
-		},
-		'Ourania Delivery Service': {
-			alias: ['ods', 'ourania'],
-			items: resolveItems([
-				'Master runecrafter hat',
-				'Master runecrafter robe',
-				'Master runecrafter skirt',
-				'Master runecrafter boots',
-				'Elder thread',
-				'Elder talisman'
-			])
+			'All Pets': {
+				alias: ['pet', 'pets'],
+				items: allPetsCL,
+				roleCategory: ['pets']
+			},
+			Camdozaal: {
+				enabled: false,
+				items: camdozaalCL
+			},
+			"Champion's Challenge": {
+				alias: ['champion', 'champion scrolls', 'champion scroll', 'scroll', 'scrolls'],
+				items: championsChallengeCL,
+				isActivity: true
+			},
+			'Chaos Druids': {
+				allItems: Monsters.ChaosDruid.allItems,
+				kcActivity: Monsters.ChaosDruid.name,
+				items: chaosDruisCL
+			},
+			'Chompy Birds': {
+				alias: ['chompy', 'bgc', 'big chompy hunting'],
+				kcActivity: 'BigChompyBirdHunting',
+				items: chompyBirdsCL
+			},
+			'Creature Creation': {
+				enabled: false,
+				items: creatureCreationCL
+			},
+			Cyclopes: {
+				alias: ['cyclops', 'wg', 'warriors guild', 'warrior guild'],
+				kcActivity: Monsters.Cyclops.name,
+				allItems: Monsters.Cyclops.allItems,
+				items: cyclopsCL
+			},
+			'Fossil Island Notes': {
+				enabled: false,
+				items: fossilIslandNotesCL
+			},
+			"Glough's Experiments": {
+				alias: Monsters.DemonicGorilla.aliases,
+				allItems: Monsters.DemonicGorilla.allItems,
+				kcActivity: Monsters.DemonicGorilla.name,
+				items: demonicGorillaCL
+			},
+			'Monkey Backpacks': {
+				alias: ['monkey', 'monkey bps', 'backpacks'],
+				kcActivity: {
+					Default: async user => user.settings.get(UserSettings.LapsScores)[6]
+				},
+				items: monkeyBackpacksCL,
+				roleCategory: ['skilling'],
+				isActivity: true
+			},
+			'Motherlode Mine': {
+				enabled: false,
+				items: motherlodeMineCL
+			},
+			'Random Events': {
+				alias: ['random'],
+				items: randomEventsCL
+			},
+			Revenants: {
+				enabled: false,
+				items: revenantsCL
+			},
+			'Rooftop Agility': {
+				alias: ['rooftop', 'laps', 'agility', 'agil'],
+				items: rooftopAgilityCL,
+				roleCategory: ['skilling'],
+				isActivity: true
+			},
+			'Shayzien Armour': {
+				enabled: false,
+				items: shayzienArmourCL
+			},
+			'Shooting Stars': { enabled: false, items: resolveItems(['Celestial ring (uncharged)', 'Star fragment']) },
+			'Skilling Pets': {
+				alias: ['skill pets'],
+				items: skillingPetsCL
+			},
+			Slayer: {
+				alias: ['slay'],
+				items: slayerCL,
+				roleCategory: ['slayer']
+			},
+			TzHaar: {
+				kcActivity: Monsters.TzHaarKet.name,
+				allItems: Monsters.TzHaarKet.allItems,
+				items: tzHaarCL
+			},
+			Miscellaneous: {
+				alias: ['misc'],
+				items: miscellaneousCL
+			},
+			'Ourania Delivery Service': {
+				alias: ['ods', 'ourania'],
+				items: resolveItems([
+					'Master runecrafter hat',
+					'Master runecrafter robe',
+					'Master runecrafter skirt',
+					'Master runecrafter boots',
+					'Elder thread',
+					'Elder talisman'
+				])
+			}
 		}
 	},
 	Custom: {
-		Holiday: {
-			counts: false,
-			items: holidayCL
-		},
-		Daily: {
-			counts: false,
-			alias: ['diango'],
-			items: dailyCL
-		},
-		Capes: {
-			counts: false,
-			items: capesCL
-		},
-		Quest: {
-			counts: false,
-			items: questCL
-		},
-		'Custom Pets': {
-			alias: ['cpets', 'custom pet', 'cpet', 'custom pet'],
-			items: customPetsCL
-		},
-		'Custom Pets (Discontinued)': {
-			alias: ['dcpets', 'disc custom pet', 'dcpet', 'dcp', 'discontinued custom pet'],
-			items: discontinuedCustomPetsCL,
-			counts: false
-		},
-		Skilling: {
-			items: resolveItems([
-				'Prospector helmet',
-				'Prospector jacket',
-				'Prospector legs',
-				'Prospector boots',
-				'Mining gloves',
-				'Superior mining gloves',
-				'Expert mining gloves',
-				'Golden nugget',
-				'Unidentified minerals',
-				'Big swordfish',
-				'Big shark',
-				'Big bass',
-				'Tangleroot',
-				'Bottomless compost bucket',
-				"Farmer's strawhat",
-				"Farmer's jacket",
-				"Farmer's shirt",
-				"Farmer's boro trousers",
-				"Farmer's boots",
-				"Pharaoh's sceptre (3)",
-				'Baby chinchompa',
-				'Kyatt hat',
-				'Kyatt top',
-				'Kyatt legs',
-				'Spotted cape',
-				'Spottier cape',
-				'Gloves of silence',
-				'Small pouch',
-				'Medium pouch',
-				'Large pouch',
-				'Giant pouch',
-				'Crystal pickaxe',
-				'Crystal axe',
-				'Crystal harpoon',
-				'Rift guardian',
-				'Rock golem',
-				'Heron',
-				'Rocky',
-				'Herbi',
-				'Beaver'
-			]),
-			roleCategory: ['skilling']
-		},
-		Dungeoneering: {
-			alias: ['dg', 'dung', 'dungeoneering'],
-			items: resolveItems([
-				'Chaotic rapier',
-				'Chaotic longsword',
-				'Chaotic maul',
-				'Chaotic staff',
-				'Chaotic crossbow',
-				'Offhand Chaotic rapier',
-				'Offhand Chaotic longsword',
-				'Offhand chaotic crossbow',
-				'Scroll of life',
-				'Scroll of efficiency',
-				'Scroll of cleansing',
-				'Scroll of dexterity',
-				'Scroll of teleportation',
-				'Scroll of farming',
-				'Scroll of proficiency',
-				'Scroll of mystery',
-				'Scroll of longevity',
-				'Farseer kiteshield',
-				'Chaotic remnant',
-				'Frosty',
-				'Gorajan shards',
-				'Amulet of zealots',
-				'Herbicide',
-				'Gorajan warrior helmet',
-				'Gorajan warrior top',
-				'Gorajan warrior legs',
-				'Gorajan warrior gloves',
-				'Gorajan warrior boots',
-				'Gorajan archer helmet',
-				'Gorajan archer top',
-				'Gorajan archer legs',
-				'Gorajan archer gloves',
-				'Gorajan archer boots',
-				'Gorajan occult helmet',
-				'Gorajan occult top',
-				'Gorajan occult legs',
-				'Gorajan occult gloves',
-				'Gorajan occult boots',
-				'Arcane blast necklace',
-				'Farsight snapshot necklace',
-				"Brawler's hook necklace"
-			]),
-			roleCategory: ['skilling']
-		},
-		Miscellaneous: {
-			alias: ['misc'],
-			items: miscellaneousCL
-		},
-		Farming: {
-			counts: false,
-			items: allFarmingItems
+		activities: {
+			Holiday: {
+				counts: false,
+				items: holidayCL
+			},
+			Daily: {
+				counts: false,
+				alias: ['diango'],
+				items: dailyCL
+			},
+			Capes: {
+				counts: false,
+				items: capesCL
+			},
+			Quest: {
+				counts: false,
+				items: questCL
+			},
+			'Custom Pets': {
+				alias: ['cpets', 'custom pet', 'cpet', 'custom pet'],
+				items: customPetsCL
+			},
+			'Custom Pets (Discontinued)': {
+				alias: ['dcpets', 'disc custom pet', 'dcpet', 'dcp', 'discontinued custom pet'],
+				items: discontinuedCustomPetsCL,
+				counts: false
+			},
+			Skilling: {
+				items: resolveItems([
+					'Prospector helmet',
+					'Prospector jacket',
+					'Prospector legs',
+					'Prospector boots',
+					'Mining gloves',
+					'Superior mining gloves',
+					'Expert mining gloves',
+					'Golden nugget',
+					'Unidentified minerals',
+					'Big swordfish',
+					'Big shark',
+					'Big bass',
+					'Tangleroot',
+					'Bottomless compost bucket',
+					"Farmer's strawhat",
+					"Farmer's jacket",
+					"Farmer's shirt",
+					"Farmer's boro trousers",
+					"Farmer's boots",
+					"Pharaoh's sceptre (3)",
+					'Baby chinchompa',
+					'Kyatt hat',
+					'Kyatt top',
+					'Kyatt legs',
+					'Spotted cape',
+					'Spottier cape',
+					'Gloves of silence',
+					'Small pouch',
+					'Medium pouch',
+					'Large pouch',
+					'Giant pouch',
+					'Crystal pickaxe',
+					'Crystal axe',
+					'Crystal harpoon',
+					'Rift guardian',
+					'Rock golem',
+					'Heron',
+					'Rocky',
+					'Herbi',
+					'Beaver'
+				]),
+				roleCategory: ['skilling']
+			},
+			Dungeoneering: {
+				alias: ['dg', 'dung', 'dungeoneering'],
+				items: resolveItems([
+					'Chaotic rapier',
+					'Chaotic longsword',
+					'Chaotic maul',
+					'Chaotic staff',
+					'Chaotic crossbow',
+					'Offhand Chaotic rapier',
+					'Offhand Chaotic longsword',
+					'Offhand chaotic crossbow',
+					'Scroll of life',
+					'Scroll of efficiency',
+					'Scroll of cleansing',
+					'Scroll of dexterity',
+					'Scroll of teleportation',
+					'Scroll of farming',
+					'Scroll of proficiency',
+					'Scroll of mystery',
+					'Scroll of longevity',
+					'Farseer kiteshield',
+					'Chaotic remnant',
+					'Frosty',
+					'Gorajan shards',
+					'Amulet of zealots',
+					'Herbicide',
+					'Gorajan warrior helmet',
+					'Gorajan warrior top',
+					'Gorajan warrior legs',
+					'Gorajan warrior gloves',
+					'Gorajan warrior boots',
+					'Gorajan archer helmet',
+					'Gorajan archer top',
+					'Gorajan archer legs',
+					'Gorajan archer gloves',
+					'Gorajan archer boots',
+					'Gorajan occult helmet',
+					'Gorajan occult top',
+					'Gorajan occult legs',
+					'Gorajan occult gloves',
+					'Gorajan occult boots',
+					'Arcane blast necklace',
+					'Farsight snapshot necklace',
+					"Brawler's hook necklace"
+				]),
+				roleCategory: ['skilling']
+			},
+			Miscellaneous: {
+				alias: ['misc'],
+				items: miscellaneousCL
+			},
+			Farming: {
+				counts: false,
+				items: allFarmingItems
+			}
 		}
 	}
 };
@@ -943,7 +977,7 @@ export const allDroppedItems = [
 	...new Set([
 		...Object.entries(allCollectionLogs)
 			.map(e =>
-				Object.entries(e[1])
+				Object.entries(e[1].activities)
 					.filter(f => f[1].enabled === undefined && f[1].hidden === undefined && f[1].counts === undefined)
 					.map(a => [...new Set([...a[1].items, ...(a[1].allItems !== undefined ? a[1].allItems : [])])])
 			)
@@ -959,7 +993,7 @@ export const allCLItems = [
 	...new Set(
 		Object.entries(allCollectionLogs)
 			.map(e =>
-				Object.entries(e[1])
+				Object.entries(e[1].activities)
 					.filter(f => f[1].enabled === undefined && f[1].hidden === undefined && f[1].counts === undefined)
 					.map(a => a[1].items)
 			)
@@ -985,7 +1019,7 @@ export function getItemsRole(role: TRoleCategories) {
 		...new Set(
 			Object.values(allCollectionLogs)
 				.map(c =>
-					Object.values(c)
+					Object.values(c.activities)
 						.map(a => {
 							if (a.hidden === undefined || a.enabled === undefined)
 								return a.roleCategory?.includes(role) ? a.items : undefined;
@@ -1016,7 +1050,7 @@ function getLeftList(
 	for (const [category, entries] of Object.entries(allCollectionLogs)) {
 		if (category === checkCategory) {
 			// Sort list by alphabetical order
-			const catEntries = Object.entries(entries).sort((a, b) => 0 - (a > b ? -1 : 1));
+			const catEntries = Object.entries(entries.activities).sort((a, b) => 0 - (a > b ? -1 : 1));
 			for (const [activityName, attributes] of catEntries) {
 				if (attributes.enabled === false || attributes.hidden === true) continue;
 				let items: number[] = [];
@@ -1064,8 +1098,8 @@ export function getPossibleOptions() {
 
 	// Get categories and enabled activities
 	for (const [category, entries] of Object.entries(allCollectionLogs)) {
-		categories.push(['General', category, '']);
-		for (const [activityName, attributes] of Object.entries(entries)) {
+		categories.push(['General', category, entries.alias ? entries.alias.join(', ') : '']);
+		for (const [activityName, attributes] of Object.entries(entries.activities)) {
 			if (attributes.enabled === false || attributes.hidden === true) continue;
 			categories.push(['Activity', activityName, attributes.alias ? attributes.alias.join(', ') : '']);
 		}
@@ -1085,10 +1119,13 @@ export function getPossibleOptions() {
 export function getCollectionItems(collection: string, allItems = false, removeCoins = false): number[] {
 	let _items: number[] = [];
 	loop: for (const [category, entries] of Object.entries(allCollectionLogs)) {
-		if (stringMatches(category, collection)) {
+		if (
+			stringMatches(category, collection) ||
+			(entries.alias && entries.alias.some(a => stringMatches(a, collection)))
+		) {
 			_items = [
 				...new Set(
-					Object.entries(entries)
+					Object.entries(entries.activities)
 						.filter(e => e[1].enabled === undefined && e[1].hidden === undefined)
 						.map(e => [...new Set([...e[1].items, ...(allItems && e[1].allItems ? e[1].allItems : [])])])
 						.flat(2)
@@ -1096,7 +1133,7 @@ export function getCollectionItems(collection: string, allItems = false, removeC
 			];
 			break;
 		}
-		for (const [activityName, attributes] of Object.entries(entries)) {
+		for (const [activityName, attributes] of Object.entries(entries.activities)) {
 			if (
 				attributes.enabled === undefined &&
 				(stringMatches(activityName, collection) ||
@@ -1153,7 +1190,7 @@ export async function getCollection(options: {
 	const [totalCl, userAmount] = getUserClData(userCheckBank.bank, clItems);
 
 	for (const [category, entries] of Object.entries(allCollectionLogs)) {
-		if (stringMatches(category, search)) {
+		if (stringMatches(category, search) || (entries.alias && entries.alias.some(a => stringMatches(a, search)))) {
 			return {
 				category,
 				name: category,
@@ -1164,7 +1201,7 @@ export async function getCollection(options: {
 				userItems: userCheckBank
 			};
 		}
-		for (const [activityName, attributes] of Object.entries(entries)) {
+		for (const [activityName, attributes] of Object.entries(entries.activities)) {
 			if (
 				attributes.enabled !== false &&
 				(stringMatches(activityName, search) ||

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1656,7 +1656,6 @@ export const slayerCL = resolveItems([
 	'Monkey tail',
 	'Ballista limbs',
 	'Ballista spring',
-	'Black mask',
 	'Granite longsword',
 	'Dragon chainbody'
 	// Not obtainable yet

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2050,6 +2050,5 @@ export const customBossesDropsThatCantBeDroppedInMBs = [
 	...nexCL,
 	...kalphiteKingCL,
 	...ignecarusCL,
-	...treeBeardCL,
-	...seaKrakenCL
+	...treeBeardCL
 ];

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -43,7 +43,10 @@ export interface ICollectionActivity {
 }
 
 export interface ICollection {
-	[key: string]: ICollectionActivity;
+	[key: string]: {
+		alias?: string[];
+		activities: ICollectionActivity;
+	};
 }
 
 export const abyssalSireCL = resolveItems([
@@ -2020,4 +2023,34 @@ export const kalphiteKingCL = resolveItems([
 	'Baby kalphite king'
 ]);
 
-export const customBossesCL = [...kingGoldemarCL, ...abyssalDragonCL, ...vasaMagusCL, ...nexCL, ...kalphiteKingCL];
+export const ignecarusCL = resolveItems(['Ignecarus scales', 'Ignecarus dragonclaw', 'Dragon egg', 'Ignis ring']);
+
+export const treeBeardCL = resolveItems([
+	// Tangleroot pets
+	20_661,
+	24_555,
+	24_557,
+	24_559,
+	24_561,
+	24_563,
+	'Mysterious seed',
+	'Ent hide'
+]);
+
+export const seaKrakenCL = resolveItems([
+	// Tangleroot pets
+	'Fish sack',
+	'Pufferfish',
+	'Fishing trophy'
+]);
+
+export const customBossesDropsThatCantBeDroppedInMBs = [
+	...kingGoldemarCL,
+	...abyssalDragonCL,
+	...vasaMagusCL,
+	...nexCL,
+	...kalphiteKingCL,
+	...ignecarusCL,
+	...treeBeardCL,
+	...seaKrakenCL
+];

--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -13,7 +13,7 @@ import { itemNameFromID, removeDuplicatesFromArray } from '../util';
 import itemID from '../util/itemID';
 import resolveItems from '../util/resolveItems';
 import { LampTable } from '../xpLamps';
-import { chambersOfXericCl, customBossesCL, frozenKeyPieces } from './CollectionsExport';
+import { chambersOfXericCl, customBossesDropsThatCantBeDroppedInMBs, frozenKeyPieces } from './CollectionsExport';
 
 interface Openable {
 	name: string;
@@ -490,7 +490,7 @@ let allItemsIDs = Openables.map(i => (typeof i.table !== 'function' && i.table.a
 allItemsIDs = removeDuplicatesFromArray(allItemsIDs);
 const cantBeDropped = [
 	...chambersOfXericCl,
-	...customBossesCL,
+	...customBossesDropsThatCantBeDroppedInMBs,
 	itemID('Abyssal pouch'),
 	itemID('Dwarven crate'),
 	itemID('Halloween mask set'),

--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -486,8 +486,8 @@ export default class CollectionLogTask extends Task {
 				// Canvas height - top area until list starts - left area, where list should end
 				const listHeightSpace = ctx.canvas.height - 62 - 13;
 
+				// Check if in the start of the list
 				if (selectedPos <= listHeightSpace) {
-					// Check if in the start of the list
 					ctx.drawImage(
 						leftListCanvas,
 						0,
@@ -504,7 +504,6 @@ export default class CollectionLogTask extends Task {
 					leftListCanvas.height - listHeightSpace <=
 					selectedPos
 				) {
-					// Check if in the start of the list
 					ctx.drawImage(
 						leftListCanvas,
 						0,

--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -334,8 +334,8 @@ export default class CollectionLogTask extends Task {
 			this.drawText(
 				ctx,
 				cl,
-				x + this.scls.tabBorderInactive.width / 2,
-				39 + this.scls.tabBorderInactive.height / 2 + 6 // 6 is to proper center the text
+				Math.floor(x + this.scls.tabBorderInactive.width / 2),
+				Math.floor(39 + this.scls.tabBorderInactive.height / 2 + 6) // 6 is to proper center the text
 			);
 			aclIndex++;
 		}
@@ -477,7 +477,7 @@ export default class CollectionLogTask extends Task {
 		ctx.restore();
 		if (leftListCanvas && !fullSize) {
 			if (!Boolean(flags.tall)) {
-				let selectedPos = 0;
+				let selectedPos = 8;
 				const listItemSize = 15;
 				for (const name of objectKeys(collectionLog.leftList!)) {
 					if (name === collectionLog.name) break;
@@ -485,6 +485,7 @@ export default class CollectionLogTask extends Task {
 				}
 				// Canvas height - top area until list starts - left area, where list should end
 				const listHeightSpace = ctx.canvas.height - 62 - 13;
+
 				if (selectedPos <= listHeightSpace) {
 					// Check if in the start of the list
 					ctx.drawImage(
@@ -500,7 +501,8 @@ export default class CollectionLogTask extends Task {
 					);
 				} else if (
 					// Check if in the end of the list
-					Math.ceil(leftListCanvas.height / listHeightSpace) === Math.ceil(selectedPos / listHeightSpace)
+					leftListCanvas.height - listHeightSpace <=
+					selectedPos
 				) {
 					// Check if in the start of the list
 					ctx.drawImage(


### PR DESCRIPTION
### Description:

- Collection log tab names are being improperly drawn;
- You cant do =cl boss;
- Ignecarus, Treebeard and Sea Kraken are missing from the Bosses Log;
- It is possible to drawn the selected activity in the left list  and have it hidden if its top-leftmost pixel is still visible.

### Changes:

- Fix left list drawn logic;
- Add missing activities;
- Change ICollection to allow aliases;
- Applies Math.floor to category tabs;

### Other checks:

-   [X] I have tested all my changes thoroughly.

Tabs are properly drawn
![image](https://user-images.githubusercontent.com/19570528/126794560-8963cc57-3213-4fb1-b236-793212aaeab2.png)

Hespori is drawn as last item, as it is still visible in the 'first' page of the list
![image](https://user-images.githubusercontent.com/19570528/126794644-861a8e2b-8a19-48ce-9b60-a393c7b37d3e.png)

Scorpia is drawn as active first item of the 'last' page of the list
![image](https://user-images.githubusercontent.com/19570528/126794668-0979e62d-34c4-4007-aa4c-284d70fcbaa8.png)

Kree is properly centered as it isnt either on the  'first' or 'last' page
![image](https://user-images.githubusercontent.com/19570528/126794724-1f5e50d6-2df3-467e-ad82-2c3da5c29cc4.png)