### PR TITLE
Add +bs quote search and bring back price check bank qty

### DIFF
--- a/src/commands/Minion/bank.ts
+++ b/src/commands/Minion/bank.ts
@@ -34,10 +34,13 @@ export default class extends BotCommand {
 				itemNameOrID = String(page);
 				page = undefined;
 			}
-			msg.flagArgs.search = String(itemNameOrID);
+			msg.flagArgs.search = String(itemNameOrID).trim().replace(/"/g, '');
 			// Clear item string
 			itemNameOrID = '';
-		} else if (page && itemNameOrID) itemNameOrID = `${page} ${itemNameOrID}`.trim();
+		} else if (page && itemNameOrID) {
+			itemNameOrID = `${page} ${itemNameOrID}`.trim();
+			page = undefined;
+		}
 		if (!page) page = 1;
 
 		if (msg.flagArgs.smallbank) {


### PR DESCRIPTION
### Changes:

Bring back +b 1k [item] so user can price check certain qty;
Add "" limiters to +bs, so players can search items with space like +bs "rune " or +bs " rune" for rune items or runes.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/132990291-d011ae64-c388-4294-a1a5-ed5a88fb8e4c.png)
![image](https://user-images.githubusercontent.com/19570528/132990293-bc1ee03e-7cd5-45dc-91e9-f1d9a8b847f2.png)
![image](https://user-images.githubusercontent.com/19570528/132990312-14a5e96c-0703-4b14-bc10-3a8d303bf396.png)