### PR TITLE
Ancient Wyvern Shield required skills

### DIFF
--- a/src/lib/data/creatables/dragonfireShields.ts
+++ b/src/lib/data/creatables/dragonfireShields.ts
@@ -36,8 +36,7 @@ export const dragonFireShieldCreatables: Createable[] = [
 		outputItems: {
 			'Uncharged ancient wyvern shield': 1
 		},
-		requiredSkills: { smithing: 66 },
-		requiredSkills: { magic: 66 }
+		requiredSkills: { smithing: 66, magic: 66 }
 
 	},
 	// Charged

--- a/src/lib/data/creatables/dragonfireShields.ts
+++ b/src/lib/data/creatables/dragonfireShields.ts
@@ -36,7 +36,9 @@ export const dragonFireShieldCreatables: Createable[] = [
 		outputItems: {
 			'Uncharged ancient wyvern shield': 1
 		},
-		requiredSkills: { smithing: 90 }
+		requiredSkills: { smithing: 66 },
+		requiredSkills: { magic: 66 }
+
 	},
 	// Charged
 	{

--- a/src/lib/data/creatables/dragonfireShields.ts
+++ b/src/lib/data/creatables/dragonfireShields.ts
@@ -37,7 +37,6 @@ export const dragonFireShieldCreatables: Createable[] = [
 			'Uncharged ancient wyvern shield': 1
 		},
 		requiredSkills: { smithing: 66, magic: 66 }
-
 	},
 	// Charged
 	{


### PR DESCRIPTION
Changed requirements to create an uncharged ancient wyvern shield to match OSRS.

Changed Smithing 90->66
Added 66 Magic
closes #2778 