### PR TITLE
Add dragon platebody and dragon kiteshield to createables

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -852,6 +852,34 @@ const Createables: Createable[] = [
 		requiredSkills: { smithing: 60 }
 	},
 	{
+		name: 'Dragon kiteshield',
+		inputItems: resolveNameBank({
+			'Dragon sq shield': 1,
+			'Dragon metal shard': 1,
+			'Dragon metal slice': 1
+			
+		}),
+		outputItems: resolveNameBank({
+			'Dragon kiteshield': 1
+		}),
+		QPRequired: 205,
+		requiredSkills: { smithing: 75 }
+	},
+		{
+		name: 'Dragon platebody',
+		inputItems: resolveNameBank({
+			'Dragon chainbody': 1,
+			'Dragon metal shard': 1,
+			'Dragon metal lump': 1
+			
+		}),
+		outputItems: resolveNameBank({
+			'Dragon platebody': 1
+		}),
+		QPRequired: 205,
+		requiredSkills: { smithing: 90 }
+	},
+	{
 		name: 'Coconut milk',
 		inputItems: resolveNameBank({
 			Vial: 1,

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -857,7 +857,6 @@ const Createables: Createable[] = [
 			'Dragon sq shield': 1,
 			'Dragon metal shard': 1,
 			'Dragon metal slice': 1
-			
 		}),
 		outputItems: resolveNameBank({
 			'Dragon kiteshield': 1
@@ -865,13 +864,12 @@ const Createables: Createable[] = [
 		QPRequired: 205,
 		requiredSkills: { smithing: 75 }
 	},
-		{
+	{
 		name: 'Dragon platebody',
 		inputItems: resolveNameBank({
 			'Dragon chainbody': 1,
 			'Dragon metal shard': 1,
 			'Dragon metal lump': 1
-			
 		}),
 		outputItems: resolveNameBank({
 			'Dragon platebody': 1


### PR DESCRIPTION
### Description:
Add dragon platebody and dragon kiteshield to createables

### Changes:

Add dragon platebody and dragon kiteshield to createables
205 qp, correct smithing skill reqs

### Other checks:

-   [ ] I have tested all my changes thoroughly.
- No test bot but thoroughly reviewed correct items are in place
