### PR TITLE
Fiz zombie head in +cl hard

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -736,7 +736,8 @@ export const cluesHardCL = resolveItems([
 	'Guthix crozier',
 	'Zamorak stole',
 	'Zamorak crozier',
-	'Zombie head',
+	// Zombie head
+	19_912,
 	'Cyclops head',
 	"Pirate's hat",
 	'Red cavalier',


### PR DESCRIPTION
### Description:

- Wrong Zombie head in the collection log for hard clues

### Changes:

- Forced ID 19912 to be used.

### Other checks:

-   [X] I have tested all my changes thoroughly.
