### PR TITLE
Fix `+lamp` to be artificial  (master/osb)

### DIFF
--- a/src/commands/Minion/lamp.ts
+++ b/src/commands/Minion/lamp.ts
@@ -164,9 +164,7 @@ export default class extends BotCommand {
 		}
 
 		let amount = skills[skillName]!;
-		const userXp = msg.author.rawSkills[skillName]!;
-		let artificial = false;
-		if (userXp === 200_000_000) artificial = true;
+		const artificial = true;
 		return [true, await msg.author.addXP({ skillName, amount, artificial })];
 	}
 


### PR DESCRIPTION
### Description:
Fixed lamps so they correctly flag XP as artificial.


### Other checks:

-   [x] I have tested all my changes thoroughly.
