### PR TITLE
Master allow until flag k

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -398,69 +398,89 @@ export default class extends BotCommand {
 		const displayDuration = duration;
 		const displayQuantity = quantity;
 		let factor = 1;
-		let seededLoot: { loot: ItemBank; superiorCount: number; returnLootCost: ItemBank } | undefined = undefined;
+		let seededLoot:
+			| { loot: ItemBank; superiorCount: number; returnLootCost: ItemBank; untilItems: number[] }
+			| undefined = undefined;
 		let untilStr = '';
 		// Check for until flags
 		if (msg.flagArgs.until || msg.flagArgs.clues) {
-			const usersTask = await getUsersCurrentSlayerInfo(msg.author.id);
-			const isOnTask =
-				usersTask.assignedTask !== null &&
-				usersTask.currentTask !== null &&
-				usersTask.assignedTask.monsters.includes(monster.id);
-			const mySlayerUnlocks = msg.author.settings.get(UserSettings.Slayer.SlayerUnlocks);
-			const slayerMaster = isOnTask ? getSlayerMasterOSJSbyID(usersTask.slayerMaster!.id) : undefined;
-			// Check if superiors unlock is purchased
-			const superiorsUnlocked = isOnTask
-				? mySlayerUnlocks.includes(SlayerTaskUnlocksEnum.BiggerAndBadder)
-				: undefined;
-			const superiorTable = superiorsUnlocked && monster.superior ? monster.superior : undefined;
-			const isInCatacombs = !usingCannon ? monster.existsInCatacombs ?? undefined : undefined;
-			const killOptions: MonsterKillOptions = {
-				onSlayerTask: isOnTask,
-				slayerMaster,
-				hasSuperiors: superiorTable,
-				inCatacombs: isInCatacombs
-			};
-
-			const calculatedLoot = new Bank();
-			const returnLootCost = new Bank();
-			let superiorCount = 0;
-			const untilBank = parseStringBank(msg.flagArgs.until ?? '');
+			let untilBank = parseStringBank(msg.flagArgs.until ?? '').map(u => u[0].id);
 			if (msg.flagArgs.clues) {
 				for (const c of ClueTiers) {
-					untilBank.push([getOSItem(c.scrollID), undefined]);
+					untilBank.push(getOSItem(c.scrollID).id);
 				}
 			}
-			loopQty: for (let i = 1; i <= quantity; i++) {
-				if (superiorTable && isOnTask && roll(200)) {
-					superiorCount++;
-					calculatedLoot.add(superiorTable.kill(1));
-					if (isInCatacombs) calculatedLoot.add('Dark totem base', 1);
+			if (untilBank.length > 0) {
+				const allMonsterLoot: number[] = [];
+				allMonsterLoot.push(...Monsters.get(monster.id)!.allItems);
+				if (monster.superior) allMonsterLoot.push(...Monsters.get(monster.superior!.id!)!.allItems);
+				const allowedItems: number[] = [];
+				for (const _item of [...new Set(allMonsterLoot)]) {
+					if (untilBank.includes(_item)) allowedItems.push(_item);
+				}
+				untilBank = allowedItems;
+				if (untilBank.length > 0) {
+					const usersTask = await getUsersCurrentSlayerInfo(msg.author.id);
+					const isOnTask =
+						usersTask.assignedTask !== null &&
+						usersTask.currentTask !== null &&
+						usersTask.assignedTask.monsters.includes(monster.id);
+					const mySlayerUnlocks = msg.author.settings.get(UserSettings.Slayer.SlayerUnlocks);
+					const slayerMaster = isOnTask ? getSlayerMasterOSJSbyID(usersTask.slayerMaster!.id) : undefined;
+					// Check if superiors unlock is purchased
+					const superiorsUnlocked = isOnTask
+						? mySlayerUnlocks.includes(SlayerTaskUnlocksEnum.BiggerAndBadder)
+						: undefined;
+					const superiorTable = superiorsUnlocked && monster.superior ? monster.superior : undefined;
+					const isInCatacombs = !usingCannon ? monster.existsInCatacombs ?? undefined : undefined;
+					const killOptions: MonsterKillOptions = {
+						onSlayerTask: isOnTask,
+						slayerMaster,
+						hasSuperiors: superiorTable,
+						inCatacombs: isInCatacombs
+					};
+
+					const calculatedLoot = new Bank();
+					const returnLootCost = new Bank();
+					let superiorCount = 0;
+					loopQty: for (let i = 1; i <= quantity; i++) {
+						if (superiorTable && isOnTask && roll(200)) {
+							superiorCount++;
+							calculatedLoot.add(superiorTable.kill(1));
+							if (isInCatacombs) calculatedLoot.add('Dark totem base', 1);
+						} else {
+							calculatedLoot.add(monster.table.kill(1, killOptions));
+						}
+						for (const j of untilBank) {
+							// Ignore clues that the user already have in the bank
+							if (ClueTiers.map(c => c.scrollID).includes(j) && msg.author.bank().has(j)) {
+								continue;
+							}
+							if (calculatedLoot.has(j)) {
+								factor = i / quantity;
+								duration = Math.ceil(duration * factor);
+								quantity = i;
+								const reimburseLoot = new Bank().add(lootToRemove).add(foodToGiveBack);
+								reimburseLoot.forEach((item, qty) => {
+									returnLootCost.add(item.id, Math.max(0, qty - Math.ceil(qty * factor)));
+								});
+								break loopQty;
+							}
+						}
+					}
+					seededLoot = {
+						loot: calculatedLoot.bank,
+						superiorCount,
+						returnLootCost: returnLootCost.bank,
+						untilItems: untilBank
+					};
+					untilStr += `You are killing **${monster.name}s** until one of the following drops: ${untilBank
+						.map(u => getOSItem(u).name)
+						.join(', ')}`;
 				} else {
-					calculatedLoot.add(monster.table.kill(1, killOptions));
-				}
-				for (const j of untilBank) {
-					// Ignore clues that the user already have in the bank
-					if (ClueTiers.map(c => c.scrollID).includes(j[0].id) && msg.author.bank().has(j[0].id)) {
-						continue;
-					}
-					if (calculatedLoot.has(j[0].id)) {
-						factor = i / quantity;
-						duration = Math.ceil(duration * factor);
-						quantity = i;
-						const reimburseLoot = new Bank().add(lootToRemove).add(foodToGiveBack);
-						reimburseLoot.forEach((item, qty) => {
-							returnLootCost.add(item.id, Math.max(0, qty - Math.ceil(qty * factor)));
-						});
-						break loopQty;
-					}
+					untilStr += 'None of the items defined exists or can be dropped by this monster.';
 				}
 			}
-			seededLoot = { loot: calculatedLoot.bank, superiorCount, returnLootCost: returnLootCost.bank };
-			const lootNames = [...new Set([...untilBank.map(i => i[0].name)])];
-			untilStr += `You are killing **${monster.name}s** until one of the following drops: ${lootNames.join(
-				', '
-			)}`;
 		}
 
 		updateBankSetting(this.client, ClientSettings.EconomyStats.PVMCost, lootToRemove);

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -125,7 +125,14 @@ export default class extends Extendable {
 			return `${this.minionName} is currently doing nothing.`;
 		}
 
-		const durationRemaining = currentTask.finishDate - Date.now();
+		const durationRemaining = (() => {
+			if (currentTask.displayDuration) {
+				let duration = currentTask.finishDate - currentTask.duration;
+				duration += currentTask.displayDuration;
+				return duration - Date.now();
+			}
+			return currentTask.finishDate - Date.now();
+		})();
 		const formattedDuration = `${formatDuration(durationRemaining)} remaining.`;
 
 		switch (currentTask.type) {
@@ -133,7 +140,7 @@ export default class extends Extendable {
 				const data = currentTask as MonsterActivityTaskOptions;
 				const monster = killableMonsters.find(mon => mon.id === data.monsterID);
 
-				return `${this.minionName} is currently killing ${data.quantity}x ${
+				return `${this.minionName} is currently killing ${data.displayQuantity ?? data.quantity}x ${
 					monster!.name
 				}. ${formattedDuration}`;
 			}

--- a/src/lib/minions/functions/removeFoodFromUser.ts
+++ b/src/lib/minions/functions/removeFoodFromUser.ts
@@ -19,8 +19,7 @@ export default async function removeFoodFromUser({
 	healPerAction,
 	activityName,
 	attackStylesUsed,
-	learningPercentage,
-	dontRemoveFood
+	learningPercentage
 }: {
 	client: KlasaClient;
 	user: KlasaUser;
@@ -54,10 +53,9 @@ export default async function removeFoodFromUser({
 			i => i.name
 		).join(', ')}.`;
 	} else {
-		if (!dontRemoveFood) {
-			await user.removeItemsFromBank(foodToRemove);
-			updateBankSetting(client, ClientSettings.EconomyStats.PVMCost, foodToRemove);
-		}
+		await user.removeItemsFromBank(foodToRemove);
+		updateBankSetting(client, ClientSettings.EconomyStats.PVMCost, foodToRemove);
+
 		let reductionsStr = reductions.length > 0 ? ` **Base Food Reductions:** ${reductions.join(', ')}.` : '';
 		return [`${new Bank(foodToRemove)} from ${user.username}${reductionsStr}`, foodToRemove];
 	}

--- a/src/lib/minions/functions/removeFoodFromUser.ts
+++ b/src/lib/minions/functions/removeFoodFromUser.ts
@@ -19,7 +19,8 @@ export default async function removeFoodFromUser({
 	healPerAction,
 	activityName,
 	attackStylesUsed,
-	learningPercentage
+	learningPercentage,
+	dontRemoveFood
 }: {
 	client: KlasaClient;
 	user: KlasaUser;
@@ -28,6 +29,7 @@ export default async function removeFoodFromUser({
 	activityName: string;
 	attackStylesUsed: GearSetupTypes[];
 	learningPercentage?: number;
+	dontRemoveFood?: boolean;
 }): Promise<[string, ItemBank]> {
 	await user.settings.sync(true);
 	const userBank = user.settings.get(UserSettings.Bank);
@@ -52,10 +54,10 @@ export default async function removeFoodFromUser({
 			i => i.name
 		).join(', ')}.`;
 	} else {
-		await user.removeItemsFromBank(foodToRemove);
-
-		updateBankSetting(client, ClientSettings.EconomyStats.PVMCost, foodToRemove);
-
+		if (!dontRemoveFood) {
+			await user.removeItemsFromBank(foodToRemove);
+			updateBankSetting(client, ClientSettings.EconomyStats.PVMCost, foodToRemove);
+		}
 		let reductionsStr = reductions.length > 0 ? ` **Base Food Reductions:** ${reductions.join(', ')}.` : '';
 		return [`${new Bank(foodToRemove)} from ${user.username}${reductionsStr}`, foodToRemove];
 	}

--- a/src/lib/typeorm/ActivityTable.entity.ts
+++ b/src/lib/typeorm/ActivityTable.entity.ts
@@ -1,4 +1,3 @@
-import { deepClone } from 'e';
 import { BaseEntity, Column, Entity, getConnection, Index, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
 
 import { client } from '../..';
@@ -93,7 +92,7 @@ export class ActivityTable extends BaseEntity {
 		client.oneCommandAtATimeCache.add(this.userID);
 		try {
 			const { taskData } = this;
-			const newData = { ...deepClone(taskData) };
+			const newData = { ...this.data };
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
 			if (newData.seededLoot) {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -55,7 +55,7 @@ export interface ConstructionActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface MonsterActivityTaskOptions extends ActivityTaskOptions {
-	seededLoot?: { loot: ItemBank; superiorCount: number };
+	seededLoot?: { loot: ItemBank; superiorCount: number; returnLootCost: ItemBank };
 	monsterID: number;
 	quantity: number;
 	displayQuantity?: number;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -2,12 +2,14 @@ import { MinigameKey } from '../../extendables/User/Minigame';
 import { Peak } from '../../tasks/WildernessPeakInterval';
 import { Activity } from '../constants';
 import { IPatchData } from '../minions/farming/types';
-import { BirdhouseData } from './../skilling/skills/hunter/defaultBirdHouseTrap';
+import { BirdhouseData } from '../skilling/skills/hunter/defaultBirdHouseTrap';
+import { ItemBank } from './index';
 
 export interface ActivityTaskOptions {
 	type: Activity;
 	userID: string;
 	duration: number;
+	displayDuration?: number;
 	id: string;
 	finishDate: number;
 	channelID: string;
@@ -53,8 +55,10 @@ export interface ConstructionActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface MonsterActivityTaskOptions extends ActivityTaskOptions {
+	seededLoot?: { loot: ItemBank; superiorCount: number };
 	monsterID: number;
 	quantity: number;
+	displayQuantity?: number;
 	usingCannon?: boolean;
 	cannonMulti?: boolean;
 	burstOrBarrage?: number;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -55,7 +55,7 @@ export interface ConstructionActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface MonsterActivityTaskOptions extends ActivityTaskOptions {
-	seededLoot?: { loot: ItemBank; superiorCount: number; returnLootCost: ItemBank };
+	seededLoot?: { loot: ItemBank; superiorCount: number; returnLootCost: ItemBank; untilItems: number[] };
 	monsterID: number;
 	quantity: number;
 	displayQuantity?: number;

--- a/src/tasks/minionTicker.ts
+++ b/src/tasks/minionTicker.ts
@@ -16,7 +16,7 @@ export default class extends Task {
 				if (production) {
 					query.andWhere('finish_date < now()');
 				} else {
-					query.andWhere("start_date + interval '10 seconds' < now()");
+					query.andWhere("start_date + interval '5 seconds' < now()");
 				}
 
 				const result = await query.getMany();

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -1,3 +1,4 @@
+import { objectKeys } from 'e';
 import { Task } from 'klasa';
 import { Bank, MonsterKillOptions, Monsters } from 'oldschooljs';
 
@@ -26,11 +27,18 @@ export default class extends Task {
 			usersTask.assignedTask.monsters.includes(monsterID);
 		const quantitySlayed = isOnTask ? Math.min(usersTask.currentTask!.quantityRemaining, quantity) : null;
 
+		let returnedLoot = '';
 		let newSuperiorCount = 0;
 		let loot = new Bank();
 		if (data.seededLoot) {
 			newSuperiorCount = data.seededLoot.superiorCount;
 			loot.add(data.seededLoot.loot);
+			if (objectKeys(data.seededLoot.returnLootCost).length > 0) {
+				await user.addItemsToBank(data.seededLoot.returnLootCost);
+				returnedLoot += `\nAs you returned early from your trip, you saved on some supplies: ${new Bank(
+					data.seededLoot.returnLootCost
+				)}\n`;
+			}
 		} else {
 			const mySlayerUnlocks = user.settings.get(UserSettings.Slayer.SlayerUnlocks);
 			const slayerMaster = isOnTask ? getSlayerMasterOSJSbyID(usersTask.slayerMaster!.id) : undefined;
@@ -128,6 +136,8 @@ export default class extends Task {
 			usersTask.currentTask!.quantityRemaining = quantityLeft;
 			await usersTask.currentTask!.save();
 		}
+
+		str += returnedLoot;
 
 		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true);
 


### PR DESCRIPTION
### Description:

- Allow trips to instantly finish when an item is dropped.

### Changes:

- When --clues or --until flag is used, the +k will pre-calculate the loot, just like the monsterActivity would;
- The activity will still require full supplies for the entire trip, but will return the supplies not used if ending early.

### Other checks:

-   [X] I have tested all my changes thoroughly.
