### PR TITLE
[BSO] Fixes bugs related to Runecraft

### DIFF
--- a/src/commands/Minion/rc.ts
+++ b/src/commands/Minion/rc.ts
@@ -143,9 +143,6 @@ export default class extends BotCommand {
 		if (msg.author.usingPet('Obis')) {
 			essenceRequired *= 3;
 		}
-		if (rune.name === 'Elder rune') {
-			essenceRequired *= 3;
-		}
 
 		if (numEssenceOwned === 0 || essenceRequired === 0 || numEssenceOwned < essenceRequired) {
 			return msg.channel.send(
@@ -246,7 +243,7 @@ export default class extends BotCommand {
 			await msg.author.removeItemsFromBank(removeTalismanAndOrRunes.bank);
 		}
 
-		await msg.author.removeItemsFromBank(new Bank().add('Pure essence', quantity));
+		await msg.author.removeItemsFromBank(new Bank().add('Pure essence', essenceRequired));
 
 		await addSubTaskToActivityTask<RunecraftActivityTaskOptions>({
 			runeID: rune.id,
@@ -255,10 +252,11 @@ export default class extends BotCommand {
 			essenceQuantity: quantity,
 			duration,
 			imbueCasts,
-			type: Activity.Runecraft
+			type: Activity.Runecraft,
+			obisEssenceQuantity: essenceRequired
 		});
 
-		let response = `${msg.author.minionName} is now turning ${quantity}x Essence into ${
+		let response = `${msg.author.minionName} is now turning ${essenceRequired}x Essence into ${
 			rune.name
 		}, it'll take around ${formatDuration(
 			duration

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -315,7 +315,8 @@ export default class extends Extendable {
 
 				const rune = Runecraft.Runes.find(_rune => _rune.id === data.runeID);
 
-				return `${this.minionName} is currently turning ${data.essenceQuantity}x Essence into ${
+				const quantity = data.obisEssenceQuantity ?? data.essenceQuantity;
+				return `${this.minionName} is currently turning ${quantity}x Essence into ${
 					rune!.name
 				}. ${formattedDuration} Your ${Emoji.Runecraft} Runecraft level is ${this.skillLevel(
 					SkillsEnum.Runecraft

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -29,6 +29,7 @@ export interface RunecraftActivityTaskOptions extends ActivityTaskOptions {
 	runeID: number;
 	essenceQuantity: number;
 	imbueCasts: number;
+	obisEssenceQuantity?: number;
 }
 
 export interface GloryChargingActivityTaskOptions extends ActivityTaskOptions {


### PR DESCRIPTION
### Description:
This PR fixes 3 bugs:

1) Elder runecrafting was consuming 9 essence per rune instead of 3 as intended. (27:1 with obis)
2) After the recent merge following the combination rune patch, 3x rune cost from Obis was broken.
3) Fixes the =m status screen showing wrong Essence quantities when using Obis.

### Changes:

1. Removed the 3x essence cost for Elder runes from the `=rc` command, **because the activity divides by 3 also.** This was causing 3x more essence used than intended. 
- Critically, this choice of patch ensures that the output quantity per hour remains the same, and considers you actually need to carry those 3 essence per run, not just delete them.
- If you want to keep elders at 27:1 with Obis, then just remove the first change to `commands/rc.ts`
2. Changed the response message and `removeFromBank` methods to use the 'essenceQuantity' variable.
3. a) Added an optional bso-only var to the runecraft TaskActivity interface for the 'obis' aka 'real' essence quantity
4. b) Updated the minion task `=m` message accordingly.
- Note In cases where Obis is not used, obisEssenceQuantity is equal to essenceQuantity.

### Other checks:

-   [x] I have tested all my changes thoroughly.
