### PR TITLE
Add floor 6 and 7 to Sepulchre

### DIFF
--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -69,7 +69,7 @@ const GrandmasterTierCoffin = new LootTable()
 	.add('Rocktail', [10, 20])
 	.add('Raw rocktail', [20, 30])
 	.add(RareDropTable, [2, 6])
-	.add(HerbDropTable, [2, 10], undefined, { multiply: true })
+	.add(HerbDropTable, [2, 10])
 	.add('Coins', [250_000, 500_000]);
 
 export const sepulchreFloors = [

--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -1,5 +1,7 @@
 import { randInt, Time } from 'e';
 import { Bank } from 'oldschooljs';
+import HerbDropTable from 'oldschooljs/dist/simulation/subtables/HerbDropTable';
+import RareDropTable from 'oldschooljs/dist/simulation/subtables/RareDropTable';
 import LootTable from 'oldschooljs/dist/structures/LootTable';
 import { resolveNameBank } from 'oldschooljs/dist/util';
 
@@ -41,6 +43,34 @@ const HighTierCoffin = new LootTable()
 	.add('Sanfew serum(4)', [1, 2])
 	.add('Ranarr seed', [1, 2])
 	.add('Coins', [17_500, 25_000]);
+
+const MasterTierCoffin = new LootTable()
+	.add('Dragon 2h sword')
+	.add('Dragon chainbody')
+	.add('Law rune', [250, 350])
+	.add('Blood rune', [250, 350])
+	.add('Soul rune', [250, 350])
+	.add('Runite bolts', [200, 400])
+	.add('Monkfish', [6, 12])
+	.add('Sanfew serum(4)', [3, 6])
+	.add('Ranarr seed', [4, 6])
+	.add('Coins', [37_500, 55_000]);
+
+const GrandmasterTierCoffin = new LootTable()
+	.add('Stamina potion(4)', [2, 4])
+	.add(
+		[
+			['Super restore(4)', 3],
+			['Saradomin brew(4)', 1]
+		],
+		[2, 6]
+	)
+	.add('Prayer potion(4)', [4, 8])
+	.add('Rocktail', [10, 20])
+	.add('Raw rocktail', [20, 30])
+	.add(RareDropTable, [2, 6])
+	.add(HerbDropTable, [2, 10], undefined, { multiply: true })
+	.add('Coins', [250_000, 500_000]);
 
 export const sepulchreFloors = [
 	{
@@ -97,6 +127,28 @@ export const sepulchreFloors = [
 		coffinTable: new LootTable().add(MidTierCoffin, 1, 20).add(HighTierCoffin, 1, 80),
 		numCoffins: 3,
 		marksRange: [4, 6]
+	},
+	{
+		number: 6,
+		petChance: 1800,
+		agilityLevel: 105,
+		xp: 17_550,
+		time: Time.Minute * 5.15,
+		lockpickCoffinChance: 400,
+		coffinTable: new LootTable().add(HighTierCoffin, 1, 80).add(MasterTierCoffin, 2, 20),
+		numCoffins: 4,
+		marksRange: [6, 8]
+	},
+	{
+		number: 7,
+		petChance: 1500,
+		agilityLevel: 115,
+		xp: 46_800,
+		time: Time.Minute * 7.08,
+		lockpickCoffinChance: 200,
+		coffinTable: new LootTable().add(MasterTierCoffin, 2, 80).add(GrandmasterTierCoffin, 1, 20),
+		numCoffins: 6,
+		marksRange: [12, 14]
 	}
 ];
 

--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -21,8 +21,8 @@ export default class extends Task {
 
 		for (let i = 0; i < quantity; i++) {
 			for (const floor of completedFloors) {
-				if (floor.number === 5) {
-					loot.add(GrandHallowedCoffin.roll());
+				if (floor.number >= 5) {
+					loot.add(GrandHallowedCoffin.roll(), { 5: 1, 6: 2, 7: 3 }[floor.number] ?? 1);
 				}
 
 				const numCoffinsToOpen = 1;


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129782557-fdae44d3-6edb-4953-9804-5838670037f6.png)

### Changes:

- Add floor 6 at 105 agility;
- Add floor 7 at 115 agility;
- Add Master and Grandmaster loot pools;
- Master is a better version of the High pool;
- Grandmaster has useful items like prayer potions, stamina, brews and super restores, herbs, rdt and rocktails.

- The experience, fully boosted, goes from 675_000 (at level 92) to 1_890_000 (at level 115);
- Loot value stays about the same (between 1M and 2M per run).

### Other checks:

-   [X] I have tested all my changes thoroughly.

10K laps up to Floor 5
![image](https://user-images.githubusercontent.com/19570528/129786053-d2f5720c-ace7-4263-aca1-7a53d6e5a929.png)

10K laps up to floor 6
![image](https://user-images.githubusercontent.com/19570528/129786078-dd566db3-e5d4-4882-bc39-f082c3f220c7.png)

10K laps up to floor 7
![image](https://user-images.githubusercontent.com/19570528/129786103-b3870d21-54e3-48d1-915e-fefb7ac619ef.png)