### PR TITLE
Added uncharged dfs to buyables

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -203,6 +203,16 @@ const questBuyables: Buyable[] = [
 		gpCost: 10_000
 	},
 	{
+		name: 'Uncharged dragonfire shield',
+		qpRequired: 34,
+		aliases: ['dfs', 'dragonfire shield'],
+		gpCost: 1_250_000,
+		itemCost: resolveNameBank({ 'Draconic visage': 1 }),
+		outputItems: resolveNameBank({
+			'Uncharged dragonfire shield': 1,
+		}),
+	},
+	{
 		name: 'Hardleather gloves',
 		qpRequired: 5,
 		gpCost: 50_000


### PR DESCRIPTION
You can buy a dfs from oziach after ds1 for 1.25m

### Description:

Added a buyable to the config.
I did not manage to test locally, so im not sure if you can add gpcost and itemcost like this.

Should we 10x the price though?


### Other checks:

-   [ ] I have tested all my changes thoroughly.
