### PR TITLE
Add all MBs to cl daily

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1816,8 +1816,12 @@ export const dailyCL = resolveItems([
 	'Mask of balance',
 	'Druidic wreath',
 	'Disk of returning',
-	'Mystery box',
-	'Stale baguette'
+	'Stale baguette',
+	'Tradeable mystery box',
+	'Untradeable mystery box',
+	'Equippable mystery box',
+	'Holiday mystery box',
+	'Pet mystery box'
 ]);
 export const capesCL = resolveItems([
 	'Mining hood',


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/132023478-d547446c-991b-47e2-a317-a824928ab9df.png)
- Dailies can give all MBs, but the CL only shows TMB.

### Changes:

- Add all missing MBs to the cl Daily.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/132023401-e3c1e058-57fb-4ae4-8e50-59421b0e3a88.png)