### PR TITLE
Add aliases to enchantables.ts for dragon necklaces

### DIFF
--- a/src/commands/Minion/enchant.ts
+++ b/src/commands/Minion/enchant.ts
@@ -56,7 +56,10 @@ export default class extends BotCommand {
 		}
 
 		const enchantable = Enchantables.find(
-			item => stringMatches(item.name, name) || stringMatches(itemNameFromID(item.id)!, name)
+			item =>
+				stringMatches(item.name, name) ||
+				stringMatches(itemNameFromID(item.id)!, name) ||
+				item.alias?.some(a => stringMatches(a, name))
 		);
 
 		if (!enchantable) {

--- a/src/lib/skilling/skills/magic/enchantables.ts
+++ b/src/lib/skilling/skills/magic/enchantables.ts
@@ -2,12 +2,13 @@ import { Bank } from 'oldschooljs';
 import { itemID } from 'oldschooljs/dist/util';
 
 interface Enchantable {
+	name: string;
+	alias?: string[];
 	id: number;
 	input: Bank;
 	output: Bank;
-	name: string;
-	level: number;
 	xp: number;
+	level: number;
 }
 
 const jewelery: Enchantable[] = [
@@ -80,6 +81,7 @@ const jewelery: Enchantable[] = [
 	// Dragonstone
 	{
 		name: 'Dragon necklace',
+		alias: ['Dragonstone necklace'],
 		id: itemID('Dragon necklace'),
 		input: new Bank().add('Dragon necklace').add('Cosmic rune', 1).add('Earth rune', 15).add('Water rune', 15),
 		output: new Bank().add('Skills necklace'),


### PR DESCRIPTION
### Description:

Add aliases to enchantables to allow users to do `+enchant dragonstone necklace`, as that is the only dragonstone jewelery called `dragon necklace`.

### Other checks:

-   [X] I have tested all my changes thoroughly.
