### PR TITLE
Add MMMR and ODS to the minigames role category

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -806,7 +806,8 @@ export const allCollectionLogs: ICollection = {
 					'Mysterious seed',
 					'Mango seed',
 					'Magical artifact'
-				])
+				]),
+				roleCategory: ['minigames']
 			},
 			"Mad Marimbo's Monkey Rumble": {
 				alias: ['mr', 'mmmr', 'mmr', 'monkey rumble', 'mad marimbos monkey rumble'],
@@ -824,7 +825,8 @@ export const allCollectionLogs: ICollection = {
 					'Ninja rumble greegree',
 					'Expert ninja rumble greegree',
 					'Gorilla rumble greegree'
-				])
+				]),
+				roleCategory: ['minigames']
 			}
 		}
 	},


### PR DESCRIPTION
### Changes:

- add the category minigames to both ODS and MMMR collections;

### Other checks:

-   [X] I have tested all my changes thoroughly.
![image](https://user-images.githubusercontent.com/19570528/132949966-91dec66c-71df-4b90-9a85-81ec20d8438f.png)
![image](https://user-images.githubusercontent.com/19570528/132949970-43eaafee-7799-4253-831a-e7f4405c1e42.png)
