### PR TITLE
Fix `+farm` bug with default farming compost tier.

### DIFF
--- a/src/commands/Minion/defaultfarming.ts
+++ b/src/commands/Minion/defaultfarming.ts
@@ -63,14 +63,16 @@ export default class extends BotCommand {
 					` For example, \`${msg.cmdPrefix}defaultfarming tier supercompost\`.`
 			);
 		}
+		const cleanedNewCompostTier = compostTier.name.toLowerCase();
 
 		const currentCompostTier = msg.author.settings.get(UserSettings.Minion.DefaultCompostToUse);
 
-		if (currentCompostTier !== newCompostTier) {
-			await msg.author.settings.update(UserSettings.Minion.DefaultCompostToUse, newCompostTier);
+		// I am purposefully not toLowerCase()ing current so people can fix theirs if broken.
+		if (currentCompostTier !== cleanedNewCompostTier) {
+			await msg.author.settings.update(UserSettings.Minion.DefaultCompostToUse, cleanedNewCompostTier);
 
 			return msg.channel.send(
-				`Your minion will now automatically use ${newCompostTier} for farming, if you have any.`
+				`Your minion will now automatically use ${cleanedNewCompostTier} for farming, if you have any.`
 			);
 		}
 		return msg.channel.send('You are already automatically using this type of compost.');

--- a/src/commands/Minion/defaultfarming.ts
+++ b/src/commands/Minion/defaultfarming.ts
@@ -67,7 +67,6 @@ export default class extends BotCommand {
 
 		const currentCompostTier = msg.author.settings.get(UserSettings.Minion.DefaultCompostToUse);
 
-		// I am purposefully not toLowerCase()ing current so people can fix theirs if broken.
 		if (currentCompostTier !== cleanedNewCompostTier) {
 			await msg.author.settings.update(UserSettings.Minion.DefaultCompostToUse, cleanedNewCompostTier);
 

--- a/src/commands/Minion/farm.ts
+++ b/src/commands/Minion/farm.ts
@@ -15,6 +15,7 @@ import { BotCommand } from '../../lib/structures/BotCommand';
 import { FarmingActivityTaskOptions } from '../../lib/types/minions';
 import {
 	bankHasItem,
+	cleanString,
 	formatDuration,
 	itemNameFromID,
 	removeItemFromBank,
@@ -59,7 +60,7 @@ export default class extends BotCommand {
 		const currentDate = new Date().getTime();
 
 		let payment = false;
-		let upgradeType: 'compost' | 'supercompost' | 'ultracompost' | null = null;
+		let upgradeType: string | null = null;
 		const infoStr: string[] = [];
 		const boostStr: string[] = [];
 
@@ -254,7 +255,9 @@ export default class extends BotCommand {
 			infoStr.push('You did not have enough payment to automatically pay for crop protection.');
 		}
 
-		const defaultCompostTier = msg.author.settings.get(UserSettings.Minion.DefaultCompostToUse);
+		const defaultCompostTier = cleanString(
+			msg.author.settings.get(UserSettings.Minion.DefaultCompostToUse) ?? 'compost'
+		).toLowerCase();
 		if (upgradeType === 'supercompost' || upgradeType === 'ultracompost') {
 			const hasCompostType = await msg.author.hasItem(itemID(upgradeType), quantity);
 			if (!hasCompostType) {

--- a/src/lib/minions/farming/types.ts
+++ b/src/lib/minions/farming/types.ts
@@ -25,7 +25,7 @@ export interface IPatchData {
 	patchPlanted: boolean; // false -> nothing planted, true -> something planted
 	plantTime: number;
 	lastQuantity: number;
-	lastUpgradeType: 'compost' | 'supercompost' | 'ultracompost' | 'null' | null;
+	lastUpgradeType: string | null;
 	lastPayment: boolean;
 	wasReminded?: true;
 }

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -183,7 +183,7 @@ export interface FarmingActivityTaskOptions extends ActivityTaskOptions {
 	plantsName: string | null;
 	channelID: string;
 	quantity: number;
-	upgradeType: 'compost' | 'supercompost' | 'ultracompost' | null;
+	upgradeType: string | null;
 	payment?: boolean;
 	patchType: IPatchData;
 	getPatchType: string;


### PR DESCRIPTION
### Description:
Currently there's a bug when if you do not specify 'ultracompost' EXACTLY (case sensitive) in the `+defaultfarming tier ultracompost` command, then you could end up burning ultracompost but still not getting the boost.

**Example**: `+defaultfarming tier Ultra COMPOST` will match ultracompost to set the new default because it uses stringMatch(). However, it does not use the matched compost type for the Settings value, instead using the raw value as passed to the command, 'Ultra COMPOST'.  When `+farm` checks to see if you have 'Ultra COMPOST' in the bank, itemID will match because it uses cleanString(). It removes the compost, and again, sets the patch's compost type to 'Ultra COMPOST.'
In farmingActivity.ts, this is compared === 'ultracompost' which fails. 
(Resulting in the minimum 3 lives per patch, even though you spent the ultracompost)

I removed the useless in-line type definition `'compost' | 'supercompost' | 'ultracompost' | null` because this is only  a compile-time helper.
It does nothing at run-time, and is the reason this bug manifested is because the value was coming directly from the database unchecked [by the compiler, which assumed it would be valid].


### Changes:

- Changed the compost types to be `string | null`
- Use the name from the matched compost type`.toLowerCase()` to store in the database.
- Updated the +farm command, so even if a user has a bad value in the database, it will still convert it into the correct form for use by farmingActivity.

### Other checks:

-   [x] I have tested all my changes thoroughly.
