### PR TITLE
Adds fletching Elder logs into (normal) arrow shafts

### DIFF
--- a/src/lib/skilling/skills/fletching/fletchables/shafts.ts
+++ b/src/lib/skilling/skills/fletching/fletchables/shafts.ts
@@ -86,6 +86,15 @@ const Shafts: Fletchable[] = [
 		outputMultiple: 105
 	},
 	{
+		name: 'Elder arrow shaft',
+		id: itemID('Arrow shaft'),
+		level: 105,
+		xp: 100,
+		inputItems: new Bank({ 'Elder logs': 1 }),
+		tickRate: 2,
+		outputMultiple: 300
+	},
+	{
 		name: 'Battlestaff',
 		id: itemID('Battlestaff'),
 		level: 40,


### PR DESCRIPTION
### Description:

In game, you can fletch various logs into Arrow shafts, increasing depending on the tier. Now, Elder logs can be fletched into arrow shafts for consistency. 

They give an output of 300 Arrow shafts per Elder log, which may seem like a lot but honestly fletching arrows isn't meta anyways so shouldn't have an impact. 300 felt right for an 'endgame' log.  The XP per fletching is 100, which is consistent with the formula the game uses for arrow shaft fletching.

### Changes:

- Added Elder logs to Shaft.ts as a fletchable item for Shafts

### Other checks:

-   [ ] I have tested all my changes thoroughly. 
Honestly copy pasted the format for other logs and filled in the relevant info. 
