### PR TITLE
Fix brew usage in volcanic mine

### DIFF
--- a/src/commands/Minion/volcanicmine.ts
+++ b/src/commands/Minion/volcanicmine.ts
@@ -177,7 +177,7 @@ export default class extends BotCommand {
 		const boosts: string[] = [];
 
 		const suppliesUsage = new Bank()
-			.add('Saradomin brew (4)', userHitpointsLevel >= 80 ? 3 : 2)
+			.add('Saradomin brew (4)', userHitpointsLevel < 80 ? 3 : 2)
 			.add('Prayer potion (4)', 1)
 			.add('Numulite', 30);
 


### PR DESCRIPTION
### Description:

- Volcanic mine is using more brews if you are above 80 HP. It should be the other way around.

### Changes:

- Change the saradomin brew check to be `< 80` instead of `>= 80`

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/133121026-5184e74f-dec5-4682-83e4-617cb802a0a2.png)