### PR TITLE
Fix overall skills leaderboard, as people are starting to have more than intMax total XP

### DIFF
--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -448,7 +448,7 @@ export default class extends BotCommand {
 			const query = `SELECT
 								u.id,
 								${skillsVals.map(s => `"skills.${s.id}"`)},
-								${skillsVals.map(s => `"skills.${s.id}"`).join(' + ')} as totalxp,
+								${skillsVals.map(s => `"skills.${s.id}"::int8`).join(' + ')} as totalxp,
 								u."minion.ironman"
 							FROM
 								users u


### PR DESCRIPTION
### Description:

- People with over intMax total xp are crashing the `+lb`

### Changes:

- Cast the XP to int8 during sum.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/131689693-49e62c2d-57c3-453b-bb0a-3d68fa87f03a.png)
