### PR TITLE
Added Treebeard CL items to Mystery boxes 

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2023,8 +2023,7 @@ export const customBossesDropsThatCantBeDroppedInMBs = [
 	...vasaMagusCL,
 	...nexCL,
 	...kalphiteKingCL,
-	...ignecarusCL,
-	...treeBeardCL
+	...ignecarusCL
 ];
 export const implingsCL = objectEntries(implings).map(m => Number(m[0]));
 


### PR DESCRIPTION
### Description:

Treebeard 'uniques' (Ent hide and the tangleroots) were previously in the `customBossesDropsThatCantBeDroppedInMBs` list. There is no real reason for this, as Tangleroot holds no value and Ent hides are stuck at 50m market price. Furthermore, Master farmer drops from boxes so this won't effect prices in the least.

### Changes:

- Removed treeBeardCL from `customBossesDropsThatCantBeDroppedInMBs`

### Other checks:

-   [ ] I have tested all my changes thoroughly.
I saw that Gided did this change successfully for Sea Kraken drops by removing its log from the list, so assume same works for Tree