### PR TITLE
Add the "you have opened n x times" to any openable

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -156,9 +156,8 @@ export default class extends BotCommand {
 		}
 
 		await msg.author.removeItemFromBank(osjsOpenable.id, quantity);
-
 		const loot = osjsOpenable.open(quantity, {});
-
+		const score = msg.author.getOpenableScore(osjsOpenable.id) + quantity;
 		this.client.emit(
 			Events.Log,
 			`${msg.author.username}[${msg.author.id}] opened ${quantity} ${osjsOpenable.name}.`
@@ -173,6 +172,7 @@ export default class extends BotCommand {
 
 		return msg.channel.sendBankImage({
 			bank: loot,
+			content: `You have opened the ${osjsOpenable.name.toLowerCase()} ${score.toLocaleString()} times.`,
 			title: `You opened ${quantity} ${osjsOpenable.name}`,
 			flags: { showNewCL: 1, ...msg.flagArgs },
 			user: msg.author,
@@ -201,11 +201,8 @@ export default class extends BotCommand {
 		}
 
 		await msg.author.removeItemFromBank(botOpenable.itemID, quantity);
-
-		const score = msg.author.getOpenableScore(itemID('Spoils of war'));
-
+		const score = msg.author.getOpenableScore(botOpenable.itemID);
 		const loot = botOpenable.table.roll(quantity);
-
 		if (loot.has("Lil' creator")) {
 			this.client.emit(
 				Events.ServerNotification,
@@ -228,6 +225,9 @@ export default class extends BotCommand {
 
 		return msg.channel.sendBankImage({
 			bank: loot.values(),
+			content: `You have opened the ${botOpenable.name.toLowerCase()} ${(
+				score + quantity
+			).toLocaleString()} times.`,
 			title: `You opened ${quantity} ${botOpenable.name}`,
 			flags: { showNewCL: 1, ...msg.flagArgs },
 			user: msg.author,


### PR DESCRIPTION
### Description:

Only clues shows the 'You have opened x n times" (total);
This PR add that message for all openables.

### Changes:

Show score for all openables.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/127183598-c0f479cc-6d18-4e64-8df4-4266573d2f42.png)
![image](https://user-images.githubusercontent.com/19570528/127183588-f6816a9e-49c1-4dc1-9de0-3ddd0fcb6570.png)
![image](https://user-images.githubusercontent.com/19570528/127183623-4af53793-d0e3-466e-9c14-884bcd84ab3e.png)
![image](https://user-images.githubusercontent.com/19570528/127183639-78d575cd-7f83-40bc-ae58-14350d917faa.png)
![image](https://user-images.githubusercontent.com/19570528/127183658-4bae6f59-b369-406f-8862-94e36c332cc5.png)
