### PR TITLE
Allow checking farming contracts when busy

### DIFF
--- a/src/commands/Minion/farmingcontract.ts
+++ b/src/commands/Minion/farmingcontract.ts
@@ -1,6 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 
-import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
+import { requiresMinion } from '../../lib/minions/decorators';
 import { defaultFarmingContract } from '../../lib/minions/farming';
 import { FarmingContract } from '../../lib/minions/farming/types';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -29,7 +29,6 @@ export default class extends BotCommand {
 		});
 	}
 
-	@minionNotBusy
 	@requiresMinion
 	async run(msg: KlasaMessage, [contractLevel]: ['easy' | 'medium' | 'hard' | 'easier' | 'current' | 'completed']) {
 		await msg.author.settings.sync(true);
@@ -161,6 +160,18 @@ export default class extends BotCommand {
 				files: [
 					await chatHeadImage({
 						content: `Your current contract (${currentContract.difficultyLevel}) is to grow ${currentContract.plantToGrow}. Please come back when you have finished this contract first.${easierStr}`,
+						head: 'jane'
+					})
+				]
+			});
+		}
+
+		if (msg.author.minionIsBusy) {
+			return msg.channel.send({
+				files: [
+					await chatHeadImage({
+						content:
+							"You are busy at the moment! I can't give you a new farming contract like that. Please, come back when you have some free time for us to talk.",
 						head: 'jane'
 					})
 				]


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129774895-4df56aa8-98e6-48e8-a6f7-7333facda581.png)

### Changes:

- Remove minionIsBusy decorator;
- Applies busy logic before allowing the user to get a new contract.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129775059-c50f69b2-0658-494a-ac28-da4da2af8c1e.png)
![image](https://user-images.githubusercontent.com/19570528/129775078-b17def05-bfe3-4616-93d7-4013b75eee5d.png)

No contract and trying to get a new one when busy
![image](https://user-images.githubusercontent.com/19570528/129775128-446edb3e-36e8-439a-9815-5d6f136fc491.png)