### PR TITLE
Fix filterLootReplace issue - certain items unobtainable, deleted on sale.

### DIFF
--- a/src/commands/Minion/offer.ts
+++ b/src/commands/Minion/offer.ts
@@ -10,7 +10,6 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { birdsNestID, treeSeedsNest } from '../../lib/simulation/birdsNest';
 import Prayer from '../../lib/skilling/skills/prayer';
 import { SkillsEnum } from '../../lib/skilling/types';
-import { filterLootReplace } from '../../lib/slayer/slayerUtil';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { ItemBank } from '../../lib/types';
 import { OfferingActivityTaskOptions } from '../../lib/types/minions';
@@ -93,9 +92,8 @@ export default class extends BotCommand {
 			let loot = new Bank();
 			loot.add(whichOfferable.table.roll(quantity));
 
-			filterLootReplace(msg.author.allItemsOwned(), loot);
 			let score = 0;
-			const { previousCL } = await msg.author.addItemsToBank(loot.values(), true);
+			const { previousCL, itemsAdded } = await msg.author.addItemsToBank(loot.values(), true, true);
 			if (whichOfferable.economyCounter) {
 				score = msg.author.settings.get(whichOfferable.economyCounter) as number;
 				if (typeof quantity !== 'number') quantity = parseInt(quantity);
@@ -107,14 +105,14 @@ export default class extends BotCommand {
 					msg.author,
 					whichOfferable.name,
 					whichOfferable.uniques,
-					loot.bank,
+					itemsAdded,
 					quantity,
 					score + rand(1, quantity)
 				);
 			}
 
 			return msg.channel.sendBankImage({
-				bank: loot.values(),
+				bank: itemsAdded,
 				title: `Loot from offering ${quantity} ${whichOfferable.name}`,
 				flags: { showNewCL: 1 },
 				user: msg.author,

--- a/src/extendables/User/Bank.ts
+++ b/src/extendables/User/Bank.ts
@@ -92,7 +92,8 @@ export default class extends Extendable {
 	public async addItemsToBank(
 		this: User,
 		inputItems: ItemBank | Bank,
-		collectionLog = false
+		collectionLog: boolean = true,
+		filterLoot: boolean = false
 	): Promise<{ previousCL: ItemBank; itemsAdded: ItemBank }> {
 		return this.queueFn(async user => {
 			const _items = inputItems instanceof Bank ? { ...inputItems.bank } : inputItems;
@@ -116,7 +117,9 @@ export default class extends Extendable {
 			let items = new Bank({
 				..._items
 			});
-			const { bankLoot, clLoot } = filterLootReplace(user.allItemsOwned(), items);
+			const { bankLoot, clLoot } = filterLoot
+				? filterLootReplace(user.allItemsOwned(), items)
+				: { bankLoot: items, clLoot: items };
 			items = bankLoot;
 			if (collectionLog) {
 				await user.addItemsToCollectionLog(clLoot.bank);

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -328,7 +328,6 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 
 	myLoot.filter(l => {
 		return (
-			l.id !== 420 &&
 			l.id !== itemID('Black mask (10)') &&
 			l.id !== itemID("Hydra's eye") &&
 			l.id !== itemID("Hydra's fang") &&

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -139,7 +139,8 @@ declare module 'discord.js' {
 	interface User {
 		addItemsToBank(
 			items: ItemBank | Bank,
-			collectionLog?: boolean
+			collectionLog?: boolean,
+			filterLoot?: boolean
 		): Promise<{ previousCL: ItemBank; itemsAdded: ItemBank }>;
 		removeItemsFromBank(items: ItemBank | Bank, collectionLog?: boolean): Promise<SettingsUpdateResult>;
 		addItemsToCollectionLog(items: ItemBank): Promise<SettingsUpdateResult>;

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -128,7 +128,7 @@ export default class extends Task {
 			await usersTask.currentTask!.save();
 		}
 
-		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true);
+		const { previousCL, itemsAdded } = await user.addItemsToBank(loot, true, true);
 
 		const { image } = await this.client.tasks
 			.get('bankImage')!


### PR DESCRIPTION
### Description:
Someone moved the `filterLootReplace` function into `addItemsToBank()`. 
This is bad for multiple reasons, 2 of which are:

1. It's relatively costly-CPU wise and shouldn't run on everything.
2. If you run it on sales or similar item collection methods, it will remove or change the item in question.

The `filterLootReplace` function currently should only be in 2 places: 

1. PvM Loot in monsterActivity.ts
2. `Offer`ing loot in offer.ts (Unsired)

### Changes:

- Added a new parameter to `addItemsToBank()`
- Only enable this filter when it's needed.
- Removed the redundant call to filterLootReplace in offer.ts and passed the modified return loot to bank image generator.
- Removed distillator filter from the filterLootReplace function as it's no longer needed.

### Other checks:

-   [x] I have tested all my changes thoroughly.

PS. I did it this way because it seems like you want it centralized, but I can rewrite it so the function is called directly just by those 2 pages if you want. (The way it was originally written)                                                                        