### PR TITLE
Save tames monster kills/items collected

### DIFF
--- a/src/lib/typeorm/TamesTable.entity.ts
+++ b/src/lib/typeorm/TamesTable.entity.ts
@@ -57,6 +57,9 @@ export class TamesTable extends BaseEntity {
 	@Column('integer', { name: 'max_support_level', nullable: false })
 	public maxSupportLevel!: number;
 
+	@Column('json', { name: 'activities_done', nullable: false, default: {} })
+	public activitiesDone!: ItemBank;
+
 	@Column('json', { name: 'max_total_loot', nullable: false })
 	public totalLoot!: ItemBank;
 

--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -472,7 +472,7 @@ export default class CollectionLogTask extends Task {
 			13
 		);
 
-		if (collectionLog.completions && ['collection', 'bank'].includes(type)) {
+		if (collectionLog.completions && ['collection', 'bank', 'tame'].includes(type)) {
 			let drawnSoFar = '';
 			// Times done/killed
 			ctx.font = '16px OSRSFontCompact';


### PR DESCRIPTION
### Description:

- Currently, tames are not storing their monsters kills or total items collected.
- This PR adds away to store that information directly into the tame table, just like user monster kills.

### Changes:

- Add a new field in the Tames table, called `activities_done`, which will store, as an ItemBank type of json, the ID and QTY of the monster killed or item collected;
- Made changes to the Collections to allow for tame kills to show in the log. For that, it was required to create a new function called `getKCByName` to more easily select if it would get the information from user or tame;
- Changed the tame handleTrip to automatically update the new field with the qty done in the trip;
- Changed the CollectionLogTask to allow qty to show for tames.

### After Merge:

Run the following SQL, to populate the activities:

```
with activities as (
	select tame, jsonb_object_agg(thing, qty) as banks 
	from (
		select 
			tame_id as tame, 
			case 
				when type = 'pvm' then (data->>'monsterID')::int
				when type = 'collect' then (data->>'itemID')::int
				else 0
			end as thing,
			sum((data->>'quantity')::int) as qty 
		from tame_activity 
		group by 1, 2
	) as activity
	group by tame
)
update tames
   set activities_done = activities.banks
from activities
 where 
 	id = activities.tame;
```

To preview the update SQL, the following SQL can be executed:

```
with activities as (
	select tame, jsonb_object_agg(thing, qty) as banks 
	from (
		select 
			tame_id as tame, 
			case 
				when type = 'pvm' then (data->>'monsterID')::int
				when type = 'collect' then (data->>'itemID')::int
				else 0
			end as thing,
			sum((data->>'quantity')::int) as qty 
		from tame_activity 
		group by 1, 2
	) as activity
	group by tame
)
select * from activities
```

### Other checks:

-   [X] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/19570528/133643327-ee6967a0-c649-4c16-a757-bc3dc842e110.png)
![image](https://user-images.githubusercontent.com/19570528/133643372-5c4de265-6cfc-4973-af01-51372f2ccb00.png)
![image](https://user-images.githubusercontent.com/19570528/133643446-5bf9e4ff-174e-4555-96c6-fe75ef736d89.png)