### PR TITLE
Add fish sack barrel

### DIFF
--- a/src/commands/Minion/fish.ts
+++ b/src/commands/Minion/fish.ts
@@ -104,6 +104,14 @@ export default class extends BotCommand {
 				break;
 		}
 
+		if (msg.author.allItemsOwned().has('Fish sack barrel') || msg.author.allItemsOwned().has('Fish barrel')) {
+			boosts.push(
+				`+9 trip minutes for having a ${
+					msg.author.allItemsOwned().has('Fish sack barrel') ? 'Fish sack barrel' : 'Fish barrel'
+				}`
+			);
+		}
+
 		const maxTripLength = msg.author.maxTripLength(Activity.Fishing);
 
 		if (quantity === null) {

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -679,7 +679,7 @@ export default class extends Extendable {
 
 		switch (activity) {
 			case Activity.Fishing:
-				if (this.allItemsOwned().has('Fish barrel sack') || this.allItemsOwned().has('Fish barrel')) {
+				if (this.allItemsOwned().has('Fish sack barrel') || this.allItemsOwned().has('Fish barrel')) {
 					max += Time.Minute * 9;
 				}
 				break;

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -679,7 +679,7 @@ export default class extends Extendable {
 
 		switch (activity) {
 			case Activity.Fishing:
-				if (this.hasItemEquippedAnywhere('Fish sack')) {
+				if (this.allItemsOwned().has('Fish barrel sack') || this.allItemsOwned().has('Fish barrel')) {
 					max += Time.Minute * 9;
 				}
 				break;

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -4825,7 +4825,17 @@ const Createables: Createable[] = [
 	...slayerCreatables,
 	...capeCreatables,
 	...dragonFireShieldCreatables,
-	...revWeapons
+	...revWeapons,
+	{
+		name: 'Fish sack barrel',
+		inputItems: new Bank({
+			'Fish sack': 1,
+			'Fish barrel': 1
+		}).bank,
+		outputItems: {
+			'Fish sack barrel': 1
+		}
+	}
 ];
 
 export default Createables;


### PR DESCRIPTION
### WARNING: MERGE ONLY AFTER BSO SOTW IS OVER

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129826741-b8baf0ae-205f-4256-9e19-bfd28ff2bd4f.png)

### Changes:

- Move the Fish sack boost to Tempoross Fish barrel or the new createable, Fish sack barrel;
- Add a message saying the user trip is extended by  minutes for having one of the boosting items.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129825625-320b89c3-746c-46aa-bba9-0571cff15930.png)
![image](https://user-images.githubusercontent.com/19570528/129825634-ea1295c8-5409-4cf0-9532-5d2306ca6455.png)
![image](https://user-images.githubusercontent.com/19570528/129825643-b3a6a2ec-167a-4a82-8f90-d3be3eb2f39c.png)
![image](https://user-images.githubusercontent.com/19570528/129825647-37ad327e-2c32-4ab9-9e57-8db971d67910.png)