### PR TITLE
Add ornament versions of ToB items to similarItems

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -397,7 +397,12 @@ const source: [string, (string | number)[]][] = [
 		]
 	],
 	['Zaryte bow', ['Hellfire bow']],
-	['Twisted bow', ['Hellfire bow']]
+	['Twisted bow', ['Hellfire bow']],
+	['Ghrazi rapier', ['Holy ghrazi rapier']],
+	['Scythe of vitur', ['Sanguine scythe of vitur', 'Holy scythe of vitur']],
+	['Scythe of vitur (uncharged)', ['Sanguine scythe of vitur (uncharged)', 'Holy scythe of vitur (uncharged)']],
+	['Sanguinesti staff', ['Holy sanguinesti staff']],
+	['Sanguinesti staff (uncharged)', ['Holy sanguinesti staff (uncharged)']]
 ];
 
 export const similarItems: Map<number, number[]> = new Map(


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/130375319-3b7095f9-a1b9-4a50-9000-6b7b29e04594.png)

### Changes:

- Add ornament versions to similarItems of Scythe of vitur, Ghrazi rapier and Sanguinesti staff, including its uncharged versions.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/130375385-1f60290a-6175-49eb-9b50-4bcb9cc7ae38.png)
![image](https://user-images.githubusercontent.com/19570528/130375390-4d01a3a4-3459-419e-9681-a338c4b5da91.png)
