### PR TITLE
Fix leaderboard.ts sorting and xpgains

### DIFF
--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -393,14 +393,13 @@ ORDER BY u.petcount DESC LIMIT 2000;`
 								${skillsVals.map(s => `"skills.${s.id}"`)},
 								${skillsVals.map(s => `"skills.${s.id}"`).join(' + ')} as totalxp,
 								u."minion.ironman",
-								(select max(x.date) from "xp_gains" x where x.user_id = u.id and (not x.post_max or x.post_max is null)) as last_date_xp
+								(select max(x.date) from "xp_gains" x where x.user_id = u.id and not x.post_max) as last_date_xp
 							FROM
 								users u
 							ORDER BY
-								1 DESC,
-								4 ASC
+								totalxp DESC,
+								last_date_xp ASC
 							LIMIT 2000;`;
-			console.log(query);
 			res = await this.query(query);
 			overallUsers = res.map(user => {
 				let totalLevel = 0;
@@ -425,12 +424,12 @@ ORDER BY u.petcount DESC LIMIT 2000;`
 
 			const query = `SELECT
 								u."skills.${skill.id}", u.id, u."minion.ironman",
-								(select max(x.date) from "xp_gains" x where x.user_id = u.id and x.skill = '${skill.id}' and (not x.post_max or x.post_max is null)) as last_date_xp
+								(select max(x.date) from "xp_gains" x where x.user_id = u.id and x.skill = '${skill.id}' and not x.post_max) as last_date_xp
 							FROM
 								users u
 							ORDER BY
 								1 DESC,
-								4 ASC
+								last_date_xp ASC
 							LIMIT 2000;`;
 			res = await this.query(query);
 		}

--- a/src/commands/OSRS_Accounts/lvl.ts
+++ b/src/commands/OSRS_Accounts/lvl.ts
@@ -3,6 +3,7 @@ import { Hiscores } from 'oldschooljs';
 import { SkillsScore } from 'oldschooljs/dist/meta/types';
 import { convertLVLtoXP, convertXPtoLVL } from 'oldschooljs/dist/util';
 
+import { MAX_XP } from '../../lib/constants';
 import { BotCommand } from '../../lib/structures/BotCommand';
 
 const xpLeft = (xp: number) => {
@@ -37,7 +38,7 @@ export default class extends BotCommand {
 			if (res.level < 99) {
 				str += ` **${xpLeft(res.xp)}** XP away from level **${res.level + 1}**.`;
 			} else {
-				str += ` **${(200_000_000 - res.xp).toLocaleString()}** XP away from **200m**.`;
+				str += ` **${(MAX_XP - res.xp).toLocaleString()}** XP away from **200m**.`;
 			}
 
 			return msg.channel.send(str);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -399,6 +399,7 @@ export const badges: { [key: number]: string } = {
 };
 
 export const MAX_QP = 284;
+export const MAX_XP = 200_000_000;
 
 export const MIMIC_MONSTER_ID = 23_184;
 

--- a/src/lib/typeorm/XPGainsTable.entity.ts
+++ b/src/lib/typeorm/XPGainsTable.entity.ts
@@ -26,4 +26,7 @@ export class XPGainsTable extends BaseEntity {
 
 	@Column({ type: 'boolean', name: 'artificial', nullable: true })
 	public artificial!: boolean | null;
+
+	@Column({ type: 'boolean', name: 'post_max', nullable: false, default: false })
+	public postMax!: boolean | null;
 }


### PR DESCRIPTION
### Description:

- Every time someone do +lb skills, someone is randomly sorted to be first if more than 1 has the same xp.
- This update sorts by who got the xp first

### Changes:

- For older 200m players, that got 200m before May 14th 2021, the following query needs to be executed in the DB, to allow those players to be sorted (otherwise, they will always appear as last, instead of their actual position).
- Add a MAX_XP const to easily merge updates between OSB and BSO;
- Adds a new field in the XP_GAINS table, for POST_MAX XP GAINS, for xpgains control.
```
insert into xp_gains (user_id, date, skill, xp, post_max)
values
( 212931609123487744,'2020-06-24 00:00:00', 'cooking', 0, false ),
( 479677110634676224,'2020-07-21 00:00:00', 'firemaking', 0, false ),
( 481438127630581800,'2020-08-02 00:00:00', 'prayer', 0, false ),
( 531981148092628992,'2020-09-22 00:00:00', 'fletching', 0, false ),
( 196669708248940545,'2020-10-09 00:00:00', 'woodcutting', 0, false ),
( 212931609123487744,'2021-01-29 00:00:00', 'construction', 0, false ),
( 212931609123487744,'2021-01-31 00:00:00', 'thieving', 0, false ),
( 150768805637914624,'2021-03-16 00:00:00', 'hunter', 0, false ),
( 212931609123487744,'2021-04-24 00:00:00', 'crafting', 0, false ),
( 308930175905562624,'2021-05-01 00:00:00', 'agility', 0, false ),
( 244872016237166593,'2021-05-09 00:00:00', 'prayer', 0, false ),
( 228954929681661952,'2021-04-29 00:00:00', 'firemaking', 0, false ),
( 216271853751107585,'2021-04-28 00:00:00', 'crafting', 0, false ),
( 319914426499334144,'2021-04-27 00:00:00', 'hunter', 0, false ),
( 228579750677970946,'2021-04-15 00:00:00', 'cooking', 0, false ),
( 126040633801441280,'2021-03-31 00:00:00', 'cooking', 0, false ),
( 239249584726081536,'2021-03-28 00:00:00', 'construction', 0, false ),
( 170312142975664128,'2021-03-20 00:00:00', 'hunter', 0, false ),
( 244872016237166593,'2021-03-15 00:00:00', 'thieving', 0, false ),
( 481438127630581800,'2021-03-07 00:00:00', 'thieving', 0, false ),
( 216895304430125059,'2021-02-02 00:00:00', 'woodcutting', 0, false ),
( 481438127630581800,'2021-01-30 00:00:00', 'construction', 0, false ),
( 189566248747663370,'2021-01-12 00:00:00', 'firemaking', 0, false ),
( 244872016237166593,'2021-01-07 00:00:00', 'firemaking', 0, false ),
( 212931609123487744,'2020-12-06 00:00:00', 'fletching', 0, false ),
( 212931609123487744,'2020-08-20 00:00:00', 'prayer', 0, false ),
( 414701655758471179,'2020-08-05 00:00:00', 'firemaking', 0, false ),
( 189566248747663370,'2020-08-02 00:00:00', 'cooking', 0, false ),
( 212931609123487744,'2020-07-25 00:00:00', 'firemaking', 0, false ),
( 244872016237166593,'2020-07-13 00:00:00', 'cooking', 0, false );
```

### Other checks:

-   [X] I have tested all my changes thoroughly.
