### PR TITLE
Add KK and Nex CL to filterables.ts

### DIFF
--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -27,8 +27,8 @@ import {
 	cluesMasterRareCL,
 	cluesMediumCL,
 	cluesSharedCL,
-	nexCL,
 	kalphiteKingCL,
+	nexCL,
 	temporossCL,
 	wintertodtCL
 } from './CollectionsExport';

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -27,10 +27,10 @@ import {
 	cluesMasterRareCL,
 	cluesMediumCL,
 	cluesSharedCL,
-	temporossCL,
-	wintertodtCL,
 	nexCL,
-	kalphiteKingCL
+	kalphiteKingCL,
+	temporossCL,
+	wintertodtCL
 } from './CollectionsExport';
 import { Eatables } from './eatables';
 import Openables, { tmbTable, umbTable } from './openables';

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -28,7 +28,9 @@ import {
 	cluesMediumCL,
 	cluesSharedCL,
 	temporossCL,
-	wintertodtCL
+	wintertodtCL,
+	nexCL,
+	kalphiteKingCL
 } from './CollectionsExport';
 import { Eatables } from './eatables';
 import Openables, { tmbTable, umbTable } from './openables';
@@ -1136,5 +1138,15 @@ export const filterableTypes: Filterable[] = [
 		name: 'Fruit',
 		aliases: ['fruit'],
 		items: monkeyEatables.map(i => i.item.id)
+	},
+	{
+		name: 'Nex uniques',
+		aliases: ['nex'],
+		items: nexCL
+	},
+	{
+		name: 'KK',
+		aliases: ['KK', 'Kalphiteking'],
+		items: kalphiteKingCL
 	}
 ];


### PR DESCRIPTION
### Description:

Added Kalphite King and Nex to the bank filters

### Changes:

- Added nexCL to the collectionsExport list in the filterables.ts file
- Did the same with kalphiteKingCL
- Added a bank filter for both of these collection logs.

### Other checks:

-   [ ] I have tested all my changes thoroughly.