### PR TITLE
Fix +cl --missing / Add +cl --text

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -1192,7 +1192,7 @@ export async function getCollection(options: {
 		return {
 			category: 'Custom',
 			name: search,
-			collection: roleCategory,
+			collection: clItems,
 			collectionObtained: userAmount,
 			collectionTotal: totalCl,
 			userItems: userCheckBank

--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -216,7 +216,7 @@ export default class CollectionLogTask extends Task {
 
 		await user.settings.sync(true);
 
-		let collectionLog = undefined;
+		let collectionLog: IToReturnCollection | undefined | false = undefined;
 
 		if (collection) {
 			collectionLog = await getCollection({
@@ -226,10 +226,33 @@ export default class CollectionLogTask extends Task {
 				logType: type
 			});
 		}
+
 		if (!collectionLog) {
 			return {
 				content: "That's not a valid collection log type. The valid types are: ",
 				files: [getPossibleOptions()]
+			};
+		}
+
+		if (flags.text) {
+			return {
+				content: 'This is the items on your log:',
+				files: [
+					new MessageAttachment(
+						Buffer.from(
+							collectionLog.collection
+								.map(i => {
+									let _i = getOSItem(i);
+									const _q = (collectionLog as IToReturnCollection).userItems.amount(_i.id);
+									if (_q === 0 && !flags.missing) return undefined;
+									return `${flags.nq || flags.missing ? '' : `${_q}x `}${_i.name}`;
+								})
+								.filter(f => f)
+								.join(flags.comma ? ', ' : '\n')
+						),
+						'yourLogItems.txt'
+					)
+				]
 			};
 		}
 


### PR DESCRIPTION
### Description:

- +cl --missing was improperly filtering items;
- Suggested to add a way to export cl items as text

### Changes:

- Fix +cl missing by using the correct clItems when a role is selected;
- Add --text ( and the following tags to support it: --nq (no quantity), --comma (separate by comma instead of \n));

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129810003-9512560d-add1-4fc4-b448-d677fb34eea5.png)
![image](https://user-images.githubusercontent.com/19570528/129810020-0c9da3c8-f8d0-4a03-a15c-249039f2c8b8.png)