### PR TITLE
Add vasa cloak boost to zulrah

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -90,6 +90,9 @@ const killableBosses: KillableMonster[] = [
 		qpRequired: 75,
 		itemInBankBoosts: [
 			{
+				[itemID('Vasa cloak')]: 5
+			},
+			{
 				[itemID('Ranger boots')]: 2,
 				[itemID('Pegasian boots')]: 4
 			},


### PR DESCRIPTION
### Description:

- Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129243567-51899956-b0b1-4880-8b62-90bb4e67fcfa.png)

### Changes:

- Add 5% boost to Zulrah from having a Vasa Cloak

### Other checks:

-   [X] I have tested all my changes thoroughly.

No cape
![image](https://user-images.githubusercontent.com/19570528/129243822-295fb28c-b85e-4848-af30-21ac09e2c282.png)

With cape
![image](https://user-images.githubusercontent.com/19570528/129243856-832d8d10-a0e5-408c-973b-7a26ec0182aa.png)