### PR TITLE
Fix ate a ori typo and ceil Ori effect instead of floor

### DIFF
--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -112,7 +112,7 @@ export async function runTameTask(activity: TameActivityTable) {
 			let str = `${user}, ${activity.tame.name} finished killing ${quantity}x ${fullMonster.name}.`;
 			const boosts = [];
 			if (hasOri) {
-				boosts.push('25% extra loot (ate a Ori)');
+				boosts.push('25% extra loot (ate an Ori)');
 			}
 			if (boosts.length > 0) {
 				str += `\n\n**Boosts:** ${boosts.join(', ')}.`;

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -99,7 +99,7 @@ export async function runTameTask(activity: TameActivityTable) {
 			// If less than 8 kills, roll 25% chance per kill
 			if (hasOri) {
 				if (killQty >= 8) {
-					killQty = Math.floor(killQty * 1.25);
+					killQty = Math.ceil(killQty * 1.25);
 				} else {
 					for (let i = 0; i < quantity; i++) {
 						if (roll(4)) killQty++;


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129767747-34f29fb4-2c07-4d40-8773-c95105264db2.png)
![image](https://user-images.githubusercontent.com/19570528/129768167-51b92f91-8cbc-4e95-986d-91416701d564.png)

### Changes:

- Fix 'a Ori' to 'an Ori';
- Ceil Ori effect when over 8KC a trip, instead of Floor, to match player effect.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129768507-c097102a-2b18-460f-82f1-08a6153cd0cb.png)