### PR TITLE
Add requirements for earth warrior and steel dragons to stop receiving tasks if you can't kill it

### DIFF
--- a/src/commands/Testing/settask.ts
+++ b/src/commands/Testing/settask.ts
@@ -4,7 +4,7 @@ import { MoreThan } from 'typeorm';
 import { getNewUser } from '../../lib/settings/settings';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { slayerMasters } from '../../lib/slayer/slayerMasters';
-import { getCommonTaskName } from '../../lib/slayer/slayerUtil';
+import { getCommonTaskName, userCanUseTask } from '../../lib/slayer/slayerUtil';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { SlayerTaskTable } from '../../lib/typeorm/SlayerTaskTable.entity';
 import { stringMatches } from '../../lib/util';
@@ -30,6 +30,11 @@ export default class extends BotCommand {
 			b => stringMatches(b.monster.name, task) || b.monster.aliases.some(a => stringMatches(a, task))
 		);
 		if (!selectedTask) return msg.channel.send(`${task} is not a valid task from ${slayerMaster.name}`);
+
+		if (!userCanUseTask(msg.author, selectedTask, slayerMaster)) {
+			return msg.channel.send('You do not met the requirements to do this task.');
+		}
+
 		const newUser = await getNewUser(msg.author.id);
 		await SlayerTaskTable.update(
 			{

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import killableMonsters from '../../minions/data/killableMonsters';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -411,6 +412,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [10, 20],
 		weight: 7,
 		monsters: [Monsters.SteelDragon.id],
+		levelRequirements: killableMonsters.find(k => k.id === Monsters.SteelDragon.id)!.levelRequirements,
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.PedalToTheMetals,
 		combatLevel: 85,

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import killableMonsters from '../../minions/data/killableMonsters';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -387,6 +388,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [30, 50],
 		weight: 7,
 		monsters: [Monsters.SteelDragon.id],
+		levelRequirements: killableMonsters.find(k => k.id === Monsters.SteelDragon.id)!.levelRequirements,
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.PedalToTheMetals,
 		combatLevel: 85,

--- a/src/lib/slayer/tasks/mazchnaTasks.ts
+++ b/src/lib/slayer/tasks/mazchnaTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import killableMonsters from '../../minions/data/killableMonsters';
 import { AssignableSlayerTask } from '../types';
 
 export const mazchnaTasks: AssignableSlayerTask[] = [
@@ -108,6 +109,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 		amount: [40, 70],
 		weight: 6,
 		monsters: [Monsters.EarthWarrior.id],
+		levelRequirements: killableMonsters.find(k => k.id === Monsters.EarthWarrior.id)!.levelRequirements,
 		combatLevel: 35,
 		unlocked: true
 	},

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import killableMonsters from '../../minions/data/killableMonsters';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -386,6 +387,7 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		amount: [30, 60],
 		weight: 5,
 		monsters: [Monsters.SteelDragon.id],
+		levelRequirements: killableMonsters.find(k => k.id === Monsters.SteelDragon.id)!.levelRequirements,
 		combatLevel: 85,
 		questPoints: 34,
 		unlocked: true

--- a/src/lib/slayer/tasks/vannakaTasks.ts
+++ b/src/lib/slayer/tasks/vannakaTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import killableMonsters from '../../minions/data/killableMonsters';
 import { AssignableSlayerTask } from '../types';
 
 export const vannakaTasks: AssignableSlayerTask[] = [
@@ -175,6 +176,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		amount: [40, 80],
 		weight: 6,
 		monsters: [Monsters.EarthWarrior.id],
+		levelRequirements: killableMonsters.find(k => k.id === Monsters.EarthWarrior.id)!.levelRequirements,
 		combatLevel: 35,
 		unlocked: true
 	},


### PR DESCRIPTION
### Description:

- Earth warrior and steel dragons were missing level requirements from their respective assignable tasks;

### Changes:

- Add the level requirements to both Steel Dragon and Earth Warriors to all slayer masters that assigns them;
- Change `+settier` to take into consideration the `userCanUseTask` before assigning the user the task.

### Other checks:

-   [X] I have tested all my changes thoroughly.