### PR TITLE
Allow for wrong commands to have its cooldown removed

### DIFF
--- a/src/commands/Minion/collectionlog.ts
+++ b/src/commands/Minion/collectionlog.ts
@@ -41,7 +41,11 @@ Go collect these items! ${notOwned.map(itemNameFromID).join(', ')}.`
 			flags: msg.flagArgs,
 			collection
 		});
+
 		if (!(result instanceof MessageAttachment)) {
+			if (result.content?.includes("That's not a valid collection log type.")) {
+				return msg.removeCooldown().channel.send(result);
+			}
 			return msg.channel.send(result);
 		}
 		return msg.channel.send({ files: [result as MessageAttachment] });

--- a/src/commands/Patrons/drystreak.ts
+++ b/src/commands/Patrons/drystreak.ts
@@ -24,7 +24,7 @@ export default class extends BotCommand {
 	async run(msg: KlasaMessage, [monName, itemName]: [string, string]) {
 		const mon = effectiveMonsters.find(mon => mon.aliases.some(alias => stringMatches(alias, monName)));
 		if (!mon) {
-			return msg.channel.send("That's not a valid monster or minigame.");
+			return msg.removeCooldown().channel.send("That's not a valid monster or minigame.");
 		}
 
 		const item = getOSItem(itemName);

--- a/src/extendables/Message/Message.ts
+++ b/src/extendables/Message/Message.ts
@@ -2,6 +2,7 @@ import { Message, Permissions, TextChannel } from 'discord.js';
 import { Extendable, ExtendableStore, KlasaMessage } from 'klasa';
 
 import { customClientOptions } from '../../config';
+import { ReturnFlags, ReturnFlagsMap } from '../../lib/constants';
 import { getGuildSettingsCached } from '../../lib/settings/settings';
 import { noOp } from '../../lib/util';
 
@@ -24,5 +25,10 @@ export default class extends Extendable {
 		) {
 			this.reactions.removeAll().catch(noOp);
 		}
+	}
+
+	removeCooldown(this: KlasaMessage) {
+		ReturnFlagsMap.set(this.id, ReturnFlags.NO_COOLDOWN);
+		return this;
 	}
 }

--- a/src/finalizers/commandCooldown.ts
+++ b/src/finalizers/commandCooldown.ts
@@ -1,6 +1,6 @@
 import { Command, Finalizer, FinalizerStore, KlasaMessage, RateLimitManager } from 'klasa';
 
-import { BitField } from '../lib/constants';
+import { BitField, ReturnFlagsMap } from '../lib/constants';
 
 export default class extends Finalizer {
 	public cooldowns: WeakMap<object, any> = new WeakMap();
@@ -10,6 +10,11 @@ export default class extends Finalizer {
 	}
 
 	run(message: KlasaMessage, command: Command) {
+		if (ReturnFlagsMap.has(message.id)) {
+			ReturnFlagsMap.delete(message.id);
+			return false;
+		}
+
 		if (
 			command.cooldown <= 0 ||
 			this.client.owners.has(message.author) ||

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -482,3 +482,11 @@ export const lastTripCache = new Map<
 	string,
 	{ continue: (message: KlasaMessage) => Promise<KlasaMessage | KlasaMessage[] | null>; data: ActivityTaskOptions }
 >();
+
+// Object that will hold the message id and the flag it requires to run
+export const ReturnFlagsMap = new Map<string, ReturnFlags>();
+
+// Powers of 2 return flags for Finalizer processing
+export const enum ReturnFlags {
+	NO_COOLDOWN = 8
+}

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -94,6 +94,7 @@ declare module 'klasa' {
 
 		makePartyAwaiter(options: MakePartyOptions): Promise<KlasaUser[]>;
 		removeAllReactions(): void;
+		removeCooldown(): this;
 		confirm(this: KlasaMessage, str: string): Promise<void>;
 	}
 


### PR DESCRIPTION
### Description:

- Doing drystreak and missing a letter from the item you want to find puts you on a 2 minutes cooldown, even if nothing happens.
- This happens A LOT on bso, but it is a good addition for both bots.

### Changes:

- Add a new message map that allows for the finalizer to ignore cooldown if the messageid is present on the map.
- Usage is really simple, just add `.removeCooldown()` before the message send, eg. `msg.removeCooldown().channel.send('Yeah, wrong command buddy!')`.

### Other checks:

-   [X] I have tested all my changes thoroughly.
