### PR TITLE
Removed ROE (uncharged) boost from sepulchre

### DIFF
--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -105,8 +105,7 @@ export const sepulchreBoosts = resolveNameBank({
 	'Hallowed grapple': 3,
 	'Hallowed focus': 3,
 	'Hallowed symbol': 3,
-	'Hallowed hammer': 3,
-	'Ring of endurance (uncharged)': 4
+	'Hallowed hammer': 3
 });
 
 export function openCoffin(floor: number): ItemBank {


### PR DESCRIPTION
- removed the boost at sepulchre for ring of endurance (uncharged)

The ring gives no benefit to sepulchre on osrs, and i believe the boost was only to give it a use on the bot and because we couldnt charge them at the time of being added

closes #2898 