### PR TITLE
Add boost messages to the Dwarven knife

### DIFF
--- a/src/commands/Minion/fletch.ts
+++ b/src/commands/Minion/fletch.ts
@@ -84,18 +84,20 @@ export default class extends BotCommand {
 			timeToFletchSingleItem = fletchable.tickRate * Time.Second * 0.6;
 		}
 
-		let hasScruffy = false;
+		const boostMsg: string[] = [];
+		let boost = 1;
 		if (msg.author.usingPet('Scruffy')) {
-			timeToFletchSingleItem /= 2;
-			hasScruffy = true;
+			boost += 1;
+			boostMsg.push(
+				'<:scruffy:749945071146762301> To help out, Scruffy is fetching items from the bank for you - making your training much faster! Good boy! (+100% for Scruffy)'
+			);
 		}
 		if (msg.author.hasItemEquippedAnywhere('Dwarven knife')) {
-			if (hasScruffy) {
-				timeToFletchSingleItem /= 1.5;
-			} else {
-				timeToFletchSingleItem /= 2;
-			}
+			boostMsg.push('+100% for Dwarven knife');
+			boost += 1;
 		}
+
+		timeToFletchSingleItem /= boost;
 
 		// If no quantity provided, set it to the max the player can make by either the items in bank or max time.
 		const maxTripLength = msg.author.maxTripLength(Activity.Fletching);
@@ -140,11 +142,9 @@ export default class extends BotCommand {
 		return msg.channel.send(
 			`${msg.author.minionName} is now Fletching ${quantity}${sets} ${
 				fletchable.name
-			}, it'll take around ${formatDuration(duration)} to finish. Removed ${itemsNeeded} from your bank. ${
-				hasScruffy
-					? '\n<:scruffy:749945071146762301> To help out, Scruffy is fetching items from the bank for you - making your training much faster! Good boy.'
-					: ''
-			}`
+			}, it'll take around ${formatDuration(
+				duration
+			)} to finish. Removed ${itemsNeeded} from your bank.\n${boostMsg.join(', ')}`
 		);
 	}
 }


### PR DESCRIPTION
### Description:

- Fletching now shows what is boosting its trip;

### Changes:

- Changehow the boost% is calculated and add a message for each boost.

### Other checks:

-   [X] I have tested all my changes thoroughly.

 
![image](https://user-images.githubusercontent.com/19570528/128009938-e3df5351-5c53-4ec1-9487-66cde4f9929d.png)
![image](https://user-images.githubusercontent.com/19570528/128009959-7b79b458-7340-4a84-a67b-0d373a0b51c8.png)
![image](https://user-images.githubusercontent.com/19570528/128010061-da40c8b6-47f6-4c61-8b3e-395cd7300eed.png)
![image](https://user-images.githubusercontent.com/19570528/128010069-4b3df7d7-b936-4355-a9ce-aa5136d10172.png)
