### PR TITLE
Fix hellfire bow not consuming arrows for wilderness monsters that does not require food.

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -442,24 +442,24 @@ export default class extends BotCommand {
 		// Check food
 		let foodStr: undefined | string = undefined;
 
-		let gearToCheck = GearSetupTypes.Melee;
+		let gearToCheck = monster.wildy ? GearSetupTypes.Wildy : GearSetupTypes.Melee;
 
 		if (monster.healAmountNeeded && monster.attackStyleToUse && monster.attackStylesUsed) {
 			const [healAmountNeeded, foodMessages] = calculateMonsterFood(monster, msg.author);
 			messages = messages.concat(foodMessages);
 
-			switch (monster.attackStyleToUse) {
-				case GearStat.AttackMagic:
-					gearToCheck = GearSetupTypes.Mage;
-					break;
-				case GearStat.AttackRanged:
-					gearToCheck = GearSetupTypes.Range;
-					break;
-				default:
-					break;
+			if (!monster.wildy) {
+				switch (monster.attackStyleToUse) {
+					case GearStat.AttackMagic:
+						gearToCheck = GearSetupTypes.Mage;
+						break;
+					case GearStat.AttackRanged:
+						gearToCheck = GearSetupTypes.Range;
+						break;
+					default:
+						break;
+				}
 			}
-
-			if (monster.wildy) gearToCheck = GearSetupTypes.Wildy;
 
 			const [result] = await removeFoodFromUser({
 				client: this.client,

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -442,24 +442,20 @@ export default class extends BotCommand {
 		// Check food
 		let foodStr: undefined | string = undefined;
 
-		let gearToCheck = monster.wildy ? GearSetupTypes.Wildy : GearSetupTypes.Melee;
+		let gearToCheck = GearSetupTypes.Melee;
+
+		// Check if the gear should be changed to another combat style or the wilderness preset.
+		if (monster.wildy) {
+			gearToCheck = GearSetupTypes.Wildy;
+		} else if (monster.attackStyleToUse === GearStat.AttackMagic) {
+			gearToCheck = GearSetupTypes.Mage;
+		} else if (monster.attackStyleToUse === GearStat.AttackRanged) {
+			gearToCheck = GearSetupTypes.Range;
+		}
 
 		if (monster.healAmountNeeded && monster.attackStyleToUse && monster.attackStylesUsed) {
 			const [healAmountNeeded, foodMessages] = calculateMonsterFood(monster, msg.author);
 			messages = messages.concat(foodMessages);
-
-			if (!monster.wildy) {
-				switch (monster.attackStyleToUse) {
-					case GearStat.AttackMagic:
-						gearToCheck = GearSetupTypes.Mage;
-						break;
-					case GearStat.AttackRanged:
-						gearToCheck = GearSetupTypes.Range;
-						break;
-					default:
-						break;
-				}
-			}
 
 			const [result] = await removeFoodFromUser({
 				client: this.client,


### PR DESCRIPTION
### Description:

- If a monster does not pass the `if (monster.healAmountNeeded && monster.attackStyleToUse && monster.attackStylesUsed)` check, it will have its gear default to melee, even if it is in the wilderness.

### Changes:

- Remove the gear check from said if, so any calculation is based on the proper gear to be used for the combat.

### Special thanks:

- Titan#2171 - Reported this

### Other checks:

-   [X] I have tested all my changes thoroughly.
