### PR TITLE
Clue Boost Changes

### DIFF
--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -101,9 +101,19 @@ export default class extends BotCommand {
 			duration *= 0.9;
 		}
 
-		if (msg.author.hasItemEquippedAnywhere(['Achievement diary cape', 'Achievement diary cape(t)'], false)) {
+		if (msg.author.hasItemEquippedOrInBank(['Achievement diary cape', 'Achievement diary cape (t)'])) {
 			boosts.push('10% for Achievement diary cape');
-			duration *= 0.9;
+			duration *= 0.95;
+		}
+		
+		if (msg.author.hasItemEquippedOrInBank('Quest point cape', 'Quest point cape (t)')) {
+			boosts.push('5% for Quest point cape');
+			duration *= 0.95;
+		}
+
+		if (msg.author.hasItemEquippedOrInBank('Music cape', 'Music cape(t)') && clueTier.name === 'Master') {
+			boosts.push('5% for Music cape');
+			duration *= 0.95;
 		}
 
 		await addSubTaskToActivityTask<ClueActivityTaskOptions>({

--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -101,17 +101,17 @@ export default class extends BotCommand {
 			duration *= 0.9;
 		}
 
-		if (msg.author.hasItemEquippedOrInBank(['Achievement diary cape', 'Achievement diary cape (t)'])) {
-			boosts.push('10% for Achievement diary cape');
+		if (msg.author.hasItemEquippedOrInBank('Achievement diary cape')) {
+			boosts.push('5% for Achievement diary cape');
 			duration *= 0.95;
 		}
-		
-		if (msg.author.hasItemEquippedOrInBank('Quest point cape', 'Quest point cape (t)')) {
+
+		if (msg.author.hasItemEquippedOrInBank('Quest point cape')) {
 			boosts.push('5% for Quest point cape');
 			duration *= 0.95;
 		}
 
-		if (msg.author.hasItemEquippedOrInBank('Music cape', 'Music cape(t)') && clueTier.name === 'Master') {
+		if (msg.author.hasItemEquippedOrInBank('Music cape') && clueTier.name === 'Master') {
 			boosts.push('5% for Music cape');
 			duration *= 0.95;
 		}

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1843,6 +1843,8 @@ export const capesCL = resolveItems([
 	'Quest point cape',
 	'Achievement diary hood',
 	'Achievement diary cape(t)',
+	'Music hood',
+	'Music cape(t)',
 	'Max hood',
 	'Max cape',
 	'Ardougne max hood',

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -314,7 +314,10 @@ const source: [string, (string | number)[]][] = [
 			'Trident of the swamp (e)',
 			'Uncharged toxic trident (e)'
 		]
-	]
+	],
+	['Quest point cape', ['Quest point cape (t)']],
+	['Music cape', ['Music cape(t)']],
+	['Achievement diary cape', ['Achievement diary cape (t)']]
 ];
 
 export const similarItems: Map<number, number[]> = new Map(


### PR DESCRIPTION
- Changed Achievement Diary cape clue boost from 10% to 5%
- Gave the spare 5% boost from above to Quest cape
- Gave Music cape a 5% boost to master clues (let you decide how to add the cape itself)
- Added trimmed versions of the capes to similaritems (ty gid)
- Added Music cape to capesCL

Re-made this PR as previous had conflicts due to you fixing chompy chick cl and to remove music cape buyable