### PR TITLE
Buffs elder log clues when the user is 120 woodcutting

### DIFF
--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -21,7 +21,8 @@ export default class extends Task {
 		let xpReceived = quantity * log.xp;
 		if (logID === itemID('Elder logs')) {
 			const userWcLevel = user.skillLevel(SkillsEnum.Woodcutting);
-			if (userWcLevel >= MAX_LEVEL) clueChance = 20_434;
+			// Bring it as close as possible to Rocktails
+			if (userWcLevel >= MAX_LEVEL) clueChance = 13_011;
 			xpReceived *= 2;
 		}
 		let bonusXP = 0;

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -1,4 +1,4 @@
-import { deepClone, Time } from 'e';
+import { Time } from 'e';
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
@@ -15,8 +15,7 @@ export default class extends Task {
 		const { logID, quantity, userID, channelID, duration } = data;
 		const user = await this.client.fetchUser(userID);
 
-		const log = { ...deepClone(Woodcutting.Logs.find(Log => Log.id === logID))! };
-
+		const log = Woodcutting.Logs.find(Log => Log.id === logID)!;
 		let clueChance = log.clueScrollChance;
 		let xpReceived = quantity * log.xp;
 		if (logID === itemID('Elder logs')) {


### PR DESCRIPTION
### Description:

Requested by #bso-vote
![image](https://user-images.githubusercontent.com/19570528/132108608-14fe1685-e971-40c1-ad53-0608ba4376cc.png)

### Changes:

- Checks if the user is 120+ wc on the woodcuttingActivity and modifies the cloned log object to increase the clue chance.
- The odd of receiving a clue is as close as possible to fishing Raw Rocktails.

- Elder logs
![image](https://user-images.githubusercontent.com/19570528/132108878-dc875c0f-3005-4e7f-bd23-82c0c1f210e1.png)

- Rocktails
![image](https://user-images.githubusercontent.com/19570528/132108892-74ebfdb1-83c4-444a-81fa-a43fa04137f8.png)

### Other checks:

-   [X] I have tested all my changes thoroughly.
