### PR TITLE
Add Dragon metal shard to buyables

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -598,6 +598,12 @@ const Buyables: Buyable[] = [
 		gpCost: 1_000_000
 	},
 	{
+		name: 'Dragon metal shard,
+		aliases: ['metal shard'],
+		qpRequired: 205,
+		gpCost: 2_500_000
+	},
+	{
 		name: 'Eye of newt',
 		aliases: ['eye of newt', 'newt eye'],
 		gpCost: 300

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -598,7 +598,7 @@ const Buyables: Buyable[] = [
 		gpCost: 1_000_000
 	},
 	{
-		name: 'Dragon metal shard,
+		name: 'Dragon metal shard',
 		aliases: ['metal shard'],
 		qpRequired: 205,
 		gpCost: 2_500_000


### PR DESCRIPTION
### Description:
Add Dragon metal shard to buyables for D kite/platebody

### Changes:

Added shard for 2.5m (slightly more expensive than osrs) and associated qp for DS2 completion

### Other checks:

-   [ ] I have tested all my changes thoroughly.
- No test bot but thoroughly reviewed correct items are in place
