### PR TITLE
Fix farming contracts

### DIFF
--- a/src/lib/skilling/functions/calcFarmingContracts.ts
+++ b/src/lib/skilling/functions/calcFarmingContracts.ts
@@ -85,9 +85,9 @@ export function getPlantToGrow(
 ): [string, PlantTier] {
 	const farmingLevel = user.skillLevel(SkillsEnum.Farming);
 	let contractType: PlantsList = [];
-	if (contractLevel === 'easy') contractType = easyPlants;
-	if (contractLevel === 'medium') contractType = mediumPlants;
-	if (contractLevel === 'hard') contractType = hardPlants;
+	if (contractLevel === 'easy') contractType = [...easyPlants];
+	if (contractLevel === 'medium') contractType = [...mediumPlants];
+	if (contractLevel === 'hard') contractType = [...hardPlants];
 
 	for (let i = contractType.length; i > 0; i--) {
 		const [farmingLevelNeeded, plantName] = contractType[i - 1];


### PR DESCRIPTION
### Description:
A bug in the original implementation of farming contracts meant that anytime a plant was removed from the list (like for level requirements), it was **permanently** removed from the **Master** list.

When I added the code to avoid getting the same contract b2b, this used the same mechanism, but now had the ability to remove ANY contract, leading to the problem today.

As a nice consequence, this means contract variety will go up, because it won't permanently delete the high-level tasks when a low level person requests a farming contract.

### Changes:
Deep clones the local copy of the farming contract list instead of a by-reference copy.

**That's why you never saw redwood trees when you get contracts!**

### Other checks:

-   [x] I have tested all my changes thoroughly.
