### PR TITLE
Allow nex to continue trips and fix nex giving shared XP

### DIFF
--- a/src/lib/minions/functions/index.ts
+++ b/src/lib/minions/functions/index.ts
@@ -4,6 +4,7 @@ import Monster from 'oldschooljs/dist/structures/Monster';
 
 import { NIGHTMARES_HP } from '../../constants';
 import { KalphiteKingMonster } from '../../kalphiteking';
+import { NexMonster } from '../../nex';
 import { SkillsEnum } from '../../skilling/types';
 import { randomVariation } from '../../util';
 import { xpCannonVaryPercent, xpPercentToCannon, xpPercentToCannonM } from '../data/combatConstants';
@@ -48,6 +49,7 @@ export function resolveAttackStyles(
 ): [KillableMonster | undefined, Monster | undefined, AttackStyles[]] {
 	if (params.monsterID === KingGoldemar.id) return [undefined, undefined, meleeOnly(user)];
 	if (params.monsterID === VasaMagus.id) return [undefined, undefined, [SkillsEnum.Magic]];
+	if (params.monsterID === NexMonster.id) return [undefined, undefined, [SkillsEnum.Ranged]];
 
 	const killableMon = killableMonsters.find(m => m.id === params.monsterID);
 

--- a/src/tasks/minions/minigames/nexActivity.ts
+++ b/src/tasks/minions/minigames/nexActivity.ts
@@ -149,16 +149,20 @@ export default class extends Task {
 				sendToChannelID(this.client, channelID, { content: resultStr + debug });
 			}
 		} else {
-			const { image } = await this.client.tasks
-				.get('bankImage')!
-				.generateBankImage(
-					soloItemsAdded,
-					`Loot From ${quantity} ${NexMonster.name}:`,
-					true,
-					{ showNewCL: 1 },
-					leaderUser,
-					soloPrevCl
-				);
+			const image = !kcAmounts[userID]
+				? undefined
+				: (
+						await this.client.tasks
+							.get('bankImage')!
+							.generateBankImage(
+								soloItemsAdded,
+								`Loot From ${quantity} ${NexMonster.name}:`,
+								true,
+								{ showNewCL: 1 },
+								leaderUser,
+								soloPrevCl
+							)
+				  ).image;
 			handleTripFinish(
 				this.client,
 				leaderUser,
@@ -174,7 +178,7 @@ export default class extends Task {
 					leaderUser.log('continued nex');
 					return this.client.commands.get('nex')!.run(res, ['solo']);
 				},
-				!kcAmounts[userID] ? undefined : image!,
+				image!,
 				data,
 				soloItemsAdded
 			);


### PR DESCRIPTION
### Description:

- Nex isnt using the trip handling system for solo kills;
- Nex is giving shared exp.

### Changes:

- Change solo kills to use trip handling system, even on deaths;
- Force Nex to award Ranged experience.

### Other checks:

-   [X] I have tested all my changes thoroughly.
- 
![image](https://user-images.githubusercontent.com/19570528/127794554-2a169b11-3820-40af-a4a9-f3ee58a4be5f.png)