### PR TITLE
Added Bank lottery ticket to cantBeDropped

### DIFF
--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -553,6 +553,7 @@ const cantBeDropped = [
 	itemID('Clue hunter boots'),
 	itemID('Clue hunter cloak'),
 	itemID('Cob'),
+	itemID('Bank lottery ticket'),
 	itemID('Tester gift box'),
 	22_664, // JMOD Scythe of Vitur,
 	...resolveItems([


### PR DESCRIPTION
### Description:

Bank lotto tickets dropped from UMBs, which allowed ironmen to receive one if lucky enough. This PR fixes that by banning tickets from being received from boxes.
![image](https://user-images.githubusercontent.com/63373565/130299290-9bd0b25a-2d36-4a6c-9ba4-d0dae78c7b31.png)


### Changes:

- Added bank lottery ticket to cantbedropped

### Other checks:

-   [] I have tested all my changes thoroughly.  
     Do not have testbot, but followed the format of other items in the list, which is what was done in the past to add previous items to the list.
