### PR TITLE
Add aliases to craftables.ts for dragon necklaces

### DIFF
--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -56,7 +56,9 @@ export default class extends BotCommand {
 
 		if (craftName.toLowerCase().includes('zenyte') && quantity === null) quantity = 1;
 
-		const craftable = Crafting.Craftables.find(item => stringMatches(item.name, craftName));
+		const craftable = Crafting.Craftables.find(
+			item => stringMatches(item.name, craftName) || item.alias?.some(a => stringMatches(a, craftName))
+		);
 
 		if (!craftable) {
 			return msg.channel.send(

--- a/src/lib/skilling/skills/crafting/craftables/gold.ts
+++ b/src/lib/skilling/skills/crafting/craftables/gold.ts
@@ -231,7 +231,8 @@ const Gold: Craftable[] = [
 		tickRate: 3
 	},
 	{
-		name: 'Dragonstone necklace',
+		name: 'Dragon necklace',
+		alias: ['Dragonstone necklace'],
 		id: itemID('Dragon necklace'),
 		level: 72,
 		xp: 105,

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -141,6 +141,7 @@ export interface SmithedItem {
 
 export interface Craftable {
 	name: string;
+	alias?: string[];
 	id: number;
 	level: number;
 	xp: number;


### PR DESCRIPTION
### Description:

- Similar to the enchantables, crafting a dragon necklace is using the incorrect name.
- Add alias so players can use both dragon necklace or dragonstone necklace.
- closes #2671 

### Other checks:

-   [X] I have tested all my changes thoroughly.
