### PR TITLE
Fix qty position on some cl small cl items

### DIFF
--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -396,7 +396,7 @@ export default class CollectionLogTask extends Task {
 					ctx,
 					formatItemStackQuantity(qtyText),
 					Math.floor(i * (itemSize + itemSpacer) + (itemSize - itemImage.width) / 2) + 1,
-					Math.floor(y * (itemSize + itemSpacer) + (itemSize - itemImage.height) / 2) + 9
+					y * (itemSize + itemSpacer) + 11
 				);
 			}
 


### PR DESCRIPTION
### Description:

- Some small items where having its qty messed up in the +cl command

### Changes:

- Remove item height from the calc that sets the qty position

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129036842-2229adc7-5a1c-4ba3-ac64-dbba4192c812.png)