### PR TITLE
Add gorajan warrior boost to KK

### DIFF
--- a/src/commands/bso/kk.ts
+++ b/src/commands/bso/kk.ts
@@ -1,4 +1,4 @@
-import { increaseNumByPercent, reduceNumByPercent, Time } from 'e';
+import { increaseNumByPercent, reduceNumByPercent, round, Time } from 'e';
 import { CommandStore, KlasaMessage, KlasaUser } from 'klasa';
 import { Bank } from 'oldschooljs';
 
@@ -18,6 +18,7 @@ import { formatDuration, updateBankSetting } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import calcDurQty from '../../lib/util/calcMassDurationQuantity';
 import { getKalphiteKingGearStats } from '../../lib/util/getKalphiteKingGearStats';
+import { gorajanWarriorOutfit } from '../../tasks/minions/dungeoneeringActivity';
 
 const minimumSoloGear = new Gear({
 	body: 'Torva platebody',
@@ -169,10 +170,16 @@ export default class extends BotCommand {
 				}
 			}
 
+			if (meleeGear.hasEquipped(gorajanWarriorOutfit, true)) {
+				const perUserPercent = round(15 / users.length, 2);
+				effectiveTime = reduceNumByPercent(effectiveTime, perUserPercent);
+				msgs.push(`${perUserPercent}% for Gorajan warrior`);
+			}
+
 			if (data.gearStats.attack_crush < 200) {
 				const percent = 10;
 				effectiveTime = increaseNumByPercent(effectiveTime, percent);
-				msgs.push(`-${percent}% penalty for 140 attack crush`);
+				msgs.push(`-${percent}% penalty for 200 attack crush`);
 			}
 
 			if (!equippedWeapon || !equippedWeapon.equipment || equippedWeapon.equipment.attack_crush < 95) {


### PR DESCRIPTION
### Description:

Request by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129764167-12116804-300d-48f5-8977-ad0454faf0cb.png)

### Changes:

- Add 15% boost for Gorajan Warrior on KK;
- Fix the incorrect 140 crush attack to show 200, as it is validated by that.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129764294-89118780-1fb9-4885-b9a3-7ce150eaa5f5.png)