### PR TITLE
Swapped order of Mage and range setups

### DIFF
--- a/src/lib/gear/types.ts
+++ b/src/lib/gear/types.ts
@@ -6,7 +6,7 @@ export type UserFullGearSetup = {
 	[key in GearSetupType]: Gear;
 };
 
-export const GearSetupTypes = ['melee', 'mage', 'range', 'misc', 'skilling', 'wildy', 'fashion', 'other'] as const;
+export const GearSetupTypes = ['melee', 'range', 'mage', 'misc', 'skilling', 'wildy', 'fashion', 'other'] as const;
 
 export type GearSetupType = typeof GearSetupTypes[number];
 


### PR DESCRIPTION
### Description:

Gear order in "gearall" got changed in a recent update, this fixes that. It was "Melee, Mage, Range" but I swapped mage and range to their proper positions.

### Changes:

- Swapped order of mage and range setups in gearall

### Other checks:

-   [ ] I have tested all my changes thoroughly.
I just swapped the text around, not sure if theres anything else beyond that honestly
