### PR TITLE
Change tick rate of anti venom+ to 2 like in-game

### DIFF
--- a/src/lib/skilling/skills/herblore/mixables/potions.ts
+++ b/src/lib/skilling/skills/herblore/mixables/potions.ts
@@ -435,7 +435,7 @@ const Potions: Mixable[] = [
 		level: 94,
 		xp: 125,
 		inputItems: resolveNameBank({ 'Anti-venom (4)': 1, Torstol: 1 }),
-		tickRate: 4,
+		tickRate: 2,
 		bankTimePerPotion: 0.3
 	},
 	{


### PR DESCRIPTION
This supposedly got changed in osrs at an unknown date (according to osrs wiki), so it was likely still 4 when herblore in the bot was released.
