### PR TITLE
[ENGINE] Bugfixes for overloaded `channel.send` function.

### DIFF
--- a/src/extendables/TextDMChannel.ts
+++ b/src/extendables/TextDMChannel.ts
@@ -55,20 +55,21 @@ export default class extends Extendable {
 	async send(this: TextChannel, input: string | MessageOptions): Promise<KlasaMessage> {
 		const maxLength = 2000;
 		if (typeof input === 'string' && input.length > maxLength) {
-			let firstMessage = null;
+			let lastMessage = null;
 			for (const chunk of Util.splitMessage(input, { maxLength })) {
 				const sentMessage = await this.send(chunk);
-				if (!firstMessage) firstMessage = sentMessage;
+				lastMessage = sentMessage;
 			}
-			return firstMessage!;
+			return lastMessage!;
 		}
 		if (isObject(input) && input.content && input.content.length > maxLength) {
 			const split = Util.splitMessage(input.content, { maxLength });
-			const firstMessage = await this.send({ ...input, content: split[0] });
+			await this.send({ ...input, content: split[0] });
+			let lastMessage = null;
 			for (let i = 1; i < split.length; i++) {
-				await this.send(split[i]);
+				lastMessage = await this.send(split[i]);
 			}
-			return firstMessage;
+			return lastMessage!;
 		}
 
 		if (this instanceof User || this instanceof GuildMember) {

--- a/src/extendables/TextDMChannel.ts
+++ b/src/extendables/TextDMChannel.ts
@@ -53,20 +53,22 @@ export default class extends Extendable {
 	}
 
 	async send(this: TextChannel, input: string | MessageOptions): Promise<KlasaMessage> {
-		if (typeof input === 'string' && input.length > 2000) {
+		const maxLength = 2000;
+		if (typeof input === 'string' && input.length > maxLength) {
 			let firstMessage = null;
-			for (const chunk of Util.splitMessage(input)) {
+			for (const chunk of Util.splitMessage(input, { maxLength })) {
 				const sentMessage = await this.send(chunk);
 				if (!firstMessage) firstMessage = sentMessage;
 			}
 			return firstMessage!;
 		}
-		if (isObject(input) && input.content && input.content.length > 2000) {
-			const split = Util.splitMessage(input.content);
-			await this.send({ ...input, content: split[0] });
+		if (isObject(input) && input.content && input.content.length > maxLength) {
+			const split = Util.splitMessage(input.content, { maxLength });
+			const firstMessage = await this.send({ ...input, content: split[0] });
 			for (let i = 1; i < split.length; i++) {
 				await this.send(split[i]);
 			}
+			return firstMessage;
 		}
 
 		if (this instanceof User || this instanceof GuildMember) {


### PR DESCRIPTION
### Description:

- The overloaded send function was sending the entire message after sending the chunk'd version when the argument was an object. ( Basically double sending, causing error for message body too big)
- Interactions would be built into the first message and split up the content, but would also break because they had no message object returned.

### Changes:

- Set the maxLength to a const for easy tweaking if we need buffer, and removes 'magic numbers'
- Return the msg handle of the `firstMessage` [sent] to prevent falling thru into the remainder of the function which proceeded to send the entire object (again).
- Fixes interactions by separating them from the initial message and re-attaching them to the final message.
- Does the same with attached files so they don't split up the message.

### Other checks:

-   [x] I have tested all my changes thoroughly.

It's possible this is responsible for the failed loot messages, although you'd think the chunk'd messages would go thru. Without the logs, my best guess is discord rejected all messages sent to this channel for a brief period due to the excessively large message sent.