### PR TITLE
fix wildy hunter

### DIFF
--- a/src/lib/gear/functions/hasWildyHuntGearEquipped.ts
+++ b/src/lib/gear/functions/hasWildyHuntGearEquipped.ts
@@ -6,22 +6,22 @@ export function hasWildyHuntGearEquipped(setup: GearSetup): [boolean, string, nu
 	const userLegsID = setup.legs?.item;
 
 	const minimumStatRequirmentsBodyLegs = {
-		DefenceMage: 76,
-		DefenceRanged: 84,
-		DefenceStab: 70,
-		DefenceSlash: 60,
-		DefenceCrush: 75
+		DefenceMage: 68,
+		DefenceRanged: 76,
+		DefenceStab: 48,
+		DefenceSlash: 58,
+		DefenceCrush: 71
 	};
 
 	if (!userBodyID || !userLegsID) {
-		return [false, 'Body and leg armour equipped in misc setup.', 0];
+		return [false, 'Body and leg armour equipped in wildy setup.', 0];
 	}
 
 	const userBodyItem = getOSItem(userBodyID);
 	const userLegsItem = getOSItem(userLegsID);
 
 	if (!userBodyItem.equipment || !userLegsItem.equipment) {
-		return [false, "The body and or legs equipped in misc setup dosen't have any stats.", 0];
+		return [false, "The body and or legs equipped in wildy setup dosen't have any stats.", 0];
 	}
 
 	const userStatsBodyLegs = {
@@ -41,7 +41,7 @@ export function hasWildyHuntGearEquipped(setup: GearSetup): [boolean, string, nu
 	) {
 		return [
 			false,
-			`The combined defensive stats for the body and legs equipped in misc setup dosen't meet the minimum required stats: ${minimumStatRequirmentsBodyLegs.DefenceMage} Magic Defence, ${minimumStatRequirmentsBodyLegs.DefenceRanged} Ranged Defence, ${minimumStatRequirmentsBodyLegs.DefenceStab} Stab Defence, ${minimumStatRequirmentsBodyLegs.DefenceSlash} Slash Defence, ${minimumStatRequirmentsBodyLegs.DefenceCrush} Crush Defence.`,
+			`The combined defensive stats for the body and legs equipped in wildy setup dosen't meet the minimum required stats: ${minimumStatRequirmentsBodyLegs.DefenceMage} Magic Defence, ${minimumStatRequirmentsBodyLegs.DefenceRanged} Ranged Defence, ${minimumStatRequirmentsBodyLegs.DefenceStab} Stab Defence, ${minimumStatRequirmentsBodyLegs.DefenceSlash} Slash Defence, ${minimumStatRequirmentsBodyLegs.DefenceCrush} Crush Defence.`,
 			0
 		];
 	}
@@ -69,7 +69,7 @@ export function hasWildyHuntGearEquipped(setup: GearSetup): [boolean, string, nu
 
 	return [
 		true,
-		`The combined defensive stats for the body and legs equipped in misc setup is ${score}% of maximum possible stats in each defensive stats.`,
+		`The combined defensive stats for the body and legs equipped in wildy setup is ${score}% of maximum possible stats in each defensive stats.`,
 		score
 	];
 }


### PR DESCRIPTION
### Description:

Changed so that the new stats for black d'hide body and top works for wildy hunter along with changed so that it no longer mentions misc anywhere and just wildy setup. Closes #2908 and Closes #2907 

### Changes:

Changed so that the new stats for black d'hide body and top works for wildy hunter along with changed so that it no longer mentions misc anywhere and just wildy setup

### Other checks:

-   [X] I have tested all my changes thoroughly.
