### PR TITLE
Show boosts for the tame k trip

### DIFF
--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -664,11 +664,15 @@ export default class extends BotCommand {
 			duration
 		});
 
-		return msg.channel.send(
-			`${selectedTame.name} is now killing ${quantity}x ${monster.name}. The trip will take ${formatDuration(
-				duration
-			)}.\n\nRemoved ${foodStr}`
-		);
+		let reply = `${selectedTame.name} is now killing ${quantity}x ${
+			monster.name
+		}. The trip will take ${formatDuration(duration)}.\n\nRemoved ${foodStr}`;
+
+		if (boosts.length > 0) {
+			reply += `\n\n**Boosts:** ${boosts.join(', ')}.`;
+		}
+
+		return msg.channel.send(reply);
 	}
 
 	async c(msg: KlasaMessage, [str = '']: [string]) {


### PR DESCRIPTION
### Description:

- Deepscan is giving an error on another PR because the boosts is being initiated here, but never used.

### Changes:

- Changes the return message to show boosts.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/132957148-f8851e78-c556-48f6-8a58-3ef4447e905d.png)
