### PR TITLE
Fix Revenant Trips Not Continuing If User is Skulled

### DIFF
--- a/src/tasks/minions/revenantsActivity.ts
+++ b/src/tasks/minions/revenantsActivity.ts
@@ -101,6 +101,7 @@ export default class extends Task {
 			channelID,
 			str,
 			res => {
+				const flags: Record<string, string> = skulled ? { skull: 'skull' } : {};
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				if (!res.prompter) res.prompter = {};


### PR DESCRIPTION
Fixes #2918 

### Description:

Revenant trips were not continuing if the user was skulled in previous trip.

### Changes:

Caused because flags were not defined on the continue trip handler. Added the definition and checked whether user's previous trip was skulled or not to continue trips accordingly.

### Other checks:

-   [X] I have tested all my changes thoroughly.
