### PR TITLE
Allow Shelledon to boost drift net

### DIFF
--- a/src/commands/Minion/driftnet.ts
+++ b/src/commands/Minion/driftnet.ts
@@ -99,6 +99,8 @@ export default class extends BotCommand {
 			itemsToRemove.add('Stamina potion(4)', 1);
 		}
 
+		if (msg.author.usingPet('Shelldon')) boosts.push('2x more fish for using Shelldon');
+
 		const quantity = Math.round(tripLength / oneDriftNetTime);
 		const duration = quantity * oneDriftNetTime;
 


### PR DESCRIPTION
### Description:

- Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129238526-c7bf869d-e7a8-4da9-ab9d-2a8c416c172d.png)

- Allow Shelldon to double fish loot from Drift Net and award 1.5x more fishing experience.

### Changes:

- Add a fish table loot so shelldon knows what to double (cant use Fishing.Fishes because some Fishes are exclusive to Trawler).

### Other checks:

-   [X] I have tested all my changes thoroughly.
No Shelldon
![image](https://user-images.githubusercontent.com/19570528/129238890-2a9d97c4-ac2e-4399-a752-f22fcd5aabd6.png)

Shelldon
![image](https://user-images.githubusercontent.com/19570528/129238846-156c4c42-d711-4628-b31c-aff72b992c82.png)
