### PR TITLE
Fix rogues den dupe protection for equipped pieces

### DIFF
--- a/src/tasks/minions/minigames/roguesDenMazeActivity.ts
+++ b/src/tasks/minions/minigames/roguesDenMazeActivity.ts
@@ -30,7 +30,7 @@ export default class extends Task {
 
 		const loot = new Bank();
 		const user = await this.client.users.fetch(userID);
-		const userBankCopy = user.bank();
+		const userBankCopy = user.allItemsOwned();
 
 		let str = `<@${userID}>, ${user.minionName} finished completing ${quantity}x laps of the Rogues' Den Maze.`;
 


### PR DESCRIPTION
Make roguesDenMazeActivity.ts check for equipped pieces too when deciding what to drop

### Description:

- Rogues den is not checking for equipped pieces of the the rogues outfit when deciding what to drop.

### Changes:

- Change `userBankCopy` to use allOwnedItems instead of only the user bank.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/127588912-21065949-504f-46aa-8810-d62621164c0b.png)
![image](https://user-images.githubusercontent.com/19570528/127588919-d8491058-7619-4022-87d8-bf9aa9a8fdb8.png)