### PR TITLE
Allow --each flag to be used with sellto

### DIFF
--- a/src/commands/Minion/sellto.ts
+++ b/src/commands/Minion/sellto.ts
@@ -40,9 +40,6 @@ export default class extends BotCommand {
 			rawPrice = rawPrice.replace('#', bankToSell.amount(item[0].id).toString());
 		}
 		let price = evalMathExpression(rawPrice ?? '1') ?? 1;
-		if (price < 1 || price > 100_000_000_000) {
-			return msg.channel.send('Invalid price.');
-		}
 
 		// If the each flag is set, multiply the value for each of the items being sold
 		if (msg.flagArgs.each) {
@@ -50,6 +47,10 @@ export default class extends BotCommand {
 				.items()
 				.map(i => i[1])
 				.reduce((a, b) => a + b);
+		}
+
+		if (price < 1 || price > 100_000_000_000) {
+			return msg.channel.send('Invalid price.');
 		}
 
 		// Make sure blacklisted members can't be traded.

--- a/src/commands/Minion/sellto.ts
+++ b/src/commands/Minion/sellto.ts
@@ -50,7 +50,13 @@ export default class extends BotCommand {
 		}
 
 		if (price < 1 || price > 100_000_000_000) {
-			return msg.channel.send('Invalid price.');
+			return msg.channel.send(
+				`Invalid price. ${
+					price > 100_000_000_000
+						? "Total price of trade can't be over 100b."
+						: "The price of the trade can't be lower than 1."
+				}`
+			);
 		}
 
 		// Make sure blacklisted members can't be traded.

--- a/src/commands/Minion/sellto.ts
+++ b/src/commands/Minion/sellto.ts
@@ -39,9 +39,17 @@ export default class extends BotCommand {
 			const item = bankToSell.items()[0];
 			rawPrice = rawPrice.replace('#', bankToSell.amount(item[0].id).toString());
 		}
-		const price = evalMathExpression(rawPrice ?? '1') ?? 1;
+		let price = evalMathExpression(rawPrice ?? '1') ?? 1;
 		if (price < 1 || price > 100_000_000_000) {
 			return msg.channel.send('Invalid price.');
+		}
+
+		// If the each flag is set, multiply the value for each of the items being sold
+		if (msg.flagArgs.each) {
+			price *= bankToSell
+				.items()
+				.map(i => i[1])
+				.reduce((a, b) => a + b);
 		}
 
 		// Make sure blacklisted members can't be traded.


### PR DESCRIPTION
### Description:

- Something that is used a lot, is whe users want to buy something for a certain price each, like, 25_000 gold ore for 5000 each. Often, certain trades would need users doing math and calculators. This PR aims to solve that by allowing users to apply a ONE price for each items in the trade.

### Changes:

- Add the flag `each` to `sellto`.
- Players can use it like this: `+sellto @gidedin 50 1000 feather, 500 flax, 600 bowstring` and the final price will be `105_000`, as it will add the amount of all items (`1000` + `500` + `600`) and multiply that by `50`.

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/133612611-6719feb6-0812-41f2-bfe4-f80dd7ae5815.png)