### PR TITLE
[BSO] Master farming cape - Incentivize longer trips

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -488,8 +488,12 @@ export default class extends Task {
 				loot[itemID('Plopper')] = 1;
 			}
 
-			if (roll(10) && user.hasItemEquippedOrInBank(itemID('Farming master cape'))) {
-				loot = addItemToBank(loot, getRandomMysteryBox());
+			if (user.hasItemEquippedOrInBank(itemID('Farming master cape'))) {
+				for (let j = 0; j < alivePlants; j++) {
+					if (roll(10)) {
+						loot = addItemToBank(loot, getRandomMysteryBox());
+					}
+				}
 			}
 			// Give boxes for planting when harvesting
 			if (planting && plant.name === 'Mysterious tree') {


### PR DESCRIPTION
### Description:

- Based on player feedback and math, changing the roll to per-patch.
- Currently you can only get less than 1 box per hour, and short-trips are still incentivized because minimizing harvest time is the META.
- The changes would buff that to around 5 boxes per hour, but only when farming with ALL paches, buffs, and boosts, including all extra patches, graceful, ring of endurance, ardy elite. And you spend at least 20 minutes per hour farming. (40 minutes of a 2-hour segment)

These are the 6 fastest growing plants:
```
90 minutes for 14 herbs - 6:41 harvest - less than 1 box /hr
40 minutes for 7 seaweed  - 3:18 harvest - approx 1 box/hr
35 minutes for 17 grapes  - 5 minute harvest - approx 1.5 box/hr
80 minutes for 17 pataches -  approx 1.25 box/hr
3 hours for 10 patches - 5 minute harvest - 0.333 box/hr
6 hours for 11 trees - 5 minutes harvest - 1/6th box per hour
```

The time cost is around 40 minutes every 2 hours,  or 1/3 total time.

So at **most** you can get 5.25 boxes per hour (on average) if you farm full trips with max patches+boosts. (_The longer patches take so long to grow that they don't add a significant amount of boxes to the hourly total._)

- If you harvest small trips that don't take much time, you will get just under 1 box per hour, on average.
- For comparison, when you got 1 box guaranteed per harvest, you could get 5 boxes every 2 hours for 2 minutes of time.

### Changes:

- Change function to roll per (alive) patch instead of per trip.
- You could adjust the roll chance to 1 in 12 to reduce boxes per hour to ~4, but again, the seed + time investment is significant in order to farm max patches to get the maximum.

### Other checks:

-   [x] I have tested all my changes thoroughly.
