### PR TITLE
fix chaos alias

### DIFF
--- a/src/commands/Minion/rc.ts
+++ b/src/commands/Minion/rc.ts
@@ -37,8 +37,9 @@ export default class extends BotCommand {
 			quantity = null;
 		}
 
-		if (name.endsWith('s') || name.endsWith('S')) name = name.slice(0, name.length - 1);
-
+		if (name.toLowerCase() !== 'chaos') {
+			if (name.endsWith('s') || name.endsWith('S')) name = name.slice(0, name.length - 1);
+		}
 		const rune = Runecraft.Runes.find(
 			_rune => stringMatches(_rune.name, name) || stringMatches(_rune.name.split(' ')[0], name)
 		);


### PR DESCRIPTION
### Description:

Fix chaos to work as alias while doing runecraft. Resolves #2874 

### Changes:

Changed so if the word chaos is used it won't try split away the ''s''

### Other checks:

-   [x] I have tested all my changes thoroughly.
