### PR TITLE
Add user param to daily.ts sendBankImage

### DIFF
--- a/src/commands/Minion/daily.ts
+++ b/src/commands/Minion/daily.ts
@@ -157,13 +157,14 @@ export default class DailyCommand extends BotCommand {
 			updateGPTrackSetting(this.client, ClientSettings.EconomyStats.GPSourceDaily, loot[COINS_ID]);
 		}
 
-		await user.addItemsToBank(loot, true);
+		const { itemsAdded, previousCL } = await user.addItemsToBank(loot, true);
 
 		return msg.channel.sendBankImage({
-			bank: loot,
+			bank: itemsAdded,
+			user: msg.author,
 			title: `${msg.author.username}'s Daily`,
 			content: dmStr,
-			background: msg.author.settings.get(UserSettings.BankBackground)
+			cl: previousCL
 		});
 	}
 }


### PR DESCRIPTION
### Description:

- With the addition of smallbank BF the daily interface was the one that was passing the bankbg and not the user var to it.
- Add the user that is doing the daily to the sendBankImage method, so the user BFs can be used when generating the loot image.
- This should also fix custom transparent bgs with user defined colors to work.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/128238347-1670a7b6-74f4-4d84-9892-cecb891bfae2.png)
![image](https://user-images.githubusercontent.com/19570528/128238366-3b90e45c-1e95-4a75-91c1-7e79f7b539a0.png)
![image](https://user-images.githubusercontent.com/19570528/128238429-4d64ce4f-fdd2-4b23-9ac0-3957c5bb5e79.png)
