### PR TITLE
Add a warning message when using AEP for wilderness preset

### DIFF
--- a/src/commands/Minion/autoequip.ts
+++ b/src/commands/Minion/autoequip.ts
@@ -8,6 +8,7 @@ import minionNotBusy from '../../lib/minions/decorators/minionNotBusy';
 import getUserBestGearFromBank from '../../lib/minions/functions/getUserBestGearFromBank';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
+import { WILDY_PRESET_WARNING_MESSAGE } from './equip';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -32,6 +33,8 @@ export default class extends BotCommand {
 		[gearType, type, style, extra = null]: [GearSetupTypes, string, string, string | null]
 	) {
 		await msg.author.settings.sync(true);
+
+		if (gearType === 'wildy') await msg.confirm(WILDY_PRESET_WARNING_MESSAGE);
 
 		await msg.author.queueFn(async () => {
 			const { gearToEquip, userFinalBank } = getUserBestGearFromBank(

--- a/src/commands/Minion/equip.ts
+++ b/src/commands/Minion/equip.ts
@@ -9,6 +9,9 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { formatSkillRequirements, itemNameFromID, skillsMeetRequirements, toTitleCase } from '../../lib/util';
 
+export const WILDY_PRESET_WARNING_MESSAGE =
+	"You are equipping items to your **wilderness** setup. *Every* item in this setup can potentially be lost if you're doing activities in the wilderness. Are you sure you want to equip it?";
+
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
@@ -83,9 +86,7 @@ export default class extends BotCommand {
 		}
 
 		if (gearType === GearSetupTypes.Wildy) {
-			await msg.confirm(
-				"You are equipping items to your **wilderness** setup. *Every* item in this setup can potentially be lost if you're doing activities in the wilderness. Are you sure you want to equip it?"
-			);
+			await msg.confirm(WILDY_PRESET_WARNING_MESSAGE);
 		}
 		/**
 		 * If there's already an item equipped in this slot, unequip it,


### PR DESCRIPTION
### Description:

- Add a warning message for +autoequip and the wilderness gear preset.

### Changes:

- Change the +equip message to a const;
- Use the same message on +aep

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/128012436-d0fa03a1-1d50-418d-a7f4-4f9a3b59469d.png)
