### PR TITLE
Force --names when opening UMB and TMB, but only if --id is not set.

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -241,9 +241,18 @@ export default class extends BotCommand {
 		const hasSmokey = msg.author.allItemsOwned().has('Smokey');
 		const loot = new Bank();
 		let smokeyBonus = 0;
-		if (botOpenable.name.toLowerCase().includes('mystery') && hasSmokey) {
-			for (let i = 0; i < quantity; i++) {
-				if (roll(10)) smokeyBonus++;
+		if (botOpenable.name.toLowerCase().includes('mystery')) {
+			// Force names to TMBs/UMBs
+			if (
+				['Tradeables Mystery box', 'Untradeables Mystery box'].includes(botOpenable.name) &&
+				!Boolean(msg.flagArgs.id)
+			) {
+				msg.flagArgs.names = 'yes';
+			}
+			if (hasSmokey) {
+				for (let i = 0; i < quantity; i++) {
+					if (roll(10)) smokeyBonus++;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description:

- Everyone mostly uses --names for opening TMB and UMB. This makes that automatic.

### Changes:

- If --id is set, does not override it.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/132021675-0800517c-63af-4562-9b55-eb327fc4a338.png)
