### PR TITLE
Infernal Pick/Axe Boosts

### DIFF
--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -25,7 +25,7 @@ const axes = [
 	},
 	{
 		id: itemID('Infernal axe'),
-		reductionPercent: 11,
+		reductionPercent: 9,
 		wcLvl: 61
 	},
 	{

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -24,7 +24,7 @@ const pickaxes = [
 	},
 	{
 		id: itemID('Infernal pickaxe'),
-		reductionPercent: 10,
+		reductionPercent: 6,
 		miningLvl: 61
 	},
 	{


### PR DESCRIPTION
Changed boosts for infernal pickaxe and axe to match Dragon, as they are the same on osrs