### PR TITLE
Allow +lamp to be used when busy

### DIFF
--- a/src/commands/Minion/lamp.ts
+++ b/src/commands/Minion/lamp.ts
@@ -6,7 +6,7 @@ import { Bank } from 'oldschooljs';
 import { toKMB } from 'oldschooljs/dist/util';
 
 import { Emoji, skillEmoji } from '../../lib/constants';
-import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
+import { requiresMinion } from '../../lib/minions/decorators';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
@@ -248,7 +248,6 @@ export default class extends BotCommand {
 		}
 	}
 
-	@minionNotBusy
 	@requiresMinion
 	async run(msg: KlasaMessage, [qty, cmd]: [number, string]) {
 		await msg.author.settings.sync(true);


### PR DESCRIPTION
### Description:

- +lamp is limiting busy minions from using lamps

### Changes:

- Remove minionNotBusy decorator

### Other checks:

-   [X] I have tested all my changes thoroughly.
