### PR TITLE
[BSO] Update pingtester and pingmass roles for BSO.

### DIFF
--- a/src/commands/Owner/pingmass.ts
+++ b/src/commands/Owner/pingmass.ts
@@ -1,7 +1,7 @@
 import { TextChannel } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 
-import { Roles, SupportServer } from '../../lib/constants';
+import { DefaultPingableRoles, Roles, SupportServer } from '../../lib/constants';
 import { BotCommand } from '../../lib/structures/BotCommand';
 
 export default class extends BotCommand {
@@ -17,16 +17,10 @@ export default class extends BotCommand {
 		if (!msg.guild || msg.guild.id !== SupportServer) return;
 		if (!msg.member) return;
 		if (!(msg.channel instanceof TextChannel)) return;
-		if (!msg.member.roles.cache.has('734055552933429280') && !msg.member.roles.cache.has(Roles.Moderator)) {
+		if (!msg.member.roles.cache.has(Roles.BSOMassHoster) && !msg.member.roles.cache.has(Roles.Moderator)) {
 			return;
 		}
-		if (msg.channel.id === '789717054902763520') {
-			return msg.channel.send('<@&789724904885846016>');
-		}
 
-		if (msg.channel.parentID === '835876917252587581') {
-			return msg.channel.send('<@&836539487815204865>');
-		}
-		return msg.channel.send('<@&711215501543473182>');
+		return msg.channel.send(`<@&${DefaultPingableRoles.BSOMass}>`);
 	}
 }

--- a/src/commands/Owner/pingtesters.ts
+++ b/src/commands/Owner/pingtesters.ts
@@ -1,6 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 
-import { Roles } from '../../lib/constants';
+import { DefaultPingableRoles, Roles } from '../../lib/constants';
 import { BotCommand } from '../../lib/structures/BotCommand';
 
 export default class extends BotCommand {
@@ -20,6 +20,6 @@ export default class extends BotCommand {
 		) {
 			return;
 		}
-		return msg.channel.send('<@&682052620809928718>');
+		return msg.channel.send(`<@&${DefaultPingableRoles.BSOTester}>`);
 	}
 }

--- a/src/commands/bso/pingbsomass.ts
+++ b/src/commands/bso/pingbsomass.ts
@@ -1,6 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 
-import { Roles, SupportServer } from '../../lib/constants';
+import { DefaultPingableRoles, Roles, SupportServer } from '../../lib/constants';
 import { BotCommand } from '../../lib/structures/BotCommand';
 
 export default class extends BotCommand {
@@ -14,11 +14,11 @@ export default class extends BotCommand {
 	async run(msg: KlasaMessage) {
 		if (!msg.guild || msg.guild.id !== SupportServer) return;
 		if (!msg.member) return;
-		if (!msg.member.roles.cache.has('759572886364225558') && !msg.member.roles.cache.has(Roles.Moderator)) {
+		if (!msg.member.roles.cache.has(Roles.BSOMassHoster) && !msg.member.roles.cache.has(Roles.Moderator)) {
 			return;
 		}
 		return msg.channel.send(
-			'<@&759573020464906242> - *Note: You can type `.roles bso-mass` to remove, or add, this role to yourself.'
+			`<@&${DefaultPingableRoles.BSOMass}> - *Note: You can type \`.roles bso-mass\` to remove, or add, this role to yourself.`
 		);
 	}
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -27,6 +27,8 @@ export const enum Roles {
 	PatronTier2 = '678967943979204608',
 	PatronTier3 = '687408140832342043',
 	Patron = '679620175838183424',
+	MassHoster = '734055552933429280',
+	BSOMassHoster = '759572886364225558',
 	// Status Roles
 	TopSkiller = '848966830617788427',
 	TopCollector = '848966773885763586',
@@ -34,6 +36,14 @@ export const enum Roles {
 	TopClueHunter = '848967350120218636',
 	TopSlayer = '867967551819358219',
 	TopMinigamer = '867967884515770419'
+}
+
+export const enum DefaultPingableRoles {
+	// Tester roles:
+	Tester = '682052620809928718',
+	BSOTester = '829368646182371419',
+	// Mass roles:
+	BSOMass = '759573020464906242'
 }
 
 export const enum Emoji {


### PR DESCRIPTION
### Description:
Updated =pingtester so it pings BSOTester instead of tester. Currently contribs have no way to ping @BSOTester.
Also updated =pingmass on mylife's request :)

### Changes:

- Added constants for the builtin-pinagle-roles
- Updated pingtester + pingmass commands to use the BSO variants.

### Other checks:

-   I did NOT test this because of the nature of server-specific roles, but it's a fairly simple change, and I let the IDE generate most of the code, and check it all.