### PR TITLE
Fix MAXQP on Lumb/Draynor Diary

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -420,6 +420,7 @@ export const badges: { [key: number]: string } = {
 	12: Emoji.SOTW
 };
 
+export const MAX_REAL_QP = 284;
 export const MAX_QP = 5000;
 
 export const MIMIC_MONSTER_ID = 23_184;

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -4,7 +4,7 @@ import { Bank, Monsters } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 
 import { MinigameKey } from '../extendables/User/Minigame';
-import { MAX_QP } from './constants';
+import { MAX_REAL_QP } from './constants';
 import { UserSettings } from './settings/types/UserSettings';
 import { courses } from './skilling/skills/agility';
 import { Skills } from './types';
@@ -471,7 +471,7 @@ export const FaladorDiary: Diary = {
 			thieving: 13,
 			woodcutting: 75
 		},
-		qp: 284,
+		qp: MAX_REAL_QP,
 		collectionLogReqs: resolveItems(['Air rune', 'Saradomin brew(3)'])
 	}
 };
@@ -844,7 +844,7 @@ export const LumbridgeDraynorDiary: Diary = {
 			woodcutting: 75
 		},
 		collectionLogReqs: resolveItems(['Magic logs', 'Water rune', 'Adamant platebody']),
-		qp: MAX_QP
+		qp: MAX_REAL_QP
 	}
 };
 


### PR DESCRIPTION
### Description:

- Lumbridge/Draynor diary was checking for MAX_QP (5000) instead of 284.

### Changes:

- Add a new const called MAX_REAL_QP, that should store the current OSRS MAX QP (Same as MAX_QP in OSB);
- Use that new const as check for Falador and Lumb diary.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/128203933-8dbc84c3-e4ee-4be3-84b4-f370971fe469.png)
![image](https://user-images.githubusercontent.com/19570528/128203955-7fdfcf48-5b54-43b4-a54d-130f5aa97645.png)
