### PR TITLE
[BSO] Fix tames. Babys cant grow without this

### DIFF
--- a/src/lib/typeorm/TamesTable.entity.ts
+++ b/src/lib/typeorm/TamesTable.entity.ts
@@ -39,7 +39,7 @@ export class TamesTable extends BaseEntity {
 	@Column({ type: 'enum', enum: TameGrowthStage, name: 'growth_stage', enumName: 'tame_growth' })
 	public growthStage!: TameGrowthStage;
 
-	@Column('integer', { name: 'growth_percent', nullable: false })
+	@Column('real', { name: 'growth_percent', nullable: false })
 	public currentGrowthPercent!: number;
 
 	@Column('integer', { name: 'max_combat_level', nullable: false })
@@ -66,7 +66,7 @@ export class TamesTable extends BaseEntity {
 	async addDuration(duration: number): Promise<string | null> {
 		if (this.growthStage === TameGrowthStage.Adult) return null;
 		const percentToAdd = duration / Time.Minute / 20;
-		let newPercent = Math.floor(Math.max(1, Math.min(100, this.currentGrowthPercent + percentToAdd)));
+		let newPercent = Math.max(1, Math.min(100, this.currentGrowthPercent + percentToAdd));
 
 		if (newPercent === 100) {
 			newPercent = 0;
@@ -78,7 +78,7 @@ export class TamesTable extends BaseEntity {
 		}
 		this.currentGrowthPercent = newPercent;
 		await this.save();
-		return `Your tame has grown ${percentToAdd}%!`;
+		return `Your tame has grown ${percentToAdd.toFixed(2)}%!`;
 	}
 
 	hasBeenFed(item: string) {


### PR DESCRIPTION
### Description:
Currently there needs to be a code and database update in order for fractional growth percentages to be tracked.

**Before applying this patch, you must run:**
```SQL
 alter table tames alter column growth_percent TYPE real;
```
On the psql database. (Simply updating the typeorm description attempts to make a new column instead of altering the existing one)

**Important note:** Do not use `real` type for anything that requires precision, like money, or larger numbers. Real is only 4 bytes floating point. `double precision` is 8-bytes FP, and there is a `decimal` type for arbitrary precision with exact math (at a performance cost). However, `real` is the perfect type for a number 1 - 100 with decimal digits.

### Changes:

- Updated the typeorm description for growth_percent
- Stopped rounding down the new growth value before db insertion
- Fix the displayed growth % to 2 digits past the decimal.

### Other checks:

-   [x] I have tested all my changes thoroughly.
