### PR TITLE
Add items bought from tokkulshop.ts to the collection log

### DIFF
--- a/src/commands/Minion/tokkulshop.ts
+++ b/src/commands/Minion/tokkulshop.ts
@@ -1,6 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Bank, Monsters } from 'oldschooljs';
-import { addBanks, bankHasAllItemsFromBank, removeBankFromBank } from 'oldschooljs/dist/util';
+import { bankHasAllItemsFromBank } from 'oldschooljs/dist/util';
 
 import TokkulShopItem from '../../lib/data/buyables/tokkulBuyables';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -100,10 +100,8 @@ export default class extends BotCommand {
 			} **${items}** for **${tokkul}**.`
 		);
 
-		await msg.author.settings.update(
-			UserSettings.Bank,
-			addBanks([outItems.bank, removeBankFromBank(userBank, inItems.bank)])
-		);
+		await msg.author.addItemsToBank(outItems.bank, true);
+		await msg.author.removeItemsFromBank(inItems.bank);
 
 		return msg.channel.send(`You ${type === 'buy' ? 'bought' : 'sold'} **${items}** for **${tokkul}**.`);
 	}


### PR DESCRIPTION
### Description:

- Tokkulshop is not adding items bought to the user collection log. Not sure if intended or not.

### Changes:

- Change it so, when items are added to the bank, also adds to the collection log.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/126814983-9f9ae5d5-e773-4b29-94ae-75f32d49ac05.png)
![image](https://user-images.githubusercontent.com/19570528/126814962-0945e255-4f0a-4597-9e35-7aff0505bf30.png)