### PR TITLE
Some Revs Changes

### DIFF
--- a/src/commands/Minion/revs.ts
+++ b/src/commands/Minion/revs.ts
@@ -320,11 +320,11 @@ Skulled: \`${skulled}\` - You can choose to go skulled into the Revenants cave. 
 			monster.name
 		}, it'll take around ${formatDuration(duration)} to finish. ${debug.join(', ')}
 ${Emoji.OSRSSkull} ${skulled ? 'Skulled' : 'Unskulled'}
-**Death Chance:** ${deathChance.toFixed(2)}% (${deathChanceFromGear.toFixed(
-			2
-		)}% from magic def, ${deathChanceFromDefenceLevel.toFixed(2)}% from defence level).${
-			cost.length > 0 ? `\nRemoved from bank: ${cost}` : ''
-		}${boosts.length > 0 ? `\nBoosts: ${boosts.join(', ')}` : ''}`;
+**Death Chance:** ${deathChance.toFixed(2)}% (${deathChanceFromGear.toFixed(2)}% from magic def${
+			deathChanceFromDefenceLevel > 0 ? `, ${deathChanceFromDefenceLevel.toFixed(2)}% from defence level` : ''
+		} + 5% as default chance).${cost.length > 0 ? `\nRemoved from bank: ${cost}` : ''}${
+			boosts.length > 0 ? `\nBoosts: ${boosts.join(', ')}` : ''
+		}`;
 
 		return msg.channel.send(response);
 	}

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -64,6 +64,7 @@ export interface RevenantOptions extends ActivityTaskOptions {
 	monsterID: number;
 	quantity: number;
 	died: boolean;
+	usingPrayerPots: boolean;
 	skulled: boolean;
 	style: 'melee' | 'range' | 'mage';
 }

--- a/src/tasks/minions/revenantsActivity.ts
+++ b/src/tasks/minions/revenantsActivity.ts
@@ -21,9 +21,9 @@ export default class extends Task {
 		const monster = revenantMonsters.find(mon => mon.id === monsterID)!;
 		const user = await this.client.users.fetch(userID);
 		if (died) {
-			// 1 in 50 to get smited
+			// 1 in 20 to get smited without prayer potions and 1 in 300 if the user has prayer potions
 			const hasPrayerLevel = user.hasSkillReqs({ [SkillsEnum.Prayer]: 25 })[0];
-			const protectItem = roll(50) ? false : hasPrayerLevel;
+			const protectItem = roll(data.usingPrayerPots ? 300 : 20) ? false : hasPrayerLevel;
 			const userGear = { ...deepClone(user.settings.get(UserSettings.Gear.Wildy)!) };
 
 			const calc = calculateGearLostOnDeathWilderness({


### PR DESCRIPTION
### Description:

- Even with this, I feel the calculation to get to 10% death chance if off and should be looked at.
- Allowing for lower death chance allows people to use better gear to try and reduce that, risking more stuff in the end.

### Changes:

- Reduce death chance limit by 10%;
- Add prayer potion usage;
- Prayer potion usage reduces smite chance;
- Set min time when dead to 3 minutes, so it doesn't look weird dying in 1 second after the trip is sent.
- Show the default death chance in the trip message;
- Show prayer potions used in the trip message.

### Other checks:

-   [X] I have tested all my changes thoroughly.
