### PR TITLE
Prevent alching untradeables like crystal crown

### DIFF
--- a/src/extendables/User/User.ts
+++ b/src/extendables/User/User.ts
@@ -135,7 +135,7 @@ export default class extends Extendable {
 			.get(UserSettings.FavoriteAlchables)
 			.filter(id => this.bank().has(id))
 			.map(getOSItem)
-			.filter(i => i.highalch > 0)
+			.filter(i => i.highalch > 0 && i.tradeable)
 			.sort((a, b) => b.highalch - a.highalch);
 	}
 }


### PR DESCRIPTION
### Description:

- A relatively recent update changed the alching function so that it no longer restricted untradeable items. While technically some untradeables can be alched, there is no flag in the item_data.json database for this, and it's being abused by people alching `Crystal crown`'s for 150m when they should not be alchable.
- We have always prevented untradables from being alched, so it's just consistent as well.

### Changes:
Added check for tradeable to the filter in getUserFavAlchs

### Other checks:

-   [x] I have tested all my changes thoroughly.
