### PR TITLE
Add customDurationBoost to KillableMonster & nerf Giant Mole

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -247,6 +247,19 @@ export default class extends BotCommand {
 			boosts.push(`${boostCannon}% for Cannon in singles`);
 		}
 
+		// Custom buffs
+		if (monster.customDurationBoost) {
+			const reductions = await monster.customDurationBoost(msg.author);
+			for (const reduction of reductions) {
+				if (reduction.percent < 0) {
+					timeToFinish = increaseNumByPercent(timeToFinish, Math.abs(reduction.percent));
+				} else {
+					timeToFinish = reduceNumByPercent(timeToFinish, Math.abs(reduction.percent));
+				}
+				boosts.push(reduction.message);
+			}
+		}
+
 		const maxTripLength = msg.author.maxTripLength(Activity.MonsterKilling);
 
 		// If no quantity provided, set it to the max.

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -2,6 +2,7 @@ import { Time } from 'e';
 import { Monsters } from 'oldschooljs';
 
 import { corporealBeastCL } from '../../../../data/CollectionsExport';
+import { FaladorDiary, userhasDiaryTier } from '../../../../diaries';
 import { GearSetupTypes, GearStat } from '../../../../gear';
 import { SkillsEnum } from '../../../../skilling/types';
 import itemID from '../../../../util/itemID';
@@ -36,7 +37,18 @@ const killableBosses: KillableMonster[] = [
 			prayer: 43
 		},
 		defaultAttackStyles: [SkillsEnum.Attack],
-		combatXpMultiplier: 1.075
+		combatXpMultiplier: 1.075,
+		customDurationBoost: async user => {
+			const reductions: { percent: number; message: string }[] = [];
+			const userHardDiary = await userhasDiaryTier(user, FaladorDiary.hard);
+			if (!userHardDiary[0]) {
+				reductions.push({
+					percent: -50,
+					message: '50% slower kills for not having the Falador hard diary'
+				});
+			}
+			return reductions;
+		}
 	},
 	{
 		id: Monsters.Vorkath.id,

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -1,5 +1,5 @@
 import { Image } from 'canvas';
-import { KlasaMessage } from 'klasa';
+import { KlasaMessage, KlasaUser } from 'klasa';
 import { Bank, MonsterKillOptions } from 'oldschooljs';
 import { BeginnerCasket } from 'oldschooljs/dist/simulation/clues/Beginner';
 import { EasyCasket } from 'oldschooljs/dist/simulation/clues/Easy';
@@ -104,6 +104,11 @@ export interface KillableMonster {
 	canBarrage?: boolean;
 	canCannon?: boolean;
 	cannonMulti?: boolean;
+	/**
+	 * Returns an array of {percent;message} of all the custom boosts that this monster can have.
+	 * @param user
+	 */
+	customDurationBoost?: (user: KlasaUser) => Promise<{ percent: number; message: string }[]>;
 }
 /*
  * Monsters will have an array of Consumables


### PR DESCRIPTION
### Description:

- Add customDurationBoost to KillableMonsters, where custom boosts can be applies on a specific monster;
- Nerfs Giant Mole, to make it use the Falador Hard Diary Locate on the shield.

### Changes:

- Nerfs Giant Mole by increasing its time to kill by 50% if the user does not have the Falador Hard diary.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/132030011-2b16b389-51a6-4a74-8ca2-1098e556114b.png)
![image](https://user-images.githubusercontent.com/19570528/132030150-94431f64-9a63-4bb7-9342-0906dac91f91.png)