### PR TITLE
Give 10% boost for every monster if having all 3 gorajan sets equipped.

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -299,8 +299,12 @@ export default class extends BotCommand {
 			boosts.push('5% for Amulet of zealots');
 		}
 
+		const allGorajan = gorajanBoosts.every(e => msg.author.getGear(e[1]).hasEquipped(e[0], true));
 		for (const [outfit, setup] of gorajanBoosts) {
-			if (monster.attackStyleToUse?.includes(setup) && msg.author.getGear(setup).hasEquipped(outfit, true)) {
+			if (
+				allGorajan ||
+				(monster.attackStyleToUse?.includes(setup) && msg.author.getGear(setup).hasEquipped(outfit, true))
+			) {
 				boosts.push('10% for gorajan');
 				timeToFinish *= 0.9;
 				break;


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/130378386-68d022e7-0582-46a3-a2f3-0364f8ce2fab.png)

### Changes:

- Do a alLGorajan equipped check and if that is true, apply 10%, independent of which gear the monster checks.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Having all 3 gears equipped
![image](https://user-images.githubusercontent.com/19570528/130378422-0fc559f4-4249-43dd-9061-2e1252706348.png)

Not having all 3 gears
![image](https://user-images.githubusercontent.com/19570528/130378440-2fefd969-7ec3-4d98-91d4-832e02429820.png)

Still applies as normal if only 1 set is owned
![image](https://user-images.githubusercontent.com/19570528/130378453-b4f7a4b3-47d5-40e9-af34-f4782e0ee71e.png)