### PR TITLE
Add BSO boosts do Volcanic Mine

### DIFF
--- a/src/commands/Minion/volcanicmine.ts
+++ b/src/commands/Minion/volcanicmine.ts
@@ -180,7 +180,9 @@ export default class extends BotCommand {
 			.add('Numulite', 30);
 
 		// Activity boosts
-		if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {
+		if (userMiningLevel >= 99 && userSkillingGear.hasEquipped('Dwarven pickaxe')) {
+			boosts.push('2x boost for having a Dwarven pickaxe equipped.');
+		} else if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {
 			boosts.push('50% boost for having a Crystal pickaxe equipped.');
 		} else if (userMiningLevel >= 61 && userSkillingGear.hasEquipped('Dragon pickaxe')) {
 			boosts.push('30% boost for having a Dragon pickaxe equipped.');
@@ -208,6 +210,9 @@ export default class extends BotCommand {
 					: 'No prayer potion usage for having 80+ prayer and a Dragonbone necklace equipped.'
 			);
 		}
+
+		if (msg.author.usingPet('Doug')) boosts.push('20% more Mining XP for having Doug helping you!');
+		if (msg.author.usingPet('Flappy')) boosts.push('2x more loot and points for having Flappy helping you!');
 
 		suppliesUsage.multiply(numberOfGames);
 		if (!msg.author.owns(suppliesUsage)) {


### PR DESCRIPTION
### Description:

- Add Dwarven pickaxe, doug and flappy boosts to Volcanic mine.

### Changes:

- Dwarven Pickaxe doubles the XP/h;
- Doug adds 20% more EXP;
- Flappy doubles loot and points rewarded;

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/131925729-b8d610c8-0bfc-46b2-b436-ba44976f6084.png)
![image](https://user-images.githubusercontent.com/19570528/131925732-def9df7f-695f-4eda-aac3-b2da5fda638a.png)