### PR TITLE
Change the wrong item message on getOSItem

### DIFF
--- a/src/lib/util/getOSItem.ts
+++ b/src/lib/util/getOSItem.ts
@@ -21,7 +21,7 @@ export default function getOSItem(itemName: string | number): Item {
 	}
 
 	const osItem = Items.get(identifier) as Item | undefined;
-	if (!osItem) throw `${identifier}That item doesn't exist.`;
+	if (!osItem) throw `The item **${identifier}** does not exist.`;
 	cache.set(itemName, osItem);
 	return osItem;
 }


### PR DESCRIPTION
### Description:

![image](https://user-images.githubusercontent.com/19570528/129460293-c2c72685-6033-48e6-bb8a-a12499cd53b3.png)

### Changes:

- Change the message to `The item **itemName** does not exist.`

### Other checks:

-   [X] I have tested all my changes thoroughly.
