### PR TITLE
Add +bs alias for +b --search

### DIFF
--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -16,17 +16,26 @@ export default class extends BotCommand {
 			description: 'Shows your bank, with all your items and GP.',
 			cooldown: 3,
 			oneAtTime: true,
-			usage: '[page:int|name:string]',
+			usage: '[page:int{1}] [name:...string]',
+			usageDelim: ' ',
 			requiredPermissions: ['ATTACH_FILES'],
-			aliases: ['b'],
+			aliases: ['b', 'bs'],
 			examples: ['+b'],
 			categoryFlags: ['minion']
 		});
 	}
 
-	async run(msg: KlasaMessage, [pageNumberOrItemName]: [number | string | undefined]) {
+	async run(msg: KlasaMessage, [page = undefined, itemNameOrID]: [number | undefined, number | string | undefined]) {
 		await msg.author.settings.sync(true);
 		const baseBank = msg.author.bank({ withGP: true });
+
+		if (msg.commandText === 'bs') {
+			msg.flagArgs.search = String(itemNameOrID);
+			// Clear item string
+			itemNameOrID = '';
+		} else {
+			itemNameOrID = `${page ?? 0} ${itemNameOrID}`;
+		}
 
 		if (msg.flagArgs.smallbank) {
 			const userBg = msg.author.settings.get(UserSettings.BankBackground);
@@ -49,7 +58,7 @@ export default class extends BotCommand {
 		const bank = parseBank({
 			inputBank: baseBank,
 			flags: msg.flagArgs,
-			inputStr: typeof pageNumberOrItemName === 'string' ? pageNumberOrItemName : undefined
+			inputStr: itemNameOrID
 		});
 
 		if (bank.length === 0) {
@@ -110,7 +119,7 @@ export default class extends BotCommand {
 			title: `${msg.author.username}'s Bank`,
 			flags: {
 				...msg.flagArgs,
-				page: typeof pageNumberOrItemName === 'number' ? pageNumberOrItemName - 1 : 0
+				page: page ? page - 1 : 0
 			},
 			user: msg.author,
 			gearPlaceholder: msg.author.rawGear()


### PR DESCRIPTION
### Description:

- We use `+b --search` a lot. This makes it so `+bs` is an alias for the --search flag.

### Changes:

- Changes some stuff around to allow page control when using the +bs alias.

### Other checks:

-   [X] I have tested all my changes thoroughly.

This still works
![image](https://user-images.githubusercontent.com/19570528/132350248-78a1f45b-ed7d-4c0a-994c-95ff229cc7d2.png)

![image](https://user-images.githubusercontent.com/19570528/132350278-00380abe-f0b1-4e72-94f1-f5f64787d230.png)
![image](https://user-images.githubusercontent.com/19570528/132350293-fd185b73-29dc-4f87-940e-ac2348affc1e.png)
![image](https://user-images.githubusercontent.com/19570528/132350304-9c67c584-2906-4e56-af34-5fcda4a1e45a.png)
![image](https://user-images.githubusercontent.com/19570528/132350313-8d87eda7-c335-4444-8785-6c5a6c394551.png)
![image](https://user-images.githubusercontent.com/19570528/132350337-cdae4a1d-b195-45f7-8a5d-6d68cc7e7c0c.png)
![image](https://user-images.githubusercontent.com/19570528/132350412-7a3ec3dd-8411-4f65-9ed6-f07a4d4ed0e4.png)