### PR TITLE
Don't allow raid mass when minion busy

### DIFF
--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -153,7 +153,7 @@ export default class extends BotCommand {
 			}
 		}
 		if (msg.author.minionIsBusy) {
-			return msg.channel.send("Your minion is busy, so you can't host a mass.");
+			return msg.channel.send("Your minion is busy, so you can't start a raid.");
 		}
 
 		const partyOptions: MakePartyOptions = {

--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -152,6 +152,9 @@ export default class extends BotCommand {
 				);
 			}
 		}
+		if (msg.author.minionIsBusy) {
+			return msg.channel.send("Your minion is busy, so you can't host a mass.");
+		}
 
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,


### PR DESCRIPTION
### Description:
Prevents someone starting a raid mass when their minion is busy.

### Changes:
Add `msg.author.minionIsBusy` check before starting the party awaiter.

### Other checks:

-   [x] I have tested all my changes thoroughly.
