### PR TITLE
[BSO] Make 2x Loot work if you send trip on time.

### DIFF
--- a/src/lib/doubleLoot.ts
+++ b/src/lib/doubleLoot.ts
@@ -6,8 +6,8 @@ import { ClientSettings } from './settings/types/ClientSettings';
 import { formatDuration } from './util';
 import { sendToChannelID } from './util/webhook';
 
-export function isDoubleLootActive(client: KlasaClient) {
-	return Date.now() < client.settings.get(ClientSettings.DoubleLootFinishTime);
+export function isDoubleLootActive(client: KlasaClient, duration: number) {
+	return Date.now() - duration < client.settings.get(ClientSettings.DoubleLootFinishTime);
 }
 
 export async function addToDoubleLootTimer(client: KlasaClient, amount: number, reason: string) {

--- a/src/lib/doubleLoot.ts
+++ b/src/lib/doubleLoot.ts
@@ -6,7 +6,7 @@ import { ClientSettings } from './settings/types/ClientSettings';
 import { formatDuration } from './util';
 import { sendToChannelID } from './util/webhook';
 
-export function isDoubleLootActive(client: KlasaClient, duration: number) {
+export function isDoubleLootActive(client: KlasaClient, duration: number = 0) {
 	return Date.now() - duration < client.settings.get(ClientSettings.DoubleLootFinishTime);
 }
 

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -147,7 +147,7 @@ export default class extends Task {
 
 					let quantity = 1;
 
-					if (isDoubleLootActive(this.client)) {
+					if (isDoubleLootActive(this.client, duration)) {
 						quantity *= 2;
 					}
 					loot.add(item.id, quantity);

--- a/src/tasks/minions/dungeoneeringActivity.ts
+++ b/src/tasks/minions/dungeoneeringActivity.ts
@@ -117,7 +117,7 @@ export default class extends Task {
 				str += ' **1x Gorajan shards**';
 				let quantity = 1;
 
-				if (isDoubleLootActive(this.client)) {
+				if (isDoubleLootActive(this.client, duration)) {
 					quantity *= 2;
 				}
 				await u.addItemsToBank(new Bank().add('Gorajan shards', quantity), true);

--- a/src/tasks/minions/minigames/ignecarusActivity.ts
+++ b/src/tasks/minions/minigames/ignecarusActivity.ts
@@ -87,7 +87,7 @@ export default class extends Task {
 				else lootRolls = quantity - deaths[user.id].qty;
 			}
 			const loot = new Bank().add(IgnecarusLootTable.roll(lootRolls));
-			if (isDoubleLootActive(this.client)) {
+			if (isDoubleLootActive(this.client, duration)) {
 				loot.multiply(2);
 			}
 			totalLoot.add(loot);

--- a/src/tasks/minions/minigames/kalphiteKingActivity.ts
+++ b/src/tasks/minions/minigames/kalphiteKingActivity.ts
@@ -70,7 +70,7 @@ export default class extends Task {
 
 			const loot = new Bank();
 			loot.add(KalphiteKingMonster.table.kill(1, {}));
-			if (isDoubleLootActive(this.client)) {
+			if (isDoubleLootActive(this.client, duration)) {
 				loot.multiply(2);
 			}
 			const winner = teamTable.roll()?.item;

--- a/src/tasks/minions/minigames/kingGoldemarActivity.ts
+++ b/src/tasks/minions/minigames/kingGoldemarActivity.ts
@@ -72,7 +72,7 @@ export default class extends Task {
 			if (dwwhRecipient === user) {
 				loot.add('Broken dwarven warhammer');
 			}
-			if (isDoubleLootActive(this.client)) {
+			if (isDoubleLootActive(this.client, duration)) {
 				loot.multiply(2);
 			}
 			totalLoot.add(loot);

--- a/src/tasks/minions/minigames/nexActivity.ts
+++ b/src/tasks/minions/minigames/nexActivity.ts
@@ -73,7 +73,7 @@ export default class extends Task {
 			if (roll(80 + users.length * 2)) {
 				loot.add(randArrItem(nexUniqueDrops), 1);
 			}
-			if (isDoubleLootActive(this.client)) {
+			if (isDoubleLootActive(this.client, duration)) {
 				loot.multiply(2);
 			}
 			const winner = teamTable.roll()?.item;

--- a/src/tasks/minions/minigames/vasaMagusActivity.ts
+++ b/src/tasks/minions/minigames/vasaMagusActivity.ts
@@ -58,7 +58,7 @@ export default class extends Task {
 			.map(l => `${l[1]}x ${l[0]}`)
 			.join(', ')}`;
 
-		if (isDoubleLootActive(this.client)) {
+		if (isDoubleLootActive(this.client, duration)) {
 			loot.multiply(2);
 		}
 

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -78,7 +78,7 @@ export default class extends Task {
 		};
 		// Regular loot
 		const loot = (monster as KillableMonster).table.kill(
-			isDoubleLootActive(this.client) ? quantity * 2 : boostedQuantity,
+			isDoubleLootActive(this.client, duration) ? quantity * 2 : boostedQuantity,
 			killOptions
 		);
 
@@ -171,7 +171,7 @@ export default class extends Task {
 			str += '\n\n<:klik:749945070932721676> A small fairy dragon appears! Klik joins you on your adventures.';
 		}
 
-		if (isDoubleLootActive(this.client)) {
+		if (isDoubleLootActive(this.client, duration)) {
 			str += '\n\n**Double Loot!**';
 		} else if (oriBoost) {
 			str += '\n\nOri has used the abyss to transmute you +25% bonus loot!';

--- a/src/tasks/presence.ts
+++ b/src/tasks/presence.ts
@@ -16,9 +16,7 @@ export default class extends Task {
 		}
 
 		const set = () => {
-			let str = isDoubleLootActive(this.client, 0)
-				? 'Double Loot is active!'
-				: `${this.client.options.prefix}info`;
+			let str = isDoubleLootActive(this.client) ? 'Double Loot is active!' : `${this.client.options.prefix}info`;
 			if (this.client.user!.presence.activities[0]?.name !== str) {
 				this.client.user?.setActivity(str);
 			}

--- a/src/tasks/presence.ts
+++ b/src/tasks/presence.ts
@@ -16,7 +16,9 @@ export default class extends Task {
 		}
 
 		const set = () => {
-			let str = isDoubleLootActive(this.client) ? 'Double Loot is active!' : `${this.client.options.prefix}info`;
+			let str = isDoubleLootActive(this.client, 0)
+				? 'Double Loot is active!'
+				: `${this.client.options.prefix}info`;
 			if (this.client.user!.presence.activities[0]?.name !== str) {
 				this.client.user?.setActivity(str);
 			}


### PR DESCRIPTION
### Description:

Currently, if a 2x is started for a low tier, you may only have a 3 minute window where you trip has to END. Basically noone can take advantage of a 2x unless its longer than 30 minutes, so why even announce it?

**This change makes it so that if a 2x is active during any part of your trip, you will get the bonus.** 

- See the 2x notice? Start your trip, you're good! 
- Just started a trip and now you see the notice? Don't worry, you're also good!

### Changes:

- Added a new function, `wasDoubleLootActive()` which additionally takes a `duration` parameter.
- Replaced all instances of `isDoubleLootActive` with `wasDoubleLootActive`

### Other checks:

-   [x] I have tested all my changes thoroughly.
-  Tested all combinations of trips + end-time-locations. (before, middle, after)
