### PR TITLE
Allow clues to calculate the qty automatically and add y to continue.

### DIFF
--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -116,7 +116,9 @@ export default class extends BotCommand {
 		const maxTripLength = msg.author.maxTripLength(Activity.ClueCompletion);
 		const maxPerTrip = Math.floor(maxTripLength / timeToFinish);
 		if (quantity === -1) quantity = maxPerTrip;
-		if (numOfScrolls < quantity) quantity = numOfScrolls;
+		if (numOfScrolls < quantity) {
+			return msg.channel.send(`You only have ${numOfScrolls}x ${clueTier.name.toLowerCase()} clue scrolls.`);
+		}
 
 		let duration = timeToFinish * quantity;
 

--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -7,24 +7,19 @@ import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { ClueTier } from '../../lib/minions/types';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
-import { Gear } from '../../lib/structures/Gear';
 import { ClueActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, isWeekend, rand, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
+import resolveItems from '../../lib/util/resolveItems';
 
-export function hasClueHunterEquipped(setup: Gear) {
-	return setup.hasEquipped(
-		[
-			'Helm of raedwald',
-			'Clue hunter garb',
-			'Clue hunter trousers',
-			'Clue hunter boots',
-			'Clue hunter gloves',
-			'Clue hunter cloak'
-		],
-		true
-	);
-}
+export const clueHunterOutfit = resolveItems([
+	'Helm of raedwald',
+	'Clue hunter garb',
+	'Clue hunter trousers',
+	'Clue hunter boots',
+	'Clue hunter gloves',
+	'Clue hunter cloak'
+]);
 
 function reducedClueTime(clueTier: ClueTier, score: number) {
 	// Every 3 hours become 1% better to a cap of 10%
@@ -91,7 +86,7 @@ export default class extends BotCommand {
 
 		if (percentReduced >= 1) boosts.push(`${percentReduced}% for clue score`);
 
-		if (hasClueHunterEquipped(msg.author.getGear('skilling'))) {
+		if (msg.author.hasItemEquippedAnywhere(clueHunterOutfit, true)) {
 			timeToFinish /= 2;
 			boosts.push('2x Boost for Clue hunter outfit');
 		}

--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -15,7 +15,7 @@ import { addBanks, addItemToBank, rand, roll, stringMatches, updateGPTrackSettin
 import { formatOrdinal } from '../../lib/util/formatOrdinal';
 import itemID from '../../lib/util/itemID';
 import resolveItems from '../../lib/util/resolveItems';
-import { hasClueHunterEquipped } from './mclue';
+import { clueHunterOutfit } from './mclue';
 
 const itemsToNotifyOf = resolveItems([
 	'Dwarven blessing',
@@ -87,7 +87,7 @@ export default class extends BotCommand {
 
 		await msg.author.removeItemFromBank(clueTier.id, quantity);
 
-		const hasCHEquipped = hasClueHunterEquipped(msg.author.getGear('skilling'));
+		const hasCHEquipped = msg.author.hasItemEquippedAnywhere(clueHunterOutfit, true);
 
 		let extraClueRolls = 0;
 		let loot: ItemBank = {};

--- a/src/tasks/minions/clueActivity.ts
+++ b/src/tasks/minions/clueActivity.ts
@@ -71,6 +71,15 @@ export default class extends Task {
 			`${user.username}[${user.id}] received ${quantity} ${clueTier.name} Clue Caskets.`
 		);
 
-		handleTripFinish(this.client, user, channelID, str, undefined, undefined, data, loot);
+		handleTripFinish(
+			this.client,
+			user,
+			channelID,
+			str,
+			res => this.client.commands.get('mclue')!.run(res, [-1, clueTier.name]),
+			undefined,
+			data,
+			loot
+		);
 	}
 }

--- a/src/tasks/minions/clueActivity.ts
+++ b/src/tasks/minions/clueActivity.ts
@@ -76,7 +76,7 @@ export default class extends Task {
 			user,
 			channelID,
 			str,
-			res => this.client.commands.get('mclue')!.run(res, [-1, clueTier.name]),
+			res => this.client.commands.get('mclue')!.run(res, [quantity, clueTier.name]),
 			undefined,
 			data,
 			loot


### PR DESCRIPTION
### Description:

- Clues on BSO is a pain to do.

### Changes:

- Clues are now calculated based on what the user can do and will lower it automatically to what the user has in bank if a higher qty is informed;
- Applies the capes and graceful boosts BEFORE the calculation, to allow for some more clues to be done (like every other activity);
- Y to continue sends the same amount of clues;
- Allows clue hunter outfit to be worn anywhere.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129821229-b62cfa8b-3cc5-4d26-b252-52d0b016f565.png)
![image](https://user-images.githubusercontent.com/19570528/129821242-dcb9d031-a52d-44fa-9601-d1083bbf7351.png)
![image](https://user-images.githubusercontent.com/19570528/129821273-fc05ea45-b376-46b0-bb55-98584491317e.png)