### PR TITLE
Allow wintertoad to roll based on trip length.

### DIFF
--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -38,7 +38,7 @@ export default class extends Task {
 		}
 
 		let gotToad = false;
-		if (roll(100) && duration > Time.Minute * 20) {
+		if (duration > Time.Minute * 20 && roll(3000 / Math.floor(duration / Time.Minute))) {
 			gotToad = true;
 			loot[itemID('Wintertoad')] = 1;
 		}


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129823784-069d4fcc-64ed-4a89-b08a-80fb0322a8b4.png)
- Wintertoad is worse to get being a patreon than a normal user, because trips are fixed and rolls are done once per trip.

### Changes:

- Allow trip length to change the odds of the rolls. The average is still 1 in 100, but it is now fair for everyone.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129822968-e2b2ed63-8eab-4f63-9ac1-77af23ba157b.png)