### PR TITLE
[BSO] Add Blacksmith crates to King Goldemar

### DIFF
--- a/src/lib/customItems.ts
+++ b/src/lib/customItems.ts
@@ -1756,6 +1756,7 @@ setCustomItem(
 setCustomItem(48_222, 'Hellfire arrowtips', 'Dragon arrowtips', {}, 1000);
 setCustomItem(48_223, 'Scroll of the hunt', 'Coal', {}, 1_000_000);
 
+setCustomItem(48_224, 'Blacksmith crate', 'Mystery box', {}, 100_000);
 /**
  * Misc Items
  *

--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -238,6 +238,13 @@ const DwarvenCrateTable = new LootTable()
 	.add('Beer', 1, 3)
 	.add('Kebab', 1, 3);
 
+const BlacksmithCrateTable = new LootTable()
+	.add('Blacksmith helmet')
+	.add('Blacksmith top')
+	.add('Blacksmith apron')
+	.add('Blacksmith gloves')
+	.add('Blacksmith boots');
+
 export const SpoilsOfWarBaseTable = new LootTable()
 	.add('Pure essence', [4000, 6000], 6)
 	.add('Coins', [20_000, 30_000], 5)
@@ -409,6 +416,13 @@ const Openables: Openable[] = [
 		itemID: itemID('Dwarven crate'),
 		aliases: ['dwarven crate', 'dc'],
 		table: DwarvenCrateTable,
+		emoji: Emoji.MysteryBox
+	},
+	{
+		name: 'Blacksmith crate',
+		itemID: itemID('Blacksmith crate'),
+		aliases: ['blacksmith crate', 'bsc'],
+		table: BlacksmithCrateTable,
 		emoji: Emoji.MysteryBox
 	},
 	{

--- a/src/lib/minions/data/killableMonsters/custom/KingGoldemar.ts
+++ b/src/lib/minions/data/killableMonsters/custom/KingGoldemar.ts
@@ -38,7 +38,8 @@ export const KingGoldemarLootTable = new LootTable()
 	.add('Dwarven rock cake')
 	.add('Dwarven stout')
 	.tertiary(15, 'Clue scroll (grandmaster)')
-	.tertiary(20, MysteryBoxes);
+	.tertiary(20, MysteryBoxes)
+	.tertiary(60, 'Blacksmith crate');
 
 setCustomMonster(696_969, 'King Goldemar', KingGoldemarLootTable, Monsters.GeneralGraardor, {
 	id: 696_969,


### PR DESCRIPTION
### Description:
Blacksmith outfit is required for smithing Dwarven tools + armour, which have huge benefits, and are requirements for the Igne boss.

The only way to obtain this armour was from TMBs, making it very difficult to obtain for ironmen, or people playing a solo-style account. Specifically, the average number of TMBs to complete Blacksmith is around 8,750. (Median 7846)

This update gives King Goldemar a 1 in 60 chance to drop a crate containing a random piece of Blacksmith.

### Changes:

- Added Blacksmith crate
- Added drop to Goldemar
- Added loottable for opening blacksmith crate

### Other checks:

-   [x] I have tested all my changes thoroughly.
-   I just copied image 8871 to 48224 reusing the graphic of the dwarven crate.
