### PR TITLE
Fix Gorajan XP boost copy-paste error

### DIFF
--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -828,10 +828,10 @@ export default class extends Extendable {
 			wildyOutfit.hasEquipped(gorajanWarriorOutfit, true);
 		const gorajanRangeEquipped =
 			this.getGear('range').hasEquipped(gorajanArcherOutfit, true) ||
-			wildyOutfit.hasEquipped(gorajanWarriorOutfit, true);
+			wildyOutfit.hasEquipped(gorajanArcherOutfit, true);
 		const gorajanMageEquipped =
 			this.getGear('mage').hasEquipped(gorajanOccultOutfit, true) ||
-			wildyOutfit.hasEquipped(gorajanWarriorOutfit, true);
+			wildyOutfit.hasEquipped(gorajanOccultOutfit, true);
 
 		// Determine if boost should apply based on skill + equipped sets:
 		let gorajanBoost = false;


### PR DESCRIPTION
### Description:
Fixes the gorajan check in addXp so that it looks for the correct style in the wildy slot.

### Changes:
Replaced gorajanWarriorOutfit with the correct style specific entries.

### Other checks:

-   [ ] I did not test this, you'll see why in the code :)
