### PR TITLE
[BSO] Fix KK/Nex bug with death's where everyone stays dead the entire trip.

### DIFF
--- a/src/tasks/minions/minigames/kalphiteKingActivity.ts
+++ b/src/tasks/minions/minigames/kalphiteKingActivity.ts
@@ -46,9 +46,12 @@ export default class extends Task {
 		for (let i = 0; i < quantity; i++) {
 			const teamTable = new SimpleTable<string>();
 
+			// Track deaths per kill so you don't stay dead the entire trip.
+			const deathsThisKill: Record<string, number> = {};
+
 			let teamFailed = false;
 			for (const user of parsedUsers.sort((a, b) => b.chanceOfDeath - a.chanceOfDeath)) {
-				const currentDeaths = Object.keys(deaths).length;
+				const currentDeaths = Object.keys(deathsThisKill).length;
 				if (calcWhatPercent(currentDeaths, users.length) >= 50) {
 					// If over 50% of the team died, the entire team dies.
 					teamFailed = true;
@@ -56,6 +59,8 @@ export default class extends Task {
 
 				if (teamFailed || percentChance(user.chanceOfDeath)) {
 					deaths[user.id] = Boolean(deaths[user.id]) ? deaths[user.id] + 1 : 1;
+					// Mark user as dead this kill:
+					deathsThisKill[user.id] = 1;
 				} else {
 					// weight on damagedone
 					teamTable.add(user.id, user.damageDone);

--- a/src/tasks/minions/minigames/nexActivity.ts
+++ b/src/tasks/minions/minigames/nexActivity.ts
@@ -46,9 +46,12 @@ export default class extends Task {
 		for (let i = 0; i < quantity; i++) {
 			const teamTable = new SimpleTable<string>();
 
+			// Track deaths per kill so you don't stay dead the entire trip.
+			const deathsThisKill: Record<string, number> = {};
+
 			let teamFailed = false;
 			for (const user of parsedUsers.sort((a, b) => b.chanceOfDeath - a.chanceOfDeath)) {
-				const currentDeaths = Object.keys(deaths).length;
+				const currentDeaths = Object.keys(deathsThisKill).length;
 				if (calcWhatPercent(currentDeaths, users.length) >= 50) {
 					// If over 50% of the team died, the entire team dies.
 					teamFailed = true;
@@ -56,6 +59,8 @@ export default class extends Task {
 
 				if (teamFailed || percentChance(user.chanceOfDeath)) {
 					deaths[user.id] = Boolean(deaths[user.id]) ? deaths[user.id] + 1 : 1;
+					// Mark user as dead this kill:
+					deathsThisKill[user.id] = 1;
 				} else {
 					// weight on damagedone
 					teamTable.add(user.id, user.damageDone);


### PR DESCRIPTION
### Description:
Currently, in Nex or Kalphite King, for example:
3 man team, 20 kill trip: If 2/3 people die on the first kill, then the entire team wipes, and STAYS DEAD for the entire trip. (Still consumes all potions, though as if it were continuing to fight)
- Without this change, Tier 0 with no Zak is meta for solos + masses.

### Changes:

- Reset deaths per kill, as every other boss does. 

### Other checks:

-   [x] I have tested all my changes thoroughly.
