### PR TITLE
fix sepulchre boosts

### DIFF
--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -102,11 +102,10 @@ export const sepulchreFloors = [
 
 export const sepulchreBoosts = resolveNameBank({
 	'Strange old lockpick': 1,
-	'Hallowed grapple': 3,
-	'Hallowed focus': 3,
-	'Hallowed symbol': 3,
-	'Hallowed hammer': 3,
-	'Ring of endurance (uncharged)': 4
+	'Hallowed grapple': 4,
+	'Hallowed focus': 4,
+	'Hallowed symbol': 4,
+	'Hallowed hammer': 4
 });
 
 export function openCoffin(floor: number): ItemBank {


### PR DESCRIPTION
### Description:

removed ring of endurance (uncharged) from boosting sepulchre and rebalanced to keep the overall xp/hour same. closes #2898 

### Changes:

removed ring of endurance (uncharged) from boosting sepulchre and rebalanced to keep the overall xp/hour same

### Other checks:

-   [X] I have tested all my changes thoroughly.
