### PR TITLE
DDS boost at PC

### DIFF
--- a/src/commands/Minion/pestcontrol.ts
+++ b/src/commands/Minion/pestcontrol.ts
@@ -18,7 +18,7 @@ let itemBoosts = [
 	[['Barrows gloves', 'Ferocious gloves'].map(getOSItem), 4],
 	[['Amulet of fury', 'Amulet of torture'].map(getOSItem), 5],
 	[['Fire cape', 'Infernal cape'].map(getOSItem), 6],
-	[['Dragon claws'].map(getOSItem), 5]
+	[['Dragon claws', 'Dragon dagger'].map(getOSItem), 5]
 ] as const;
 
 export type PestControlBoat = ['veteran' | 'intermediate' | 'novice', 3 | 4 | 5];

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -152,6 +152,7 @@ const source: [string, (string | number)[]][] = [
 	['Abyssal whip', ['Volcanic abyssal whip', 'Frozen abyssal whip']],
 	['Granite maul', [12_848]],
 	['Rune scimitar', [23_330, 23_332, 23_334]],
+	['Dragon dagger', ['Dragon dagger(p)', 'Dragon dagger(p+)', 'Dragon dagger(p++)']],
 	[
 		"Black d'hide body",
 		[


### PR DESCRIPTION
- Added boost for Dragon Dagger at pest control, if you don’t have Dragon Claws
- Added variants of dragon dagger (such as dds) to similaritems