### PR TITLE
Twisted/Hellfire Bow

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -396,7 +396,8 @@ const source: [string, (string | number)[]][] = [
 			'Uncharged toxic trident (e)'
 		]
 	],
-	['Zaryte bow', ['Hellfire bow']]
+	['Zaryte bow', ['Hellfire bow']],
+	['Twisted bow', ['Hellfire bow']]
 ];
 
 export const similarItems: Map<number, number[]> = new Map(


### PR DESCRIPTION
Added Twisted bow as a similar item for hellfire bow, so you can still get twisted bow boosts without needing to get another after making the hellfire bow