### PR TITLE
Allow +mostdrops to be issued for anything in the collection log

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -921,7 +921,7 @@ export const allDroppedItems = [
 		...Object.entries(allCollectionLogs)
 			.map(e =>
 				Object.entries(e[1].activities)
-					.filter(f => f[1].enabled === undefined && f[1].hidden === undefined && f[1].counts === undefined)
+					.filter(f => f[1].enabled === undefined)
 					.map(a => [...new Set([...a[1].items, ...(a[1].allItems !== undefined ? a[1].allItems : [])])])
 			)
 			.flat(100),


### PR DESCRIPTION
### Description:

- Anything on the collection log that is marked as hidden or that it doesnt count to the total, cant be used in `+mostdrops`.

### Changes:

- Allows those items to be checked.

### Other checks:

-   [X] I have tested all my changes thoroughly.
