### PR TITLE
Add LMS Gambling +lmsg

### DIFF
--- a/src/commands/Gambling/lmsgambling.ts
+++ b/src/commands/Gambling/lmsgambling.ts
@@ -15,7 +15,7 @@ import LastManStandingCommand from '../OSRS_Fun/LastManStanding';
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '[price:int{0,1000000000}] [minUsers:int{3,40}] [maxUsers:int{3,40}]',
+			usage: '[price:int{0,1000000000}] [minUsers:int{4,40}] [maxUsers:int{4,40}]',
 			usageDelim: ' ',
 			aliases: ['lmsg']
 		});
@@ -23,13 +23,10 @@ export default class extends BotCommand {
 
 	@ironsCantUse
 	@requiresMinion
-	async run(msg: KlasaMessage, [price = 0, minUsers = 2, maxUsers = 40]: [number, number, number]) {
+	async run(msg: KlasaMessage, [price = 0, minUsers = 4, maxUsers = 40]: [number, number, number]) {
 		if (msg.author.settings.get(UserSettings.GP) < price) {
 			return msg.channel.send('You do not have enough GP to host this LMS.');
 		}
-
-		if (msg.flagArgs.min && !isNaN(Number(msg.flagArgs.min))) minUsers = Number(msg.flagArgs.min);
-		if (msg.flagArgs.max && !isNaN(Number(msg.flagArgs.max))) maxUsers = Number(msg.flagArgs.max);
 
 		if (channelsPlayingLms.has(msg.channel.id)) {
 			return msg.channel.send(

--- a/src/commands/Gambling/lmsgambling.ts
+++ b/src/commands/Gambling/lmsgambling.ts
@@ -1,0 +1,210 @@
+import { MessageButton } from 'discord.js';
+import { objectEntries, objectValues, sleep, Time } from 'e';
+import { CommandStore, KlasaMessage } from 'klasa';
+
+import { toKMB } from '../../../.yalc/oldschooljs/dist/util';
+import { Activity } from '../../lib/constants';
+import { ironsCantUse, requiresMinion } from '../../lib/minions/decorators';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { BotCommand } from '../../lib/structures/BotCommand';
+import { LmsGamblingActivityTaskOptions } from '../../lib/types/minions';
+import { addArrayOfNumbers } from '../../lib/util';
+import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
+import LastManStandingCommand, { channelsPlayingLms } from '../OSRS_Fun/LastManStanding';
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			usage: '[price:int{0,1000000000}] [minUsers:int{3,40}] [maxUsers:int{3,40}]',
+			usageDelim: ' ',
+			aliases: ['lmsg']
+		});
+	}
+
+	@ironsCantUse
+	@requiresMinion
+	async run(msg: KlasaMessage, [price = 0, minUsers = 2, maxUsers = 40]: [number, number, number]) {
+		if (msg.author.settings.get(UserSettings.GP) < price) {
+			return msg.channel.send('You do not have enough GP to host this LMS.');
+		}
+
+		if (msg.flagArgs.min && !isNaN(Number(msg.flagArgs.min))) minUsers = Number(msg.flagArgs.min);
+		if (msg.flagArgs.max && !isNaN(Number(msg.flagArgs.max))) maxUsers = Number(msg.flagArgs.max);
+
+		if (channelsPlayingLms.has(msg.channel.id)) {
+			return msg.channel.send(
+				'There is a LMS going on on this channel at the moment. Try again in a few moments.'
+			);
+		}
+
+		await msg.confirm(
+			`Do you want to host a LMS ${price > 0 ? `with a fee of ${price.toLocaleString()} GP` : 'for free'}?`
+		);
+
+		channelsPlayingLms.add(msg.channel.id);
+
+		let usersIn = [
+			{ id: msg.author.id, name: `${msg.author.username}#${msg.author.discriminator}`, user: msg.author }
+		];
+		let started = false;
+
+		let contentMsg = () => {
+			const prize = usersIn.length * price;
+			const str = `${msg.author} is hosting a Last Man Standing! The fee to enter is ${
+				prize > 0 ? `${toKMB(price)} GP` : '**Free**'
+			}! Press Join to enter!\n**Current users in:** ${usersIn.length}\n${usersIn
+				.map(u => u.name)
+				.join(', ')}\n\n**Total prize pool:** ${(prize > 0
+				? toKMB(prize)
+				: 'Free Entrance - No prize'
+			).toLocaleString()}\n**Min. Users to Start:** ${minUsers}\n**Users to auto start:** ${maxUsers}`;
+			return {
+				content: str,
+				components: [
+					[
+						new MessageButton({
+							label: `Join (${price > 0 ? `Pay ${toKMB(price)} GP` : 'Free'})`,
+							style: 'PRIMARY',
+							customID: 'CONFIRM',
+							emoji: '<:RSGP:369349580040437770>'
+						}),
+						new MessageButton({
+							label: 'Force Start',
+							style: 'SECONDARY',
+							customID: 'START',
+							disabled: usersIn.length < minUsers
+						}),
+						new MessageButton({
+							label: 'Cancel / Leave',
+							style: 'DANGER',
+							customID: 'CANCEL'
+						})
+					]
+				]
+			};
+		};
+
+		const confirmMessage = await msg.channel.send(contentMsg());
+
+		const collector = confirmMessage.createMessageComponentInteractionCollector({
+			time: Time.Minute * 2,
+			filter: i => {
+				if (i.customID === 'CONFIRM') {
+					if (usersIn.map(u => u.user).includes(i.user)) {
+						i.reply({ ephemeral: true, content: 'You already joined this LMS.' });
+						return false;
+					}
+					if (i.user.settings.get(UserSettings.GP) < price) {
+						i.reply({
+							ephemeral: true,
+							content: `You do not have enough GP (${toKMB(
+								price
+							)} / ${price.toLocaleString()}) to join this LMS.`
+						});
+						return false;
+					}
+					if (i.user.isIronman) {
+						i.reply({ ephemeral: true, content: "Ironman can't join this LMS." });
+						return false;
+					}
+				}
+				if (!usersIn.map(u => u.user).includes(i.user) && i.customID === 'CANCEL') {
+					i.reply({ ephemeral: true, content: 'You can not leave what you never joined!' });
+					return false;
+				}
+				if (i.user === msg.author && i.customID === 'START' && usersIn.length < minUsers) {
+					i.reply({
+						ephemeral: true,
+						content: 'You can not start the LMS before the minimum amount of users is reached.'
+					});
+					return false;
+				}
+				return true;
+			}
+		});
+
+		collector.on('collect', async interaction => {
+			if (interaction.isButton()) {
+				if (interaction.customID === 'CONFIRM') {
+					usersIn.push({
+						id: interaction.user.id,
+						name: `${interaction.user.username}#${interaction.user.discriminator}`,
+						user: interaction.user
+					});
+					if (usersIn.length < maxUsers) {
+						await interaction.update(contentMsg());
+					} else {
+						started = true;
+						collector.stop();
+					}
+				}
+				if (interaction.customID === 'CANCEL') {
+					if (interaction.user.id !== msg.author.id) {
+						const userIndex = usersIn.findIndex(f => f.id === interaction.user.id);
+						usersIn.splice(userIndex, 1);
+						usersIn.filter(f => f);
+						await interaction.update(contentMsg());
+					} else {
+						usersIn = [];
+						started = false;
+						collector.stop();
+					}
+				}
+				if (interaction.customID === 'START' && usersIn.length >= minUsers) {
+					started = true;
+					collector.stop();
+				}
+			}
+		});
+
+		collector.on('end', async () => {
+			let extraReason = '';
+			if (started || usersIn.length >= minUsers) {
+				for (const data of usersIn) {
+					try {
+						await data.user.removeGP(price);
+					} catch (e) {
+						const userIndex = usersIn.findIndex(f => f.id === data.id);
+						usersIn.splice(userIndex, 1);
+						extraReason += `\n${data.user} was removed because it does not have enough cash for the entrance fee.`;
+					}
+				}
+				// Remove undefined
+				usersIn.filter(f => f);
+				if (usersIn.length < minUsers) {
+					await Promise.all(usersIn.map(u => u.user.addGP(price)));
+					started = false;
+				}
+			}
+
+			if (started || usersIn.length >= minUsers) {
+				await confirmMessage.edit({ components: [] });
+				await msg.channel.send({
+					content: `The LMS has started! Good luck!${extraReason ? `\n${extraReason}` : ''}`
+				});
+
+				const lmsCommand = this.client.commands.get('lastmanstanding') as unknown as LastManStandingCommand;
+				const lmsGame = lmsCommand.playAsyncLms(new Set(usersIn.map(u => u.name)));
+				const winner = await usersIn.find(f => f.name === lmsGame.winner)!.id;
+				await addSubTaskToActivityTask<LmsGamblingActivityTaskOptions>({
+					userID: msg.author.id,
+					channelID: msg.channel.id,
+					winner,
+					users: usersIn.map(u => u.id),
+					prize: price * usersIn.length,
+					duration: addArrayOfNumbers(objectValues(lmsGame.messages).map(m => m.time)),
+					type: Activity.LmsGambling
+				});
+				for (const [message, data] of objectEntries(lmsGame.messages)) {
+					const gameMessage = await msg.channel.send(message);
+					await sleep(data.time);
+					gameMessage.delete();
+				}
+			} else {
+				channelsPlayingLms.delete(msg.channel.id);
+				await confirmMessage.edit({ components: [] });
+				await msg.channel.send({ content: `The LMS failed to start.${extraReason ? `${extraReason}` : ''}` });
+			}
+		});
+	}
+}

--- a/src/commands/Gambling/lmsgambling.ts
+++ b/src/commands/Gambling/lmsgambling.ts
@@ -1,8 +1,8 @@
 import { MessageButton } from 'discord.js';
 import { objectEntries, objectValues, sleep, Time } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
+import { toKMB } from 'oldschooljs/dist/util/util';
 
-import { toKMB } from '../../../.yalc/oldschooljs/dist/util';
 import { Activity, channelsPlayingLms } from '../../lib/constants';
 import { ironsCantUse, requiresMinion } from '../../lib/minions/decorators';
 import { UserSettings } from '../../lib/settings/types/UserSettings';

--- a/src/commands/OSRS_Fun/LastManStanding.ts
+++ b/src/commands/OSRS_Fun/LastManStanding.ts
@@ -1,11 +1,10 @@
 import { chunk, sleep } from '@klasa/utils';
 import { CommandStore, KlasaMessage } from 'klasa';
 
+import { channelsPlayingLms } from '../../lib/constants';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import LastManStandingUsage, { LMS_FINAL, LMS_PREP, LMS_ROUND } from '../../lib/structures/LastManStandingUsage';
 import { cleanMentions } from '../../lib/util';
-
-export const channelsPlayingLms: Set<string> = new Set();
 
 export default class LastManStandingCommand extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -563,6 +563,9 @@ export default class extends Extendable {
 				const data = currentTask as MinigameActivityTaskOptions;
 				return `${this.minionName} is currently doing ${data.quantity} games of Pest Control. ${formattedDuration}`;
 			}
+			case Activity.LmsGambling: {
+				return `${this.minionName} is fighting for its life on a LMS game!`;
+			}
 		}
 	}
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -204,7 +204,8 @@ export const enum Tasks {
 	DarkAltar = 'darkAltarActivity',
 	TrekkingActivity = 'templeTrekkingActivity',
 	RevenantsActivity = 'revenantsActivity',
-	PestControl = 'pestControlActivity'
+	PestControl = 'pestControlActivity',
+	LmsGambling = 'lmsGamblingActivity'
 }
 
 export enum Activity {
@@ -269,8 +270,11 @@ export enum Activity {
 	DarkAltar = 'DarkAltar',
 	Trekking = 'Trekking',
 	Revenants = 'Revenants',
-	PestControl = 'PestControl'
+	PestControl = 'PestControl',
+	LmsGambling = 'LmsGambling'
 }
+
+export const NotBusyActivity = [Activity.LmsGambling];
 
 export enum ActivityGroup {
 	Skilling = 'Skilling',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -484,3 +484,5 @@ export const lastTripCache = new Map<
 	string,
 	{ continue: (message: KlasaMessage) => Promise<KlasaMessage | KlasaMessage[] | null>; data: ActivityTaskOptions }
 >();
+
+export const channelsPlayingLms: Set<string> = new Set();

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -5,7 +5,7 @@ import { getConnection } from 'typeorm';
 
 import { client } from '../..';
 import { MinigameKey, Minigames } from '../../extendables/User/Minigame';
-import { Emoji } from '../constants';
+import { Emoji, NotBusyActivity } from '../constants';
 import { ActivityTable } from '../typeorm/ActivityTable.entity';
 import { MinigameTable } from '../typeorm/MinigameTable.entity';
 import { NewUserTable } from '../typeorm/NewUserTable.entity';
@@ -126,7 +126,8 @@ export async function getMinionName(userID: string): Promise<string> {
 export const minionActivityCache = new Map<string, ActivityTaskData>();
 export function getActivityOfUser(userID: string) {
 	const task = minionActivityCache.get(userID);
-	return task ?? null;
+	if (!task || NotBusyActivity.includes(task.type)) return null;
+	return task;
 }
 
 export async function cancelTask(userID: string) {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -322,6 +322,12 @@ export interface BlastFurnaceActivityTaskOptions extends ActivityTaskOptions {
 	quantity: number;
 }
 
+export interface LmsGamblingActivityTaskOptions extends ActivityTaskOptions {
+	winner: string;
+	prize: number;
+	users: string[];
+}
+
 export type ActivityTaskData =
 	| ActivityTaskOptions
 	| MonsterActivityTaskOptions
@@ -343,4 +349,5 @@ export type ActivityTaskData =
 	| FletchingActivityTaskOptions
 	| RunecraftActivityTaskOptions
 	| TempleTrekkingActivityTaskOptions
-	| TemporossActivityTaskOptions;
+	| TemporossActivityTaskOptions
+	| LmsGamblingActivityTaskOptions;

--- a/src/lib/util/taskNameFromType.ts
+++ b/src/lib/util/taskNameFromType.ts
@@ -126,5 +126,7 @@ export function taskNameFromType(activityType: Activity) {
 			return Tasks.RevenantsActivity;
 		case Activity.PestControl:
 			return Tasks.PestControl;
+		case Activity.LmsGambling:
+			return Tasks.LmsGambling;
 	}
 }

--- a/src/tasks/minions/OtherActivitities/lmsGamblingActivity.ts
+++ b/src/tasks/minions/OtherActivitities/lmsGamblingActivity.ts
@@ -1,0 +1,18 @@
+import { Task } from 'klasa';
+
+import { channelsPlayingLms } from '../../../commands/OSRS_Fun/LastManStanding';
+import { LmsGamblingActivityTaskOptions } from '../../../lib/types/minions';
+import { sendToChannelID } from '../../../lib/util/webhook';
+
+export default class extends Task {
+	async run(data: LmsGamblingActivityTaskOptions) {
+		const user = await this.client.fetchUser(data.winner);
+		await user.addGP(data.prize);
+		await sendToChannelID(this.client, data.channelID, {
+			content: `The winner is **${user}**! Congratulations! You won${
+				data.prize > 0 ? `**${data.prize.toLocaleString()}** GP` : ''
+			}!`
+		});
+		channelsPlayingLms.add(data.channelID);
+	}
+}

--- a/src/tasks/minions/OtherActivitities/lmsGamblingActivity.ts
+++ b/src/tasks/minions/OtherActivitities/lmsGamblingActivity.ts
@@ -1,18 +1,18 @@
 import { Task } from 'klasa';
 
-import { channelsPlayingLms } from '../../../commands/OSRS_Fun/LastManStanding';
+import { channelsPlayingLms } from '../../../lib/constants';
 import { LmsGamblingActivityTaskOptions } from '../../../lib/types/minions';
 import { sendToChannelID } from '../../../lib/util/webhook';
 
 export default class extends Task {
 	async run(data: LmsGamblingActivityTaskOptions) {
 		const user = await this.client.fetchUser(data.winner);
-		await user.addGP(data.prize);
+		if (data.prize > 0) await user.addGP(data.prize);
 		await sendToChannelID(this.client, data.channelID, {
-			content: `The winner is **${user}**! Congratulations! You won${
-				data.prize > 0 ? `**${data.prize.toLocaleString()}** GP` : ''
+			content: `And the Last Man Standing is... **${user}**! Congratulations! You won${
+				data.prize > 0 ? ` **${data.prize.toLocaleString()}** GP` : ''
 			}!`
 		});
-		channelsPlayingLms.add(data.channelID);
+		channelsPlayingLms.delete(data.channelID);
 	}
 }


### PR DESCRIPTION
### Description:

- Was asked to make something like this a few times.

### Changes:

- Add a new `+lmsg` command, that allow users to create a LMS where people can join and compete against others (Same random system as +lms);
- An entrance fee can be set. The entrace fee is added to the prize pool. The winner takes it all.
- A minimum of 2 and maximum of 40 players is set.
- Users can change the min/max by adding another two parameters (`+lmsg 100m 10 20` means it will require 100m to enter, minimum users is 10 and auto starts at 20).

- Add a new folder to commands called Gambling;
- Add a new system for NonBusyActivity, where the minion is not considered Busy when doing;
- Currently, only add lmsGamblingActivity to the NonBusyActivity.

### To Consider:

- Currently, it can be used anywhere. Maybe force it to be used on a certain channel only?

### Other checks:

-   [X] I have tested all my changes thoroughly.