### PR TITLE
Fix strange message when the user doest have enough runes to alch

### DIFF
--- a/src/commands/Minion/laps.ts
+++ b/src/commands/Minion/laps.ts
@@ -60,7 +60,7 @@ function alching(msg: KlasaMessage, tripLength: number) {
 		bankToRemove.add('Fire rune', maxCasts * 5);
 	}
 
-	if (maxCasts === 0 || bankToRemove.items().length === 0) return null;
+	if (maxCasts === 0 || bankToRemove.length === 0) return null;
 
 	return {
 		maxCasts,

--- a/src/commands/Minion/laps.ts
+++ b/src/commands/Minion/laps.ts
@@ -60,6 +60,8 @@ function alching(msg: KlasaMessage, tripLength: number) {
 		bankToRemove.add('Fire rune', maxCasts * 5);
 	}
 
+	if (maxCasts === 0 || bankToRemove.items().length === 0) return null;
+
 	return {
 		maxCasts,
 		bankToRemove,


### PR DESCRIPTION
### Description:

- When the user doesnt have enough runes to fav its alchables, it will say it is removing nothing from the bank, instead of not showing anything.

### Changes:

- Make a check if the maxcasts is 0 or the to remove from bank is empty.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Before
![image](https://user-images.githubusercontent.com/19570528/127893876-a94747ae-108a-45af-abc0-fb7fa03ecbe4.png)

After
![image](https://user-images.githubusercontent.com/19570528/127893854-750c4ca7-5f2e-4acc-8ced-da452b21ea63.png)
