### PR TITLE
Little change to announceLoot

### DIFF
--- a/src/lib/minions/functions/announceLoot.ts
+++ b/src/lib/minions/functions/announceLoot.ts
@@ -22,17 +22,17 @@ export default async function announceLoot({
 	const notifyDrops = _notifyDrops.flat(Infinity);
 	const kc = user.settings.get(UserSettings.MonsterScores)[monsterID] ?? 0;
 	const itemsToAnnounce = loot.clone().filter(i => notifyDrops.includes(i.id));
-	if (Object.keys(itemsToAnnounce).length > 0) {
+	if (itemsToAnnounce.length > 0) {
 		let notif = '';
 
-		if (team) {
-			notif = `In **${team.leader.username}'s** party of ${team.size} minions killing ${
+		if (team && team.size > 1) {
+			notif = `In ${team.leader.username}'s party of ${team.size} minions killing ${
 				Monsters.get(monsterID)!.name
-			}, ${team.lootRecipient.username} just received **${loot}**!`;
+			}, **${team.lootRecipient.username}** just received **${itemsToAnnounce}**!`;
 		} else {
 			notif = `**${user.username}'s** minion, ${user.minionName}, just received **${itemsToAnnounce}**, their ${
 				Monsters.get(monsterID)!.name
-			} KC is ${kc}!`;
+			} KC is ${kc.toLocaleString()}!`;
 		}
 
 		user.client.emit(Events.ServerNotification, notif);


### PR DESCRIPTION
### Description:

Changes the announceLoot function to not display the entire loot received on a team, only shows team loot when team size is higher than 1 and toLocaleString the monster KC.

### Other checks:

-   [X] I have tested all my changes thoroughly.

Current
![image](https://user-images.githubusercontent.com/19570528/132758076-fb13e8e0-584d-4bd7-8d7b-e0bf01820b21.png)

![image](https://user-images.githubusercontent.com/19570528/132758142-89024eb0-af06-4428-be46-91101e937d1f.png)
![image](https://user-images.githubusercontent.com/19570528/132758193-bac9a54a-e1dd-466d-8f85-5804c72b7a6a.png)
