### PR TITLE
fixed typo in givebox.ts

### DIFF
--- a/src/commands/bso/givebox.ts
+++ b/src/commands/bso/givebox.ts
@@ -33,7 +33,7 @@ export default class extends BotCommand {
 		}
 		// Disable box to self or irons
 		if (user.id === msg.author.id) return msg.channel.send("You can't give boxes to yourself!");
-		if (user.isIronman) return msg.channel.send("You can't give boxes to ironmans!");
+		if (user.isIronman) return msg.channel.send("You can't give boxes to ironmen!");
 
 		await msg.author.settings.update(UserSettings.LastGivenBox, currentDate);
 


### PR DESCRIPTION
### Description:

fixed typo in the message for attempted givebox to ironmen 
### Changes:

"can't givebox to ironmans!" > "can't givebox to ironmen!"

### Other checks:

-   [ ] I have tested all my changes thoroughly.
