### PR TITLE
Allow clue trips to automatically do a lower qty if the user doesnt have enough for a full trip

### DIFF
--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -111,8 +111,11 @@ export default class extends BotCommand {
 		const maxTripLength = msg.author.maxTripLength(Activity.ClueCompletion);
 		const maxPerTrip = Math.floor(maxTripLength / timeToFinish);
 		if (quantity === -1) quantity = maxPerTrip;
+
+		let qtyWarning = '';
 		if (numOfScrolls < quantity) {
-			return msg.channel.send(`You only have ${numOfScrolls}x ${clueTier.name.toLowerCase()} clue scrolls.`);
+			qtyWarning = `You can't do ${quantity} because you only have ${numOfScrolls}x ${clueTier.name.toLowerCase()} clue scrolls.`;
+			quantity = numOfScrolls;
 		}
 
 		let duration = timeToFinish * quantity;
@@ -148,7 +151,7 @@ export default class extends BotCommand {
 		return msg.channel.send(
 			`${msg.author.minionName} is now completing ${quantity}x ${
 				clueTier.name
-			} clues, it'll take around ${formatDuration(duration)} to finish.${
+			} clues, it'll take around ${formatDuration(duration)} to finish. ${qtyWarning}${
 				boosts.length > 0 ? `\n\n**Boosts:** ${boosts.join(', ')}` : ''
 			}`
 		);


### PR DESCRIPTION
### Description:

Voted by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/130373908-6005f248-bee4-434b-8c7e-b6f6d712a302.png)

### Changes:

- Updates the qty automatically if the user doesnt have enough for a full trip.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/130374011-ae514917-577e-41d3-bdc2-38bab863588e.png)