### PR TITLE
Add aliases to achievement diaries

### DIFF
--- a/src/commands/Minion/achievementdiary.ts
+++ b/src/commands/Minion/achievementdiary.ts
@@ -38,7 +38,7 @@ export default class extends BotCommand {
 	}
 
 	async run(msg: KlasaMessage, [input = '']: [string | undefined]) {
-		const diary = diaries.find(d => stringMatches(d.name, input));
+		const diary = diaries.find(d => stringMatches(d.name, input) || d.alias?.some(a => stringMatches(a, input)));
 
 		if (!diary) {
 			let str = 'Your Achievement Diaries\n\n';
@@ -73,21 +73,21 @@ export default class extends BotCommand {
 			}
 
 			if (tier.qp) {
-				thisStr += `- ${tier.qp} QP\n`;
+				thisStr += `- **${tier.qp}** QP\n`;
 			}
 
 			if (tier.minigameReqs) {
 				const entries = Object.entries(tier.minigameReqs);
 				for (const [key, neededScore] of entries) {
 					const minigame = Minigames.find(m => m.key === key)!;
-					thisStr += `- Must Have ${neededScore} KC in ${minigame.name}`;
+					thisStr += `- Must Have **${neededScore}** KC in ${minigame.name}\n`;
 				}
 			}
 
 			if (tier.lapsReqs) {
 				const entries = Object.entries(tier.lapsReqs);
 				for (const [name, score] of entries) {
-					thisStr += `- Must Have ${score} Laps of ${name}`;
+					thisStr += `- Must Have **${score}** Laps of ${name}\n`;
 				}
 			}
 
@@ -95,7 +95,7 @@ export default class extends BotCommand {
 				const entries = Object.entries(tier.monsterScores);
 				for (const [name, score] of entries) {
 					const mon = Monsters.find(mon => mon.name === name)!;
-					thisStr += `- Must Have ${score} KC of ${mon.name}`;
+					thisStr += `- Must Have **${score}** KC of ${mon.name}\n`;
 				}
 			}
 
@@ -105,7 +105,7 @@ export default class extends BotCommand {
 	}
 
 	async claim(msg: KlasaMessage, [input = '']: [string | undefined]) {
-		const diary = diaries.find(d => stringMatches(d.name, input));
+		const diary = diaries.find(d => stringMatches(d.name, input) || d.alias?.some(a => stringMatches(a, input)));
 
 		if (!diary) {
 			return msg.channel.send(

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -26,6 +26,7 @@ export interface DiaryTier {
 }
 interface Diary {
 	name: string;
+	alias?: string[];
 	easy: DiaryTier;
 	medium: DiaryTier;
 	hard: DiaryTier;
@@ -120,6 +121,7 @@ export async function userhasDiaryTier(user: KlasaUser, tier: DiaryTier): Promis
 
 export const WesternProv: Diary = {
 	name: 'Western Provinces',
+	alias: ['western', 'wp', 'west', 'west prov'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Western banner 1'),
@@ -217,6 +219,7 @@ export const WesternProv: Diary = {
 };
 export const ArdougneDiary: Diary = {
 	name: 'Ardougne',
+	alias: ['ardy', 'ardougn'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Ardougne cloak 1'),
@@ -390,6 +393,7 @@ export const DesertDiary: Diary = {
 
 export const FaladorDiary: Diary = {
 	name: 'Falador',
+	alias: ['fally', 'fal'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Falador shield 1'),
@@ -478,6 +482,7 @@ export const FaladorDiary: Diary = {
 
 export const FremennikDiary: Diary = {
 	name: 'Fremennik',
+	alias: ['fremmy', 'fremenik', 'fremmenik', 'frem'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Fremennik sea boots 1'),
@@ -557,6 +562,7 @@ export const FremennikDiary: Diary = {
 
 export const KandarinDiary: Diary = {
 	name: 'Kandarin',
+	alias: ['kand'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Kandarin headgear 1'),
@@ -644,6 +650,7 @@ export const KandarinDiary: Diary = {
 
 export const KaramjaDiary: Diary = {
 	name: 'Karamja',
+	alias: ['ramja', 'ram', 'karam', 'kar'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Karamja gloves 1'),
@@ -705,6 +712,7 @@ export const KaramjaDiary: Diary = {
 
 export const KourendKebosDiary: Diary = {
 	name: 'Kourend & Kebos',
+	alias: ['kebos', 'kouren', 'kourend', 'kk', 'kek'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem("Rada's blessing 1"),
@@ -779,6 +787,7 @@ export const KourendKebosDiary: Diary = {
 };
 export const LumbridgeDraynorDiary: Diary = {
 	name: 'Lumbridge & Draynor',
+	alias: ['lumb', 'draynor', 'lumbridge', 'led'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem("Explorer's ring 1"),
@@ -850,6 +859,7 @@ export const LumbridgeDraynorDiary: Diary = {
 
 export const MorytaniaDiary: Diary = {
 	name: 'Morytania',
+	alias: ['mory', 'swamp'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Morytania legs 1'),
@@ -928,6 +938,7 @@ export const MorytaniaDiary: Diary = {
 
 export const VarrockDiary: Diary = {
 	name: 'Varrock',
+	alias: ['var'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Varrock armour 1'),
@@ -994,6 +1005,7 @@ export const VarrockDiary: Diary = {
 
 export const WildernessDiary: Diary = {
 	name: 'Wilderness',
+	alias: ['wild', 'wildy'],
 	easy: {
 		name: 'Easy',
 		item: getOSItem('Wilderness sword 1'),


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/131933875-4e0861f6-dc10-467b-ae87-f2469cfe35fe.png)
- Allow achievement diaries to be called using aliases.

### Changes:

- Add aliases to most achievement diaries.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/131933826-bd76a8cf-7165-4f72-9174-04a4c110db2d.png)
![image](https://user-images.githubusercontent.com/19570528/131933835-ece6f66c-3d14-43f6-830b-26cdc15c3fa7.png)
![image](https://user-images.githubusercontent.com/19570528/131933846-835f7a4a-b171-4dad-970d-0d31ea7fe005.png)