### PR TITLE
Rework alching & favalch

### DIFF
--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -1,16 +1,16 @@
 import { Time } from 'e';
-import { CommandStore, KlasaMessage } from 'klasa';
-import { Bank, Util } from 'oldschooljs';
+import { CommandStore, KlasaMessage, KlasaUser } from 'klasa';
+import { Bank } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 
 import { Activity } from '../../lib/constants';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
-import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, updateBankSetting } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
+import { parseStringBank } from '../../lib/util/parseStringBank';
 import resolveItems from '../../lib/util/resolveItems';
 
 const unlimitedFireRuneProviders = resolveItems([
@@ -26,11 +26,94 @@ const unlimitedFireRuneProviders = resolveItems([
 	'Tome of fire'
 ]);
 
+export function calculateAlchItemByTripDuration(params: {
+	user: KlasaUser;
+	duration: number;
+	items?: { item: Item; qty: number }[];
+	qtyLimit?: number;
+	calculateByRunesOwned?: boolean;
+}) {
+	let { items, duration, user, qtyLimit, calculateByRunesOwned } = params;
+	const userBank = user.bank().clone();
+
+	if (!items) items = [];
+
+	if (items.length === 0) {
+		for (const i of user.getUserFavAlchs() as Item[]) {
+			// Ignore alchs that are already on the alch items
+			if (items.find(a => a.item.id === i.id)) continue;
+			items.push({
+				item: i,
+				qty: qtyLimit
+					? qtyLimit < userBank.amount(i.id)
+						? qtyLimit
+						: userBank.amount(i.id)
+					: userBank.amount(i.id)
+			});
+		}
+		if (items.length === 0) return false;
+	}
+
+	// Check if user has infinite fire runes
+	let infiniteFireRunes = false;
+	for (const runeProvider of unlimitedFireRuneProviders) {
+		if (user.hasItemEquippedAnywhere(runeProvider)) {
+			infiniteFireRunes = true;
+			break;
+		}
+	}
+
+	// 5 tick action
+	const timePerAlch = Time.Second * 3;
+	let maxCasts = Math.floor(duration / timePerAlch);
+	if (qtyLimit && maxCasts > qtyLimit) maxCasts = qtyLimit;
+
+	// If calculateByRunesOwned is true, limit casts to what the user have runes for
+	if (calculateByRunesOwned) {
+		const maxRuneCasts = userBank.fits(
+			new Bank().add('Fire rune', infiniteFireRunes ? 0 : 5).add('Nature rune', 1)
+		);
+		if (maxCasts > maxRuneCasts) {
+			maxCasts = maxRuneCasts;
+		}
+	}
+
+	const alchBank = new Bank();
+	let totalValue = 0;
+
+	let castsLeft = maxCasts;
+	for (const i of items) {
+		let numberOfCasts = i.qty;
+		if (castsLeft < i.qty) numberOfCasts = castsLeft;
+		castsLeft -= numberOfCasts;
+		alchBank.add(i.item.id, numberOfCasts);
+		totalValue += i.item.highalch * numberOfCasts;
+		if (castsLeft === 0) break;
+	}
+
+	// Calculate number of casts
+	const casts = maxCasts - castsLeft;
+
+	// Means nothing is being alched
+	if (maxCasts === 0 || maxCasts === castsLeft) return false;
+
+	// Check runes to be used
+	const runeBank = new Bank().add('Fire rune', infiniteFireRunes ? 0 : casts * 5).add('Nature rune', casts);
+
+	return {
+		casts,
+		items: alchBank,
+		runes: runeBank,
+		duration: casts * timePerAlch,
+		value: totalValue
+	} as { casts: number; items: Bank; runes: Bank; duration: number; value: number };
+}
+
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			cooldown: 1,
-			usage: '[quantity:int{1}] [item:...item]',
+			usage: '[quantity:int{1}] [item:...string] [ignoreConfirm:string]',
 			usageDelim: ' ',
 			oneAtTime: true,
 			description: 'Allows you to send your minion to alch items from your bank',
@@ -41,85 +124,91 @@ export default class extends BotCommand {
 
 	@minionNotBusy
 	@requiresMinion
-	async run(msg: KlasaMessage, [quantity = null, item]: [number | null, Item[]]) {
+	async run(
+		msg: KlasaMessage,
+		[quantity = undefined, item, ignoreConfirm = undefined]: [number | undefined, string, undefined | true]
+	) {
 		const userBank = msg.author.bank();
-		let osItem = item?.find(i => userBank.has(i.id) && i.highalch && i.tradeable);
 
-		const [favAlchs] = msg.author.getUserFavAlchs() as Item[];
-
-		if (!osItem && !favAlchs) {
-			return msg.channel.send("You don't have any of that item to alch.");
+		// Make sure the qty is not used when the first item doesnt have a qty
+		const parsedItems = parseStringBank(item);
+		if (parsedItems.length > 0 && parsedItems[0][1] === 0 && quantity !== null) {
+			parsedItems[0][1] = quantity;
+			quantity = undefined;
 		}
 
-		if (msg.author.skillLevel(SkillsEnum.Magic) < 55) {
-			return msg.channel.send('You need level 55 Magic to cast High Alchemy');
-		}
+		// If nothing is defined to alch, it means the user wants to alch favorites.
+		// This will be used on the handle trip finish
+		let alchFavorites = parsedItems.length === 0;
 
-		if (!osItem) {
-			osItem = favAlchs;
-			quantity = null;
-		}
+		// Parse the items the user defined
+		let itemsToAlch = parsedItems
+			.filter(i => userBank.has(i[0].id) && i[0].highalch && i[0].tradeable)
+			.map(i => {
+				return {
+					item: i[0],
+					qty: i[1] && i[1] > 0 && userBank.amount(i[0].id) > i[1] ? i[1] : userBank.amount(i[0].id)
+				};
+			});
 
-		// 5 tick action
-		const timePerAlch = Time.Second * 3;
-		const maxTripLength = msg.author.maxTripLength(Activity.Alching);
-
-		const maxCasts = Math.min(Math.floor(maxTripLength / timePerAlch), userBank.amount(osItem.id));
-
-		if (!quantity) {
-			quantity = maxCasts;
-		}
-
-		if (quantity * timePerAlch > maxTripLength) {
-			return msg.channel.send(`The max number of alchs you can do is ${maxCasts}!`);
-		}
-
-		const duration = quantity * timePerAlch;
-		let fireRuneCost = quantity * 5;
-
-		for (const runeProvider of unlimitedFireRuneProviders) {
-			if (msg.author.hasItemEquippedAnywhere(runeProvider)) {
-				fireRuneCost = 0;
-				break;
-			}
-		}
-
-		const alchValue = quantity * osItem.highalch;
-		const consumedItems = new Bank({
-			...(fireRuneCost > 0 ? { 'Fire rune': fireRuneCost } : {}),
-			'Nature rune': quantity
+		// Calculate what can be alched
+		const result = calculateAlchItemByTripDuration({
+			user: msg.author,
+			duration: msg.author.maxTripLength(Activity.Alching),
+			items: itemsToAlch,
+			qtyLimit: quantity
 		});
-		consumedItems.add(osItem.id, quantity);
+
+		if (!result)
+			return msg.channel.send(
+				'You dont have any item to alch. You can leave the items to alch blank to alch your favorites.'
+			);
+
+		const consumedItems = result.items.clone().add(result.runes);
 
 		if (!msg.author.owns(consumedItems)) {
-			return msg.channel.send(`You don't have the required items, you need ${consumedItems}`);
+			return msg.channel.send(
+				`You can't alch ${result.items} because you don't own enough runes. You need ${
+					result.runes
+				}, but you are missing ${result.runes.clone().remove(msg.author.bank())}.`
+			);
 		}
 
-		await msg.confirm(
-			`${msg.author}, please confirm you want to alch ${quantity} ${osItem.name} (${Util.toKMB(
-				alchValue
-			)}). This will take approximately ${formatDuration(duration)}, and consume ${quantity}x Nature runes.`
-		);
+		if (!ignoreConfirm) {
+			await msg.confirm(
+				`Are you sure you want to use **${result.runes}** to alch **${
+					result.items
+				}** and convert it to <:RSGP:369349580040437770> **${result.value.toLocaleString()}** coins? This will take approximately ${formatDuration(
+					result.duration
+				)}`
+			);
+		}
 
 		await msg.author.removeItemsFromBank(consumedItems);
 		await updateBankSetting(this.client, ClientSettings.EconomyStats.MagicCostBank, consumedItems);
 
 		await addSubTaskToActivityTask<AlchingActivityTaskOptions>({
-			itemID: osItem.id,
+			alchedBank: result.items.bank,
 			userID: msg.author.id,
 			channelID: msg.channel.id,
+			favorites: alchFavorites,
 			quantity,
-			duration,
-			alchValue,
+			duration: result.duration,
+			alchValue: result.value,
 			type: Activity.Alching
 		});
 
-		msg.author.log(`alched Quantity[${quantity}] ItemID[${osItem.id}] for ${alchValue}`);
+		msg.author.log(
+			`alched Quantity[${quantity}] Items[${result.items
+				.items()
+				.map(i => `${i[1]}x ${i[0].id}`)
+				.join(', ')}] for ${result.value}`
+		);
 
-		const response = `${msg.author.minionName} is now alching ${quantity}x ${
-			osItem.name
-		}, it'll take around ${formatDuration(duration)} to finish.`;
-
-		return msg.channel.send(response);
+		return msg.channel.send(
+			`${msg.author.minionName} is now alching **${result.items}**. It will take around ${formatDuration(
+				result.duration
+			)} to finish.`
+		);
 	}
 }

--- a/src/commands/Minion/alch.ts
+++ b/src/commands/Minion/alch.ts
@@ -3,7 +3,7 @@ import { CommandStore, KlasaMessage, KlasaUser } from 'klasa';
 import { Bank } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 
-import { Activity } from '../../lib/constants';
+import { Activity, Emoji } from '../../lib/constants';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
@@ -40,8 +40,6 @@ export function calculateAlchItemByTripDuration(params: {
 
 	if (items.length === 0) {
 		for (const i of user.getUserFavAlchs() as Item[]) {
-			// Ignore alchs that are already on the alch items
-			if (items.find(a => a.item.id === i.id)) continue;
 			items.push({
 				item: i,
 				qty: qtyLimit
@@ -51,8 +49,10 @@ export function calculateAlchItemByTripDuration(params: {
 					: userBank.amount(i.id)
 			});
 		}
-		if (items.length === 0) return false;
 	}
+
+	if (items.length === 0) return false;
+	items = items.sort((a, b) => b.item.highalch - a.item.highalch);
 
 	// Check if user has infinite fire runes
 	let infiniteFireRunes = false;
@@ -176,9 +176,9 @@ export default class extends BotCommand {
 
 		if (!ignoreConfirm) {
 			await msg.confirm(
-				`Are you sure you want to use **${result.runes}** to alch **${
-					result.items
-				}** and convert it to <:RSGP:369349580040437770> **${result.value.toLocaleString()}** coins? This will take approximately ${formatDuration(
+				`Are you sure you want to use **${result.runes}** to alch **${result.items}** and convert it to ${
+					Emoji.GP
+				} **${result.value.toLocaleString()}** coins? This will take approximately ${formatDuration(
 					result.duration
 				)}`
 			);

--- a/src/commands/Minion/favalch.ts
+++ b/src/commands/Minion/favalch.ts
@@ -1,52 +1,75 @@
+import { MessageAttachment } from 'discord.js';
 import { ArrayActions, CommandStore, KlasaMessage } from 'klasa';
-import { Item } from 'oldschooljs/dist/meta/types';
 
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
+import { ItemBank } from '../../lib/types';
 import { itemNameFromID } from '../../lib/util';
+import { parseStringBank } from '../../lib/util/parseStringBank';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '[item:item]',
+			usage: '[item:...string]',
 			description: 'Favorites an item to be used in alching.',
-			examples: ['+favalch rune platebody'],
+			examples: ['+favalch rune platebody', '+favalch rune platebody, dragon halberd, dragon longsword'],
 			categoryFlags: ['minion', 'skilling']
 		});
 	}
 
-	async run(msg: KlasaMessage, [items]: [Item[] | undefined]) {
+	async run(msg: KlasaMessage, [str]: [string]) {
 		const currentFavorites = msg.author.settings.get(UserSettings.FavoriteAlchables);
-
-		if (!items || items.length === 0) {
-			const currentFavorites = msg.author.settings.get(UserSettings.FavoriteAlchables);
-			if (currentFavorites.length === 0) {
-				return msg.channel.send('You have no favorited alchable items.');
+		const newFavorites: number[] = [...currentFavorites];
+		const items = parseStringBank(str);
+		if (!str || items.length === 0) {
+			if (currentFavorites.length === 0) return msg.channel.send('You have no favorited alchable items.');
+			if (msg.flagArgs.text) {
+				return msg.channel.send(
+					`Your current favorite alchable items are: ${currentFavorites
+						.map(id => itemNameFromID(id))
+						.join(', ')}.`
+				);
 			}
+			const imageBank: ItemBank = {};
+			for (const i of newFavorites) imageBank[i] = 0;
+			const { image } = await this.client.tasks
+				.get('bankImage')!
+				.generateBankImage(imageBank, 'Your current favorite alchable items', false, { id: 'yes' }, msg.author);
+			return msg.channel.send({ files: [new MessageAttachment(image!, 'youFavoriteItems.png')] });
+		}
+
+		const dupeCheck: string[] = [];
+		const cantAlchItems: string[] = [];
+		const removed: string[] = [];
+		const added: string[] = [];
+		for (const [item] of items) {
+			if (dupeCheck.includes(item.name)) continue;
+			if (!item.highalch) {
+				cantAlchItems.push(item.name);
+				continue;
+			}
+			if (newFavorites.includes(item.id)) {
+				newFavorites.splice(newFavorites.indexOf(item.id), 1);
+				removed.push(item.name);
+			} else {
+				newFavorites.push(item.id);
+				added.push(item.name);
+			}
+			dupeCheck.push(item.name);
+		}
+
+		if (msg.author.settings.get(UserSettings.FavoriteAlchables) !== newFavorites) {
+			await msg.author.settings.update(UserSettings.FavoriteAlchables, newFavorites, {
+				arrayAction: ArrayActions.Overwrite
+			});
 			return msg.channel.send(
-				`Your current favorite alchable items are: ${currentFavorites
-					.map(id => itemNameFromID(id))
-					.join(', ')}.`
+				`Updated your alch favorites.${
+					added.length > 0 ? `\nAdded the following items: ${added.join(', ')}` : ''
+				}${removed.length > 0 ? `\nRemoved the following items: ${removed.join(', ')}` : ''}${
+					cantAlchItems.length > 0 ? `\nThe following items can't be alched: ${cantAlchItems.join(', ')}` : ''
+				}`
 			);
 		}
-
-		const [item] = items;
-
-		if (!item.highalch) {
-			return msg.channel.send("That item isn't alchable.");
-		}
-
-		if (currentFavorites.includes(item.id)) {
-			await msg.author.settings.update(UserSettings.FavoriteAlchables, item.id, {
-				arrayAction: ArrayActions.Remove
-			});
-			return msg.channel.send(`Removed ${item.name} from your favorite alchable items.`);
-		}
-
-		await msg.author.settings.update(UserSettings.FavoriteAlchables, item.id, {
-			arrayAction: ArrayActions.Add
-		});
-
-		return msg.channel.send(`Added ${item.name} to your favorite alchable items.`);
+		return msg.channel.send('Nothing changed on your alch favorites.');
 	}
 }

--- a/src/commands/Minion/favalch.ts
+++ b/src/commands/Minion/favalch.ts
@@ -83,12 +83,12 @@ export default class extends BotCommand {
 		const removed: string[] = [];
 		const added: string[] = [];
 
-		items.map(i => {
+		for (const i of items) {
 			const { item } = i;
-			if (dupeCheck.includes(item.id)) return;
+			if (dupeCheck.includes(item.id)) continue;
 			if (!item.highalch) {
 				cantAlchItems.push(item.name);
-				return;
+				continue;
 			}
 			if (newFavorites.includes(item.id)) {
 				newFavorites.splice(newFavorites.indexOf(item.id), 1);
@@ -98,7 +98,7 @@ export default class extends BotCommand {
 				added.push(`${item.name} (${item.id})`);
 			}
 			dupeCheck.push(item.id);
-		});
+		}
 
 		if (msg.author.settings.get(UserSettings.FavoriteAlchables) !== newFavorites) {
 			await msg.author.settings.update(UserSettings.FavoriteAlchables, newFavorites, {

--- a/src/commands/Minion/favalch.ts
+++ b/src/commands/Minion/favalch.ts
@@ -11,9 +11,8 @@ import { ItemBank } from '../../lib/types';
 import { itemNameFromID } from '../../lib/util';
 
 interface IParsedItem {
-	item: Item;
-	forcedID: boolean;
 	qty: number;
+	item: Item;
 }
 function customItemParse(str: string): IParsedItem[] {
 	const parsedItems = str
@@ -33,9 +32,8 @@ function customItemParse(str: string): IParsedItem[] {
 					const _i = Items.get(forcedID ? Number(_s) : _s);
 					if (_i) {
 						return {
-							item: _i,
-							forcedID,
-							qty: _q
+							qty: _q,
+							item: _i
 						};
 					}
 				})

--- a/src/commands/Minion/favalch.ts
+++ b/src/commands/Minion/favalch.ts
@@ -1,4 +1,5 @@
 import { MessageAttachment } from 'discord.js';
+import { chunk } from 'e';
 import { ArrayActions, CommandStore, KlasaMessage } from 'klasa';
 
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -25,9 +26,12 @@ export default class extends BotCommand {
 			if (currentFavorites.length === 0) return msg.channel.send('You have no favorited alchable items.');
 			if (msg.flagArgs.text) {
 				return msg.channel.send(
-					`Your current favorite alchable items are: ${currentFavorites
-						.map(id => itemNameFromID(id))
-						.join(', ')}.`
+					`Your current favorite alchable items are: ${chunk(
+						currentFavorites.map(id => itemNameFromID(id)),
+						50
+					)
+						.map(m => m.join(', '))
+						.join('\n')}.`
 				);
 			}
 			const imageBank: ItemBank = {};

--- a/src/commands/Minion/laps.ts
+++ b/src/commands/Minion/laps.ts
@@ -89,7 +89,7 @@ export default class extends BotCommand {
 		if (alchResult) {
 			const removedItems = alchResult.items.clone().add(alchResult.runes);
 			await msg.author.removeItemsFromBank(removedItems);
-			response += `\n\nYour minion is alching ${alchResult.items} while training. Removed ${removedItems} from your bank.`;
+			response += `\n\nYour minion is alching ${alchResult.items} while training. Removed ${alchResult.runes} from your bank.`;
 			updateBankSetting(this.client, ClientSettings.EconomyStats.MagicCostBank, removedItems);
 		}
 

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -332,10 +332,7 @@ export default class extends Extendable {
 
 			case Activity.Alching: {
 				const data = currentTask as AlchingActivityTaskOptions;
-
-				return `${this.minionName} is currently alching ${data.quantity}x ${itemNameFromID(
-					data.itemID
-				)}. ${formattedDuration}`;
+				return `${this.minionName} is currently alching ${new Bank(data.alchedBank)}. ${formattedDuration}`;
 			}
 
 			case Activity.Farming: {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -3,6 +3,7 @@ import { Peak } from '../../tasks/WildernessPeakInterval';
 import { Activity } from '../constants';
 import { IPatchData } from '../minions/farming/types';
 import { BirdhouseData } from './../skilling/skills/hunter/defaultBirdHouseTrap';
+import { ItemBank } from './index';
 
 export interface ActivityTaskOptions {
 	type: Activity;
@@ -37,10 +38,7 @@ export interface DarkAltarOptions extends ActivityTaskOptions {
 export interface AgilityActivityTaskOptions extends ActivityTaskOptions {
 	courseID: string;
 	quantity: number;
-	alch: {
-		itemID: number;
-		quantity: number;
-	} | null;
+	alch: ItemBank | null;
 }
 
 export interface CookingActivityTaskOptions extends ActivityTaskOptions {
@@ -164,9 +162,10 @@ export interface HunterActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface AlchingActivityTaskOptions extends ActivityTaskOptions {
-	itemID: number;
-	quantity: number;
+	alchedBank: ItemBank;
 	alchValue: number;
+	quantity?: number;
+	favorites?: boolean;
 }
 
 export interface FightCavesActivityTaskOptions extends ActivityTaskOptions {

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -71,7 +71,7 @@ export default class extends Task {
 			let valueAlched = 0;
 			let totalAchs = 0;
 			alchedBank.forEach((i, q) => {
-				valueAlched += i.highalch;
+				valueAlched += i.highalch * q;
 				totalAchs += q;
 			});
 			loot.add('Coins', valueAlched);

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -10,7 +10,6 @@ import Agility from '../../lib/skilling/skills/agility';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { AgilityActivityTaskOptions } from '../../lib/types/minions';
 import { addItemToBank, updateGPTrackSetting } from '../../lib/util';
-import getOSItem from '../../lib/util/getOSItem';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
 export default class extends Task {
@@ -68,15 +67,20 @@ export default class extends Task {
 		});
 
 		if (alch) {
-			const alchedItem = getOSItem(alch.itemID);
-			const alchGP = alchedItem.highalch * alch.quantity;
-			loot.add('Coins', alchGP);
+			const alchedBank = new Bank(alch);
+			let valueAlched = 0;
+			let totalAchs = 0;
+			alchedBank.forEach((i, q) => {
+				valueAlched += i.highalch;
+				totalAchs += q;
+			});
+			loot.add('Coins', valueAlched);
 			xpRes += ` ${await user.addXP({
 				skillName: SkillsEnum.Magic,
-				amount: alch.quantity * 65,
+				amount: totalAchs * 65,
 				duration
 			})}`;
-			updateGPTrackSetting(this.client, ClientSettings.EconomyStats.GPSourceAlching, alchGP);
+			updateGPTrackSetting(this.client, ClientSettings.EconomyStats.GPSourceAlching, valueAlched);
 		}
 
 		let str = `${user}, ${user.minionName} finished ${quantity} ${

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -5,8 +5,7 @@ import { resolveNameBank } from 'oldschooljs/dist/util';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { AlchingActivityTaskOptions } from '../../lib/types/minions';
-import { roll, updateGPTrackSetting } from '../../lib/util';
-import getOSItem from '../../lib/util/getOSItem';
+import { addArrayOfNumbers, roll, updateGPTrackSetting } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import itemID from '../../lib/util/itemID';
 
@@ -14,17 +13,19 @@ const bryophytasStaffId = itemID("Bryophyta's staff");
 
 export default class extends Task {
 	async run(data: AlchingActivityTaskOptions) {
-		let { itemID, quantity, channelID, alchValue, userID, duration } = data;
+		let { alchedBank, favorites, quantity, channelID, alchValue, userID, duration } = data;
 		const user = await this.client.fetchUser(userID);
 		const loot = new Bank({ Coins: alchValue });
 
-		const item = getOSItem(itemID);
+		const parsedBank = new Bank(alchedBank);
+
+		const casts = quantity ?? addArrayOfNumbers(parsedBank.items().map(i => i[1]));
 
 		// If bryophyta's staff is equipped when starting the alch activity
 		// calculate how many runes have been saved
 		let savedRunes = 0;
 		if (user.hasItemEquippedAnywhere(bryophytasStaffId)) {
-			for (let i = 0; i < quantity; i++) {
+			for (let i = 0; i < casts; i++) {
 				if (roll(15)) savedRunes++;
 			}
 
@@ -39,7 +40,7 @@ export default class extends Task {
 		await user.addItemsToBank(loot);
 		updateGPTrackSetting(this.client, ClientSettings.EconomyStats.GPSourceAlching, alchValue);
 
-		const xpReceived = quantity * 65;
+		const xpReceived = casts * 65;
 		const xpRes = await user.addXP({
 			skillName: SkillsEnum.Magic,
 			amount: xpReceived,
@@ -47,9 +48,7 @@ export default class extends Task {
 		});
 
 		const saved = savedRunes > 0 ? `Your Bryophyta's staff saved you ${savedRunes} Nature runes.` : '';
-		let responses = [
-			`${user}, ${user.minionName} has finished alching ${quantity}x ${item.name}! ${loot} has been added to your bank. ${xpRes}. ${saved}`
-		].join('\n');
+		let responses = `${user}, ${user.minionName} has finished alching ${parsedBank}!\n${loot} has been added to your bank.\n${xpRes}.\n${saved}`;
 
 		handleTripFinish(
 			this.client,
@@ -57,8 +56,18 @@ export default class extends Task {
 			channelID,
 			responses,
 			res => {
-				user.log(`continued trip of alching ${quantity}x ${item.name}`);
-				return this.client.commands.get('alch')!.run(res, [quantity, [item]]);
+				user.log(`continued trip of alching ${parsedBank}`);
+				return this.client.commands.get('alch')!.run(res, [
+					quantity,
+					favorites
+						? ''
+						: parsedBank
+								.items()
+								.map(i => `${i[1]} ${i[0].name}`)
+								.join(', ')
+								.toLowerCase(),
+					true
+				]);
 			},
 			undefined,
 			data,

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -48,7 +48,8 @@ export default class extends Task {
 		});
 
 		const saved = savedRunes > 0 ? `Your Bryophyta's staff saved you ${savedRunes} Nature runes.` : '';
-		let responses = `${user}, ${user.minionName} has finished alching ${parsedBank}!\n${loot} has been added to your bank.\n${xpRes}.\n${saved}`;
+		let responses =
+			`${user}, ${user.minionName} has finished alching ${parsedBank}!\n${loot} has been added to your bank.\n${xpRes}\n${saved}`.trim();
 
 		handleTripFinish(
 			this.client,


### PR DESCRIPTION
### Description:

- Alching is limited to 1 item at time.
- Fav items is limited to adding/removing 1 item at time.

### Changes:

- Reworks the alching system to allow for multiple items to be alched, be it using `+alch` or on agility laps.
- Allow `+favalch` to receive multiple items as parameters.
- Allow `+favalch` now returns an image with the items (and their ID) by default. `--text` was added to allow for a text to be exported.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/131260888-afb46567-6b60-4ced-a24c-08bf122a2631.png)
![image](https://user-images.githubusercontent.com/19570528/131260899-034c19d0-2160-4c16-b3fd-76abc8024655.png)
![image](https://user-images.githubusercontent.com/19570528/131260902-99b5cc85-76a8-4883-820d-63e6274e3a8e.png)