### PR TITLE
Fix rich presence on double time

### DIFF
--- a/src/tasks/presence.ts
+++ b/src/tasks/presence.ts
@@ -14,8 +14,12 @@ export default class extends Task {
 		if (this.client._presenceInterval) {
 			clearTimeout(this.client._presenceInterval);
 		}
-		let str = isDoubleLootActive(this.client) ? 'Double Loot is active!' : `${this.client.options.prefix}info`;
-		const set = () => this.client.user?.setActivity(str);
+
+		const set = () => {
+			let str = isDoubleLootActive(this.client) ? 'Double Loot is active!' : `${this.client.options.prefix}info`;
+			this.client.user?.setActivity(str);
+		};
+
 		this.client._presenceInterval = setInterval(set, Time.Hour);
 		set();
 	}


### PR DESCRIPTION
### Description:

- Bot rich presence is not updating correctly when double loot ends.
- Makes the `str` to be calculated inside the `set()` function.

### Suggestion 

As good as it looks, using the rich presence for this is not a good idea, as it is updated once every hour, it may show that is it enabled (or not), while it is the other way around. So, reducing it to 5 minutes would be idea. I was able to change the rich presence like 30 times in a row, so, don't think discord blocks it.

### Other checks:

-   [X] I have tested all my changes thoroughly.
