### PR TITLE
[BSO] Add Dark relics to lamps (from CoX)

### DIFF
--- a/src/commands/bso/lamp.ts
+++ b/src/commands/bso/lamp.ts
@@ -37,9 +37,12 @@ export default class extends BotCommand {
 			return msg.channel.send(`You don't have any ${lamp.name} lamps!`);
 		}
 
+		const amount = lamp.amountFn
+			? lamp.amountFn(skillName as SkillsEnum, msg.author.skillLevel(skillName as SkillsEnum))
+			: lamp.amount!;
 		await msg.author.addXP({
 			skillName: skillName as SkillsEnum,
-			amount: lamp.amount,
+			amount,
 			duration: undefined,
 			minimal: false,
 			multiplier: false,
@@ -48,9 +51,7 @@ export default class extends BotCommand {
 		await msg.author.removeItemFromBank(lamp.itemID);
 
 		return msg.channel.send(
-			`Added ${lamp.amount.toLocaleString()} ${toTitleCase(skillName)} XP from your ${itemNameFromID(
-				lamp.itemID
-			)}`
+			`Added ${amount.toLocaleString()} ${toTitleCase(skillName)} XP from your ${itemNameFromID(lamp.itemID)}`
 		);
 	}
 }

--- a/src/lib/xpLamps.ts
+++ b/src/lib/xpLamps.ts
@@ -1,10 +1,27 @@
 import LootTable from 'oldschooljs/dist/structures/LootTable';
 
+import { SkillsEnum } from './skilling/types';
+import itemID from './util/itemID';
+
 export interface XPLamp {
 	itemID: number;
-	amount: number;
+	amount?: number;
+	amountFn?: (_skill: SkillsEnum, _level: number) => number;
 	name: string;
 }
+
+const darkRelicBoostSkills: SkillsEnum[] = [
+	SkillsEnum.Mining,
+	SkillsEnum.Woodcutting,
+	SkillsEnum.Herblore,
+	SkillsEnum.Fishing,
+	SkillsEnum.Hunter,
+	SkillsEnum.Cooking,
+	SkillsEnum.Farming,
+	SkillsEnum.Thieving,
+	SkillsEnum.Firemaking,
+	SkillsEnum.Agility
+];
 
 export const XPLamps: XPLamp[] = [
 	// Achievement diary lamps
@@ -53,6 +70,13 @@ export const XPLamps: XPLamp[] = [
 		itemID: 11_157,
 		amount: 5_000_000,
 		name: 'Huge lamp'
+	},
+	{
+		itemID: itemID('Dark relic'),
+		amountFn: (skill, level) => {
+			return darkRelicBoostSkills.includes(skill) ? level * 150 : level * 50;
+		},
+		name: 'Dark relic'
 	}
 ];
 


### PR DESCRIPTION
### Description:
Added Dark relics to the `=lamp` command.

### Changes:

- Added optional amountFn() function to XPLamp type for level/skill based multipliers
- Added Dark relics to the lamps list

### Other checks:

-   [x] I have tested all my changes thoroughly.
