### PR TITLE
Brock boosts to Gauntlet

### DIFF
--- a/src/commands/Minion/gauntlet.ts
+++ b/src/commands/Minion/gauntlet.ts
@@ -77,15 +77,20 @@ export default class extends BotCommand {
 			msg.author.getMinigameScore('Gauntlet')
 		]);
 
-		if (type === 'corrupted' && normalKC < 50) {
+		if (type === 'corrupted' && normalKC < (msg.author.usingPet('Brock') ? 0 : 50)) {
 			return msg.channel.send(
 				"You can't attempt the Corrupted Gauntlet, you have less than 50 normal Gauntlets completed - you would not stand a chance in the Corrupted Gauntlet!"
 			);
 		}
 
+		const boosts = [];
+
 		let baseLength = type === 'corrupted' ? Time.Minute * 10 : Time.Minute * 14;
 
-		const boosts = [];
+		if (msg.author.usingPet('Brock')) {
+			boosts.push('2x faster for having Brock');
+			baseLength /= 2;
+		}
 
 		const scoreBoost = Math.min(100, calcWhatPercent(type === 'corrupted' ? corruptedKC : normalKC, 100)) / 5;
 		if (scoreBoost > 1) {


### PR DESCRIPTION
### Description:

Partially requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/130380663-fd38977a-0f03-4439-b0bc-dda85594ac1a.png)

### Changes:

- Allow brock to bypass the 50 normal gaunglet KC for the corrupted gauntlet;
- Halves the duration required for a gauntlet floor.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/130380706-eba5f3e7-9bba-4ce3-9220-0e41766be07e.png)
![image](https://user-images.githubusercontent.com/19570528/130380719-608a7d25-4650-4d13-8a5c-15a74fdfbba6.png)