### PR TITLE
[BSO] Rework Farming master cape + Scroll of life

### DIFF
--- a/src/commands/Minion/farm.ts
+++ b/src/commands/Minion/farm.ts
@@ -1,4 +1,4 @@
-import { calcPercentOfNum, Time } from 'e';
+import {calcPercentOfNum, percentChance, Time} from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Bank } from 'oldschooljs';
 
@@ -213,6 +213,7 @@ export default class extends BotCommand {
 		let newBank = { ...userBank };
 		let econBank = new Bank();
 		const hasScroll = await msg.author.hasItem(itemID('Scroll of life'));
+		const hasMasterFarmingCape = await msg.author.hasItemEquippedOrInBank(itemID('Farming master cape'));
 
 		const requiredSeeds: [string, number][] = Object.entries(plants.inputItems);
 		for (const [seedID, qty] of requiredSeeds) {
@@ -223,7 +224,21 @@ export default class extends BotCommand {
 					throw `You don't have enough ${itemNameFromID(parseInt(seedID))}s.`;
 				}
 			}
-			const _qty = hasScroll ? Math.floor(calcPercentOfNum(85, qty * quantity)) : qty * quantity;
+			let _qty = 0;
+			if (hasScroll) {
+				if (hasMasterFarmingCape) {
+					// Always round down with Farming master cape
+					_qty = Math.floor(calcPercentOfNum(85, qty * quantity));
+				} else {
+					// 15% chance to negate seed cost
+					for (let i = 0; i < quantity; i++) {
+						if (!percentChance(15)) _qty += qty;
+					}
+				}
+			} else {
+				// Total quantity = per patch qty * total patches used
+				_qty = qty * quantity;
+			}
 			newBank = removeItemFromBank(newBank, parseInt(seedID), _qty);
 			econBank.add(parseInt(seedID), _qty);
 			if (hasScroll) {

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -488,7 +488,7 @@ export default class extends Task {
 				loot[itemID('Plopper')] = 1;
 			}
 
-			if (duration > Time.Minute * 20 && user.hasItemEquippedAnywhere(itemID('Farming master cape'))) {
+			if (roll(10) && user.hasItemEquippedOrInBank(itemID('Farming master cape'))) {
 				loot = addItemToBank(loot, getRandomMysteryBox());
 			}
 			// Give boxes for planting when harvesting


### PR DESCRIPTION
### Description:
Reworks Master farming cape + Scroll of life for balancing changes.

### Changes:
- Since it's impossible to get a 20 minute farming trip, I instead changed the Mystery box bonus to be a 1 in 10 chance on harvest to receive a MB.
- Allows Master farming cape to work from bank, like the majority of other Farming boosts.
- Scroll of life's existing behavior now only applies if you have a `Farming master cape,` otherwise it only gives a 15% chance to save the seeds.
_I experimented with rounding up without the Farming master cape, which was simpler code, but that just made the scroll useless for most farming, so the 15% chance is much better IMO._ 

### Other checks:

-   [x] I have tested all my changes thoroughly.
