### PR TITLE
Return after disabling farming reminders to break loop.

### DIFF
--- a/src/tasks/farmingPatchReminders.ts
+++ b/src/tasks/farmingPatchReminders.ts
@@ -86,7 +86,9 @@ export default class extends Task {
 								await user.send(
 									'Farming patch reminders have been disabled. You can enable them again using `+farm --enablereminders`.'
 								);
-							} else if (user.minionIsBusy) {
+								return;
+							}
+							if (user.minionIsBusy) {
 								selection.reply({ content: 'Your minion is busy.' });
 								return;
 							}


### PR DESCRIPTION
### Description:
Added a `return` after disabling farming reminders to break out of the loop.
Otherwise if you have multiple plants ready it continues thru the loop when you press DISABLE. Not a big deal, but technically a bug imo.

### Other checks:

-   [x] I have tested all my changes thoroughly.
