### PR TITLE
Allow for automatic qty calculation of monsters that require items to be killed

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -330,8 +330,14 @@ export default class extends BotCommand {
 			lootToRemove.remove('Water rune', lootToRemove.amount('Water rune'));
 		}
 
-		const itemCost = monster.itemCost ? monster.itemCost.clone().multiply(quantity) : null;
+		const itemCost = monster.itemCost ? monster.itemCost.clone() : null;
 		if (itemCost) {
+			const fits = msg.author.bank({ withGP: true }).fits(itemCost);
+			if (fits < quantity) {
+				duration *= Math.ceil(fits / quantity);
+				quantity = fits;
+			}
+			itemCost.multiply(quantity);
 			pvmCost = true;
 			lootToRemove.add(itemCost);
 		}


### PR DESCRIPTION
### Description:

- Doing +k skotizo will try to kill the maximum it can in the maximumTripLength instead of what the user have enough items for.
- Same applies for monsters like Alchemical Hydra.

### Changes:

- Changes the how the itemCost is checked, to allow for a bank fits calculation.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Current system for Alchemical Hydra
![image](https://user-images.githubusercontent.com/19570528/130484579-74231ced-f9b4-49e6-9145-5d1b950336b6.png)

New System for Alchemical Hydra
![image](https://user-images.githubusercontent.com/19570528/130484682-90b8029a-d611-4f71-89ae-4c7e93350538.png)

Current System for Obor
![image](https://user-images.githubusercontent.com/19570528/130484857-582d03a3-ece7-4cdd-9228-6313027692c5.png)

New System for Obor
![image](https://user-images.githubusercontent.com/19570528/130484814-3a0711d9-edab-48d7-a261-f0103383c17b.png)
