### PR TITLE
Add aliases for +lb minigame

### DIFF
--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -307,7 +307,7 @@ export default class extends BotCommand {
 
 	async minigame(msg: KlasaMessage, [name = '']: [string]) {
 		const minigame = Minigames.find(
-			m => stringMatches(m.name, name) || m.aliases?.some(a => stringMatches(a, name))
+			m => stringMatches(m.name, name) || m.aliases.some(a => stringMatches(a, name))
 		);
 		if (!minigame) {
 			return msg.channel.send(

--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -306,7 +306,9 @@ export default class extends BotCommand {
 	}
 
 	async minigame(msg: KlasaMessage, [name = '']: [string]) {
-		const minigame = Minigames.find(m => stringMatches(m.name, name));
+		const minigame = Minigames.find(
+			m => stringMatches(m.name, name) || m.aliases?.some(a => stringMatches(a, name))
+		);
 		if (!minigame) {
 			return msg.channel.send(
 				`That's not a valid minigame. Valid minigames are: ${Minigames.map(m => m.name).join(', ')}.`

--- a/src/extendables/User/Minigame.ts
+++ b/src/extendables/User/Minigame.ts
@@ -7,7 +7,7 @@ import { MinigameTable } from '../../lib/typeorm/MinigameTable.entity';
 
 export interface Minigame {
 	name: string;
-	aliases?: string[];
+	aliases: string[];
 	key: MinigameKey;
 	column: string;
 }
@@ -100,12 +100,13 @@ export const Minigames: Minigame[] = [
 	},
 	{
 		name: 'Gauntlet',
+		aliases: ['gauntlet', 'gaunt'],
 		key: 'Gauntlet',
 		column: 'gauntlet'
 	},
 	{
 		name: 'Corrupted Gauntlet',
-		aliases: ['cgauntlet', 'corruptedg', 'corruptg'],
+		aliases: ['cgauntlet', 'corruptedg', 'corruptg', 'cg'],
 		key: 'CorruptedGauntlet',
 		column: 'corrupted_gauntlet'
 	},

--- a/src/extendables/User/Minigame.ts
+++ b/src/extendables/User/Minigame.ts
@@ -100,7 +100,7 @@ export const Minigames: Minigame[] = [
 	},
 	{
 		name: 'Gauntlet',
-		aliases: ['gauntlet', 'gaunt'],
+		aliases: ['gauntlet', 'gaunt', 'ng'],
 		key: 'Gauntlet',
 		column: 'gauntlet'
 	},

--- a/src/extendables/User/Minigame.ts
+++ b/src/extendables/User/Minigame.ts
@@ -7,6 +7,7 @@ import { MinigameTable } from '../../lib/typeorm/MinigameTable.entity';
 
 export interface Minigame {
 	name: string;
+	aliases?: string[];
 	key: MinigameKey;
 	column: string;
 }
@@ -21,66 +22,79 @@ export type MinigameKey = EntityFieldsNames<Omit<MinigameTable, 'userID' | 'id'>
 export const Minigames: Minigame[] = [
 	{
 		name: 'Tithe farm',
+		aliases: ['tf', 'tithe'],
 		key: 'TitheFarm',
 		column: 'tithe_farm'
 	},
 	{
 		name: 'Wintertodt',
+		aliases: ['wt'],
 		key: 'Wintertodt',
 		column: 'wintertodt'
 	},
 	{
 		name: 'Tempoross',
+		aliases: ['temp', 'ross', 'tempo', 'watertodt'],
 		key: 'Tempoross',
 		column: 'tempoross'
 	},
 	{
 		name: 'Hallowed Sepulchre',
+		aliases: ['hs', 'sepulchre'],
 		key: 'Sepulchre',
 		column: 'sepulchre'
 	},
 	{
 		name: 'Fishing Trawler',
+		aliases: ['trawler', 'ft'],
 		key: 'FishingTrawler',
 		column: 'fishing_trawler'
 	},
 	{
 		name: 'Barbarian Assault',
+		aliases: ['ba', 'barb'],
 		key: 'BarbarianAssault',
 		column: 'barb_assault'
 	},
 	{
 		name: 'Pyramid Plunder',
+		aliases: ['pp', 'pyramid', 'plunder'],
 		key: 'PyramidPlunder',
 		column: 'pyramid_plunder'
 	},
 	{
 		name: 'Brimhaven Agility Arena',
+		aliases: ['baa', 'aa', 'agilarena'],
 		key: 'AgilityArena',
 		column: 'agility_arena'
 	},
 	{
 		name: "Champions' Challenge",
+		aliases: ['champion', 'scrolls'],
 		key: 'ChampionsChallenge',
 		column: 'champions_challenge'
 	},
 	{
 		name: 'Mahogany Homes',
+		aliases: ['mh', 'mahogany', 'homes'],
 		key: 'MahoganyHomes',
 		column: 'mahogany_homes'
 	},
 	{
 		name: 'Gnome Restaurant',
+		aliases: ['gh', 'gnome', 'restaurant'],
 		key: 'GnomeRestaurant',
 		column: 'gnome_restaurant'
 	},
 	{
 		name: 'Soul Wars',
+		aliases: ['sw', 'soul'],
 		key: 'SoulWars',
 		column: 'soul_wars'
 	},
 	{
 		name: "Rogues' Den",
+		aliases: ['rd', 'rogues', 'den'],
 		key: 'RoguesDenMaze',
 		column: 'rogues_den'
 	},
@@ -91,46 +105,55 @@ export const Minigames: Minigame[] = [
 	},
 	{
 		name: 'Corrupted Gauntlet',
+		aliases: ['cgauntlet', 'corruptedg', 'corruptg'],
 		key: 'CorruptedGauntlet',
 		column: 'corrupted_gauntlet'
 	},
 	{
 		name: 'Castle Wars',
+		aliases: ['cw', 'cwars'],
 		key: 'CastleWars',
 		column: 'castle_wars'
 	},
 	{
 		name: "Chamber's of Xeric",
+		aliases: ['cox', 'raid1', 'raids1', 'chambers', 'xeric'],
 		key: 'Raids',
 		column: 'raids'
 	},
 	{
 		name: "Chamber's of Xeric - Challenge Mode",
+		aliases: ['coxcm', 'raid1cm', 'raids1cm', 'chamberscm', 'xericcm'],
 		key: 'RaidsChallengeMode',
 		column: 'raids_challenge_mode'
 	},
 	{
 		name: 'Magic Training Arena',
+		aliases: ['mta'],
 		key: 'MagicTrainingArena',
 		column: 'magic_training_arena'
 	},
 	{
 		name: 'Big Chompy Bird Hunting',
+		aliases: ['chimpy', 'bcbh'],
 		key: 'BigChompyBirdHunting',
 		column: 'big_chompy_bird_hunting'
 	},
 	{
 		name: 'Temple Trekking',
+		aliases: ['tt', 'trek'],
 		key: 'TempleTrekking',
 		column: 'temple_trekking'
 	},
 	{
 		name: 'Pest Control',
+		aliases: ['pest', 'pc'],
 		key: 'PestControl',
 		column: 'pest_control'
 	},
 	{
 		name: 'Volcanic Mine',
+		aliases: ['vm'],
 		key: 'VolcanicMine',
 		column: 'volcanic_mine'
 	}


### PR DESCRIPTION
### Description:

- Some minigames have names way too big or complex.
- Allows addition of aliases to the Minigame object, for easy use.

### Changes:

- Add optional `aliases` parameter to `interface Minigame`.
- Add aliases to all minigames but gauntlet. No idea what to put there.

### Tithe farm is still glitched. #2603 will fix it.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/132958223-df1aa194-e7fc-4c6a-a928-6b1a6d1f2c76.png)
![image](https://user-images.githubusercontent.com/19570528/132958224-ab1ee0e0-3a3e-416f-b047-65785ae0a33d.png)