### PR TITLE
Make Ori boost more fair (Tames + MonsterKilling)

### DIFF
--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -9,6 +9,7 @@ import BankImageTask from '../tasks/bankImage';
 import { UserSettings } from './settings/types/UserSettings';
 import { TameActivityTable } from './typeorm/TameActivityTable.entity';
 import { TamesTable } from './typeorm/TamesTable.entity';
+import { roll } from './util';
 import getOSItem from './util/getOSItem';
 import { sendToChannelID } from './util/webhook';
 
@@ -91,8 +92,15 @@ export async function runTameTask(activity: TameActivityTable) {
 			const { quantity, monsterID } = activity.data;
 			let killQty = quantity;
 			const hasOri = activity.tame.hasBeenFed('Ori');
+			// If less than 8 kills, roll 25% chance per kill
 			if (hasOri) {
-				killQty = Math.floor(killQty * 1.25);
+				if (killQty >= 8) {
+					killQty = Math.floor(killQty * 1.25);
+				} else {
+					for (let i = 0; i < killQty; i++) {
+						if (roll(4)) killQty++;
+					}
+				}
 			}
 			const fullMonster = Monsters.get(monsterID)!;
 			const loot = fullMonster.kill(killQty, {});

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -97,7 +97,7 @@ export async function runTameTask(activity: TameActivityTable) {
 				if (killQty >= 8) {
 					killQty = Math.floor(killQty * 1.25);
 				} else {
-					for (let i = 0; i < killQty; i++) {
+					for (let i = 0; i < quantity; i++) {
 						if (roll(4)) killQty++;
 					}
 				}

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -77,7 +77,7 @@ export default class extends Task {
 			inCatacombs: isInCatacombs
 		};
 		const loot = (monster as KillableMonster).table.kill(
-			Math.ceil(quantity * (isDoubleLootActive(this.client) ? 2 : boostedQuantity)),
+			isDoubleLootActive(this.client) ? quantity * 2 : boostedQuantity,
 			killOptions
 		);
 		let newSuperiorCount = loot.bank[420];


### PR DESCRIPTION
### Description:

- If Ori is equipped but the time limit (5 minutes) isn't reached, then a 25% chance is rolled for each kill. 
- This still gives players a chance at the 25% bonus, without making 1 KC trips overpowered.
- Also, it makes feeding an Ori to your tame useful for slower monsters, since tames' Ori bonus always round down.

### Changes:
Monster Killing:
-  If > 5 minutes, no change
- If <= 5 minutes, roll 25% chance for each kill to add 1 KC.

Tames:
- If KC >= 8, then use original Floor(1.25 * KC)
- If KC < 8, then roll 25% chance for each kill to add 1 KC.

### Other checks:

-   [x] I have tested all my changes thoroughly.
