### PR TITLE
fixed hellfire bow not counting as Twisted bow

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -380,7 +380,8 @@ const source: [string, (string | number)[]][] = [
 	['Salve amulet', ['Salve amulet(ei)', 'Salve amulet(i)', 'Salve amulet (e)']],
 	['Salve amulet (e)', ['Salve amulet(ei)']],
 	['Salve amulet (i)', ['Salve amulet(ei)']],
-	['Zaryte bow', ['Hellfire bow', 'Hellfire bownana']]
+	['Zaryte bow', ['Hellfire bow', 'Hellfire bownana']],
+	['Twisted bow', ['Hellfire bow', 'Hellfire bownana']]
 ];
 for (const { baseItem, dyedVersions } of dyedItems) {
 	source.push([baseItem.name, dyedVersions.map(i => i.item.id)]);


### PR DESCRIPTION
### Description:

There were reports of Hellfire bow (including dyed) not counting as a Twisted bow. This *should* fix it, though I'm not too familiar with it all. Probably a better solution 

### Changes:

- Added Twisted bow to similaritems.ts
- Added Hellfire bow and Hellfire bownana as similar items to the above.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
