### PR TITLE
Let Vasa cloak work from bank for Eternal imps

### DIFF
--- a/src/lib/implings.ts
+++ b/src/lib/implings.ts
@@ -109,7 +109,7 @@ export function handlePassiveImplings(user: KlasaUser, data: ActivityTaskOptions
 			const [imp, , levelReq, inhibitor] = ImplingTable.roll()!.item;
 			if (inhibitor && !inhibitor(data)) continue;
 
-			if (level < levelReq || (imp === EternalImpling && !user.hasItemEquippedAnywhere('Vasa cloak'))) {
+			if (level < levelReq || (imp === EternalImpling && !user.hasItemEquippedOrInBank('Vasa cloak'))) {
 				missed.push(imp);
 			} else {
 				bank.add(imp.id);


### PR DESCRIPTION
### Description:
Let Vasa cloak work from bank when catching Eternal implings.

### Changes:
Change check to `hasItemEquippedOrInBank('Vasa cloak')`

### Other checks:

-   [x] I have tested all my changes thoroughly. I jacked up the rates and tested on + off, in bank , and dropped. Working as intended.
