### PR TITLE
Boost daily correct answers

### DIFF
--- a/src/commands/Minion/daily.ts
+++ b/src/commands/Minion/daily.ts
@@ -122,6 +122,9 @@ export default class DailyCommand extends BotCommand {
 
 		if (!triviaCorrect) {
 			loot[COINS_ID] = 0;
+		} else if (loot[COINS_ID] <= 1_000_000_000) {
+			// Correct daily gives 10% more cash if the jackpot is not won
+			loot[COINS_ID] = Math.floor(loot[COINS_ID] * 1.1);
 		}
 
 		// Ensure amount of GP is an integer

--- a/src/lib/simulation/dailyTable.ts
+++ b/src/lib/simulation/dailyTable.ts
@@ -47,11 +47,8 @@ const DailyTable = new LootTable()
 
 export default function dailyRoll(qty = 1, correct = false) {
 	const loot = new Bank();
-
-	for (let i = 0; i < qty; i++) {
-		loot.add(DailyTable.roll());
-		if (correct) loot.add(CommonTable.roll());
-	}
-
+	loot.add(DailyTable.roll(qty));
+	// Correct trivia gives 2x extra daily roll
+	if (correct) loot.add(CommonTable.roll(qty)).add(DailyTable.roll(2));
 	return loot.values();
 }


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129827654-7d7c3a4d-ccc3-402d-81e3-012ec7cf4788.png)

### Changes:

- Add 2 extra daily rolls and 10% extra GP on correct trivia answers.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Wrong
![image](https://user-images.githubusercontent.com/19570528/129827754-9b83ef5f-7a12-4d13-8bcb-f85f473ac84a.png)
![image](https://user-images.githubusercontent.com/19570528/129827756-968cbb2a-ceb2-4dd2-b8c9-50971927a776.png)
![image](https://user-images.githubusercontent.com/19570528/129827761-b2887f53-dae8-4770-bda8-e391382c6f8f.png)

Correct
![image](https://user-images.githubusercontent.com/19570528/129827774-8978d54a-e40c-4b49-9d1f-cf7a53da6812.png)
![image](https://user-images.githubusercontent.com/19570528/129827781-86f56685-8018-43ab-a309-151b8390ca24.png)
![image](https://user-images.githubusercontent.com/19570528/129827788-ac1f20d6-26b4-4257-a6e7-f13285b2940a.png)