### PR TITLE
Allow 'disable farming reminders' while busy.

### DIFF
--- a/src/tasks/farmingPatchReminders.ts
+++ b/src/tasks/farmingPatchReminders.ts
@@ -1,4 +1,4 @@
-import { MessageButton } from 'discord.js';
+import { MessageActionRow, MessageButton } from 'discord.js';
 import { Time } from 'e';
 import { KlasaMessage, Task, TaskStore } from 'klasa';
 
@@ -53,22 +53,26 @@ export default class extends Task {
 						if (patch.wasReminded) continue;
 						await user.settings.update(key, { ...patch, wasReminded: true });
 
+						// Build buttons (only show Harvest/replant if not busy):
+						const farmingReminderButtons: MessageActionRow = new MessageActionRow();
+						if (!user.minionIsBusy) {
+							farmingReminderButtons.addComponents(
+								new MessageButton()
+									.setLabel('Harvest & Replant')
+									.setStyle('PRIMARY')
+									.setCustomID('HARVEST')
+							);
+						}
+						// Always show disable reminders:
+						farmingReminderButtons.addComponents(
+							new MessageButton()
+								.setLabel('Disable Reminders')
+								.setStyle('SECONDARY')
+								.setCustomID('DISABLE')
+						);
 						const message = await user.send({
 							content: `${user.username}, the ${planted.name} planted in your ${patchType} patches is ready to be harvested!`,
-							components: user.minionIsBusy
-								? undefined
-								: [
-										[
-											new MessageButton()
-												.setLabel('Harvest & Replant')
-												.setStyle('PRIMARY')
-												.setCustomID('HARVEST'),
-											new MessageButton()
-												.setLabel('Disable Reminders')
-												.setStyle('SECONDARY')
-												.setCustomID('DISABLE')
-										]
-								  ]
+							components: [farmingReminderButtons]
 						});
 						try {
 							const selection = await message.awaitMessageComponentInteraction({
@@ -76,6 +80,13 @@ export default class extends Task {
 							});
 							message.edit({ components: [] });
 
+							// Check disable first so minion doesn't have to be free to disable reminders.
+							if (selection.customID === 'DISABLE') {
+								await user.settings.update(UserSettings.FarmingPatchReminders, false);
+								await user.send(
+									'Farming patch reminders have been disabled. You can enable them again using `+farm --enablereminders`.'
+								);
+							}
 							if (user.minionIsBusy) {
 								selection.reply({ content: 'Your minion is busy.' });
 								return;
@@ -83,12 +94,6 @@ export default class extends Task {
 							if (selection.customID === 'HARVEST') {
 								message.author = user;
 								this.client.commands.get('farm')?.run(message as KlasaMessage, [planted.name]);
-							}
-							if (selection.customID === 'DISABLE') {
-								await user.settings.update(UserSettings.FarmingPatchReminders, false);
-								await user.send(
-									'Farming patch reminders have been disabled. You can enable them again using `+farm --enablereminders`.'
-								);
 							}
 						} catch {
 							message.edit({ components: [] });

--- a/src/tasks/farmingPatchReminders.ts
+++ b/src/tasks/farmingPatchReminders.ts
@@ -86,8 +86,7 @@ export default class extends Task {
 								await user.send(
 									'Farming patch reminders have been disabled. You can enable them again using `+farm --enablereminders`.'
 								);
-							}
-							if (user.minionIsBusy) {
+							} else if (user.minionIsBusy) {
 								selection.reply({ content: 'Your minion is busy.' });
 								return;
 							}


### PR DESCRIPTION
### Description:
When I got t3 on my iron, I proceeded to get pinged every 5 minutes for the next hour+ because my patches were all ready. 1 every 5 minutes... I could not disable this reminder because the buttons don't appear when minion is busy.

This fixes that.

### Changes:

- Always shows, 'Disable farming reminders' button on farming notifications.
- Moves processing of `DISABLE` button to before the `minionIsBusy` check so the interaction won't fail due to a busy minion.
- Will only show the harvest/replant option when minion is free, but that could also be changed to always show since the interaction will fail anyway if the minion is or becomes busy.

### Other checks:

-   [x] I have tested all my changes thoroughly.
- Tested on both OSB + BSO, `minionIsBusy` + free. Works as described.
