### PR TITLE
Add magic master cape perk active perk to voidling

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -141,7 +141,9 @@ export async function handleTripFinish(
 		const voidlingEquipped = user.usingPet('Voidling');
 		const alchResult = alching({
 			user,
-			tripLength: voidlingEquipped ? data.duration : data.duration / randInt(6, 7),
+			tripLength: voidlingEquipped
+				? data.duration * (user.hasItemEquippedAnywhere('Magic master cape') ? 3 : 1)
+				: data.duration / (user.hasItemEquippedAnywhere('Magic master cape') ? 1 : randInt(6, 7)),
 			isUsingVoidling: true,
 			flags: { alch: 'yes' }
 		});
@@ -158,8 +160,12 @@ export async function handleTripFinish(
 			message += `\nYour Voidling alched ${alchResult.maxCasts}x ${alchResult.itemToAlch.name}. Removed ${
 				alchResult.bankToRemove
 			} from your bank and added ${toKMB(alchGP)} GP. ${
-				!voidlingEquipped
+				!voidlingEquipped && !user.hasItemEquippedAnywhere('Magic master cape')
 					? "As you left your Voidling alone in the bank, it got distracted easily and didn't manage to alch at its full potential."
+					: ''
+			}${
+				user.hasItemEquippedAnywhere('Magic master cape')
+					? '\nVoidling notices your Magic Master cape and wants to be just like you. Voidling is now alching much faster!'
 					: ''
 			}`;
 		} else if (user.getUserFavAlchs().length !== 0) {


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/130379811-c96e9d53-69f0-43cf-a2f5-f52869b3f02f.png)

### Changes:

- When the magic master cape is equipped, voidling alchs faster.
- 3x faster if voidling is equipped;
- Base speed if not equipped.
- Add the message `Voidling notices your Magic Master cape and wants to be just like you. Voidling is now alching much faster!` when the cape is equipped.

### Other checks:

-   [X] I have tested all my changes thoroughly.

1. Voidling equipped
![image](https://user-images.githubusercontent.com/19570528/130379905-a74db5b5-925f-417f-8106-c46aa536c8d0.png)

2. Voidling not equipped
![image](https://user-images.githubusercontent.com/19570528/130379932-08d66ba1-dcf0-41a5-9340-df0c11bd19b2.png)

3. No Voidling equipped and No master cape
![image](https://user-images.githubusercontent.com/19570528/130379948-86cd8384-0a42-42dd-9f3b-ce8ee9d42bfd.png)

4. Voidling equipped and no cape (same as 2.)
![image](https://user-images.githubusercontent.com/19570528/130379982-f83c0ac6-1dd1-47d2-96d1-63b302e7ce2f.png)