### PR TITLE
Fix nex gorajan archer to only apply bonus when entire set is equipped

### DIFF
--- a/src/commands/bso/nex.ts
+++ b/src/commands/bso/nex.ts
@@ -162,7 +162,7 @@ export default class extends BotCommand {
 				}
 			}
 
-			if (rangeGear.hasEquipped(gorajanArcherOutfit)) {
+			if (rangeGear.hasEquipped(gorajanArcherOutfit, true)) {
 				const perUserPercent = round(15 / users.length, 2);
 				effectiveTime = reduceNumByPercent(effectiveTime, perUserPercent);
 				msgs.push(`${perUserPercent}% for Gorajan archer`);


### PR DESCRIPTION
### Description:

- Nex is giving boost for having only 1 piece or gorajan archer equipped

### Changes:

- Force every = true, like all other gorajan sets

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/128865961-2b28e65e-d045-445a-91ed-fa1ebed24cae.png)
![image](https://user-images.githubusercontent.com/19570528/128865976-25e1079b-d048-4ba7-942e-7c78b0fabec3.png)
