### PR TITLE
Allow contributors to use commands in disabled channels

### DIFF
--- a/src/inhibitors/onlyStaffCanUseCommands.ts
+++ b/src/inhibitors/onlyStaffCanUseCommands.ts
@@ -1,6 +1,6 @@
 import { Command, Inhibitor, KlasaMessage } from 'klasa';
 
-import { Channel } from '../lib/constants';
+import { BitField, SupportServer } from '../lib/constants';
 import { getGuildSettings } from '../lib/settings/settings';
 import { GuildSettings } from '../lib/settings/types/GuildSettings';
 import { UserSettings } from '../lib/settings/types/UserSettings';
@@ -11,13 +11,15 @@ export default class extends Inhibitor {
 		if (msg.channel.id === '855691390339121194' && cmd.name === 'tag') {
 			return;
 		}
-		if (
-			[Channel.SupportChannel, '855691390339121194'].includes(msg.channel.id) &&
-			msg.author.settings.get(UserSettings.Badges).includes(5)
-		) {
-			return;
+		const userBitfield = msg.author.settings.get(UserSettings.BitField);
+		const isStaff = userBitfield.includes(BitField.isModerator) || userBitfield.includes(BitField.isContributor);
+
+		// Allow contributors + moderators to use disabled channels in SupportServer
+		if (msg.guild.id === SupportServer && isStaff) {
+			return false;
 		}
 
+		// Allow guild-moderators to use commands in disabled channels
 		const settings = await getGuildSettings(msg.guild!);
 		if (settings.get(GuildSettings.StaffOnlyChannels).includes(msg.channel.id)) {
 			const hasPerm = await msg.hasAtLeastPermissionLevel(6);


### PR DESCRIPTION
### Description:
Does what it says on the tin. Allows contributors, (and moderators, but they already could), use commands in disabled channels in the oldschoolgg discord guild/server.


### Other checks:

-   [x] I have tested all my changes thoroughly.
