### PR TITLE
Bowfa boosts

### DIFF
--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -328,6 +328,10 @@ const itemBoosts = [
 			boost: 9
 		},
 		{
+			item: getOSItem('Bow of faerdhinen (c)'),
+			boost: 7
+		},
+		{
 			item: getOSItem('Dragon hunter crossbow'),
 			boost: 5
 		}

--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -65,6 +65,7 @@ const killableBosses: KillableMonster[] = [
 			},
 			{
 				[itemID('Armadyl crossbow')]: 5,
+				[itemID('Bow of faerdhinen (c))]: 7,
 				[itemID('Twisted bow')]: 10
 			}
 		],
@@ -101,6 +102,7 @@ const killableBosses: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Armadyl crossbow')]: 5,
+				[itemID('Bow of faerdhinen (c))]: 7,
 				[itemID('Twisted bow')]: 10
 			}
 		],
@@ -142,7 +144,8 @@ const killableBosses: KillableMonster[] = [
 				[itemID('Dragon claws')]: 3
 			},
 			{
-				[itemID('Arclight')]: 9
+				[itemID('Arclight')]: 9,
+				[itemID('Twisted bow')]: 10
 			}
 		],
 		groupKillable: true,

--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -102,7 +102,7 @@ const killableBosses: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Armadyl crossbow')]: 5,
-				[itemID('Bow of faerdhinen (c))]: 7,
+				[itemID('Bow of faerdhinen (c)')]: 7,
 				[itemID('Twisted bow')]: 10
 			}
 		],

--- a/src/lib/minions/data/killableMonsters/bosses/gwd.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/gwd.ts
@@ -65,7 +65,7 @@ const killableBosses: KillableMonster[] = [
 			},
 			{
 				[itemID('Armadyl crossbow')]: 5,
-				[itemID('Bow of faerdhinen (c))]: 7,
+				[itemID('Bow of faerdhinen (c)')]: 7,
 				[itemID('Twisted bow')]: 10
 			}
 		],

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -279,7 +279,6 @@ const killableBosses: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Armadyl crossbow')]: 6,
-				[itemID('Bow of faerdhinen (c)')]: 8,
 				[itemID('Twisted bow')]: 10
 			}
 		],

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -99,7 +99,8 @@ const killableBosses: KillableMonster[] = [
 				[itemID('Barrows gloves')]: 3
 			},
 			{
-				[itemID('Twisted bow')]: 5
+				[itemID('Twisted bow')]: 5,
+				[itemID('Bow of faerdhinen (c)')]: 3
 			},
 			{
 				[itemID('Ancestral hat')]: 2
@@ -278,6 +279,7 @@ const killableBosses: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Armadyl crossbow')]: 6,
+				[itemID('Bow of faerdhinen (c)')]: 8,
 				[itemID('Twisted bow')]: 10
 			}
 		],


### PR DESCRIPTION
Added some boosts for bowfa (c) at:
- cox (inbetween dhcb and tbow)
- zammy (also added tbow)
- sara
- kree
- zulrah

idk where else ppl use it on osrs