### PR TITLE
Enable XP Tracking past 5b for SoTW and leagues

### DIFF
--- a/src/commands/Testing/setxp.ts
+++ b/src/commands/Testing/setxp.ts
@@ -6,7 +6,7 @@ import { BotCommand } from '../../lib/structures/BotCommand';
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '<skillName:string> <amount:int{1,600000000}>',
+			usage: '<skillName:string> <amount:int{1,5000000000}>',
 			usageDelim: ' ',
 			testingCommand: true
 		});

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -752,10 +752,6 @@ export default class extends Extendable {
 
 		const name = toTitleCase(params.skillName);
 
-		if (currentXP >= 5_000_000_000) {
-			return `You received no XP because you have 5b ${name} XP already.`;
-		}
-
 		const skill = Object.values(Skills).find(skill => skill.id === params.skillName)!;
 		const currentTotalLevel = this.totalLevel();
 
@@ -834,14 +830,21 @@ export default class extends Extendable {
 
 		const newXP = Math.min(5_000_000_000, currentXP + params.amount);
 		const newLevel = convertXPtoLVL(newXP, 120);
-		const totalXPAdded = newXP - currentXP;
 
-		if (totalXPAdded > 0) {
-			XPGainsTable.insert({
-				userID: this.id,
-				skill: params.skillName,
-				xp: Math.floor(params.amount)
-			});
+		// Track XP past 5b for leagues / sotw
+		await XPGainsTable.insert({
+			userID: this.id,
+			skill: params.skillName,
+			xp: Math.floor(params.amount)
+		});
+
+		if (currentXP >= 5_000_000_000) {
+			return (
+				`**You received no XP because you have 5b ${name} XP already.**\n` +
+				`Tracked +${Math.ceil(params.amount).toLocaleString()} ${
+					skillEmoji[params.skillName]
+				}, including all boosts.`
+			);
 		}
 
 		// If they reached a XP milestone, send a server notification.

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -839,12 +839,17 @@ export default class extends Extendable {
 		});
 
 		if (currentXP >= 5_000_000_000) {
-			return (
-				`**You received no XP because you have 5b ${name} XP already.**\n` +
-				`Tracked +${Math.ceil(params.amount).toLocaleString()} ${
-					skillEmoji[params.skillName]
-				}, including all boosts.`
-			);
+			let xpStr = '';
+			if (params.duration && !params.minimal) {
+				xpStr += `You received no XP because you have 200m ${name} XP already.`;
+				xpStr += ` Tracked ${params.amount.toLocaleString()} ${skill.emoji} XP.`;
+				let rawXPHr = (params.amount / (params.duration / Time.Minute)) * 60;
+				rawXPHr = Math.floor(rawXPHr / 1000) * 1000;
+				xpStr += ` (${toKMB(rawXPHr)}/Hr)`;
+			} else {
+				xpStr += `:no_entry_sign: Tracked ${params.amount.toLocaleString()} ${skill.emoji} XP.`;
+			}
+			return xpStr;
 		}
 
 		// If they reached a XP milestone, send a server notification.


### PR DESCRIPTION
### Description:
Enables XP tracking past 5b.

### Changes:

- Enables XP Tracking past 5b
- changes setxp limit to 5b for testing.

### Other checks:

-   [x] I have tested all my changes thoroughly.

Note: It might be nice to print all of the applied boosts, but that would require more reworking that would make master=>bso merges more difficult, so not sure if we want to do that.