### PR TITLE
Fix tags, and prevent 'an error has occured' any time a command is mis-typed

### DIFF
--- a/src/commands/Utility/tag.ts
+++ b/src/commands/Utility/tag.ts
@@ -70,4 +70,13 @@ export default class extends BotCommand {
 				.join(', ')}`
 		);
 	}
+
+	async show(message: KlasaMessage, [tag]: [string]) {
+		const settings = await getGuildSettings(message.guild!);
+		const emote = settings.get(GuildSettings.Tags).find(([name]) => name === tag.toLowerCase());
+		if (!emote) {
+			return null;
+		}
+		return message.channel.send(emote[1]);
+	}
 }


### PR DESCRIPTION
### Description:
Because of an error in modifying the tags command, tags stopped working, and any message that started with the bots prefix but didn't match a command would return, 'An error has occured.' This fixes both problems.
![image](https://user-images.githubusercontent.com/10122432/130062540-8c39d11f-0d0d-4ddd-a1a1-8f8d485cd8f8.png)
![image](https://user-images.githubusercontent.com/10122432/130062581-533b7d38-9df2-4bc1-9755-f1da4216207f.png)

### Changes:

- Replaced the show() command which is called by the events/tags.ts class.
- Updating the settings calls to the new format.

### Other checks:

-   [x] I have tested all my changes thoroughly.
