### PR TITLE
Music Cape

### DIFF
--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -111,6 +111,11 @@ export default class extends BotCommand {
 			duration *= 0.95;
 		}
 
+		if (msg.author.hasItemEquippedAnywhere(['Music cape', 'Music cape(t)'], false)) {
+			boosts.push('5% for Music cape');
+			duration *= 0.95;
+		}
+
 		await addSubTaskToActivityTask<ClueActivityTaskOptions>({
 			clueID: clueTier.id,
 			userID: msg.author.id,

--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -102,8 +102,13 @@ export default class extends BotCommand {
 		}
 
 		if (msg.author.hasItemEquippedAnywhere(['Achievement diary cape', 'Achievement diary cape(t)'], false)) {
-			boosts.push('10% for Achievement diary cape');
-			duration *= 0.9;
+			boosts.push('5% for Achievement diary cape');
+			duration *= 0.95;
+		}
+
+		if (msg.author.hasItemEquippedAnywhere(['Quest point cape', 'Quest point cape(t)'], false)) {
+			boosts.push('5% for Quest point cape');
+			duration *= 0.95;
 		}
 
 		await addSubTaskToActivityTask<ClueActivityTaskOptions>({

--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -101,17 +101,17 @@ export default class extends BotCommand {
 			duration *= 0.9;
 		}
 
-		if (msg.author.hasItemEquippedAnywhere(['Achievement diary cape', 'Achievement diary cape(t)'], false)) {
+		if (msg.author.hasItemEquippedOrInBank('Achievement diary cape')) {
 			boosts.push('5% for Achievement diary cape');
 			duration *= 0.95;
 		}
 
-		if (msg.author.hasItemEquippedAnywhere(['Quest point cape', 'Quest point cape(t)'], false)) {
+		if (msg.author.hasItemEquippedOrInBank('Quest point cape')) {
 			boosts.push('5% for Quest point cape');
 			duration *= 0.95;
 		}
 
-		if (msg.author.hasItemEquippedAnywhere(['Music cape', 'Music cape(t)'], false)) {
+		if (msg.author.hasItemEquippedOrInBank('Music cape') && clueTier.name === 'Master') {
 			boosts.push('5% for Music cape');
 			duration *= 0.95;
 		}

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1335,8 +1335,7 @@ export const allPetsCL = resolveItems([
 	'Rocky',
 	'Rift guardian',
 	'Herbi',
-	// Not obtainable yet
-	// 'Chompy chick',
+	'Chompy chick',
 	'Sraracha',
 	'Smolcano',
 	'Youngllef',
@@ -1373,8 +1372,8 @@ export const championScrolls = resolveItems([
 export const championsChallengeCL = resolveItems([...championScrolls, "Champion's cape"]);
 export const chaosDruisCL = resolveItems(['Elder chaos top', 'Elder chaos robe', 'Elder chaos hood']);
 export const chompyBirdsCL = resolveItems([
-	// Not obtainable yet
-	// 'Chompy chick',
+
+	'Chompy chick',
 	'Chompy bird hat (ogre bowman)',
 	'Chompy bird hat (bowman)',
 	'Chompy bird hat (ogre yeoman)',
@@ -1682,8 +1681,7 @@ export const miscellaneousCL = resolveItems([
 	'Fire cape',
 	'Dragon warhammer',
 	'Herbi',
-	// Not obtainable yet
-	// 'Chompy chick',
+	'Chompy chick',
 	'Big swordfish',
 	'Big shark',
 	'Big bass',
@@ -1846,6 +1844,8 @@ export const capesCL = resolveItems([
 	'Quest point cape',
 	'Achievement diary hood',
 	'Achievement diary cape(t)',
+	'Music hood',
+	'Music cape(t)',
 	'Max hood',
 	'Max cape',
 	'Ardougne max hood',

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1335,7 +1335,8 @@ export const allPetsCL = resolveItems([
 	'Rocky',
 	'Rift guardian',
 	'Herbi',
-	'Chompy chick',
+	// Not obtainable yet
+	// 'Chompy chick',
 	'Sraracha',
 	'Smolcano',
 	'Youngllef',
@@ -1372,7 +1373,12 @@ export const championScrolls = resolveItems([
 export const championsChallengeCL = resolveItems([...championScrolls, "Champion's cape"]);
 export const chaosDruisCL = resolveItems(['Elder chaos top', 'Elder chaos robe', 'Elder chaos hood']);
 export const chompyBirdsCL = resolveItems([
+<<<<<<< HEAD
 	'Chompy chick',
+=======
+	// Not obtainable yet
+	// 'Chompy chick',
+>>>>>>> parent of 2721fc5d (Update CollectionsExport.ts)
 	'Chompy bird hat (ogre bowman)',
 	'Chompy bird hat (bowman)',
 	'Chompy bird hat (ogre yeoman)',
@@ -1680,7 +1686,8 @@ export const miscellaneousCL = resolveItems([
 	'Fire cape',
 	'Dragon warhammer',
 	'Herbi',
-	'Chompy chick',
+	// Not obtainable yet
+	// 'Chompy chick',
 	'Big swordfish',
 	'Big shark',
 	'Big bass',
@@ -1843,8 +1850,6 @@ export const capesCL = resolveItems([
 	'Quest point cape',
 	'Achievement diary hood',
 	'Achievement diary cape(t)',
-	'Music hood',
-	'Music cape(t)',
 	'Max hood',
 	'Max cape',
 	'Ardougne max hood',

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1372,7 +1372,6 @@ export const championScrolls = resolveItems([
 export const championsChallengeCL = resolveItems([...championScrolls, "Champion's cape"]);
 export const chaosDruisCL = resolveItems(['Elder chaos top', 'Elder chaos robe', 'Elder chaos hood']);
 export const chompyBirdsCL = resolveItems([
-
 	'Chompy chick',
 	'Chompy bird hat (ogre bowman)',
 	'Chompy bird hat (bowman)',

--- a/src/lib/data/buyables/capes.ts
+++ b/src/lib/data/buyables/capes.ts
@@ -1,8 +1,8 @@
 import { Bank } from 'oldschooljs';
 
+import { MAX_QP } from '../../constants';
 import { diaries, userhasDiaryTier } from '../../diaries';
 import { Buyable } from './buyables';
-import { MAX_QP } from '../../constants';
 
 export const capeBuyables: Buyable[] = [
 	{
@@ -36,7 +36,10 @@ export const capeBuyables: Buyable[] = [
 			for (const diary of diaries.map(d => d.elite)) {
 				const [has] = await userhasDiaryTier(user, diary);
 				if (!has) {
-					return [false, "You can't buy this because you haven't completed all the Elite achievement diaries!"];
+					return [
+						false,
+						"You can't buy this because you haven't completed all the Elite achievement diaries!"
+					];
 				}
 			}
 			return [true];

--- a/src/lib/data/buyables/capes.ts
+++ b/src/lib/data/buyables/capes.ts
@@ -2,6 +2,7 @@ import { Bank } from 'oldschooljs';
 
 import { diaries, userhasDiaryTier } from '../../diaries';
 import { Buyable } from './buyables';
+import { MAX_QP } from '../../constants';
 
 export const capeBuyables: Buyable[] = [
 	{
@@ -17,6 +18,25 @@ export const capeBuyables: Buyable[] = [
 				const [has] = await userhasDiaryTier(user, diary);
 				if (!has) {
 					return [false, "You can't buy this because you haven't completed all the Elite diaries!"];
+				}
+			}
+			return [true];
+		}
+	},
+	{
+		name: 'Music cape',
+		outputItems: new Bank({
+			'Music cape': 1,
+			'Music cape(t)': 1,
+			'Music hood': 1
+		}),
+		gpCost: 1_000_000,
+		qpRequired: MAX_QP,
+		customReq: async user => {
+			for (const diary of diaries.map(d => d.elite)) {
+				const [has] = await userhasDiaryTier(user, diary);
+				if (!has) {
+					return [false, "You can't buy this because you haven't completed all the Elite achievement diaries!"];
 				}
 			}
 			return [true];

--- a/src/lib/data/buyables/capes.ts
+++ b/src/lib/data/buyables/capes.ts
@@ -1,6 +1,5 @@
 import { Bank } from 'oldschooljs';
 
-import { MAX_QP } from '../../constants';
 import { diaries, userhasDiaryTier } from '../../diaries';
 import { Buyable } from './buyables';
 
@@ -18,28 +17,6 @@ export const capeBuyables: Buyable[] = [
 				const [has] = await userhasDiaryTier(user, diary);
 				if (!has) {
 					return [false, "You can't buy this because you haven't completed all the Elite diaries!"];
-				}
-			}
-			return [true];
-		}
-	},
-	{
-		name: 'Music cape',
-		outputItems: new Bank({
-			'Music cape': 1,
-			'Music cape(t)': 1,
-			'Music hood': 1
-		}),
-		gpCost: 1_000_000,
-		qpRequired: MAX_QP,
-		customReq: async user => {
-			for (const diary of diaries.map(d => d.elite)) {
-				const [has] = await userhasDiaryTier(user, diary);
-				if (!has) {
-					return [
-						false,
-						"You can't buy this because you haven't completed all the Elite achievement diaries!"
-					];
 				}
 			}
 			return [true];

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -314,7 +314,10 @@ const source: [string, (string | number)[]][] = [
 			'Trident of the swamp (e)',
 			'Uncharged toxic trident (e)'
 		]
-	]
+	],
+	['Quest point cape', ['Quest point cape (t)']],
+	['Music cape', ['Music cape (t)']],
+	['Achievement diary cape', ['Achievement diary cape (t)']]
 ];
 
 export const similarItems: Map<number, number[]> = new Map(


### PR DESCRIPTION
- Changed achievement diary cape clue boost to 5%
- Added 5% clue boost for quest cape
- Added 5% master clue boost for music cape (ty gid)
- Allowed the above capes boost's to work from bank (ty gid)
- Added music cape to cl capes

edit: 
- removed music cape from buyables so u can do whatever
- need to remove chompy chick cl part as saw u already fixed that