### PR TITLE
[BSO] Let `--names` and `--sv` work on Tame's loot/bank

### DIFF
--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -111,6 +111,7 @@ export default class extends BotCommand {
 			}
 			return msg.channel.sendBankImage({
 				content: `${tame!.toString()}`,
+				flags: msg.flagArgs,
 				bank: tame.totalLoot,
 				title: `All Loot ${tame.name} Has Gotten You`
 			});


### PR DESCRIPTION
### Description:
When viewing the tame's total loot with `=tame IDNUM`  you can use bank flags to show names, ids, value, etc.

### Changes:
Passes `msg.flagArgs` to the `flags` parameter of sendBankImage()

### Other checks:

-   [x] I have tested all my changes thoroughly.
