### PR TITLE
Fixed bug where `=spawnlamp` random XP was wrong range.

### DIFF
--- a/src/commands/bso/spawnlamp.ts
+++ b/src/commands/bso/spawnlamp.ts
@@ -56,7 +56,7 @@ export default class extends BotCommand {
 		await msg.author.settings.update(UserSettings.LastSpawnLamp, currentDate);
 
 		const level = randInt(1, 99);
-		const xp = randInt(convertLVLtoXP(level - 1), convertLVLtoXP(level + 1));
+		const xp = randInt(convertLVLtoXP(level), convertLVLtoXP(level + 1) - 1);
 
 		const embed = new MessageEmbed()
 			.setColor(Color.Orange)
@@ -80,7 +80,9 @@ export default class extends BotCommand {
 			const winner = col.author!;
 			const box = LampTable.roll();
 			await winner.addItemsToBank(box);
-			return msg.channel.send(`Congratulations, ${winner}! You got it. I've given you: **${box}**.`);
+			return msg.channel.send(
+				`Congratulations, ${winner}! You got it! It was: ${level}. I've given you: **${box}**.`
+			);
 		} catch (err) {
 			return msg.channel.send('Nobody got it! :(');
 		}


### PR DESCRIPTION
### Description:
With the spawnlamp change, it would end up choosing random XP that actually spanned 3 levels:

- The entire level, 
- the entire level before it, 
- and 1 xp into the next level.

### Changes:
Fixes the XP range so that it's only the entirety of the chosen level.

### Other checks:

-   [x] I have tested all my changes thoroughly.
