### PR TITLE
added Infernal cape to Infernal impling drop table

### DIFF
--- a/src/lib/simulation/customImplings.ts
+++ b/src/lib/simulation/customImplings.ts
@@ -35,6 +35,7 @@ export const InfernalImpling = new SimpleOpenable({
 		.oneIn(20, new LootTable().add('Obsidian helmet').add('Obsidian platebody').add('Obsidian platelegs'))
 		.tertiary(10, 'Clue scroll (hard)')
 		.tertiary(50, 'Clue scroll (elite)')
+		.tertiary(1500, 'Infernal cape')
 		.tertiary(1_000_000, 'Uncut onyx')
 });
 


### PR DESCRIPTION
### Description:

Random PR, but basically what title says. Infernal impling drop table could use a rare drop, and Infernal cape fits the theme perfectly. Please note, that Infernal capes don't have much market value right now and with the 1/1.5k rate, it won't flood the market either due to how rare Infernal implings are.

Also got positive turnout in bso-vote 
![image](https://user-images.githubusercontent.com/63373565/135539069-5cff260b-eeb6-4907-961c-b2cac9351cbd.png)


### Changes:

- Added Infernal cape to Infernal imp drop table, at a rate of 1/1500.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
