### PR TITLE
+tames now shows what the selected tame is doing

### DIFF
--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -120,9 +120,7 @@ export default class extends BotCommand {
 		for (const t of allTames) {
 			tames.push(
 				`${t.id}. ${t.toString()}${
-					t?.growthStage === TameGrowthStage.Adult
-						? ''
-						: ` ${t?.currentGrowthPercent}% grown ${t.growthStage}`
+					t.growthStage === TameGrowthStage.Adult ? '' : ` ${t.currentGrowthPercent}% grown ${t.growthStage}`
 				}${selectedTame?.id === t.id ? ` **Selected** - ${await getTameStatus(msg.author)}` : ''}`
 			);
 		}


### PR DESCRIPTION
### Changes:

Closes #2466 

- Create `getTameStatus(user: KlasaUser)` that will return what the selected tame is doing. Requires changes if we ever allow the minion to have multiple tames active, for different types (gatherer, artisan, pvm, etc).

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/127570437-9446348e-1279-4afc-bccc-d45cdaffb431.png)
