### PR TITLE
Fix transparent bg in gearsetup image

### DIFF
--- a/src/lib/gear/functions/generateGearImage.ts
+++ b/src/lib/gear/functions/generateGearImage.ts
@@ -103,7 +103,11 @@ export async function generateGearImage(
 	const ctx = canvas.getContext('2d');
 	ctx.imageSmoothingEnabled = false;
 
-	ctx.fillStyle = userBgImage.transparent && hexColor ? hexColor : ctx.createPattern(sprite.repeatableBg, 'repeat');
+	ctx.fillStyle = userBgImage.transparent
+		? hexColor
+			? hexColor
+			: 'transparent'
+		: ctx.createPattern(sprite.repeatableBg, 'repeat');
 	ctx.fillRect(0, 0, canvas.width, canvas.height);
 
 	if (!uniqueSprite) {
@@ -263,7 +267,11 @@ export async function generateAllGearImage(client: KlasaClient, user: KlasaUser)
 	const ctx = canvas.getContext('2d');
 	ctx.imageSmoothingEnabled = false;
 
-	ctx.fillStyle = userBg.transparent && hexColor ? hexColor : ctx.createPattern(bgSprite.repeatableBg, 'repeat');
+	ctx.fillStyle = userBg.transparent
+		? hexColor
+			? hexColor
+			: 'transparent'
+		: ctx.createPattern(bgSprite.repeatableBg, 'repeat');
 	ctx.fillRect(0, 0, canvas.width, canvas.height);
 
 	if (!hasBgSprite) {


### PR DESCRIPTION
### Changes:

- Fix transparent BG in gear images. It was doing the default pattern BG when transparent with no hexcolor

### Other checks:

-   [X] I have tested all my changes thoroughly.

Tests?
![image](https://user-images.githubusercontent.com/19570528/129771944-bf1c60fb-b675-4417-b9c5-220f7297cafb.png)

Current: 
![image](https://user-images.githubusercontent.com/19570528/129723855-633b444c-6c57-42cc-b80d-d70ea083fea8.png)

This PR: 
![image](https://user-images.githubusercontent.com/19570528/129723879-9c65787c-63dd-4192-946f-3a29d533289c.png)
![image](https://user-images.githubusercontent.com/19570528/129723892-e1477ad5-23bc-4b6c-9cc0-e6334be026d0.png)
