### PR TITLE
Allow +m lvl to use skill aliases

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -136,7 +136,7 @@ export default class MinionCommand extends BotCommand {
 	@requiresMinion
 	async lvl(msg: KlasaMessage, [input]: [string]) {
 		const values = Object.values(Skills);
-		const skill = values.find(s => stringMatches(s.name, input));
+		const skill = values.find(s => stringMatches(s.name, input) || s.aliases.some(a => stringMatches(a, input)));
 		if (!skill) {
 			return msg.channel.send(
 				`That's not a valid skill. The valid skills are: ${values.map(v => v.name).join(', ')}.`


### PR DESCRIPTION
### Description:

-Allow aliases to be used for `+m lvl <skillNameOrAlias>`

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/131364073-73e9b65e-4c8e-4f30-ac08-91b3d49b03cd.png)