### PR TITLE
[BSO] Fixes farming bug with Woodcutting requirement

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -317,7 +317,11 @@ export default class extends Task {
 					harvestXp = 0;
 				} else if (plantToHarvest.givesCrops && chopped) {
 					if (!plantToHarvest.outputCrop) return;
-					loot[plantToHarvest.outputCrop] = cropYield * alivePlants;
+					// cropYield already counts each patch if variableYield is true:
+					loot[plantToHarvest.outputCrop] =
+						plantToHarvest.fixedOutput && plantToHarvest.fixedOutputAmount
+							? plantToHarvest.fixedOutputAmount * alivePlants
+							: cropYield;
 
 					harvestXp = cropYield * alivePlants * plantToHarvest.harvestXp;
 				}


### PR DESCRIPTION
### Description:

Fixes bug that 10x's fruit trees because the woodcutting chop code is broken

### Changes:

Only multiply by `alivePlants` if it's a fixedOutput crop, otherwise use the cropYield value as-is since it already calculated the yield from multiple patches.

### Other checks:

-   [x] I have tested all my changes thoroughly.
-   Sorry I didn't set my WC level back up last time as the problem before was with a low-wc level, so I missed it :(
