### PR TITLE
Force lowercase for seedType on resolvePatchTypeSetting on harvest.ts

### DIFF
--- a/src/commands/Minion/harvest.ts
+++ b/src/commands/Minion/harvest.ts
@@ -91,10 +91,7 @@ export default class extends BotCommand {
 			}
 		}
 
-		if (!planted) {
-			this.client.wtf(new Error(`${msg.author.sanitizedName}'s patch had no plant found in it.`));
-			return;
-		}
+		if (!planted) return msg.channel.send(`${msg.author}, you have nothing planted on this patch type.`);
 
 		const timePerPatchTravel = Time.Second * planted.timePerPatchTravel;
 		const timePerPatchHarvest = Time.Second * planted.timePerHarvest;


### PR DESCRIPTION
### Description:

- Harvest does not accept uppercase characters on the seedType (mostly a problem on mobiles).
- Harvest does not output anything if trying to harvest a patch that have nothing planted on.

### Changes:

- Force seedType to lowercase when trying to figure out what patch type it is.
- Add a message showing that nothing is planted on said patch.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/131172576-decd55c2-0478-4486-9964-e1f677cc6fff.png)