### PR TITLE
Fix slayer index

### DIFF
--- a/src/lib/typeorm/SlayerTaskTable.entity.ts
+++ b/src/lib/typeorm/SlayerTaskTable.entity.ts
@@ -14,7 +14,7 @@ import { NewUserTable } from './NewUserTable.entity';
 
 @Check('quantity_remaining >= 0')
 @Entity('slayer_tasks')
-@Index('slayer_task_quantity_remaining', ['user_id', 'quantity_remaining'])
+@Index('slayer_task_quantity_remaining', ['user', 'quantityRemaining'])
 export class SlayerTaskTable extends BaseEntity {
 	@PrimaryGeneratedColumn('increment')
 	public id!: string;


### PR DESCRIPTION
### Description:

- Slayer index is malformed, using db column names instead of the code name of the field.

### Changes:

- Fix it

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/126992483-9c5bfd02-327b-4013-9516-69652341f581.png)