### PR TITLE
Fix collectionLog strange qty text

### DIFF
--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -419,7 +419,7 @@ export default class CollectionLogTask extends Task {
 					ctx,
 					formatItemStackQuantity(qtyText),
 					Math.floor(i * (itemSize + itemSpacer) + (itemSize - itemImage.width) / 2) + 1,
-					y * (itemSize + itemSpacer) + 11
+					Math.floor(y * (itemSize + itemSpacer)) + 11
 				);
 			}
 
@@ -510,7 +510,7 @@ export default class CollectionLogTask extends Task {
 				const listHeightSpace = ctx.canvas.height - 62 - 13;
 
 				// Check if in the start of the list
-				if (selectedPos <= listHeightSpace) {
+				if (selectedPos <= listHeightSpace || selectedPos > leftListCanvas.height) {
 					ctx.drawImage(
 						leftListCanvas,
 						0,


### PR DESCRIPTION
### Changes:

- Math.floor qtyText y coord

### Other checks:

-   [X] I have tested all my changes thoroughly.

Before:
![image](https://user-images.githubusercontent.com/19570528/129902114-8bed5f22-87a6-4339-ae62-610e9668dc79.png)

After
![image](https://user-images.githubusercontent.com/19570528/129902077-1d4b93ac-f6a1-4020-88d7-f45ec9627631.png)