### PR TITLE
Add Volcanic Mine

### DIFF
--- a/src/commands/Minion/volcanicmine.ts
+++ b/src/commands/Minion/volcanicmine.ts
@@ -176,7 +176,8 @@ export default class extends BotCommand {
 
 		const suppliesUsage = new Bank()
 			.add('Saradomin brew (4)', userHitpointsLevel >= 80 ? 3 : 2)
-			.add('Prayer potion (4)', 1);
+			.add('Prayer potion (4)', 1)
+			.add('Numulite', 30);
 
 		// Activity boosts
 		if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {

--- a/src/commands/Minion/volcanicmine.ts
+++ b/src/commands/Minion/volcanicmine.ts
@@ -1,0 +1,238 @@
+import { objectEntries, Time } from 'e';
+import { CommandStore, KlasaMessage } from 'klasa';
+import { Bank } from 'oldschooljs';
+import { resolveNameBank } from 'oldschooljs/dist/util';
+
+import { Activity } from '../../lib/constants';
+import { GearSetupTypes } from '../../lib/gear';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { SkillsEnum } from '../../lib/skilling/types';
+import { BotCommand } from '../../lib/structures/BotCommand';
+import { ItemBank } from '../../lib/types';
+import { VolcanicMineActivityTaskOptions } from '../../lib/types/minions';
+import { formatDuration, formatSkillRequirements, stringMatches } from '../../lib/util';
+import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
+
+export const VolcanicMineGameTime = Time.Minute * 10;
+
+const VolcanicMineShop: { name: string; output: ItemBank; cost: number; clOnly?: boolean }[] = [
+	{
+		name: 'Iron ore',
+		output: resolveNameBank({ 'Iron ore': 1 }),
+		cost: 30
+	},
+	{
+		name: 'Silver ore',
+		output: resolveNameBank({ 'Silver ore': 1 }),
+		cost: 55
+	},
+	{
+		name: 'Coal',
+		output: resolveNameBank({ Coal: 1 }),
+		cost: 60
+	},
+	{
+		name: 'Gold ore',
+		output: resolveNameBank({ 'Gold ore': 1 }),
+		cost: 150
+	},
+	{
+		name: 'Mithril ore',
+		output: resolveNameBank({ 'Mithril ore': 1 }),
+		cost: 30
+	},
+	{
+		name: 'Adamantite ore',
+		output: resolveNameBank({ 'Adamantite ore': 1 }),
+		cost: 300
+	},
+	{
+		name: 'Runite ore',
+		output: resolveNameBank({ 'Runite ore': 1 }),
+		cost: 855
+	},
+	{
+		name: 'Volcanic ash',
+		output: resolveNameBank({ 'Volcanic ash': 1 }),
+		cost: 40
+	},
+	{
+		name: 'Calcite',
+		output: resolveNameBank({ Calcite: 1 }),
+		cost: 70
+	},
+	{
+		name: 'Pyrophosphite',
+		output: resolveNameBank({ Pyrophosphite: 1 }),
+		cost: 70
+	},
+	{
+		name: 'Volcanic mine teleport',
+		output: resolveNameBank({ 'Volcanic mine teleport': 1 }),
+		cost: 200
+	},
+	{
+		name: 'Large water container',
+		output: resolveNameBank({ 'Large water container': 1 }),
+		cost: 10_000,
+		clOnly: true
+	},
+	{
+		name: 'Ash covered tome',
+		output: resolveNameBank({ 'Ash covered tome': 1 }),
+		cost: 40_000,
+		clOnly: true
+	}
+];
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			usage: '[shop] [numberOfGames|quantity:int] [item:...string]',
+			subcommands: true,
+			usageDelim: ' ',
+			cooldown: 3,
+			categoryFlags: ['minion'],
+			aliases: ['vm'],
+			description: 'Participate in games on the Volcanic Mine.',
+			examples: ['+volcanicmine', '+vm 1']
+		});
+	}
+
+	async shop(msg: KlasaMessage, [quantity = 1, item = '']: [number, string]) {
+		const currentUserPoints = msg.author.settings.get(UserSettings.VolcanicMinePoints);
+		if (!item) {
+			return msg.channel.send(`You currently have ${currentUserPoints.toLocaleString()} Volcanic Mine points.`);
+		}
+
+		const shopItem = VolcanicMineShop.find(f => stringMatches(f.name, item));
+		if (!shopItem) {
+			return msg.channel.send(
+				`This is not a valid item to buy. These are the items that can be bought using Volcanic Mine points: ${VolcanicMineShop.map(
+					v => v.name
+				).join(', ')}`
+			);
+		}
+		if (quantity * shopItem.cost > currentUserPoints) {
+			return msg.channel.send(
+				`You don't have enough points to buy ${quantity.toLocaleString()}x ${shopItem.name}. ${
+					currentUserPoints < shopItem.cost
+						? "You don't have enough points for any of this item."
+						: `You only have enough for ${Math.floor(currentUserPoints / shopItem.cost).toLocaleString()}`
+				}`
+			);
+		}
+		await msg.confirm(
+			`Are you sure you want to spent **${(
+				quantity * shopItem.cost
+			).toLocaleString()}** Volcanic Mine points to buy **${quantity.toLocaleString()}x ${shopItem.name}**?`
+		);
+
+		if (shopItem.clOnly) {
+			await msg.author.addItemsToCollectionLog(new Bank().add(shopItem.output).multiply(quantity).bank);
+		} else {
+			await msg.author.addItemsToBank(new Bank().add(shopItem.output).multiply(quantity), true);
+		}
+		await msg.author.settings.update(UserSettings.VolcanicMinePoints, currentUserPoints - shopItem.cost * quantity);
+
+		return msg.channel.send(
+			`You sucessfully bought **${quantity.toLocaleString()}x ${shopItem.name}** for ${(
+				shopItem.cost * quantity
+			).toLocaleString()} Volcanic Mine points.${
+				shopItem.clOnly
+					? `\n${quantity > 1 ? 'These items were' : 'This item was'} directly added to your collection log.`
+					: ''
+			}`
+		);
+	}
+
+	async run(msg: KlasaMessage, [numberOfGames = undefined]: [number | undefined]) {
+		const skillReqs = {
+			[SkillsEnum.Prayer]: 70,
+			[SkillsEnum.Hitpoints]: 70,
+			[SkillsEnum.Mining]: 50
+		};
+		if (!msg.author.hasSkillReqs(skillReqs)[0]) {
+			return msg.channel.send(
+				`You are not skilled enough to participate in the Volcanic Mine. You need the following requirements: ${objectEntries(
+					skillReqs
+				)
+					.map(s => {
+						return msg.author.skillLevel(s[0]) < s[1]
+							? formatSkillRequirements({ [s[0]]: s[1] }, true)
+							: undefined;
+					})
+					.filter(f => f)
+					.join(', ')}`
+			);
+		}
+		const maxGamesUserCanDo = Math.floor(msg.author.maxTripLength() / VolcanicMineGameTime);
+		if (!numberOfGames || numberOfGames > maxGamesUserCanDo) numberOfGames = maxGamesUserCanDo;
+		const userMiningLevel = msg.author.skillLevel(SkillsEnum.Mining);
+		const userPrayerLevel = msg.author.skillLevel(SkillsEnum.Prayer);
+		const userHitpointsLevel = msg.author.skillLevel(SkillsEnum.Hitpoints);
+		const userSkillingGear = msg.author.getGear(GearSetupTypes.Skilling);
+		const boosts: string[] = [];
+
+		const suppliesUsage = new Bank()
+			.add('Saradomin brew (4)', userHitpointsLevel >= 80 ? 3 : 2)
+			.add('Prayer potion (4)', 1);
+
+		// Activity boosts
+		if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {
+			boosts.push('50% boost for having a Crystal pickaxe equipped.');
+		} else if (userMiningLevel >= 61 && userSkillingGear.hasEquipped('Dragon pickaxe')) {
+			boosts.push('30% boost for having a Dragon pickaxe equipped.');
+		}
+
+		if (
+			userSkillingGear.hasEquipped(
+				['Prospector helmet', 'Prospector jacket', 'Prospector legs', 'Prospector boots'],
+				true
+			)
+		) {
+			boosts.push('2.5% more Mining XP for having the Propector outfit equipped.');
+		}
+
+		if (userSkillingGear.hasEquipped('Elysian spirit shield')) {
+			suppliesUsage.remove('Saradomin brew (4)', 1);
+			boosts.push('Lower Saradomin Brew usage for having an Elysian spirit shield equipped.');
+		}
+
+		if (userPrayerLevel >= 90 || (userSkillingGear.hasEquipped('Dragonbone necklace') && userPrayerLevel >= 80)) {
+			suppliesUsage.remove('Prayer potion (4)', 1);
+			boosts.push(
+				userPrayerLevel >= 90
+					? 'No prayer potion usage for having 90+ Prayer.'
+					: 'No prayer potion usage for having 80+ prayer and a Dragonbone necklace equipped.'
+			);
+		}
+
+		suppliesUsage.multiply(numberOfGames);
+		if (!msg.author.owns(suppliesUsage)) {
+			return msg.channel.send(
+				`You don't have all the required supplies for this number of games. You need ${suppliesUsage} for ${numberOfGames} games of Volcanic Mine.`
+			);
+		}
+
+		await msg.author.removeItemsFromBank(suppliesUsage);
+
+		let duration = VolcanicMineGameTime * numberOfGames;
+
+		const str = `${
+			msg.author.minionName
+		} is now playing ${numberOfGames}x games of Volcanic Mine. It will be back in ${formatDuration(duration)}.${
+			boosts.length > 0 ? `\n**Boosts**\n${boosts.join('\n')}` : ''
+		}\n**Supply Usage:** ${suppliesUsage}`;
+
+		await addSubTaskToActivityTask<VolcanicMineActivityTaskOptions>({
+			userID: msg.author.id,
+			channelID: msg.channel.id,
+			quantity: numberOfGames,
+			duration,
+			type: Activity.VolcanicMine
+		});
+
+		return msg.channel.send(str);
+	}
+}

--- a/src/extendables/User/Minigame.ts
+++ b/src/extendables/User/Minigame.ts
@@ -128,6 +128,11 @@ export const Minigames: Minigame[] = [
 		name: 'Pest Control',
 		key: 'PestControl',
 		column: 'pest_control'
+	},
+	{
+		name: 'Volcanic Mine',
+		key: 'VolcanicMine',
+		column: 'volcanic_mine'
 	}
 ];
 

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -76,6 +76,7 @@ import {
 	SmeltingActivityTaskOptions,
 	SmithingActivityTaskOptions,
 	SoulWarsOptions,
+	VolcanicMineActivityTaskOptions,
 	WealthChargingActivityTaskOptions,
 	WoodcuttingActivityTaskOptions,
 	ZalcanoActivityTaskOptions
@@ -562,6 +563,10 @@ export default class extends Extendable {
 			case Activity.PestControl: {
 				const data = currentTask as MinigameActivityTaskOptions;
 				return `${this.minionName} is currently doing ${data.quantity} games of Pest Control. ${formattedDuration}`;
+			}
+			case Activity.VolcanicMine: {
+				const data = currentTask as VolcanicMineActivityTaskOptions;
+				return `${this.minionName} is currently doing ${data.quantity} games of Volcanic Mine. ${formattedDuration}`;
 			}
 		}
 	}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -204,7 +204,8 @@ export const enum Tasks {
 	DarkAltar = 'darkAltarActivity',
 	TrekkingActivity = 'templeTrekkingActivity',
 	RevenantsActivity = 'revenantsActivity',
-	PestControl = 'pestControlActivity'
+	PestControl = 'pestControlActivity',
+	VolcanicMine = 'volcanicMineActivity'
 }
 
 export enum Activity {
@@ -269,7 +270,8 @@ export enum Activity {
 	DarkAltar = 'DarkAltar',
 	Trekking = 'Trekking',
 	Revenants = 'Revenants',
-	PestControl = 'PestControl'
+	PestControl = 'PestControl',
+	VolcanicMine = 'VolcanicMine'
 }
 
 export enum ActivityGroup {

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -686,8 +686,8 @@ export const allCollectionLogs: ICollection = {
 				isActivity: true
 			},
 			'Volcanic Mine': {
-				enabled: false,
 				items: volcanicMineCL,
+				alias: ['vm', 'vmine', 'volcanic'],
 				roleCategory: ['minigames'],
 				isActivity: true
 			}

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -34,6 +34,7 @@ Client.defaultUserSchema
 	.add('combat_options', 'integer', { array: true, default: [] })
 	.add('farming_patch_reminders', 'boolean', { default: true })
 	.add('pest_control_points', 'integer', { default: 0 })
+	.add('volcanic_mine_points', 'integer', { default: 0 })
 	.add('slayer', folder =>
 		folder
 			.add('points', 'integer', { default: 0 })

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -51,6 +51,7 @@ export namespace UserSettings {
 	export const CombatOptions = T<readonly CombatOptionsEnum[]>('combat_options');
 	export const FarmingPatchReminders = T<boolean>('farming_patch_reminders');
 	export const PestControlPoints = T<number>('pest_control_points');
+	export const VolcanicMinePoints = T<number>('volcanic_mine_points');
 
 	export namespace Slayer {
 		export const SlayerPoints = T<number>('slayer.points');

--- a/src/lib/typeorm/MinigameTable.entity.ts
+++ b/src/lib/typeorm/MinigameTable.entity.ts
@@ -74,4 +74,7 @@ export class MinigameTable extends BaseEntity {
 
 	@Column({ name: 'pest_control', type: 'int', nullable: false, default: 0 })
 	public PestControl!: number;
+
+	@Column({ name: 'volcanic_mine', type: 'int', nullable: false, default: 0 })
+	public VolcanicMine!: number;
 }

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -322,6 +322,10 @@ export interface BlastFurnaceActivityTaskOptions extends ActivityTaskOptions {
 	quantity: number;
 }
 
+export interface VolcanicMineActivityTaskOptions extends ActivityTaskOptions {
+	quantity: number;
+}
+
 export type ActivityTaskData =
 	| ActivityTaskOptions
 	| MonsterActivityTaskOptions
@@ -343,4 +347,5 @@ export type ActivityTaskData =
 	| FletchingActivityTaskOptions
 	| RunecraftActivityTaskOptions
 	| TempleTrekkingActivityTaskOptions
-	| TemporossActivityTaskOptions;
+	| TemporossActivityTaskOptions
+	| VolcanicMineActivityTaskOptions;

--- a/src/lib/util/taskNameFromType.ts
+++ b/src/lib/util/taskNameFromType.ts
@@ -126,5 +126,7 @@ export function taskNameFromType(activityType: Activity) {
 			return Tasks.RevenantsActivity;
 		case Activity.PestControl:
 			return Tasks.PestControl;
+		case Activity.VolcanicMine:
+			return Tasks.VolcanicMine;
 	}
 }

--- a/src/tasks/minions/volcanicMineActivity.ts
+++ b/src/tasks/minions/volcanicMineActivity.ts
@@ -1,0 +1,96 @@
+import { randFloat, roll, Time } from 'e';
+import { Task } from 'klasa';
+import { Bank } from 'oldschooljs';
+
+import { VolcanicMineGameTime } from '../../commands/Minion/volcanicmine';
+import { Emoji, Events } from '../../lib/constants';
+import { GearSetupTypes } from '../../lib/gear';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { SkillsEnum } from '../../lib/skilling/types';
+import { VolcanicMineActivityTaskOptions } from '../../lib/types/minions';
+import { handleTripFinish } from '../../lib/util/handleTripFinish';
+
+export default class extends Task {
+	async run(data: VolcanicMineActivityTaskOptions) {
+		const { quantity, userID, channelID, duration } = data;
+		const user = await this.client.fetchUser(userID);
+		const userSkillingGear = user.getGear(GearSetupTypes.Skilling);
+		const userMiningLevel = user.skillLevel(SkillsEnum.Mining);
+		let boost = 1;
+		// Activity boosts
+		if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {
+			boost += 0.5;
+		} else if (userMiningLevel >= 61 && userSkillingGear.hasEquipped('Dragon pickaxe')) {
+			boost += 0.3;
+		}
+		if (
+			userSkillingGear.hasEquipped(
+				['Prospector helmet', 'Prospector jacket', 'Prospector legs', 'Prospector boots'],
+				true
+			)
+		) {
+			boost += 0.025;
+		}
+
+		const xpReceived = Math.round(
+			userMiningLevel * ((VolcanicMineGameTime * quantity) / Time.Minute) * 10 * boost * randFloat(1.02, 1.08)
+		);
+		const xpRes = await user.addXP({
+			skillName: SkillsEnum.Mining,
+			amount: xpReceived,
+			duration
+		});
+
+		let warningMessage = '';
+
+		const currentUserPoints = user.settings.get(UserSettings.VolcanicMinePoints);
+		let pointsReceived = Math.round(xpReceived / 5.5);
+		const maxPoints = 2_097_151;
+		await user.settings.update(
+			UserSettings.VolcanicMinePoints,
+			Math.min(maxPoints, currentUserPoints + pointsReceived)
+		);
+
+		if (currentUserPoints + pointsReceived > maxPoints) {
+			const lostPoints = currentUserPoints + pointsReceived - maxPoints;
+			pointsReceived -= lostPoints;
+			warningMessage += `You did not received ${lostPoints.toLocaleString()} points, because you can't have more than ${maxPoints.toLocaleString()} points at the same time. Expend some on the Volcanic Mine shop.`;
+		} else if (currentUserPoints + pointsReceived * 5 > maxPoints) {
+			warningMessage += `You are getting close to the maximum amount of points that you can carry (${maxPoints.toLocaleString()}). You should expend some on the Volcanic Mine shop.`;
+		}
+
+		await user.incrementMinigameScore('VolcanicMine', quantity);
+
+		let str = `${user}, ${
+			user.minionName
+		} finished playing ${quantity} games of Volcanic Mine.\n${xpRes}\nYou received **${pointsReceived.toLocaleString()}** Volcanic Mine points. ${warningMessage}`;
+
+		// Roll for pet --- Average 40 fragments per game at 60K chance per fragment
+		const loot = new Bank();
+		for (let i = 0; i < 40; i++) if (roll(60_000)) loot.add('Rock golem');
+
+		if (loot.has('Rock golem')) {
+			str += "\nYou have a funny feeling you're being followed...";
+			this.client.emit(
+				Events.ServerNotification,
+				`${Emoji.Mining} **${user.username}'s** minion, ${user.minionName}, just received ${
+					loot.amount('Rock golem') > 1 ? `${loot.amount('Rock golem')}x ` : 'a'
+				} Rock golem while mining on the Volcanic Mine at level ${userMiningLevel} Mining!`
+			);
+		}
+
+		handleTripFinish(
+			this.client,
+			user,
+			channelID,
+			str,
+			res => {
+				user.log(`continued trip of ${quantity}x Volcanic Mine`);
+				return this.client.commands.get('volcanicmine')!.run(res, [quantity]);
+			},
+			undefined,
+			data,
+			loot.bank
+		);
+	}
+}

--- a/src/tasks/minions/volcanicMineActivity.ts
+++ b/src/tasks/minions/volcanicMineActivity.ts
@@ -16,7 +16,7 @@ const fossilTable = new LootTable()
 	.add('Unidentified medium fossil', 1, 5)
 	.add('Unidentified large fossil', 1, 4)
 	.add('Unidentified rare fossil', 1, 1);
-const numuliteTable = new LootTable().every('Numulite', 3).add('Calcite', 2).add('Pyrophosphite', 2);
+const numuliteTable = new LootTable().every('Numulite', 5).add('Calcite', 1).add('Pyrophosphite', 1);
 const fragmentTable = new LootTable({ limit: 175 }).add(numuliteTable, 1, 45).add(fossilTable, 1, 5);
 
 export default class extends Task {

--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -21,7 +21,8 @@ const minigames = [
 	'raids_challenge_mode',
 	'big_chompy_bird_hunting',
 	'rogues_den',
-	'temple_trekking'
+	'temple_trekking',
+	'volcanic_mine'
 ];
 
 const collections = ['overall', 'pets', 'skilling', 'clues', 'bosses', 'minigames', 'raids', 'slayer'];


### PR DESCRIPTION
### Description:

- Add the minigame Volcanic Mine to the bot `+vm [qty] / +volcanicmine [qty]`;
- Add the Volcanic Mine shop `+vm buy <item>/ +volcanicmine <item>`;

- The minigame has the following requirements:
- - 70 Prayer (For balancing purposes);
- - 70 Hitpoints (For balancing purposes);
- - 50 Mining (As in-game).

- The minigame has the following item consumption:
- - 3 Saradomin Brew 4 per game;
- - 1 Prayer potion 4 per game;

- The minigame has the following item reductions:
- - 1 less Saradomin brew 4 for having 80+ HP;
- - 1 less Saradomin brew 4 for having an Ely equipped;
- - 1 less Prayer potion 4 for having 90+ prayer OR 80+ prayer and a Dragontooth necklace equipped.

- The following boosts are applied:
- - 30% for having 61+ Mining and a Dragon Pickaxe equipped;
- - 50% for having 71+ Mining and a Crystal Pickaxe equipped;
- - 2.5% for having a full prospector equipped;

- The following drops can be acquired from the activity:
- - Numulite;
- - Calcite;
- - Pyrophosphite;
- - All 4 type of fossil.

### Changes:

- All calculations were based on the data from the Volcanic Mine discord, some random youtube videos and the OSRS wiki.
- Added the Volcanic Mine minigame;
- Added the Volcanic Mine shop;
- Added a new entry in the UserSchema for Volcanic Mine points;
- Added a new entry in the Minigames table for the Volcanic Mine.

### Special Thanks

- eggaroonie#7125
- mylife212#3106
- Dreamscape#5825

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/131206254-87121af7-24de-482e-bda1-604331ba0f24.png)

Average XP and points per hour
![image](https://user-images.githubusercontent.com/19570528/131207263-87083154-d8b6-48d4-9220-a8f8f8057e41.png)
