### PR TITLE
[BSO] Add some error tracking to luckypick.ts

### DIFF
--- a/src/commands/bso/luckypick.ts
+++ b/src/commands/bso/luckypick.ts
@@ -170,7 +170,13 @@ export default class extends BotCommand {
 			try {
 				await finalize({ button: pickedButton, interaction });
 			} catch (err) {
-				console.error(err);
+				const errStr = `${msg.author} had an error in Luckypick and was not refunded. ${JSON.stringify(
+					pickedButton
+				)} Start balance: ${currentBalance} Bet amount: ${amount} End balance: ${msg.author.settings.get(
+					UserSettings.GP
+				)} Error: ${typeof err === 'object' ? JSON.stringify(err) : err}`;
+				console.error(errStr);
+				this.client.wtf(new Error(errStr));
 			}
 		});
 


### PR DESCRIPTION
### Description:
Added some error tracking to the only place I can see the problem happening. My best guess is that the error is happening on this line (when discord is having network issues):
```
await interaction.update({ components: getCurrentButtons({ showTrueNames: true }) });
```
If that's correct, then the user didn't get 'refunded' because they chose a losing square.

This will confirm my hypothesis by logging if a similar error occurs, showing the starting + ending balance, wager amount, and button chosen.

this.client.wtf() errors go to sentry, right? It seems like they do, but i still haven't figured sentry out yet 100%, unfortuantely it doesn't look like i can just view the raw logs, it seems to only track events which are 'thrown' with a call stack, and then logs HTTP and a few other thiongs.

### Changes:

Added some error tracking to a possible failure mode of luckypick.

### Other checks:

-   [x] I have tested all my changes thoroughly.
