### PR TITLE
Fix black mask in the slayer collection

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1550,7 +1550,7 @@ export const slayerCL = resolveItems([
 	'Brine sabre',
 	'Leaf-bladed sword',
 	'Leaf-bladed battleaxe',
-	'Black mask',
+	'Black mask (10)',
 	'Granite longsword',
 	'Granite boots',
 	'Wyvern visage',


### PR DESCRIPTION
### Description:

- I mistakenly added `Black mask` to the slayer log when removing all the wrong items instead of `Black mask (10)`.

### Changes:

- Swap `Black mask` to `Black mask (10)`.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/133077657-a70a33ab-7ed2-4ea1-97bf-ca89b47905a4.png)
