### PR TITLE
Fixed Webhook messages not splitting. (Affects Igne return messages)

### DIFF
--- a/src/extendables/TextDMChannel.ts
+++ b/src/extendables/TextDMChannel.ts
@@ -67,16 +67,17 @@ export default class extends Extendable {
 			const split = Util.splitMessage(input.content, { maxLength });
 			const newPayload = { ...input };
 			// Separate files and components from payload for interactions
-			const { components, files } = newPayload;
+			const { components, files, embeds } = newPayload;
 			delete newPayload.components;
 			delete newPayload.files;
+			delete newPayload.embeds;
 			await this.send({ ...newPayload, content: split[0] });
 
 			let lastMessage = null;
 			for (let i = 1; i < split.length; i++) {
 				if (i + 1 === split.length) {
 					// Add files to last msg, and components for interactions to the final message.
-					lastMessage = await this.send({ components, files, content: split[i] });
+					lastMessage = await this.send({ components, files, embeds, content: split[i] });
 				} else {
 					await this.send(split[i]);
 				}

--- a/src/lib/util/webhook.ts
+++ b/src/lib/util/webhook.ts
@@ -1,6 +1,17 @@
-import { MessageAttachment, MessageEmbed, Permissions, TextChannel, WebhookClient } from 'discord.js';
+import {
+	BufferResolvable,
+	FileOptions,
+	MessageAttachment,
+	MessageEmbed,
+	MessageEmbedOptions,
+	Permissions,
+	TextChannel,
+	Util,
+	WebhookClient
+} from 'discord.js';
 import { KlasaClient } from 'klasa';
 import PQueue from 'p-queue';
+import { Stream } from 'stream';
 
 import { WebhookTable } from '../typeorm/WebhookTable.entity';
 import { channelIsSendable } from '../util';
@@ -77,7 +88,7 @@ export async function sendToChannelID(
 		if (data.embed) embeds.push(data.embed);
 		if (channel instanceof WebhookClient) {
 			try {
-				await channel.send({
+				await webhookSend(channel, {
 					content: data.content,
 					files,
 					embeds
@@ -97,4 +108,37 @@ export async function sendToChannelID(
 			});
 		}
 	});
+}
+
+async function webhookSend(
+	channel: WebhookClient,
+	input: {
+		content?: string;
+		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
+		embeds?: (MessageEmbed | MessageEmbedOptions)[];
+	}
+) {
+	const maxLength = 2000;
+
+	if (input.content && input.content.length > maxLength) {
+		// Moves files + components to the final message.
+		const split = Util.splitMessage(input.content, { maxLength });
+		const newPayload = { ...input };
+		// Separate files and components from payload for interactions
+		const { files, embeds } = newPayload;
+		delete newPayload.files;
+		delete newPayload.embeds;
+		await webhookSend(channel, { ...newPayload, content: split[0] });
+
+		for (let i = 1; i < split.length; i++) {
+			if (i + 1 === split.length) {
+				// Add files to last msg, and components for interactions to the final message.
+				await webhookSend(channel, { files, embeds, content: split[i] });
+			} else {
+				await webhookSend(channel, { content: split[i] });
+			}
+		}
+		return;
+	}
+	await channel.send({ content: input.content, embeds: input.embeds, files: input.files });
 }

--- a/src/lib/util/webhook.ts
+++ b/src/lib/util/webhook.ts
@@ -1,9 +1,7 @@
 import {
-	BufferResolvable,
-	FileOptions,
 	MessageAttachment,
 	MessageEmbed,
-	MessageEmbedOptions,
+	MessageOptions,
 	Permissions,
 	TextChannel,
 	Util,
@@ -11,7 +9,6 @@ import {
 } from 'discord.js';
 import { KlasaClient } from 'klasa';
 import PQueue from 'p-queue';
-import { Stream } from 'stream';
 
 import { WebhookTable } from '../typeorm/WebhookTable.entity';
 import { channelIsSendable } from '../util';
@@ -110,14 +107,7 @@ export async function sendToChannelID(
 	});
 }
 
-async function webhookSend(
-	channel: WebhookClient,
-	input: {
-		content?: string;
-		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
-		embeds?: (MessageEmbed | MessageEmbedOptions)[];
-	}
-) {
+async function webhookSend(channel: WebhookClient, input: MessageOptions) {
 	const maxLength = 2000;
 
 	if (input.content && input.content.length > maxLength) {


### PR DESCRIPTION
### Description:
Finally figured out why the Igne return messages weren't splitting when > 2,000 chars when it always worked in testing.... it uses a webhook where available, and it definitely exists here.

**This patch fixes that, finally people will be able to see their loot again in large teams!**

### Changes:

1. Updated the webhook.ts interaction code to use a refactored version of the `channel.send()` code. 
_(I tried just tacking on WebhookClient onto the Extendable, but they weren't compatible, also tried making a new extendable, but there was no access to the base API from the WebhookClient object, and lastly I tried to refactor the splitting into a separate function, but since it's recursive it would have meant a rewrite, so I ended up having to modify the webhook.ts code._
2. Updated the standard `channel.send()` code to also move embeds to the end as should have been done initially.

### Other checks:

-   [x] I have tested all my changes thoroughly. 
-   Tested deleting the webhook and ensuring the auto-delete + failover still works.
-   Tested the igne return messages.
-   Tested regular message splits to make sure they still work properly.
