### PR TITLE
Change crawling hand to use the item ID instead of NPC name

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1533,7 +1533,8 @@ export const skillingPetsCL = resolveItems([
 	'Rift guardian'
 ]);
 export const slayerCL = resolveItems([
-	'Crawling hand',
+	// Crawling hand
+	7975,
 	'Cockatrice head',
 	'Basilisk head',
 	'Kurask head',


### PR DESCRIPTION
### Changes:

Change crawling hand to use the item ID instead of NPC name

### Other checks:

-   [X] I have tested all my changes thoroughly.
- 
![image](https://user-images.githubusercontent.com/19570528/132954755-c916fb8b-d079-44d7-878e-af7b044af296.png)
