### PR TITLE
Add user settings

### DIFF
--- a/src/commands/Minion/settings.ts
+++ b/src/commands/Minion/settings.ts
@@ -1,0 +1,133 @@
+import { objectEntries, uniqueArr } from 'e';
+import { CommandStore, KlasaMessage } from 'klasa';
+
+import { BitField } from '../../lib/constants';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { BotCommand } from '../../lib/structures/BotCommand';
+import { stringMatches } from '../../lib/util';
+
+type TType = 'enable' | 'disable';
+type TBFSettings = Record<
+	string,
+	{
+		description: {
+			enabled: string;
+			disabled: string;
+		};
+		// Inverse means disabled means enabled and enabled means disabled
+		// For rare cases where it sounds better to show something is enabled when the bitfield is off
+		// Make sure the description follows its use acordingly
+		inverse: boolean;
+		alias: string[];
+		// What bitfield will be changed
+		bitfield: BitField;
+		// If necessary, a custom validation to be run
+		customValidation?: (msg: KlasaMessage, proposedState: TType) => Promise<{ allowed: boolean; reason?: string }>;
+		// When changing this BF, do...
+		// Useful when the user cant have two bitfields enabled/disabled
+		onChange?: (msg: KlasaMessage, newState: 'enabled' | 'disabled') => Promise<void>;
+	}
+>;
+
+const bitfieldSettings: TBFSettings = {
+	'Small banks': {
+		description: {
+			enabled: 'Your loot/bank images, will always show as smaller as possible.',
+			disabled:
+				'Your loot/bank images, will always show as normal. This setting is ignored when using Dark/Default/Transparent bank backgrounds.'
+		},
+		inverse: false,
+		alias: ['sb', 'smallb', 'small bank'],
+		bitfield: BitField.AlwaysSmallBank
+	}
+};
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			usage: '[type:string] [bitfield:...string]',
+			usageDelim: ' ',
+			oneAtTime: true,
+			cooldown: 5,
+			altProtection: true,
+			aliases: ['toggle'],
+			categoryFlags: ['minion'],
+			description: 'Enable or disable certain account settings that you unlock when playing.',
+			examples: ['+settings disable gorajan bonecrusher']
+		});
+	}
+
+	async run(msg: KlasaMessage, [_type, _bitfield]: [TType, string]) {
+		await msg.author.settings.sync(true);
+		const userBitfields = [...msg.author.settings.get(UserSettings.BitField)];
+
+		if (!_type || !['enable', 'disable'].includes(_type.toLowerCase()) || msg.flagArgs.help) {
+			return msg.channel.send(
+				`Here are the settings you can change:\n${objectEntries(bitfieldSettings)
+					.map(b => {
+						const current = userBitfields.includes(b[1].bitfield);
+						return `>> ${b[0]}\n**Enabled**: ${b[1].description.enabled}\n**Disabled**: ${
+							b[1].description.disabled
+						}\nYour status: \`${
+							current ? (b[1].inverse ? 'Disabled' : 'Enabled') : b[1].inverse ? 'Enabled' : 'Disabled'
+						}\``;
+					})
+					.join('\n')}`
+			);
+		}
+
+		const bitfield = objectEntries(bitfieldSettings).find(
+			b => stringMatches(b[0], _bitfield) || b[1].alias.some(a => stringMatches(a, _bitfield))
+		);
+
+		if (!bitfield) {
+			return msg.channel.send(`**${_bitfield.toLowerCase()}** is not a valid setting you can change.`);
+		}
+
+		const bfData = bitfield[1];
+		const bfName = bitfield[0];
+
+		const userHaveBitfield = userBitfields.includes(bfData.bitfield);
+
+		let type: 'enabled' | 'disabled' | undefined = undefined;
+
+		if (bfData.inverse) {
+			if (_type === 'disable') _type = 'enable';
+			else if (_type === 'enable') _type = 'disable';
+		}
+
+		if (bfData.customValidation) {
+			const bfCustomValidation = await bfData.customValidation(msg, _type as TType);
+			if (!bfCustomValidation.allowed) {
+				return msg.channel.send(
+					`You are not allowed to change the state of this setting for the following reason: ${bfCustomValidation.reason}`
+				);
+			}
+		}
+
+		if (userHaveBitfield && _type === 'disable') {
+			type = bfData.inverse ? 'enabled' : 'disabled';
+			userBitfields.splice(
+				userBitfields.findIndex(f => f === bfData.bitfield),
+				1
+			);
+		} else if (userHaveBitfield && _type === 'enable') {
+			return msg.channel.send(`You already have this setting ${bfData.inverse ? 'disabled' : 'enabled'}.`);
+		} else if (!userHaveBitfield && _type === 'disable') {
+			return msg.channel.send(`You already have this setting ${bfData.inverse ? 'enabled' : 'disabled'}.`);
+		} else {
+			type = bfData.inverse ? 'disabled' : 'enabled';
+			userBitfields.push(bfData.bitfield);
+		}
+
+		if (bfData.onChange) await bfData.onChange(msg, type);
+
+		await msg.author.settings.update(UserSettings.BitField, uniqueArr(userBitfields.filter(f => f)), {
+			arrayAction: 'overwrite'
+		});
+
+		return msg.channel.send(
+			`You have sucessfully **${type.toUpperCase()}** the **${bfName}** setting.\n${bfData.description[type]}`
+		);
+	}
+}

--- a/src/commands/Minion/settings.ts
+++ b/src/commands/Minion/settings.ts
@@ -22,7 +22,7 @@ type TBFSettings = Record<
 		// What bitfield will be changed
 		bitfield: BitField;
 		// If necessary, a custom validation to be run
-		customValidation?: (msg: KlasaMessage, proposedState: TType) => Promise<{ allowed: boolean; reason?: string }>;
+		customValidation?: (msg: KlasaMessage, proposedState?: TType) => Promise<{ allowed: boolean; reason?: string }>;
 		// When changing this BF, do...
 		// Useful when the user cant have two bitfields enabled/disabled
 		onChange?: (msg: KlasaMessage, newState: 'enabled' | 'disabled') => Promise<void>;


### PR DESCRIPTION
### Description:

- Allow users to edit certain bitfields they own.
- Certain BFs can have custom validations and/or custom postChange function to be executed. Useful for validating if the user has something in bank/cl before enabling/disabling it.

### Changes:

- Add a new command called `+settings` that can be used to enable or disable user BFs, without requiring mods to do so.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/132005981-c5ab06b0-b6b2-4e05-bf97-0898cc1bcf9e.png)
![image](https://user-images.githubusercontent.com/19570528/132005990-cd4207d5-5ffd-48e0-b157-994ec3e430a4.png)

Example of custom validation
```
customValidation: async msg => {
	if (msg.author.username === 'Gidedin') {
		return { allowed: false, reason: 'You are gidedin, and this custom validation says you cant do that!' };
	} else {
		return {allowed: true};
	}
}
```
![image](https://user-images.githubusercontent.com/19570528/132006007-2dcd81e5-2cc9-4b40-ac51-22db9ffe11ff.png)

Example of post change function
```
onChange: async (msg, newState) => {
	await msg.author.send(`Testing post change! Your new change is ${newState}`);
}
```
![image](https://user-images.githubusercontent.com/19570528/132006043-20437c9e-7199-4ab0-a879-f48158538c0a.png)