### PR TITLE
Allow bosses based on BossInstance to be killed more than one per trip

### DIFF
--- a/src/commands/bso/igne.ts
+++ b/src/commands/bso/igne.ts
@@ -15,6 +15,7 @@ import { formatDuration } from '../../lib/util';
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
+			usage: '[qty:int]',
 			usageDelim: ' ',
 			oneAtTime: true,
 			altProtection: true,
@@ -22,7 +23,7 @@ export default class extends BotCommand {
 		});
 	}
 
-	async run(msg: KlasaMessage) {
+	async run(msg: KlasaMessage, [qty]: [number]) {
 		const instance = new BossInstance({
 			leader: msg.author,
 			id: Ignecarus.id,
@@ -91,7 +92,10 @@ export default class extends BotCommand {
 				}
 				baseDeathChance -= (100 - preCalcedDeathChance) / 10;
 				return baseDeathChance;
-			}
+			},
+			quantity: qty,
+			allowMoreThan1Solo: true,
+			allowMoreThan1Group: true
 		});
 		const hasNormalFood = [];
 		for (const user of instance.bossUsers) {
@@ -105,9 +109,12 @@ export default class extends BotCommand {
 				return msg.channel.send({ files: [await instance.simulate()] });
 			}
 			const { bossUsers } = await instance.start();
+
 			const embed = new MessageEmbed()
 				.setDescription(
-					`Your team is off to fight Ignecarus. The total trip will take ${formatDuration(instance.duration)}.
+					`Your team is off to fight ${
+						instance.quantity
+					}x Ignecarus. The total trip will take ${formatDuration(instance.duration)}.
 
 ${bossUsers.map(u => `**${u.user.username}**: ${u.debugStr}`).join('\n\n')}
 `

--- a/src/commands/bso/igne.ts
+++ b/src/commands/bso/igne.ts
@@ -49,19 +49,20 @@ export default class extends BotCommand {
 				neck: "Brawler's hook necklace"
 			}),
 			gearSetup: GearSetupTypes.Melee,
-			itemCost: async user => {
-				const userBank = user.bank();
-				const kc = user.getKC(Ignecarus.id);
+			itemCost: async data => {
+				const userBank = data.user.bank();
+				const kc = data.user.getKC(Ignecarus.id);
 
 				let brewsNeeded = Math.max(1, 8 - Math.max(1, Math.ceil((kc + 1) / 30))) + 1;
 				const restoresNeeded = Math.max(1, Math.floor(brewsNeeded / 3));
 				const heatResBank = new Bank()
 					.add('Heat res. brew', brewsNeeded)
-					.add('Heat res. restore', restoresNeeded);
+					.add('Heat res. restore', restoresNeeded)
+					.multiply(data.kills);
 				const normalBank = new Bank()
 					.add('Saradomin brew(4)', brewsNeeded)
-					.add('Super restore(4)', restoresNeeded);
-
+					.add('Super restore(4)', restoresNeeded)
+					.multiply(data.kills);
 				return userBank.has(heatResBank.bank) ? heatResBank : normalBank;
 			},
 			mostImportantStat: 'attack_crush',

--- a/src/commands/bso/kinggoldemar.ts
+++ b/src/commands/bso/kinggoldemar.ts
@@ -62,7 +62,8 @@ export default class extends BotCommand {
 				neck: "Brawler's hook necklace"
 			}),
 			gearSetup: GearSetupTypes.Melee,
-			itemCost: async (user, baseFood) => baseFood.add('Coins', gpCostPerKill(user)),
+			itemCost: async data =>
+				data.baseFood.multiply(data.kills).add('Coins', gpCostPerKill(data.user) * data.kills),
 			mostImportantStat: 'attack_slash',
 			food: () => new Bank(),
 			settingsKeys: [ClientSettings.EconomyStats.KingGoldemarCost, ClientSettings.EconomyStats.KingGoldemarLoot],

--- a/src/commands/bso/vasa.ts
+++ b/src/commands/bso/vasa.ts
@@ -15,6 +15,7 @@ import { formatDuration } from '../../lib/util';
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
+			usage: '[qty:int]',
 			usageDelim: ' ',
 			oneAtTime: true,
 			altProtection: true,
@@ -22,7 +23,7 @@ export default class extends BotCommand {
 		});
 	}
 
-	async run(msg: KlasaMessage) {
+	async run(msg: KlasaMessage, [qty]: [number]) {
 		const instance = new BossInstance({
 			leader: msg.author,
 			id: VasaMagus.id,
@@ -68,7 +69,8 @@ export default class extends BotCommand {
 			minSize: 1,
 			solo: true,
 			canDie: false,
-			allowMoreThan1Solo: true
+			allowMoreThan1Solo: true,
+			quantity: qty
 		});
 		try {
 			if (msg.flagArgs.s1mulat3) {

--- a/src/commands/bso/vasa.ts
+++ b/src/commands/bso/vasa.ts
@@ -59,7 +59,8 @@ export default class extends BotCommand {
 				neck: 'Arcane blast necklace'
 			}),
 			gearSetup: GearSetupTypes.Mage,
-			itemCost: async (_user, baseFood) => baseFood.add('Elder rune', randInt(55, 100)),
+			itemCost: async data =>
+				data.baseFood.multiply(data.kills).add('Elder rune', randInt(55 * data.kills, 100 * data.kills)),
 			mostImportantStat: 'attack_magic',
 			food: () => new Bank(),
 			settingsKeys: [ClientSettings.EconomyStats.VasaCost, ClientSettings.EconomyStats.VasaLoot],

--- a/src/commands/bso/vasa.ts
+++ b/src/commands/bso/vasa.ts
@@ -67,7 +67,8 @@ export default class extends BotCommand {
 			massText: `${msg.author.username} is assembling a team to fight Vasa Magus! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
 			minSize: 1,
 			solo: true,
-			canDie: false
+			canDie: false,
+			allowMoreThan1Solo: true
 		});
 		try {
 			if (msg.flagArgs.s1mulat3) {
@@ -75,7 +76,9 @@ export default class extends BotCommand {
 			}
 			const { bossUsers } = await instance.start();
 			const embed = new MessageEmbed().setDescription(
-				`Your team is off to fight Vasa Magus. The total trip will take ${formatDuration(instance.duration)}.
+				`Your team is off to fight ${instance.quantity}x Vasa Magus. The total trip will take ${formatDuration(
+					instance.duration
+				)}.
 
 ${bossUsers.map(u => `**${u.user.username}**: ${u.debugStr}`).join('\n\n')}
 `

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -148,7 +148,7 @@ export class BossInstance {
 	bossUsers: BossUser[] = [];
 	duration: number = -1;
 	quantity: number = 1;
-	finalQuantity: number = NaN;
+	tempQty: number = NaN;
 	allowMoreThan1Solo: boolean = false;
 	allowMoreThan1Group: boolean = false;
 	totalPercent: number = -1;
@@ -207,7 +207,7 @@ export class BossInstance {
 	}
 
 	calculateQty(duration: number) {
-		let baseQty = this.finalQuantity;
+		let baseQty = this.tempQty;
 		// Calculate max kill qty
 		let tempQty = 1;
 		const maxTripLength = this.leader.maxTripLength(this.activity);
@@ -238,7 +238,7 @@ export class BossInstance {
 				return this.checkUser(user);
 			}
 		});
-		this.finalQuantity = this.quantity;
+		this.tempQty = this.quantity;
 		// Force qty to 1 for init calculations
 		this.quantity = this.calculateQty(this.baseDuration);
 		this.users = this.solo ? [this.leader] : await mass.init();

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -220,10 +220,8 @@ export class BossInstance {
 			tempQty = 1;
 		}
 		// If the user informed a higher qty than it can kill or is NaN, defaults to max
-		let toReturn = 0;
-		if (isNaN(baseQty) || baseQty > tempQty) toReturn = tempQty;
-		else toReturn = baseQty;
-		return toReturn;
+		if (isNaN(baseQty) || baseQty > tempQty) return tempQty;
+		return baseQty;
 	}
 
 	async init() {

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -255,7 +255,7 @@ export class BossInstance {
 
 	async calcFoodForUser(user: KlasaUser, solo = false) {
 		const kc = user.getKC(this.id);
-		const itemsToRemove = calcFood(solo, kc);
+		const itemsToRemove = calcFood(solo, kc).multiply(this.quantity);
 		if (this.itemCost) {
 			return this.itemCost(user, itemsToRemove);
 		}
@@ -345,13 +345,11 @@ export class BossInstance {
 
 	async start() {
 		await this.init();
-		await this.validateTeam();
 
 		// Calculate max kill qty
 		let tempQty = 1;
 		const maxTripLength = this.leader.maxTripLength(this.activity);
 		tempQty = Math.max(tempQty, Math.floor(maxTripLength / this.duration));
-
 		// This boss doesnt allow more than 1KC at time, limits to 1
 		if (
 			(this.users && this.users.length === 1 && !this.allowMoreThan1Solo) ||
@@ -359,11 +357,11 @@ export class BossInstance {
 		) {
 			tempQty = 1;
 		}
-
 		// If the user informed a higher qty than it can kill or is NaN, defaults to max
 		if (isNaN(this.quantity) || !this.quantity || this.quantity > tempQty) this.quantity = tempQty;
-
 		this.duration *= this.quantity;
+
+		await this.validateTeam();
 
 		const totalCost = new Bank();
 		for (const { user, itemsToRemove } of this.bossUsers) {

--- a/src/tasks/minions/minigames/ignecarusActivity.ts
+++ b/src/tasks/minions/minigames/ignecarusActivity.ts
@@ -1,4 +1,4 @@
-import { objectValues, percentChance, randArrItem } from 'e';
+import { objectValues, percentChance, shuffleArr } from 'e';
 import { KlasaUser, Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
@@ -45,7 +45,6 @@ export default class extends Task {
 		}
 
 		const tagAll = bossUsers.map(u => u.user.toString()).join(', ');
-
 		if (wrongFoodDeaths.length === bossUsers.length * quantity) {
 			return sendToChannelID(this.client, channelID, {
 				content: `${tagAll}\n\nYour team began the fight, but the intense heat of the dragons lair melted your potions, and spoiled them - with no food left to eat, your entire team died.`
@@ -93,9 +92,13 @@ export default class extends Task {
 		if (objectValues(deaths).length > 0) {
 			resultStr += `\n\n**Died in battle**: ${objectValues(deaths).map(
 				u =>
-					`${u.user.toString()}(${
-						wrongFoodDeaths.includes(u.user) ? 'Had no food' : randArrItem(methodsOfDeath)
-					})${u.qty > 1 ? ` x${u.qty}` : ''}`
+					`${u.user.toString()}${u.qty > 1 ? ` x${u.qty}` : ''} (${
+						wrongFoodDeaths.includes(u.user)
+							? 'Had no food'
+							: shuffleArr([...methodsOfDeath])
+									.slice(0, u.qty)
+									.join(', ')
+					})`
 			)}.`;
 		}
 

--- a/src/tasks/minions/minigames/ignecarusActivity.ts
+++ b/src/tasks/minions/minigames/ignecarusActivity.ts
@@ -57,7 +57,7 @@ export default class extends Task {
 			});
 		}
 
-		await Promise.all(bossUsers.map(u => u.user.incrementMonsterScore(Ignecarus.id, 1)));
+		await Promise.all(bossUsers.map(u => u.user.incrementMonsterScore(Ignecarus.id, quantity)));
 
 		const killStr = `Your team managed to slay ${quantity}x Ignecarus, everyone grabs some loot and escapes from the dragons lair.`;
 


### PR DESCRIPTION
### Description:

- Monsters based on BossInstance had qty fixed to one.

### Changes:

- Allow users to specify a qty to kill. If not, defaults to max.
- Add quantity, allowMoreThan1Solo and allowMoreThan1Group;
- Changed the location where the user required item is calculated;
- Changed igneActivity to allow multiple kills;
- Changed all bosses to properly account for multiple kills;

### Other checks:

-   [X] I have tested all my changes thoroughly.

Tried to use 3 as qty, but the limit per maxtrip is 2
![image](https://user-images.githubusercontent.com/19570528/127741814-1bac8a32-157f-4978-b3fd-71e3d9afba20.png)

Specified 1, so only 1 was killed
![image](https://user-images.githubusercontent.com/19570528/127741824-6e9f6044-007a-42b1-ab68-894eb4d498ee.png)

Nothing specified, kills max
![image](https://user-images.githubusercontent.com/19570528/127741833-a43e2684-e23d-4bb7-a550-52de315a18f0.png)

Multiple vasa
![image](https://user-images.githubusercontent.com/19570528/127741864-ce95cdac-612a-4044-96c4-38e5ce1033a9.png)
![image](https://user-images.githubusercontent.com/19570528/127741879-bf84761c-54b0-4365-a60e-28315c2d5347.png)

Only 1 KG was killed
![image](https://user-images.githubusercontent.com/19570528/127741893-6b8f16ba-9f45-43be-8219-fff5e0daf11a.png)