### PR TITLE
Fix giveaways after bot restart

### DIFF
--- a/src/lib/typeorm/GiveawayTable.entity.ts
+++ b/src/lib/typeorm/GiveawayTable.entity.ts
@@ -64,16 +64,17 @@ export class GiveawayTable extends BaseEntity {
 			const message = await channel?.messages.fetch(this.messageID).catch(noOp);
 
 			const reactions = message ? message.reactions.cache.get(this.reactionID) : undefined;
-			const users: KlasaUser[] = (reactions?.users.cache.array() || []).filter(
-				u => !u.isIronman && !u.bot && u.id !== this.userID
-			);
-
+			const users: KlasaUser[] = !reactions
+				? []
+				: (await reactions.users.fetch())!.array()!.filter(u => !u.isIronman && !u.bot && u.id !== this.userID);
 			const creator = await client.fetchUser(this.userID);
 
 			if (users.length === 0 || !channel || !message) {
 				console.error('Giveaway failed');
 				await creator.addItemsToBank(this.bank);
-				creator.send(`Your giveaway failed to finish, you were refunded the items: ${this.bank}.`).catch(noOp);
+				creator
+					.send(`Your giveaway failed to finish, you were refunded the items: ${new Bank(this.bank)}.`)
+					.catch(noOp);
 
 				if (message && channel) {
 					channel.send('Nobody entered the giveaway :(');


### PR DESCRIPTION
### Bug Description:

- If the bot is restarted after a giveaway is started, then it fails to assign a winner after restarting. 
- Also, the message sent to the user shows `[ Object object ]`  instead of the giveaway bank's contents.

### Changes:

- Fetches the users who reacted after a bot restart; the reactions were pulled, but the users weren't cached yet.
- Converted the Giveaway loot bank into a Bank() object for the `.toString()` method for the creator's PM.

### Other checks:

-   [x] I have tested all my changes thoroughly.
-   Gidedin helped test + develop this fix
