### PR TITLE
Rebalanced volcanic ash mining

### DIFF
--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -15,7 +15,6 @@ import {
 } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import itemID from '../../lib/util/itemID';
-import resolveItems from '../../lib/util/resolveItems';
 
 const pickaxes = [
 	{
@@ -50,31 +49,13 @@ const gloves = [
 	}
 ];
 
-const gloryAmulets = resolveItems([
-	'Amulet of eternal glory',
-	'Amulet of glory (t)',
-	'Amulet of glory (t6)',
-	'Amulet of glory (t5)',
-	'Amulet of glory (t4)',
-	'Amulet of glory (t3)',
-	'Amulet of glory (t2)',
-	'Amulet of glory (t1)',
-	'Amulet of glory',
-	'Amulet of glory(6)',
-	'Amulet of glory(5)',
-	'Amulet of glory(4)',
-	'Amulet of glory(3)',
-	'Amulet of glory(2)',
-	'Amulet of glory(1)'
-]);
-
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			altProtection: true,
 			oneAtTime: true,
 			cooldown: 1,
-			usage: '<quantity:int{1}|name:...string> [name:...string]',
+			usage: '[quantity:int{1}] [name:...string]',
 			usageDelim: ' ',
 			categoryFlags: ['minion', 'skilling'],
 			description: 'Sends your minion to go mining.',
@@ -84,12 +65,7 @@ export default class extends BotCommand {
 
 	@minionNotBusy
 	@requiresMinion
-	async run(msg: KlasaMessage, [quantity, name = '']: [null | number | string, string]) {
-		if (typeof quantity === 'string') {
-			name = quantity;
-			quantity = null;
-		}
-
+	async run(msg: KlasaMessage, [quantity = null, name = '']: [null | number, string]) {
 		const ore = Mining.Ores.find(
 			ore => stringMatches(ore.name, name) || stringMatches(ore.name.split(' ')[0], name)
 		);
@@ -129,14 +105,9 @@ export default class extends BotCommand {
 			}
 		}
 		// Give gem rocks a speed increase for wearing a glory
-		if (ore.id === 1625) {
-			for (const amulet of gloryAmulets) {
-				if (msg.author.hasItemEquippedAnywhere(amulet)) {
-					timeToMine = Math.floor(timeToMine / 2);
-					boosts.push(`50% for ${itemNameFromID(amulet)}`);
-					break;
-				}
-			}
+		if (ore.id === 1625 && msg.author.hasItemEquippedAnywhere('Amulet of glory')) {
+			timeToMine = Math.floor(timeToMine / 2);
+			boosts.push('50% for having an Amulet of glory equipped');
 		}
 
 		const maxTripLength = msg.author.maxTripLength(Activity.Mining);

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -208,6 +208,7 @@ const source: [string, (string | number)[]][] = [
 			'Amulet of glory (4)',
 			'Amulet of glory (5)',
 			'Amulet of glory (6)',
+			'Amulet of glory (t)',
 			'Amulet of glory (t1)',
 			'Amulet of glory (t2)',
 			'Amulet of glory (t3)',

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -70,7 +70,7 @@ const ores: Ore[] = [
 		xp: 10,
 		id: 21_622,
 		name: 'Volcanic ash',
-		respawnTime: 0.05,
+		respawnTime: 1.9,
 		petChance: 741_600
 	},
 	{

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -87,6 +87,23 @@ export default class extends Task {
 			for (let i = 0; i < quantity; i++) {
 				loot.add(Mining.GemRockTable.roll());
 			}
+		} else if (ore.id === 21_622) {
+			// Volcanic ash
+			const userLevel = user.skillLevel(SkillsEnum.Mining);
+			const tiers = [
+				[22, 1],
+				[37, 2],
+				[52, 3],
+				[67, 4],
+				[82, 5],
+				[97, 6]
+			];
+			for (const [lvl, multiplier] of tiers.reverse()) {
+				if (userLevel >= lvl) {
+					loot.add(ore.id, quantity * multiplier);
+					break;
+				}
+			}
 		} else {
 			loot.add(ore.id, quantity);
 		}


### PR DESCRIPTION
### Description:

- Volcanic ash is not following the same rates as in-game anymore.
- closes #2787 

### Changes:

- Rebalances the time to mine a volcanic ash, to be as close to in-game as possible. Around 1k/hour at lower levels, increasing by 1k for every 15 mining levels;
- Changes glory amulets array to use the similar items;
- Removed redudant check for qty

### Other checks:

-   [X] I have tested all my changes thoroughly.
