### PR TITLE
Allow smokey to be used from bank

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -227,7 +227,7 @@ export default class extends BotCommand {
 
 		await msg.author.removeItemFromBank(botOpenable.itemID, quantity);
 
-		const hasSmokey = msg.author.equippedPet() === itemID('Smokey');
+		const hasSmokey = msg.author.allItemsOwned().has('Smokey');
 		const loot = new Bank();
 		let smokeyBonus = 0;
 		if (botOpenable.name.toLowerCase().includes('mystery') && hasSmokey) {


### PR DESCRIPTION
### Description:

- Smokey is a very, very restricted pet to be required to be equipped.

### Changes:

- Change it to allow the user to have its effect just for having it in bank or equipped.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/128060761-48421894-f896-4e62-8ec0-c0e298d9a8df.png)
