### PR TITLE
Prevent B2B farming contracts

### DIFF
--- a/src/commands/Minion/farmingcontract.ts
+++ b/src/commands/Minion/farmingcontract.ts
@@ -11,6 +11,8 @@ import { bankHasItem } from '../../lib/util';
 import chatHeadImage from '../../lib/util/chatHeadImage';
 import itemID from '../../lib/util/itemID';
 
+type FarmingContractDifficultyLevel = 'easy' | 'medium' | 'hard';
+
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
@@ -124,7 +126,10 @@ export default class extends BotCommand {
 					});
 				}
 				const newContractLevel = currentContract.difficultyLevel === 'hard' ? 'medium' : 'easy';
-				const plantInformation = getPlantToGrow(msg.author, newContractLevel);
+				const plantInformation = getPlantToGrow(msg.author, {
+					contractLevel: newContractLevel,
+					ignorePlant: currentContract.plantToGrow!
+				});
 				const plantToGrow = plantInformation[0];
 				const plantTier = plantInformation[1];
 
@@ -141,7 +146,7 @@ export default class extends BotCommand {
 				return msg.channel.send({
 					files: [
 						await chatHeadImage({
-							content: `I suppose you were too chicken for the challange. Please could you grow a ${plantToGrow} instead for us? I'll reward you once you have checked its health.`,
+							content: `I suppose you were too chicken for the challenge. Please could you grow a ${plantToGrow} instead for us? I'll reward you once you have checked its health.`,
 							head: 'jane'
 						})
 					]
@@ -162,15 +167,16 @@ export default class extends BotCommand {
 			});
 		}
 
-		if (contractLevel === 'current' || contractLevel === 'easier') return;
-
-		const plantInformation = getPlantToGrow(msg.author, contractLevel);
+		const plantInformation = getPlantToGrow(msg.author, {
+			contractLevel: contractLevel as FarmingContractDifficultyLevel,
+			ignorePlant: currentContract.plantToGrow
+		});
 		const plantToGrow = plantInformation[0] as string;
 		const plantTier = plantInformation[1] as 0 | 1 | 2 | 3 | 4 | 5;
 
 		const farmingContractUpdate: FarmingContract = {
 			hasContract: true,
-			difficultyLevel: contractLevel,
+			difficultyLevel: contractLevel as FarmingContractDifficultyLevel,
 			plantToGrow,
 			plantTier,
 			contractsCompleted: currentContract.contractsCompleted

--- a/src/lib/skilling/functions/calcFarmingContracts.ts
+++ b/src/lib/skilling/functions/calcFarmingContracts.ts
@@ -1,6 +1,6 @@
 import { KlasaUser } from 'klasa';
 
-import { rand } from '../../../lib/util';
+import { rand, stringMatches } from '../../../lib/util';
 import { PlantTier } from '../../minions/farming/types';
 import { SkillsEnum } from '../types';
 
@@ -79,7 +79,10 @@ const hardPlants: PlantsList = [
 	[90, 'Redwood tree', 5]
 ];
 
-export function getPlantToGrow(user: KlasaUser, contractLevel: 'easy' | 'medium' | 'hard'): [string, PlantTier] {
+export function getPlantToGrow(
+	user: KlasaUser,
+	{ contractLevel, ignorePlant }: { contractLevel: 'easy' | 'medium' | 'hard'; ignorePlant: string | null }
+): [string, PlantTier] {
 	const farmingLevel = user.skillLevel(SkillsEnum.Farming);
 	let contractType: PlantsList = [];
 	if (contractLevel === 'easy') contractType = easyPlants;
@@ -87,9 +90,10 @@ export function getPlantToGrow(user: KlasaUser, contractLevel: 'easy' | 'medium'
 	if (contractLevel === 'hard') contractType = hardPlants;
 
 	for (let i = contractType.length; i > 0; i--) {
-		const [farmingLevelNeeded] = contractType[i - 1];
+		const [farmingLevelNeeded, plantName] = contractType[i - 1];
 		const index = contractType[i - 1];
-		if (farmingLevel < farmingLevelNeeded) contractType.splice(contractType.indexOf(index), 1);
+		if (farmingLevel < farmingLevelNeeded || stringMatches(ignorePlant ?? '', plantName))
+			contractType.splice(contractType.indexOf(index), 1);
 	}
 
 	const plantFromContract = contractType[rand(0, contractType.length - 1)];

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -420,7 +420,7 @@ export default class extends Task {
 				const farmingContractUpdate: FarmingContract = {
 					hasContract: false,
 					difficultyLevel: null,
-					plantToGrow: null,
+					plantToGrow: currentContract.plantToGrow,
 					plantTier: currentContract.plantTier,
 					contractsCompleted: contractsCompleted + 1
 				};


### PR DESCRIPTION
### Description:
Prevent Back 2 Back farming contracts, both when getting an 'easier' task, and when receiving a new task after completion.

### Changes:

- Update `getPlantToGrow` to accept an 'ignorePlant' option
- When getting an easier contract, pass the current contract's plantName
- When completing a contract, do not reset the plantName to null so that we can:
- Use that plant name on the next contract to pass as the `ignorePlant` value
- Fixed a spelling error
- Removed and an if(") block that will never match by using typecasts.

### Other checks:

-   [x] I have tested all my changes thoroughly.
