### PR TITLE
Fix GGS combat EXP

### DIFF
--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -560,7 +560,8 @@ export const vannakaMonsters: KillableMonster[] = [
 		],
 		healAmountNeeded: 20 * 12,
 		attackStyleToUse: GearStat.AttackSlash,
-		attackStylesUsed: [GearStat.AttackSlash, GearStat.AttackRanged, GearStat.AttackMagic]
+		attackStylesUsed: [GearStat.AttackSlash, GearStat.AttackRanged, GearStat.AttackMagic],
+		customMonsterHP: 900
 	},
 	{
 		id: Monsters.GreaterNechryael.id,

--- a/src/lib/minions/functions/index.ts
+++ b/src/lib/minions/functions/index.ts
@@ -70,14 +70,6 @@ export async function addMonsterXP(user: KlasaUser, params: AddMonsterXpParams) 
 		boostMethod
 	});
 
-	// Special use cases for some monsters
-	switch (params.monsterID) {
-		case Monsters.GrotesqueGuardians.id:
-			// Double quantity killed (Dawn and Dusk)
-			params.quantity *= 2;
-			break;
-	}
-
 	const monster = killableMonsters.find(mon => mon.id === params.monsterID);
 	let hp = miscHpMap[params.monsterID] ?? 1;
 	let xpMultiplier = 1;

--- a/src/lib/minions/functions/index.ts
+++ b/src/lib/minions/functions/index.ts
@@ -69,7 +69,6 @@ export async function addMonsterXP(user: KlasaUser, params: AddMonsterXpParams) 
 		monsterID: params.monsterID,
 		boostMethod
 	});
-
 	const monster = killableMonsters.find(mon => mon.id === params.monsterID);
 	let hp = miscHpMap[params.monsterID] ?? 1;
 	let xpMultiplier = 1;

--- a/src/lib/minions/functions/index.ts
+++ b/src/lib/minions/functions/index.ts
@@ -69,6 +69,15 @@ export async function addMonsterXP(user: KlasaUser, params: AddMonsterXpParams) 
 		monsterID: params.monsterID,
 		boostMethod
 	});
+
+	// Special use cases for some monsters
+	switch (params.monsterID) {
+		case Monsters.GrotesqueGuardians.id:
+			// Double quantity killed (Dawn and Dusk)
+			params.quantity *= 2;
+			break;
+	}
+
 	const monster = killableMonsters.find(mon => mon.id === params.monsterID);
 	let hp = miscHpMap[params.monsterID] ?? 1;
 	let xpMultiplier = 1;


### PR DESCRIPTION
### Description:

Closes #2423 

### Changes:

- Grotesque Guardians only give combat XP for 1 of the brothers;
- Changed it so, when adding XP for the monster, if the monster is GGS, it will double the Qty killed (it does not affect slayer XP).

### Other checks:

-   [X] I have tested all my changes thoroughly.

Before:
![image](https://user-images.githubusercontent.com/19570528/127201542-798cf10b-c4b6-4228-b85f-cb22d973012a.png)

After
![image](https://user-images.githubusercontent.com/19570528/127201479-f006edad-378b-4816-b129-4aa887b5ae22.png)
