### PR TITLE
Make farming contracts `+fc easier` step down, like in game.

### DIFF
--- a/src/commands/Minion/farmingcontract.ts
+++ b/src/commands/Minion/farmingcontract.ts
@@ -123,7 +123,7 @@ export default class extends BotCommand {
 						]
 					});
 				}
-				const newContractLevel = 'easy';
+				const newContractLevel = currentContract.difficultyLevel === 'hard' ? 'medium' : 'easy';
 				const plantInformation = getPlantToGrow(msg.author, newContractLevel);
 				const plantToGrow = plantInformation[0];
 				const plantTier = plantInformation[1];


### PR DESCRIPTION
### Description:
Currently `+fc easier` always drops to the 'easy' tier, when in osrs it goes from hard => medium => easy. This patch makes the behavior match osrs.

### Changes:
Instead of setting `easier` newPatchDifficulty to 'easy', set to medium if current difficulty is hard, otherwise easy.

### Other checks:

-   [x] I have tested all my changes thoroughly.
