### PR TITLE
Make remy boost jug of wine by 50%

### DIFF
--- a/src/commands/Minion/cook.ts
+++ b/src/commands/Minion/cook.ts
@@ -60,6 +60,7 @@ export default class extends BotCommand {
 		let timeToCookSingleCookable = Time.Second * 2.88;
 		if (cookable.id === itemID('Jug of wine') || cookable.id === itemID('Wine of zamorak')) {
 			timeToCookSingleCookable /= 1.6;
+			if (hasRemy) timeToCookSingleCookable /= 1.5;
 		} else if (msg.author.hasItemEquippedAnywhere(itemID('Cooking master cape'))) {
 			timeToCookSingleCookable /= 5;
 		} else if (hasRemy) {


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/128254501-798539be-2d06-4839-b7e1-d8631c846474.png)

### Changes:

- Add a 50% boost to Remy when doing Jug of Wine.

### Other checks:

-   [X] I have tested all my changes thoroughly.

No Boosts
![image](https://user-images.githubusercontent.com/19570528/128254552-6b2fed85-12c6-4757-bf70-8ff681565c9a.png)

Shark + Dwarven Gauntlets
![image](https://user-images.githubusercontent.com/19570528/128254576-4d144c15-074a-4274-879b-1f7b4ab1216d.png)

Shark + Remy
![image](https://user-images.githubusercontent.com/19570528/128254597-d41adb64-758b-4df0-a1b6-0735a1aab953.png)

Remy + jug
![image](https://user-images.githubusercontent.com/19570528/128255083-77696492-c6b8-47c0-9c36-fc22720b5ec0.png)