### PR TITLE
Add anti-venom+ and anti-venom usage to hydra

### DIFF
--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -9,7 +9,7 @@ import calculateMonsterFood from '../../lib/minions/functions/calculateMonsterFo
 import reducedTimeFromKC from '../../lib/minions/functions/reducedTimeFromKC';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
-import { formatDuration, formatItemBoosts, formatItemReqs, itemNameFromID } from '../../lib/util';
+import { formatDuration, formatItemBoosts, formatItemCosts, formatItemReqs, itemNameFromID } from '../../lib/util';
 import findMonster from '../../lib/util/findMonster';
 
 export default class MinionCommand extends BotCommand {
@@ -59,7 +59,10 @@ export default class MinionCommand extends BotCommand {
 			str.push(`${monster.name} requires **${monster.qpRequired}qp** to kill, and you have ${QP}qp.\n`);
 		}
 		if (monster.itemsRequired && monster.itemsRequired.length > 0) {
-			str.push(`**Items Required:** ${formatItemReqs(monster.itemsRequired)}\n`);
+			str.push(`**Items Required:** ${formatItemReqs(monster.itemsRequired)}`);
+		}
+		if (monster.itemCost) {
+			str.push(`**Item Cost per Kill:** ${formatItemCosts(monster.itemCost, timeToFinish)}\n`);
 		}
 
 		if (monster.healAmountNeeded && 1 > 2) {

--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -402,7 +402,6 @@ export const chaeldarMonsters: KillableMonster[] = [
 		wildy: false,
 
 		difficultyRating: 0,
-		itemsRequired: resolveItems(['Dark totem']),
 		notifyDrops: resolveItems(['Jar of darkness', 'Skotos']),
 		qpRequired: 0,
 		// Skotizo requires 1 totem per kill, and arclight makes kill 2x faster irl.
@@ -411,7 +410,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 				[itemID('Arclight')]: 50
 			}
 		],
-		itemCost: new Bank().add('Dark totem', 1),
+		itemCost: { itemCost: new Bank().add('Dark totem', 1), qtyPerKill: 1 },
 		healAmountNeeded: 20 * 15,
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash, GearStat.AttackMagic]

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -264,7 +264,7 @@ const killableMonsters: KillableMonster[] = [
 				[GearStat.AttackRanged]: 20 + 33 + 10 + 94 + 8
 			}
 		},
-		itemCost: new Bank().add('Stamina potion(4)', 5).add('Ruby dragon bolts (e)', 100)
+		itemCost: { itemCost: new Bank().add('Stamina potion(4)', 5).add('Ruby dragon bolts (e)', 100), qtyPerKill: 1 }
 	}
 ];
 

--- a/src/lib/minions/data/killableMonsters/konarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/konarMonsters.ts
@@ -1,9 +1,9 @@
 import { Time } from 'e';
-import { Monsters } from 'oldschooljs';
+import { Bank, Monsters } from 'oldschooljs';
 import { itemID } from 'oldschooljs/dist/util';
 
 import { GearStat } from '../../../gear';
-import resolveItems, { deepResolveItems } from '../../../util/resolveItems';
+import resolveItems from '../../../util/resolveItems';
 import { KillableMonster } from '../../types';
 
 export const konarMonsters: KillableMonster[] = [
@@ -112,7 +112,14 @@ export const konarMonsters: KillableMonster[] = [
 		wildy: false,
 
 		difficultyRating: 6,
-		itemsRequired: deepResolveItems(['Antidote++(4)']),
+		itemCost: {
+			itemCost: new Bank().add('Anti-venom+(4)', 1),
+			qtyPerMinute: 0.017,
+			alternativeConsumables: [
+				{ itemCost: new Bank().add('Anti-venom(4)', 1), qtyPerMinute: 0.021 },
+				{ itemCost: new Bank().add('Antidote++(4)', 1), qtyPerMinute: 0.021 }
+			]
+		},
 		notifyDrops: resolveItems(['Hydra tail']),
 		qpRequired: 0,
 		levelRequirements: {
@@ -133,7 +140,14 @@ export const konarMonsters: KillableMonster[] = [
 		wildy: false,
 
 		difficultyRating: 7,
-		itemsRequired: deepResolveItems(['Antidote++(4)']),
+		itemCost: {
+			itemCost: new Bank().add('Anti-venom+(4)', 1),
+			qtyPerMinute: 0.017,
+			alternativeConsumables: [
+				{ itemCost: new Bank().add('Anti-venom(4)', 1), qtyPerMinute: 0.021 },
+				{ itemCost: new Bank().add('Antidote++(4)', 1), qtyPerMinute: 0.021 }
+			]
+		},
 		notifyDrops: resolveItems(['Hydra leather', 'Hydra tail', "Hydra's claw", 'Ikkle hydra', 'Jar of chemicals']),
 		qpRequired: 0,
 		itemInBankBoosts: [

--- a/src/lib/minions/data/killableMonsters/mazchnaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/mazchnaMonsters.ts
@@ -3,7 +3,6 @@ import { Bank, Monsters } from 'oldschooljs';
 
 import { GearStat } from '../../../gear';
 import itemID from '../../../util/itemID';
-import resolveItems from '../../../util/resolveItems';
 import { KillableMonster } from '../../types';
 
 export const mazchnaMonsters: KillableMonster[] = [
@@ -187,8 +186,7 @@ export const mazchnaMonsters: KillableMonster[] = [
 		existsInCatacombs: false,
 		difficultyRating: 3,
 		qpRequired: 0,
-		itemsRequired: resolveItems(['Giant key']),
-		itemCost: new Bank().add('Giant key', 1),
+		itemCost: { itemCost: new Bank().add('Giant key', 1), qtyPerKill: 1 },
 		healAmountNeeded: 20 * 5,
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackCrush, GearStat.AttackRanged]

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -871,8 +871,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		existsInCatacombs: false,
 		difficultyRating: 3,
 		qpRequired: 0,
-		itemsRequired: resolveItems(['Mossy key']),
-		itemCost: new Bank().add('Mossy key', 1),
+		itemCost: { itemCost: new Bank().add('Mossy key', 1), qtyPerKill: 1 },
 		healAmountNeeded: 20 * 8,
 		attackStyleToUse: GearStat.AttackRanged,
 		attackStylesUsed: [GearStat.AttackCrush, GearStat.AttackMagic]

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -98,7 +98,7 @@ export interface KillableMonster {
 	disallowedAttackStyles?: AttackStyles[];
 	customMonsterHP?: number;
 	combatXpMultiplier?: number;
-	itemCost?: Bank;
+	itemCost?: Consumable;
 	superior?: SimpleMonster;
 	slayerOnly?: boolean;
 	canBarrage?: boolean;
@@ -116,6 +116,7 @@ export interface Consumable {
 	qtyPerKill?: number;
 	// For staff of the dead / kodai
 	isRuneCost?: boolean;
+	alternativeConsumables?: Consumable[];
 }
 
 export interface AddXpParams {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -12,6 +12,7 @@ import { promisify } from 'util';
 
 import { CENA_CHARS, continuationChars, Events, PerkTier, skillEmoji, SupportServer } from './constants';
 import { GearSetupType, GearSetupTypes } from './gear/types';
+import { Consumable } from './minions/types';
 import { ArrayItemsResolved, Skills } from './types';
 import { GroupMonsterActivityTaskOptions } from './types/minions';
 import getUsersPerkTier from './util/getUsersPerkTier';
@@ -319,6 +320,43 @@ export function formatItemReqs(items: ArrayItemsResolved) {
 		}
 	}
 	return str.join(', ');
+}
+
+export function formatItemCosts(consumable: Consumable, timeToFinish: number) {
+	const str = [];
+
+	const consumables = [consumable];
+
+	if (consumable.alternativeConsumables) {
+		for (const c of consumable.alternativeConsumables) {
+			consumables.push(c);
+		}
+	}
+
+	for (const c of consumables) {
+		const itemEntries = Object.entries(c.itemCost.values());
+		const multiple = itemEntries.length > 1;
+		const subStr = [];
+
+		let multiply = 1;
+		if (c.qtyPerKill) {
+			multiply = c.qtyPerKill;
+		} else if (c.qtyPerMinute) {
+			multiply = c.qtyPerMinute * (timeToFinish / Time.Minute);
+		}
+
+		for (const [itemId, quantity] of itemEntries) {
+			subStr.push(`${(quantity * multiply).toFixed(3)}x ${itemNameFromID(parseInt(itemId))}`);
+		}
+
+		if (multiple) {
+			str.push(`(${subStr.join(' and ')})`);
+		} else {
+			str.push(subStr.join(''));
+		}
+	}
+
+	return str.join(' or ');
 }
 
 export function formatSkillRequirements(reqs: Record<string, number>, emojis = true) {


### PR DESCRIPTION
### Description:

Added anti-venom+(4) and anti-venom(4) usage to hydra

Potions at hydra will be used in the following order: Anti-venom+(4) -> Anti-venom (4) -> Antidote++(4)
As this will be nicest order concerning herblore xp (although it can be argued that you'd use antidotes first in-game because they are cheaper)

Made a clear difference between itemsRequired and itemCost. 
Where itemsRequired are items that you need to own, but don't get consumed
And itemsCost are items that you need to own, but will get consumed before a trip

Closes #2286 

### Changes:

Changed monster.itemCost to be a Consumable
Added alternative consumables to Consumable (to keep backwards compatibility, but also allow anti-venoms at hydra)
Changed qtyPerMinute of anti-dote to 0.021 (1/48), because it's a 4 dose potion so a full potion lasts 48 minutes.
Changed +monster, to better display item costs
Removed itemsRequired from monsters with itemCost, as it's redundant to have the same items twice in the code

### Other checks:

-   [ X ] I have tested all my changes thoroughly.
