### PR TITLE
Fix one way to clobber a pet.

### DIFF
--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -15,6 +15,7 @@ export default class extends BotCommand {
 		super(store, file, directory, {
 			description: 'Shows your bank, with all your items and GP.',
 			cooldown: 3,
+			oneAtTime: true,
 			usage: '[page:int|name:string]',
 			requiredPermissions: ['ATTACH_FILES'],
 			aliases: ['b'],

--- a/src/commands/Minion/equippet.ts
+++ b/src/commands/Minion/equippet.ts
@@ -36,6 +36,11 @@ export default class extends BotCommand {
 			await this.client.commands.get('unequippet')?.run(msg, []);
 		}
 
+		const doubleCheckEquippedPet = msg.author.settings.get(UserSettings.Minion.EquippedPet);
+		if (doubleCheckEquippedPet) {
+			msg.author.log(`Aborting pet equip so we don't clobber ${doubleCheckEquippedPet}`);
+			return msg.channel.send('You still have a pet equipped, cancelling.');
+		}
 		await msg.author.settings.update([
 			[UserSettings.Minion.EquippedPet, petItem.id],
 			[UserSettings.Bank, removeItemFromBank(msg.author.settings.get(UserSettings.Bank), petItem.id)]


### PR DESCRIPTION
### Description:
If a sync starts before a pet is removed (or other setting is changed), and finishes after, that middle action gets undone. Bigger rework already in progress.

Closes https://github.com/oldschoolgg/oldschoolbot/issues/2621

### Changes:

- Adds the same delay most commands have to bank to prevent the user sync'ing over their pet.
- Checks before overwriting the pet slot if it's actually blank like we think.

### Other checks:

-   [x] I have tested all my changes thoroughly.
