### PR TITLE
Allow Igne to be killed during slayer tasks

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Monsters } from 'oldschooljs';
 
-import killableMonsters from '../../lib/minions/data/killableMonsters';
+import { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
 import { requiresMinion } from '../../lib/minions/decorators';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -79,7 +79,7 @@ export default class extends BotCommand {
 	public getAlternateMonsterList(assignedTask: AssignableSlayerTask | null) {
 		if (assignedTask) {
 			const altMobs = assignedTask.monsters;
-			const alternateMonsters = killableMonsters
+			const alternateMonsters = effectiveMonsters
 				.filter(m => {
 					return altMobs.includes(m.id) && m!.id !== assignedTask.monster.id;
 				})

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -2,6 +2,7 @@ import { Monsters } from 'oldschooljs';
 
 import { KalphiteKingMonster } from '../../kalphiteking';
 import AbyssalDragon from '../../minions/data/killableMonsters/custom/AbyssalDragon';
+import { Ignecarus } from '../../minions/data/killableMonsters/custom/Ignecarus';
 import SeaKraken from '../../minions/data/killableMonsters/custom/SeaKraken';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
@@ -90,7 +91,8 @@ export const duradelTasks: AssignableSlayerTask[] = [
 			Monsters.BlackDragon.id,
 			Monsters.BabyBlackDragon.id,
 			Monsters.BrutalBlackDragon.id,
-			Monsters.KingBlackDragon.id
+			Monsters.KingBlackDragon.id,
+			Ignecarus.id
 		],
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -2,6 +2,7 @@ import { Monsters } from 'oldschooljs';
 
 import { KalphiteKingMonster } from '../../kalphiteking';
 import AbyssalDragon from '../../minions/data/killableMonsters/custom/AbyssalDragon';
+import { Ignecarus } from '../../minions/data/killableMonsters/custom/Ignecarus';
 import SeaKraken from '../../minions/data/killableMonsters/custom/SeaKraken';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
@@ -88,7 +89,8 @@ export const konarTasks: AssignableSlayerTask[] = [
 			Monsters.BlackDragon.id,
 			Monsters.BabyBlackDragon.id,
 			Monsters.BrutalBlackDragon.id,
-			Monsters.KingBlackDragon.id
+			Monsters.KingBlackDragon.id,
+			Ignecarus.id
 		],
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -2,6 +2,7 @@ import { Monsters } from 'oldschooljs';
 
 import { KalphiteKingMonster } from '../../kalphiteking';
 import AbyssalDragon from '../../minions/data/killableMonsters/custom/AbyssalDragon';
+import { Ignecarus } from '../../minions/data/killableMonsters/custom/Ignecarus';
 import SeaKraken from '../../minions/data/killableMonsters/custom/SeaKraken';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
@@ -76,7 +77,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 			Monsters.BlackDragon.id,
 			Monsters.BabyBlackDragon.id,
 			Monsters.BrutalBlackDragon.id,
-			Monsters.KingBlackDragon.id
+			Monsters.KingBlackDragon.id,
+			Ignecarus.id
 		],
 		slayerLevel: 77,
 		combatLevel: 80,

--- a/src/tasks/minions/minigames/ignecarusActivity.ts
+++ b/src/tasks/minions/minigames/ignecarusActivity.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../lib/minions/data/killableMonsters/custom/Ignecarus';
 import { addMonsterXP } from '../../../lib/minions/functions';
 import { ClientSettings } from '../../../lib/settings/types/ClientSettings';
+import { getUsersCurrentSlayerInfo } from '../../../lib/slayer/slayerUtil';
 import { BossUser } from '../../../lib/structures/Boss';
 import { NewBossOptions } from '../../../lib/types/minions';
 import { addArrayOfNumbers, updateBankSetting } from '../../../lib/util';
@@ -66,6 +67,20 @@ export default class extends Task {
 
 		const totalLoot = new Bank();
 		for (const { user } of bossUsers) {
+			const usersTask = await getUsersCurrentSlayerInfo(user.id);
+			const isOnTask =
+				usersTask.assignedTask !== null &&
+				usersTask.currentTask !== null &&
+				usersTask.assignedTask.monsters.includes(Ignecarus.id);
+			if (isOnTask) {
+				console.log({ remaining: usersTask.currentTask!.quantityRemaining, quantity });
+				usersTask.currentTask!.quantityRemaining = Math.max(
+					0,
+					usersTask.currentTask!.quantityRemaining - quantity
+				);
+				await usersTask.currentTask!.save();
+			}
+
 			let lootRolls = quantity;
 			if (deaths[user.id]) {
 				if (deaths[user.id].qty === quantity) continue;
@@ -80,8 +95,8 @@ export default class extends Task {
 				monsterID: Ignecarus.id,
 				quantity,
 				duration,
-				isOnTask: false,
-				taskQuantity: null
+				isOnTask,
+				taskQuantity: quantity
 			});
 			await user.addItemsToBank(loot, true);
 			const purple = Object.keys(loot.bank).some(itemID => IgnecarusNotifyDrops.includes(parseInt(itemID)));


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/130377535-2244d422-ae44-40da-869f-089b08346264.png)

### Changes:

- Add Ignecarus as a alternative to Black Dragons;
- Each kill awards 50K experience;
- Same as KK, Black masks applies NO bonus;

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/130377670-4171661d-801a-4b36-92ce-084449f36449.png)
![image](https://user-images.githubusercontent.com/19570528/130377647-5d5ab74e-b549-4244-9ae8-a612b4714688.png)
![image](https://user-images.githubusercontent.com/19570528/130377660-a42c2b0b-a72c-4761-a070-2e75b4f6b64b.png)
