### PR TITLE
Add Dark relics to lamps (from CoX)

### DIFF
--- a/src/commands/Minion/lamp.ts
+++ b/src/commands/Minion/lamp.ts
@@ -22,7 +22,7 @@ const darkRelicBoostSkills: SkillsEnum[] = [
 	SkillsEnum.Agility
 ];
 
-export interface Lamp {
+export interface XPLamp {
 	itemID: number;
 	amount?: number;
 	amountFn?: (_skill: SkillsEnum, _level: number) => number;
@@ -30,7 +30,7 @@ export interface Lamp {
 	minimumLevel: number;
 }
 
-export const XPLamps: Lamp[] = [
+export const XPLamps: XPLamp[] = [
 	{
 		itemID: 11_137,
 		amount: 2500,


### PR DESCRIPTION
### Description:
Added Dark relics to the `+lamp` command.

### Changes:

- Created XPLamps type/interface like BSO
- Added optional amountFn() function to XPLamp type for level/skill based multipliers
- Added Dark relics to the lamps list

### Other checks:

-   [x] I have tested all my changes thoroughly.
