### PR TITLE
Fix creatures/laps lb sorting

### DIFF
--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -578,7 +578,7 @@ LIMIT 50;
 		if (!course) return msg.channel.send('Thats not a valid agility course.');
 
 		const data: { id: string; count: number }[] = await this.query(
-			`SELECT id, "lapsScores"->>'${course.id}' as count
+			`SELECT id, ("lapsScores"->>'${course.id}')::int as count
 				   FROM users
 				   WHERE "lapsScores"->>'${course.id}' IS NOT NULL
 				   ${msg.flagArgs.im ? ' AND "minion.ironman" = true ' : ''}
@@ -612,13 +612,11 @@ LIMIT 50;
 				`Thats not a valid creature. Valid creatures are: ${Hunter.Creatures.map(h => h.name).join(', ')}`
 			);
 
-		const data: { id: string; count: number }[] = await this.query(
-			`SELECT id, "creatureScores"->>'${creature.id}' as count
+		const query = `SELECT id, ("creatureScores"->>'${creature.id}')::int as count
 				   FROM users WHERE "creatureScores"->>'${creature.id}' IS NOT NULL
 				   ${msg.flagArgs.im ? ' AND "minion.ironman" = true ' : ''}
-				   ORDER BY count DESC LIMIT 50;`
-		);
-
+				   ORDER BY count DESC LIMIT 50;`;
+		const data: { id: string; count: number }[] = await this.query(query);
 		this.doMenu(
 			msg,
 			util


### PR DESCRIPTION
### Description:

- Creatures and Laps leaderboards were being sorted as string.

### Changes:

- Cast the count value to integer before sorting

### Other checks:

-   [X] I have tested all my changes thoroughly.

Before > After
![image](https://user-images.githubusercontent.com/19570528/131171539-c0a90fd0-2d6b-42df-82e5-59cb62e1c9bd.png)
