### PR TITLE
Disable tame shiny having max stats & add back merging

### DIFF
--- a/src/commands/bso/nursery.ts
+++ b/src/commands/bso/nursery.ts
@@ -23,16 +23,16 @@ export async function generateNewTame(user: KlasaUser, species: Species) {
 	if (species.shinyVariant && roll(100)) tame.variant = species.shinyVariant;
 
 	const [minCmbt, maxCmbt] = species.combatLevelRange;
-	tame.maxCombatLevel = gaussianRandom(minCmbt, maxCmbt);
+	tame.maxCombatLevel = gaussianRandom(minCmbt, maxCmbt, 2);
 
 	const [minArt, maxArt] = species.artisanLevelRange;
-	tame.maxArtisanLevel = gaussianRandom(minArt, maxArt);
+	tame.maxArtisanLevel = gaussianRandom(minArt, maxArt, 2);
 
 	const [minSup, maxSup] = species.supportLevelRange;
-	tame.maxSupportLevel = gaussianRandom(minSup, maxSup);
+	tame.maxSupportLevel = gaussianRandom(minSup, maxSup, 2);
 
 	const [minGath, maxGath] = species.gathererLevelRange;
-	tame.maxGathererLevel = gaussianRandom(minGath, maxGath);
+	tame.maxGathererLevel = gaussianRandom(minGath, maxGath, 2);
 
 	tame.totalLoot = {};
 	tame.fedItems = {};

--- a/src/commands/bso/nursery.ts
+++ b/src/commands/bso/nursery.ts
@@ -21,19 +21,18 @@ export async function generateNewTame(user: KlasaUser, species: Species) {
 
 	tame.variant = randArrItem(species.variants);
 	if (species.shinyVariant && roll(100)) tame.variant = species.shinyVariant;
-	let isShiny = tame.variant === species.shinyVariant;
 
 	const [minCmbt, maxCmbt] = species.combatLevelRange;
-	tame.maxCombatLevel = isShiny ? maxCmbt : gaussianRandom(minCmbt, maxCmbt);
+	tame.maxCombatLevel = gaussianRandom(minCmbt, maxCmbt);
 
 	const [minArt, maxArt] = species.artisanLevelRange;
-	tame.maxArtisanLevel = isShiny ? maxArt : gaussianRandom(minArt, maxArt);
+	tame.maxArtisanLevel = gaussianRandom(minArt, maxArt);
 
 	const [minSup, maxSup] = species.supportLevelRange;
-	tame.maxSupportLevel = isShiny ? maxSup : gaussianRandom(minSup, maxSup);
+	tame.maxSupportLevel = gaussianRandom(minSup, maxSup);
 
 	const [minGath, maxGath] = species.gathererLevelRange;
-	tame.maxGathererLevel = isShiny ? maxGath : gaussianRandom(minGath, maxGath);
+	tame.maxGathererLevel = gaussianRandom(minGath, maxGath);
 
 	tame.totalLoot = {};
 	tame.fedItems = {};

--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -589,7 +589,7 @@ export default class extends BotCommand {
 
 		const tames = await TamesTable.find({ where: { userID: msg.author.id } });
 		const toSelect = tames.find(t => stringMatches(tame, t.id.toString()) || stringMatches(tame, t.nickname ?? ''));
-		if (!toSelect) {
+		if (!toSelect || !tame) {
 			return msg.channel.send(
 				"Couldn't find a tame to participate in the ritual. Make sure you selected the correct Tame, by its number or nickname."
 			);

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -47,6 +47,7 @@ export interface Species {
 	relevantLevelCategory: 'combat' | 'artisan' | 'support' | 'gatherer';
 	hatchTime: number;
 	egg: Item;
+	mergingCost: Bank;
 	emoji: string;
 }
 
@@ -56,13 +57,18 @@ export const tameSpecies: Species[] = [
 		name: 'Igne',
 		variants: [1, 2, 3],
 		shinyVariant: 4,
-		combatLevelRange: [70, 100],
+		combatLevelRange: [70, 126],
 		artisanLevelRange: [1, 10],
 		supportLevelRange: [1, 10],
 		gathererLevelRange: [1, 10],
 		relevantLevelCategory: 'combat',
 		hatchTime: Time.Hour * 18.5,
 		egg: getOSItem(48_210),
+		mergingCost: new Bank()
+			.add('Ignecarus scales', 100)
+			.add('Zenyte', 2)
+			.add('Soul rune', 2500)
+			.add('Elder rune', 100),
 		emoji: '<:dragonEgg:858948148641660948>'
 	}
 ];

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -57,7 +57,7 @@ export const tameSpecies: Species[] = [
 		name: 'Igne',
 		variants: [1, 2, 3],
 		shinyVariant: 4,
-		combatLevelRange: [70, 126],
+		combatLevelRange: [70, 100],
 		artisanLevelRange: [1, 10],
 		supportLevelRange: [1, 10],
 		gathererLevelRange: [1, 10],

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -529,7 +529,7 @@ function gaussianRand(rolls: number = 3) {
 	return rand / rolls;
 }
 export function gaussianRandom(min: number, max: number, rolls?: number) {
-	return Math.floor(min + gaussianRand(rolls) * (max - (min - 1) + 1));
+	return Math.floor(min + gaussianRand(rolls) * (max - min + 1));
 }
 export function isValidNickname(str?: string) {
 	return (

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -529,7 +529,7 @@ function gaussianRand(rolls: number = 3) {
 	return rand / rolls;
 }
 export function gaussianRandom(min: number, max: number, rolls?: number) {
-	return Math.floor(min + gaussianRand(rolls) * (max - min + 1));
+	return Math.floor(min + gaussianRand(rolls) * (max - (min - 1) + 1));
 }
 export function isValidNickname(str?: string) {
 	return (

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -521,15 +521,15 @@ export async function wipeDBArrayByKey(user: KlasaUser, key: string): Promise<Se
 	return user.settings.update(key, active);
 }
 
-function gaussianRand() {
+function gaussianRand(rolls: number = 3) {
 	let rand = 0;
-	for (let i = 0; i < 3; i += 1) {
+	for (let i = 0; i < rolls; i += 1) {
 		rand += Math.random();
 	}
-	return rand / 3;
+	return rand / rolls;
 }
-export function gaussianRandom(min: number, max: number) {
-	return Math.floor(min + gaussianRand() * (max - min + 1));
+export function gaussianRandom(min: number, max: number, rolls?: number) {
+	return Math.floor(min + gaussianRand(rolls) * (max - min + 1));
 }
 export function isValidNickname(str?: string) {
 	return (


### PR DESCRIPTION
### Description:

- Disable shinies from giving max stats.
- Add back merging with aditional costs, for each tame.
- Increased the odds of having max level tames to 1/500 instead of 1/20k~

### Other checks:

-   [X] I have tested all my changes thoroughly.