### PR TITLE
Change tames to allow shiny chance per specie

### DIFF
--- a/src/commands/bso/nursery.ts
+++ b/src/commands/bso/nursery.ts
@@ -20,7 +20,7 @@ export async function generateNewTame(user: KlasaUser, species: Species) {
 	tame.currentGrowthPercent = 0;
 
 	tame.variant = randArrItem(species.variants);
-	if (species.shinyVariant && roll(100)) tame.variant = species.shinyVariant;
+	if (species.shinyVariant && roll(species.shinyChance)) tame.variant = species.shinyVariant;
 
 	const [minCmbt, maxCmbt] = species.combatLevelRange;
 	tame.maxCombatLevel = gaussianRandom(minCmbt, maxCmbt, 2);

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -52,6 +52,7 @@ export interface Species {
 	// Tame type within its specie
 	variants: number[];
 	shinyVariant: number;
+	shinyChance: number;
 	/**
 	 * Tames get assigned a max level in these ranges,
 	 * in a bell curve fashion, where the middle of the range
@@ -81,6 +82,7 @@ export const tameSpecies: Species[] = [
 		name: 'Igne',
 		variants: [1, 2, 3],
 		shinyVariant: 4,
+		shinyChance: 30,
 		combatLevelRange: [70, 100],
 		artisanLevelRange: [1, 10],
 		supportLevelRange: [1, 10],
@@ -101,6 +103,7 @@ export const tameSpecies: Species[] = [
 		name: 'Monkey',
 		variants: [1, 2, 3],
 		shinyVariant: 4,
+		shinyChance: 60,
 		combatLevelRange: [12, 24],
 		artisanLevelRange: [1, 10],
 		supportLevelRange: [1, 10],


### PR DESCRIPTION
### Changes:

- Add `shinyChance` to `interface Species`. The value in this property is what will be used to roll a shiny variant.
- Add a 1 in 30 chance for Igne to tach as shiny;
- Add a 1 in 60 for Monkey to hatch as shiny.

### Other checks:

-   [X] I have tested all my changes thoroughly.