### PR TITLE
Add blacksmith outfit effect to blast furnace

### DIFF
--- a/src/commands/Minion/blastfurnace.ts
+++ b/src/commands/Minion/blastfurnace.ts
@@ -19,6 +19,7 @@ import {
 	updateBankSetting
 } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
+import { hasBlackSmithEquipped } from './smith';
 
 const requiredSkills = {
 	crafting: 12,
@@ -105,6 +106,10 @@ export default class extends BotCommand {
 		if (msg.author.hasItemEquippedAnywhere('Smithing master cape')) {
 			timeToSmithSingleBar /= 2;
 			boosts.push('2x boost for Smithing master cape');
+		}
+
+		if (hasBlackSmithEquipped(msg.author.getGear('skilling'))) {
+			boosts.push('10% more XP for having the blacksmith outfit equipped');
 		}
 
 		const maxTripLength = msg.author.maxTripLength(Activity.Smithing);

--- a/src/tasks/minions/blastFurnaceActivity.ts
+++ b/src/tasks/minions/blastFurnaceActivity.ts
@@ -1,6 +1,7 @@
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
+import { hasBlackSmithEquipped } from '../../commands/Minion/smith';
 import Smithing from '../../lib/skilling/skills/smithing';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BlastFurnaceActivityTaskOptions } from '../../lib/types/minions';
@@ -16,17 +17,21 @@ export default class extends Task {
 
 		let xpReceived = quantity * bar.xp;
 
+		const hasBS = hasBlackSmithEquipped(user.getGear('skilling'));
+
 		if (bar.id === itemID('Gold bar') && user.hasItemEquippedOrInBank('Goldsmith gauntlets')) {
 			xpReceived = quantity * 56.2;
 		}
 
 		const xpRes = await user.addXP({
 			skillName: SkillsEnum.Smithing,
-			amount: xpReceived,
+			amount: xpReceived * (hasBS ? 1.1 : 1),
 			duration
 		});
 
-		let str = `${user}, ${user.minionName} finished smelting ${quantity}x ${bar.name} at the Blast Furnace. ${xpRes}`;
+		let str = `${user}, ${user.minionName} finished smelting ${quantity}x ${
+			bar.name
+		} at the Blast Furnace. ${xpRes}${hasBS ? '\n10% more XP for having the blacksmith outfit equipped' : ''}`;
 
 		const loot = new Bank({
 			[bar.id]: quantity


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129826638-21d7fd37-5db0-4762-89ee-c58166d93f2f.png)

### Changes:

- Add blacksmith gear effect (10% more smithing XP) to the Blast Furnace;
- Add a message on +bf when the effect is active;

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129826602-e46566c9-774d-4e2e-a244-ab314eaa68e1.png)