### PR TITLE
Allow voidling to work from bank, but with a lower output

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -137,8 +137,14 @@ export async function handleTripFinish(
 		}
 	}
 
-	if (user.usingPet('Voidling')) {
-		const alchResult = alching({ user, tripLength: data.duration, isUsingVoidling: true, flags: { alch: 'yes' } });
+	if (user.allItemsOwned().has('Voidling')) {
+		const voidlingEquipped = user.usingPet('Voidling');
+		const alchResult = alching({
+			user,
+			tripLength: voidlingEquipped ? data.duration : data.duration / randInt(8, 12),
+			isUsingVoidling: true,
+			flags: { alch: 'yes' }
+		});
 		if (alchResult !== null) {
 			if (!user.owns(alchResult.bankToRemove)) {
 				message += `\Your Voidling couldn't do any alching because you don't own ${alchResult.bankToRemove}.`;
@@ -151,7 +157,11 @@ export async function handleTripFinish(
 			updateGPTrackSetting(client, ClientSettings.EconomyStats.GPSourceAlching, alchGP);
 			message += `\nYour Voidling alched ${alchResult.maxCasts}x ${alchResult.itemToAlch.name}. Removed ${
 				alchResult.bankToRemove
-			} from your bank and added ${toKMB(alchGP)} GP.`;
+			} from your bank and added ${toKMB(alchGP)} GP. ${
+				!voidlingEquipped
+					? "As you left your Voidling alone in the bank, it got distracted easily and didn't manage to alch at its full potential."
+					: ''
+			}`;
 		} else {
 			message +=
 				"\nYour Voidling didn't alch anything because you either: don't have Nature runes, Fire Runes, or any Favorited alchables that you own.";


### PR DESCRIPTION
### Description:

- Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129241019-e27d42a2-9094-49ab-8b18-0a510fa616ea.png)

### Changes:

- Allows Voidling to work while being in the bank, but it will output 8 to 12 times less alchs. Qty not changed when having it equipped.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129241146-03046941-3615-41ef-a6ef-1101b72a5802.png)
![image](https://user-images.githubusercontent.com/19570528/129241169-9ff94d25-f621-4bb6-93f1-a3c047faf1b8.png)
![image](https://user-images.githubusercontent.com/19570528/129241184-e101adab-5d5d-4c21-9669-74f4591cfdc0.png)