### PR TITLE
Fix hunting using misc slot for wilderness monsters

### DIFF
--- a/src/commands/Minion/hunt.ts
+++ b/src/commands/Minion/hunt.ts
@@ -177,11 +177,11 @@ export default class extends BotCommand {
 		}
 
 		if (creature.wildy) {
-			const [bol, reason, score] = hasWildyHuntGearEquipped(msg.author.getGear('misc'));
+			const [bol, reason, score] = hasWildyHuntGearEquipped(msg.author.getGear('wildy'));
 			wildyScore = score;
 			if (!bol) {
 				return msg.channel.send(
-					`To hunt ${creature.name} in the wilderness you need to meet the following requirment: ${reason} To check current equipped gear in misc write \`${msg.cmdPrefix}gear misc\`.`
+					`To hunt ${creature.name} in the wilderness you need to meet the following requirment: ${reason} To check current equipped gear in wildy, write \`${msg.cmdPrefix}gear wildy\`.`
 				);
 			}
 			if (userBank.amount(itemID('Saradomin brew(4)')) < 10 || userBank.amount(itemID('Super restore(4)')) < 5) {
@@ -268,7 +268,7 @@ export default class extends BotCommand {
 			}
 			wildyStr = `You are hunting ${creature.name} in the Wilderness during ${
 				wildyPeak!.peakTier
-			} peak time and potentially risking your equipped body and legs in the misc setup with a score ${wildyScore} and also risking Saradomin brews and Super restore potions. If you feel unsure \`${
+			} peak time and potentially risking your equipped body and legs in the wildy setup with a score ${wildyScore} and also risking Saradomin brews and Super restore potions. If you feel unsure \`${
 				msg.cmdPrefix
 			}cancel\` the activity.`;
 		}

--- a/src/tasks/minions/HunterActivity/hunterActivity.ts
+++ b/src/tasks/minions/HunterActivity/hunterActivity.ts
@@ -71,8 +71,8 @@ export default class extends Task {
 			// The more experienced the less chance of death.
 			riskDeathChance += Math.min(Math.floor((user.getCreatureScore(creature) ?? 1) / 100), 200);
 
-			// Gives lower death chance depending on what the user got equipped in misc.
-			const [, , score] = hasWildyHuntGearEquipped(user.getGear('misc'));
+			// Gives lower death chance depending on what the user got equipped in wildy.
+			const [, , score] = hasWildyHuntGearEquipped(user.getGear('wildy'));
 			riskDeathChance += score;
 			for (let i = 0; i < duration / Time.Minute; i++) {
 				if (roll(riskPkChance)) {
@@ -89,10 +89,10 @@ export default class extends Task {
 					await user.removeItemFromBank(itemID('Saradomin brew(4)'), 10);
 					await user.removeItemFromBank(itemID('Super restore(4)'), 5);
 				}
-				const newGear = { ...user.settings.get(UserSettings.Gear.Misc) };
+				const newGear = { ...user.settings.get(UserSettings.Gear.Wildy) };
 				newGear[EquipmentSlot.Body] = null;
 				newGear[EquipmentSlot.Legs] = null;
-				await user.settings.update(UserSettings.Gear.Misc, newGear);
+				await user.settings.update(UserSettings.Gear.Wildy, newGear);
 				pkedQuantity = 0.5 * successfulQuantity;
 				xpReceived *= 0.8;
 				diedStr =


### PR DESCRIPTION
### Description:

- Changes hunter to use the Wildy gear setup instead of Misc;

### Other checks:

-   [X] I have tested all my changes thoroughly.
