### PR TITLE
Add Athelas to herbs filterable

### DIFF
--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -297,7 +297,8 @@ const herbs = resolveItems([
 	'Cadantine',
 	'Lantadyme',
 	'Dwarf weed',
-	'Torstol'
+	'Torstol',
+	'Athelas'
 ]);
 
 const secondaries = resolveItems([


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/129895095-4f51bf52-0432-485d-90d9-2f50fc180435.png)

### Changes:

- Add Athelas to --herbs filter.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/129895797-d86a72a4-b283-44c4-9abf-2f42b221e30e.png)