### PR TITLE
Prevent sacrifice changing custom minion icons

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -16,6 +16,7 @@ import {
 } from '../../lib/constants';
 import ClueTiers from '../../lib/minions/data/clueTiers';
 import { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
+import minionIcons from '../../lib/minions/data/minionIcons';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { getNewUser } from '../../lib/settings/settings';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -153,6 +154,21 @@ export default class MinionCommand extends BotCommand {
 	async seticon(msg: KlasaMessage, [icon]: [string]) {
 		if (msg.author.perkTier < PerkTier.Four) {
 			return msg.channel.send("You need to be a Tier 3 Patron to change your minion's icon to a custom icon.");
+		}
+
+		if (!icon) {
+			await msg.confirm('Would you like to return to your default minion icon?');
+			const sacValue = msg.author.settings.get(UserSettings.SacrificedValue);
+			let icon = null;
+			for (const sacIcon of minionIcons) {
+				if (sacValue < sacIcon.valueRequired) continue;
+				if (sacValue >= sacIcon.valueRequired) {
+					icon = sacIcon.emoji;
+					break;
+				}
+			}
+			await msg.author.settings.update(UserSettings.Minion.Icon, icon);
+			return msg.channel.send(`Restored your minion icon to ${icon ?? Emoji.Minion}.`);
 		}
 
 		const res = FormattedCustomEmoji.exec(icon);

--- a/src/commands/Minion/sacrifice.ts
+++ b/src/commands/Minion/sacrifice.ts
@@ -52,20 +52,22 @@ export default class extends BotCommand {
 
 		let str = '';
 		const currentIcon = msg.author.settings.get(UserSettings.Minion.Icon);
-		for (const icon of minionIcons) {
-			if (newValue < icon.valueRequired) continue;
-			if (newValue >= icon.valueRequired) {
-				if (currentIcon === icon.emoji) break;
-				await msg.author.settings.update(UserSettings.Minion.Icon, icon.emoji);
-				str += `\n\nYou have now unlocked the **${icon.name}** minion icon!`;
-				this.client.emit(
-					Events.ServerNotification,
-					`**${msg.author.username}** just unlocked the ${icon.emoji} icon for their minion.`
-				);
-				break;
+		// Ignores notifying the user/server if the user is using a custom icon
+		if (!currentIcon || minionIcons.find(m => m.emoji === currentIcon)) {
+			for (const icon of minionIcons) {
+				if (newValue < icon.valueRequired) continue;
+				if (newValue >= icon.valueRequired) {
+					if (currentIcon === icon.emoji) break;
+					await msg.author.settings.update(UserSettings.Minion.Icon, icon.emoji);
+					str += `\n\nYou have now unlocked the **${icon.name}** minion icon!`;
+					this.client.emit(
+						Events.ServerNotification,
+						`**${msg.author.username}** just unlocked the ${icon.emoji} icon for their minion.`
+					);
+					break;
+				}
 			}
 		}
-
 		return msg.channel.send(
 			`You sacrificed ${bankToSac}, with a value of ${totalPrice.toLocaleString()}gp (${Util.toKMB(
 				totalPrice


### PR DESCRIPTION
### Description:

- Users with custom icons for their minions (T3/m seticon) cant sacrifice without notifying the server and losing their minion icon.

### Changes:

- Disables icon changing when the user has a custom icon and sacrifices something;
- Allow user to restore minion icon when wanted by issuing m seticon without a parameter.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/126917430-761b06b1-b4eb-4f23-9097-82eb3602b3ae.png)
![image](https://user-images.githubusercontent.com/19570528/126917432-d89e4e3b-9370-44df-9ac8-9ad6c8ad2829.png)
![image](https://user-images.githubusercontent.com/19570528/126917434-2c0b4759-fba1-4131-876b-93326a440e0d.png)