### PR TITLE
Remove undefined if the user doesn't have smokey while opening things.

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -271,7 +271,9 @@ export default class extends BotCommand {
 			bank: loot.values(),
 			content: `You have opened the ${botOpenable.name.toLowerCase()} ${(
 				score + quantity
-			).toLocaleString()} times. ${hasSmokey ? `You got ${smokeyBonus}x bonus rolls from Smokey.` : undefined}`,
+			).toLocaleString()} times. ${
+				hasSmokey && smokeyBonus > 0 ? `You got ${smokeyBonus}x bonus rolls from Smokey.` : ''
+			}`,
 			title: `You opened ${quantity} ${botOpenable.name}`,
 			flags: {
 				showNewCL: 1,


### PR DESCRIPTION
### Description:

- Opening some stuff can say 'undefined' after the counter.

### Changes:

- Remove undefined from the notSmokey?: and add a qty check to make it not say '0 rolls'.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Before
![image](https://user-images.githubusercontent.com/19570528/128247167-340ec102-367b-4aec-8161-0b9cf7b0de34.png)

After
![image](https://user-images.githubusercontent.com/19570528/128247272-480ab63f-8660-4195-9f4b-74e335c71dca.png)
