### PR TITLE
Fix TitheFarm LB

### DIFF
--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -330,9 +330,13 @@ ORDER BY u.petcount DESC LIMIT 2000;`
 		const res: MinigameTable[] = await MinigameTable.getRepository()
 			.createQueryBuilder('user')
 			.orderBy(minigame.column, 'DESC')
-			.where(`${minigame.column} > 10`)
+			.where(`${minigame.column} >= 10`)
 			.limit(100)
 			.getMany();
+
+		if (res.length === 0) {
+			return msg.channel.send('No users meets the criteria for this minigame (10+ completions).');
+		}
 
 		this.doMenu(
 			msg,

--- a/src/commands/Minion/tithefarm.ts
+++ b/src/commands/Minion/tithefarm.ts
@@ -49,6 +49,12 @@ export default class extends BotCommand {
 		await msg.author.settings.sync(true);
 		const titheFarmPoints = msg.author.settings.get(UserSettings.Stats.TitheFarmPoints);
 
+		// Transfer KC from the old system to the new one
+		let titheFarmsCompleted = msg.author.settings.get(UserSettings.Stats.TitheFarmsCompleted);
+		if (titheFarmsCompleted > 0 && (await msg.author.getMinigameScore('TitheFarm')) === 0) {
+			await msg.author.incrementMinigameScore('TitheFarm', titheFarmsCompleted);
+		}
+
 		if (msg.flagArgs.points) {
 			return msg.channel.send(`You have ${titheFarmPoints} Tithe Farm points.`);
 		}

--- a/src/commands/Minion/tithefarm.ts
+++ b/src/commands/Minion/tithefarm.ts
@@ -18,14 +18,14 @@ export default class extends BotCommand {
 		});
 	}
 
-	determineDuration(user: KlasaUser): [number, string[]] {
+	async determineDuration(user: KlasaUser): Promise<[number, string[]]> {
 		let baseTime = Time.Second * 1500;
 		let nonGracefulTimeAddition = Time.Second * 123;
 
 		const boostStr = [];
 
 		// Reduce time based on tithe farm completions
-		const titheFarmsCompleted = user.settings.get(UserSettings.Stats.TitheFarmsCompleted);
+		const titheFarmsCompleted = await user.getMinigameScore('TitheFarm');
 		const percentIncreaseFromCompletions = Math.floor(Math.min(50, titheFarmsCompleted) / 2) / 100;
 		baseTime = Math.floor(baseTime * (1 - percentIncreaseFromCompletions));
 		Math.floor(percentIncreaseFromCompletions * 100) > 0
@@ -57,7 +57,7 @@ export default class extends BotCommand {
 			throw `${msg.author.minionName} needs 34 Farming to use the Tithe Farm!`;
 		}
 
-		const [duration, boostStr] = this.determineDuration(msg.author);
+		const [duration, boostStr] = await this.determineDuration(msg.author);
 
 		await addSubTaskToActivityTask<TitheFarmActivityTaskOptions>({
 			minigameID: 'TitheFarm',

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -673,7 +673,7 @@ export const allCollectionLogs: ICollection = {
 			'Tithe Farm': {
 				alias: ['tithe'],
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.Stats.TitheFarmsCompleted)
+					Default: async user => user.getMinigameScore('TitheFarm')
 				},
 				items: titheFarmCL,
 				roleCategory: ['minigames'],

--- a/src/lib/util/minionStatsEmbed.ts
+++ b/src/lib/util/minionStatsEmbed.ts
@@ -111,7 +111,7 @@ export async function minionStatsEmbed(user: KlasaUser) {
 	const otherStats: [string, number | string][] = [
 		['Fight Caves Attempts', user.settings.get(UserSettings.Stats.FightCavesAttempts)],
 		['Fire Capes Sacrificed', user.settings.get(UserSettings.Stats.FireCapesSacrificed)],
-		['Tithe Farm Score', user.settings.get(UserSettings.Stats.TitheFarmsCompleted)],
+		['Tithe Farm Score', await user.getMinigameScore('TitheFarm')],
 		['Dice Wins', user.settings.get(UserSettings.Stats.DiceWins)],
 		['Dice Losses', user.settings.get(UserSettings.Stats.DiceLosses)],
 		['Duel Wins', user.settings.get(UserSettings.Stats.DuelWins)],

--- a/src/tasks/minions/minigames/titheFarmActivity.ts
+++ b/src/tasks/minions/minigames/titheFarmActivity.ts
@@ -19,13 +19,19 @@ export default class extends Task {
 		const user = await this.client.users.fetch(userID);
 
 		const farmingLvl = user.skillLevel(SkillsEnum.Farming);
-		const titheFarmsCompleted = user.settings.get(UserSettings.Stats.TitheFarmsCompleted);
+		// Fix for old tithe farm kcs
+		let titheFarmsCompleted = user.settings.get(UserSettings.Stats.TitheFarmsCompleted);
+		if (titheFarmsCompleted > 0 && (await user.getMinigameScore('TitheFarm')) === 0) {
+			await user.incrementMinigameScore('TitheFarm', titheFarmsCompleted);
+		} else {
+			titheFarmsCompleted = await user.getMinigameScore('TitheFarm');
+		}
+		await user.incrementMinigameScore('TitheFarm', 1);
 		const titheFarmPoints = user.settings.get(UserSettings.Stats.TitheFarmPoints);
 
 		const determineHarvest = baseHarvest + Math.min(15, titheFarmsCompleted);
 		const determinePoints = determineHarvest - 74;
 
-		await user.settings.update(UserSettings.Stats.TitheFarmsCompleted, titheFarmsCompleted + 1);
 		await user.settings.update(UserSettings.Stats.TitheFarmPoints, titheFarmPoints + determinePoints);
 
 		let fruit = '';

--- a/src/tasks/minions/minigames/titheFarmActivity.ts
+++ b/src/tasks/minions/minigames/titheFarmActivity.ts
@@ -19,13 +19,7 @@ export default class extends Task {
 		const user = await this.client.users.fetch(userID);
 
 		const farmingLvl = user.skillLevel(SkillsEnum.Farming);
-		// Fix for old tithe farm kcs
-		let titheFarmsCompleted = user.settings.get(UserSettings.Stats.TitheFarmsCompleted);
-		if (titheFarmsCompleted > 0 && (await user.getMinigameScore('TitheFarm')) === 0) {
-			await user.incrementMinigameScore('TitheFarm', titheFarmsCompleted);
-		} else {
-			titheFarmsCompleted = await user.getMinigameScore('TitheFarm');
-		}
+		const titheFarmsCompleted = await user.getMinigameScore('TitheFarm');
 		await user.incrementMinigameScore('TitheFarm', 1);
 		const titheFarmPoints = user.settings.get(UserSettings.Stats.TitheFarmPoints);
 


### PR DESCRIPTION
### Description:

- Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129248056-42a167d7-c3cc-47c3-ada8-6626b43faec3.png)

### Changes:

- Change all Tithe Farm Completions from the UserSettings to use the Minigame table;
- When doing the +tithefarm command, the user will automatically update the MinigameTable with the old KC;
- Fix the LB to show a message when no users meet the minigame criteria;
- Change the minigame criteria to be `>= 10` instead of `> 10`;

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129248328-bec03e0f-951a-4502-9b49-f9c2454cb1ea.png)
![image](https://user-images.githubusercontent.com/19570528/129248366-1dc1dfc2-8b82-4dc6-bdb8-8eb0de66589d.png)
