### PR TITLE
Remove voidling message when user has no favalchs

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -162,9 +162,9 @@ export async function handleTripFinish(
 					? "As you left your Voidling alone in the bank, it got distracted easily and didn't manage to alch at its full potential."
 					: ''
 			}`;
-		} else {
+		} else if (user.getUserFavAlchs().length !== 0) {
 			message +=
-				"\nYour Voidling didn't alch anything because you either: don't have Nature runes, Fire Runes, or any Favorited alchables that you own.";
+				"\nYour Voidling didn't alch anything because you either don't have any nature runes or fire runes.";
 		}
 	}
 


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129771297-e8a2e4e9-f5ab-4fb5-90d9-33569eed137b.png)

### Changes:

- Change voidling message when it must be displayed;
- Don't show the message when the user has no favalchs in the bank.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129771441-7da6e62c-4ea2-475a-96e9-6d47895ee33a.png)