### PR TITLE
Replace green-gem-holders perms for SupportChannel

### DIFF
--- a/src/inhibitors/onlyStaffCanUseCommands.ts
+++ b/src/inhibitors/onlyStaffCanUseCommands.ts
@@ -1,6 +1,6 @@
 import { Command, Inhibitor, KlasaMessage } from 'klasa';
 
-import { BitField, SupportServer } from '../lib/constants';
+import { BitField, Channel, SupportServer } from '../lib/constants';
 import { getGuildSettings } from '../lib/settings/settings';
 import { GuildSettings } from '../lib/settings/types/GuildSettings';
 import { UserSettings } from '../lib/settings/types/UserSettings';
@@ -11,10 +11,17 @@ export default class extends Inhibitor {
 		if (msg.channel.id === '855691390339121194' && cmd.name === 'tag') {
 			return;
 		}
-		const userBitfield = msg.author.settings.get(UserSettings.BitField);
-		const isStaff = userBitfield.includes(BitField.isModerator) || userBitfield.includes(BitField.isContributor);
+		// Allow green gem badge holders to run commands in support channel:
+		if (
+			[Channel.SupportChannel, '855691390339121194'].includes(msg.channel.id) &&
+			msg.author.settings.get(UserSettings.Badges).includes(5)
+		) {
+			return;
+		}
 
 		// Allow contributors + moderators to use disabled channels in SupportServer
+		const userBitfield = msg.author.settings.get(UserSettings.BitField);
+		const isStaff = userBitfield.includes(BitField.isModerator) || userBitfield.includes(BitField.isContributor);
 		if (msg.guild.id === SupportServer && isStaff) {
 			return false;
 		}


### PR DESCRIPTION
### Description:
Replaced erroneously removed code allowing green gem badge-holders to run commands in support channel.

### Changes:
Replaced the original check as-is.

### Other checks:

-   [x] I did actually test this just to be sure (with a diff channel ID), even though I copied the original code directly.
