### PR TITLE
Add colored variants of bowfa

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -114,6 +114,16 @@ const slayerHelmSimilarI = resolveItems([
 	'Twisted slayer helmet (i)',
 	'Slayer helmet (i)'
 ]);
+const bowfaCorruptSimilar = resolveItems([
+	25_869, // Red, 'duplicate' according to osrsbox item-search
+	25_884, // White
+	25_886, // Black
+	25_888, // Brown?
+	25_890, // Green
+	25_892, // Yellow
+	25_894, // Light blue
+	25_896 // Dark blue
+]);
 
 const source: [string, (string | number)[]][] = [
 	['Dragon full helm', ['Dragon full helm (g)']],
@@ -247,6 +257,7 @@ const source: [string, (string | number)[]][] = [
 	['Void knight gloves', ['Void knight gloves (l)']],
 	['Trident of the seas', ['Trident of the seas (full)', 'Trident of the seas (e)']],
 	['Trident of the swamp', ['Trident of the swamp (e)']],
+	['Bow of faerdhinen (c)', bowfaCorruptSimilar],
 	['Slayer helmet', slayerHelmSimilar],
 	['Slayer helmet (i)', slayerHelmSimilarI],
 	['Black mask (i)', [...slayerHelmSimilarI, ...blackMaskISimilar]],


### PR DESCRIPTION
### Description:
Added the colored variants of the Bow of Faerdhinen (c) that currently exist in our game.

### Changes:
Added the variants to similarItems object.

### Other checks:

-   [x] I have tested all my changes thoroughly.

While the red one does appear to be a duplicate, it's marked as duplicate: false in the item_data.json, so that's why we have it. Seems to be fixed in the latest version from osrsbox though, (based on their website being correct now)

But it's in the game, so I included it. It's labelled for easy removal later.