### PR TITLE
Dragon/Infernal Pickaxe

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -153,7 +153,7 @@ const source: [string, (string | number)[]][] = [
 	['Tormented bracelet', ['Tormented bracelet (or)']],
 	['Necklace of anguish', ['Necklace of anguish (or)']],
 	['Occult necklace', ['Occult necklace (or)']],
-	['Dragon pickaxe', ['Dragon pickaxe(or)', 12_797, '3rd age pickaxe']],
+	['Dragon pickaxe', ['Dragon pickaxe(or)', 12_797, '3rd age pickaxe', 'Infernal pickaxe']],
 	['Dragon axe', ['3rd age axe']],
 	['Steam battlestaff', [12_795]],
 	['Lava battlestaff', [21_198]],


### PR DESCRIPTION
Added infernal pickaxe as a similar item for dragon so you can get the dragon pickaxe boost at volcanic mine with the infernal equipped