### PR TITLE
Fix Tangleroot loot check from hespori.

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -358,11 +358,7 @@ export default class extends Task {
 				await user.incrementMonsterScore(Monsters.Hespori.id);
 				const hesporiLoot = Monsters.Hespori.kill(1, { farmingLevel: currentFarmingLevel });
 				loot = hesporiLoot.bank;
-				for (const hesporiLoot of Object.keys(loot)) {
-					if (itemID(hesporiLoot) === itemID('Tangleroot')) {
-						tangleroot = true;
-					}
-				}
+				if (hesporiLoot.amount('Tangleroot')) tangleroot = true;
 			} else if (
 				patchType.patchPlanted &&
 				plantToHarvest.petChance &&


### PR DESCRIPTION
### Description:
The `itemID(hesporiLoot)` won't work because the Object.keys(loot) are already itemIds.
Was going change this to Number() instead of itemID, but there's no reason for use what's basically a forEach when we can simple use the Bank.amount() function.

### Changes:
Replaced for each loop with simple Bank.amount() call.

### Other checks:

-   [x] I have tested all my changes thoroughly.
