### PR TITLE
Allow users to clear their favorites

### DIFF
--- a/src/commands/Minion/favorite.ts
+++ b/src/commands/Minion/favorite.ts
@@ -23,13 +23,13 @@ export default class extends BotCommand {
 			const currentFavorites = msg.author.settings.get(UserSettings.FavoriteItems);
 			if (currentFavorites.length > 0) {
 				await msg.confirm(
-					`Do you want to clear your favorite items from your bank? You currently have ${currentFavorites.length.toLocaleString()} favorite items.`
+					`Are you sure you want to clear your favorite items list? You currently have ${currentFavorites.length.toLocaleString()} favorite items.`
 				);
 				await msg.author.settings.update(UserSettings.FavoriteItems, [], {
 					arrayAction: ArrayActions.Overwrite
 				});
 				return msg.channel.send(
-					`You cleared your favorite items. Here is what you had on your favorite list: ${currentFavorites
+					`You cleared your favorite items. Here is what you had in your favorite list: ${currentFavorites
 						.map(id => itemNameFromID(id))
 						.join(', ')}.`
 				);

--- a/src/commands/Minion/favorite.ts
+++ b/src/commands/Minion/favorite.ts
@@ -19,6 +19,24 @@ export default class extends BotCommand {
 	async run(msg: KlasaMessage, [items]: [Item[] | undefined]) {
 		const currentFavorites = msg.author.settings.get(UserSettings.FavoriteItems);
 
+		if (msg.flagArgs.clear) {
+			const currentFavorites = msg.author.settings.get(UserSettings.FavoriteItems);
+			if (currentFavorites.length > 0) {
+				await msg.confirm(
+					`Do you want to clear your favorite items from your bank? You currently have ${currentFavorites.length.toLocaleString()} favorite items.`
+				);
+				await msg.author.settings.update(UserSettings.FavoriteItems, [], {
+					arrayAction: ArrayActions.Overwrite
+				});
+				return msg.channel.send(
+					`You cleared your favorite items. Here is what you had on your favorite list: ${currentFavorites
+						.map(id => itemNameFromID(id))
+						.join(', ')}.`
+				);
+			}
+			return msg.channel.send('You dont have anything on your favorites to clear.');
+		}
+
 		if (!items || items.length === 0) {
 			const currentFavorites = msg.author.settings.get(UserSettings.FavoriteItems);
 			if (currentFavorites.length === 0) {


### PR DESCRIPTION
### Description:

- Users are complaining that they have to manually remove 1 by 1 of their favorite items.

### Changes:

- Add a --clear flag to +fav to remove everything at once.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/128376972-8892c578-7c09-4ee2-8165-e0723bc73837.png)