### PR TITLE
Add coins back to loot

### DIFF
--- a/src/extendables/User/Bank.ts
+++ b/src/extendables/User/Bank.ts
@@ -122,7 +122,7 @@ export default class extends Extendable {
 				await user.addItemsToCollectionLog(clLoot.bank);
 			}
 
-			// Get the amount of coins in the loot and remove the coins form the items to be added to the user bank
+			// Get the amount of coins in the loot and remove the coins from the items to be added to the user bank
 			const coinsInLoot = items.amount(995);
 			if (coinsInLoot > 0) {
 				await user.addGP(items.amount(995));

--- a/src/extendables/User/Bank.ts
+++ b/src/extendables/User/Bank.ts
@@ -122,13 +122,18 @@ export default class extends Extendable {
 				await user.addItemsToCollectionLog(clLoot.bank);
 			}
 
-			if (items.has(995)) {
+			// Get the amount of coins in the loot and remove the coins form the items to be added to the user bank
+			const coinsInLoot = items.amount(995);
+			if (coinsInLoot > 0) {
 				await user.addGP(items.amount(995));
 				items.remove(995, items.amount(995));
 			}
 
 			this.log(`Had items added to bank - ${JSON.stringify(items)}`);
 			await this.settings.update(UserSettings.Bank, user.bank().add(items).bank);
+
+			// Re-add the coins to the loot
+			if (coinsInLoot > 0) items.add(995, coinsInLoot);
 
 			return {
 				previousCL,


### PR DESCRIPTION
### Description:

- Coins were being removed from loot when being added to the user balance and not being re-added.
- Previous addItemToBank cloned the loot, where it would make the changed and returned the original loot, while using the cloned one to remove coins.
- COINS ARE NOT BIENG LOST. They are just not showing on the loot image/message.

### Changes:

- Restore the coins after adding the loot to the user bank.

### Other checks:

-   [X] I have tested all my changes thoroughly.
