### PR TITLE
Add cox drops back to tmb

### DIFF
--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -559,8 +559,13 @@ let allItemsIDs = Openables.map(i => (typeof i.table !== 'function' && i.table.a
 ) as number[];
 allItemsIDs = uniqueArr(allItemsIDs);
 const cantBeDropped = [
-	...chambersOfXericCL,
 	...customBossesDropsThatCantBeDroppedInMBs,
+	itemID('Metamorphic dust'),
+	itemID("Xeric's guard"),
+	itemID("Xeric's warrior"),
+	itemID("Xeric's sentinel"),
+	itemID("Xeric's general"),
+	itemID("Xeric's champion"),
 	itemID('Abyssal pouch'),
 	itemID('Dwarven crate'),
 	itemID('Halloween mask set'),


### PR DESCRIPTION
### Description:
Cox drops were removed from tmb when cox was a custom minigame to bso. That is no longer the case and bso now uses the osb cox system.

### Changes:

Add cox drops back to boxes with the exceptions of the KC capes and dust from challenge mode

### Other checks:

-   [ ] I have tested all my changes thoroughly.
