### PR TITLE
Remove force await on +st

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -1,5 +1,5 @@
 import { MessageButton } from 'discord.js';
-import { deepClone, randInt, Time } from 'e';
+import { randInt, Time } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Monsters } from 'oldschooljs';
 
@@ -54,6 +54,11 @@ const returnSuccessButtons = [
 			label: 'Block Task (100 points)',
 			style: 'DANGER',
 			customID: 'block'
+		}),
+		new MessageButton({
+			label: 'Do Nothing',
+			style: 'SECONDARY',
+			customID: 'doNothing'
 		})
 	]
 ];
@@ -104,18 +109,7 @@ export default class extends BotCommand {
 				return msg.channel.send('It was not possible to auto-slay this task. Please, try again.');
 			}
 		}
-		const components = deepClone(returnSuccessButtons);
-		// Add turael only if master is not turael
-		if (!message.toLowerCase().includes('turael')) {
-			components[1].push(
-				new MessageButton({
-					label: 'Turael Skip (Will reset streak)',
-					style: 'DANGER',
-					customID: 'turaelskip'
-				})
-			);
-		}
-		const sentMessage = await msg.channel.send({ content: message, components });
+		const sentMessage = await msg.channel.send({ content: message, components: returnSuccessButtons });
 		try {
 			const selection = await sentMessage.awaitMessageComponentInteraction({
 				filter: i => {
@@ -145,9 +139,6 @@ export default class extends BotCommand {
 				}
 				case 'block': {
 					return this.client.commands.get('slayertask')!.run(msg, ['block']);
-				}
-				case 'turaelskip': {
-					return this.client.commands.get('slayertask')!.run(msg, ['turael']);
 				}
 			}
 		} catch {
@@ -319,7 +310,8 @@ export default class extends BotCommand {
 				` has assigned you to kill ${
 					newSlayerTask.currentTask.quantity
 				}x ${commonName}${this.getAlternateMonsterList(newSlayerTask.assignedTask)}.`;
-			return this.returnSuccess(msg, returnMessage, Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay));
+			this.returnSuccess(msg, returnMessage, Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay));
+			return;
 		}
 
 		if (currentTask || !slayerMaster) {
@@ -350,11 +342,8 @@ You've done ${totalTasksDone} tasks. Your current streak is ${msg.author.setting
 				UserSettings.Slayer.TaskStreak
 			)}.`;
 			if (currentTask && !warningInfo) {
-				return this.returnSuccess(
-					msg,
-					returnMessage,
-					Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay)
-				);
+				this.returnSuccess(msg, returnMessage, Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay));
+				return;
 			}
 			return msg.channel.send(returnMessage);
 		}
@@ -396,6 +385,6 @@ You've done ${totalTasksDone} tasks. Your current streak is ${msg.author.setting
 		returnMessage += `${slayerMaster.name} has assigned you to kill ${
 			newSlayerTask.currentTask.quantity
 		}x ${commonName}${this.getAlternateMonsterList(newSlayerTask.assignedTask)}.${updateMsg}`;
-		return this.returnSuccess(msg, returnMessage, Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay));
+		this.returnSuccess(msg, returnMessage, Boolean(msg.flagArgs.as) || Boolean(msg.flagArgs.autoslay));
 	}
 }


### PR DESCRIPTION
### Description:

- People complained that when issuing +st, the bot would force them to choose one of the buttons.
- Added a do nothing button, so they can just make the btns disappear;
- Removed the await from the returnSuccess to allow the bot to not block the user.

### Changes:

- Add a do nothing btn;
- Allow the bot to receive other cmds when the buttons are being shown;

### Other checks:

-   [X] I have tested all my changes thoroughly.
