### PR TITLE
Fix tames growth (READ WARNING) and fix tames drops 

### DIFF
--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -154,7 +154,9 @@ export default class extends BotCommand {
 		for (const t of allTames) {
 			tames.push(
 				`${t.id}. ${t.toString()}${
-					t.growthStage === TameGrowthStage.Adult ? '' : ` ${t.currentGrowthPercent}% grown ${t.growthStage}`
+					t.growthStage === TameGrowthStage.Adult
+						? ''
+						: ` ${t.currentGrowthPercent.toFixed(2)}% grown ${t.growthStage}`
 				}${selectedTame?.id === t.id ? ` **Selected** - ${await getTameStatus(msg.author)}` : ''}`
 			);
 		}

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -94,7 +94,7 @@ export async function runTameTask(activity: TameActivityTable) {
 	switch (activity.type) {
 		case 'pvm': {
 			const { quantity, monsterID } = activity.data;
-			let killQty = 10_000; // quantity;
+			let killQty = quantity;
 			const hasOri = activity.tame.hasBeenFed('Ori');
 			// If less than 8 kills, roll 25% chance per kill
 			if (hasOri) {

--- a/src/lib/typeorm/TamesTable.entity.ts
+++ b/src/lib/typeorm/TamesTable.entity.ts
@@ -39,7 +39,7 @@ export class TamesTable extends BaseEntity {
 	@Column({ type: 'enum', enum: TameGrowthStage, name: 'growth_stage', enumName: 'tame_growth' })
 	public growthStage!: TameGrowthStage;
 
-	@Column('integer', { name: 'growth_percent', nullable: false })
+	@Column('float', { name: 'growth_percent', nullable: false, default: 0 })
 	public currentGrowthPercent!: number;
 
 	@Column('integer', { name: 'max_combat_level', nullable: false })
@@ -66,9 +66,9 @@ export class TamesTable extends BaseEntity {
 	async addDuration(duration: number): Promise<string | null> {
 		if (this.growthStage === TameGrowthStage.Adult) return null;
 		const percentToAdd = duration / Time.Minute / 20;
-		let newPercent = Math.floor(Math.max(1, Math.min(100, this.currentGrowthPercent + percentToAdd)));
-
-		if (newPercent === 100) {
+		let newPercent = Math.max(1, Math.min(100, this.currentGrowthPercent + percentToAdd));
+		console.log(newPercent);
+		if (newPercent >= 100) {
 			newPercent = 0;
 			this.growthStage =
 				this.growthStage === TameGrowthStage.Baby ? TameGrowthStage.Juvenile : TameGrowthStage.Adult;
@@ -78,7 +78,7 @@ export class TamesTable extends BaseEntity {
 		}
 		this.currentGrowthPercent = newPercent;
 		await this.save();
-		return `Your tame has grown ${percentToAdd}%!`;
+		return `Your tame has grown ${percentToAdd.toFixed(2)}%!`;
 	}
 
 	hasBeenFed(item: string) {

--- a/src/lib/typeorm/TamesTable.entity.ts
+++ b/src/lib/typeorm/TamesTable.entity.ts
@@ -67,7 +67,7 @@ export class TamesTable extends BaseEntity {
 		if (this.growthStage === TameGrowthStage.Adult) return null;
 		const percentToAdd = duration / Time.Minute / 20;
 		let newPercent = Math.max(1, Math.min(100, this.currentGrowthPercent + percentToAdd));
-		console.log(newPercent);
+
 		if (newPercent >= 100) {
 			newPercent = 0;
 			this.growthStage =


### PR DESCRIPTION
### Description:

- Tames are showing wrong items being dropped )two of the same ring piece for Alchemycal Hydra, for example);
- Tames are not showing purple items for new tame cl drops;
- Tames are always using the default background.

### Changes:

- Change growth control from integer to float (READ WARNING);
- Change params used in tame handleFinish to allow for user to be used;
- Add showNewCL flag and store the previously tame cl to use when generating the loot image;

### WARNING

- THIS WILL RESET THE CURRENT GROWTH_PERCENT **IF LETTING THE BOT UPDATE THE DB**.
- When changing the database from integer to float, **the bot will recreate** the column and reset all values on it.
- To properly update, **MANUALLY CHANGE THE GROWTH_PERCENT COLUMN TO DOUBLE_PRECISION**.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Tame advancing stages
![image](https://user-images.githubusercontent.com/19570528/129410363-ca9a21cc-51c7-4b92-8ae9-dd4e986cacd8.png)

Tame purples + BG
![image](https://user-images.githubusercontent.com/19570528/129410402-aef97b39-ff9c-4178-87bf-969133b822e6.png)

Tame Growth%
![image](https://user-images.githubusercontent.com/19570528/129410421-0a152a1e-76e4-4c2c-b3b9-5ebbfa861b9e.png)

Tame properly sorting drop items when required
![image](https://user-images.githubusercontent.com/19570528/129410460-5d8fb57a-fb63-42a9-84ae-bb1f14736730.png)