### PR TITLE
Add new settings command

### DIFF
--- a/src/commands/Minion/settings.ts
+++ b/src/commands/Minion/settings.ts
@@ -1,0 +1,92 @@
+import { objectEntries, uniqueArr } from 'e';
+import { CommandStore, KlasaMessage } from 'klasa';
+
+import { BitField } from '../../lib/constants';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { BotCommand } from '../../lib/structures/BotCommand';
+import { stringMatches } from '../../lib/util';
+
+const bitfieldSettings = {
+	'Gorajan bonecrusher': {
+		description: {
+			enabled: 'The Gorajan Bonecrusher will automatically bury bones for you and award 4x the experience.',
+			disabled: 'The Gorajan Bonecrusher will STOP automatically burying bones for you.'
+		},
+		inverse: true,
+		alias: ['dgb', 'gb', 'gorajan bonecrusher', 'gorajan', 'bonecrusher'],
+		bitfield: BitField.DisableGorajanBonecrusher
+	},
+	'Small banks': {
+		description: {
+			enabled: 'Your loot/bank images, will always show as smaller as possible.',
+			disabled:
+				'Your loot/bank images, will always show as normal. This setting is ignored when using Dark/Default/Transparent bank backgrounds.'
+		},
+		inverse: false,
+		alias: ['sb', 'smallb', 'small bank'],
+		bitfield: BitField.AlwaysSmallBank
+	}
+};
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			usage: '<enable|disable> <bitfield:...string>',
+			usageDelim: ' ',
+			oneAtTime: true,
+			cooldown: 5,
+			altProtection: true,
+			aliases: ['toggle'],
+			categoryFlags: ['minion'],
+			description: 'Enable or disable certain account settings that you unlock when playing.',
+			examples: ['+settings disable gorajan bonecrusher']
+		});
+	}
+
+	async run(msg: KlasaMessage, [_type, _bitfield]: ['enable' | 'disable', string]) {
+		await msg.author.settings.sync(true);
+
+		const bitfield = objectEntries(bitfieldSettings).find(
+			b => stringMatches(b[0], _bitfield) || b[1].alias.some(a => stringMatches(a, _bitfield))
+		);
+
+		if (!bitfield) {
+			return msg.channel.send(`**${_bitfield.toLowerCase()}** is not a valid setting you can change.`);
+		}
+
+		const userBitfields = [...msg.author.settings.get(UserSettings.BitField)];
+		const userHaveBitfield = userBitfields.includes(bitfield[1].bitfield);
+
+		let type: 'enabled' | 'disabled' | undefined = undefined;
+
+		if (bitfield[1].inverse) {
+			if (_type === 'disable') _type = 'enable';
+			else if (_type === 'enable') _type = 'disable';
+		}
+
+		if (userHaveBitfield && _type === 'disable') {
+			type = bitfield[1].inverse ? 'enabled' : 'disabled';
+			userBitfields.splice(
+				userBitfields.findIndex(f => f === bitfield[1].bitfield),
+				1
+			);
+		} else if (userHaveBitfield && _type === 'enable') {
+			return msg.channel.send(`You already have this setting ${bitfield[1].inverse ? 'disabled' : 'enabled'}.`);
+		} else if (!userHaveBitfield && _type === 'disable') {
+			return msg.channel.send(`You already have this setting ${bitfield[1].inverse ? 'enabled' : 'disabled'}.`);
+		} else {
+			type = bitfield[1].inverse ? 'disabled' : 'enabled';
+			userBitfields.push(bitfield[1].bitfield);
+		}
+
+		await msg.author.settings.update(UserSettings.BitField, uniqueArr(userBitfields.filter(f => f)), {
+			arrayAction: 'overwrite'
+		});
+
+		return msg.channel.send(
+			`You have sucessfully **${type.toUpperCase()}** the **${bitfield[0]}** setting.\n${
+				bitfield[1].description[type]
+			}`
+		);
+	}
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -389,7 +389,8 @@ export const enum BitField {
 	HasPermanentSpawnLamp = 201,
 	HasScrollOfFarming = 202,
 	HasScrollOfLongevity = 203,
-	HasScrollOfTheHunt = 204
+	HasScrollOfTheHunt = 204,
+	DisableGorajanBonecrusher = 205
 }
 
 interface BitFieldData {

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -3,7 +3,7 @@ import { Task } from 'klasa';
 import { MonsterKillOptions, Monsters } from 'oldschooljs';
 import { MonsterAttribute } from 'oldschooljs/dist/meta/monsterData';
 
-import { Emoji } from '../../lib/constants';
+import { BitField, Emoji } from '../../lib/constants';
 import { frozenKeyPieces } from '../../lib/data/CollectionsExport';
 import { getRandomMysteryBox } from '../../lib/data/openables';
 import { isDoubleLootActive } from '../../lib/doubleLoot';
@@ -192,7 +192,10 @@ export default class extends Task {
 			loot.add('Clue hunter boots');
 		}
 
-		if (user.settings.get(UserSettings.Bank)[itemID('Gorajan bonecrusher')]) {
+		if (
+			user.settings.get(UserSettings.Bank)[itemID('Gorajan bonecrusher')] &&
+			!user.bitfield.includes(BitField.DisableGorajanBonecrusher)
+		) {
 			let totalXP = 0;
 			for (const bone of bones) {
 				const amount = loot.amount(bone.inputId);


### PR DESCRIPTION
### Description:

Requested partially by #bso-vote: 
![image](https://user-images.githubusercontent.com/19570528/131933143-398cdbf0-d63c-49b0-aef8-f6d49f85e185.png)

- Allow users to edit certain bitfields they own;
- Users can enable or disable the gorajan bonecrusher (Defaults to enabled).

### Changes:

- Add a new command called `=settings` that can be used to enable or disable user BFs, without requiring mods to do so.
- Add a new BitField called DisableGorajanBonecrusher.

### Other checks:

-   [X] I have tested all my changes thoroughly.

--help or no parameter will show this
![image](https://user-images.githubusercontent.com/19570528/131932666-fb8b4070-2d9d-4dfb-b692-c431cbe4ba1b.png)
![image](https://user-images.githubusercontent.com/19570528/131931898-235905a4-4c15-4ad4-b390-aa285f15d220.png)
![image](https://user-images.githubusercontent.com/19570528/131931912-f56bb2de-f00a-4587-912a-afe917ee333b.png)
![image](https://user-images.githubusercontent.com/19570528/131931928-9e864eb4-3d04-43e5-a24b-e487b78fcf07.png)
