### PR TITLE
Add More Clue Scroll / Reward Casket Shortcuts

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -60,7 +60,7 @@ export default class MinionCommand extends BotCommand {
 			oneAtTime: true,
 			cooldown: 1,
 			aliases: ['m'],
-			usage: '[lvl|seticon|clues|k|kill|setname|buy|clue|kc|pat|stats|ironman] [quantity:int{1}|name:...string] [name:...string] [name:...string]',
+			usage: '[lvl|seticon|clues|k|kill|setname|buy|clue|open|kc|pat|stats|ironman] [quantity:int{1}|name:...string] [name:...string] [name:...string]',
 			usageDelim: ' ',
 			subcommands: true,
 			requiredPermissions: ['EMBED_LINKS']
@@ -400,6 +400,11 @@ Please click the buttons below for important links.`
 	@requiresMinion
 	async clue(msg: KlasaMessage, [quantity, tierName]: [number | string, string]) {
 		runCommand(msg, 'mclue', [quantity, tierName]);
+	}
+
+	@requiresMinion
+	async open(msg: KlasaMessage, [quantity, casketTierName]: [number | string, string]) {
+		runCommand(msg, 'open', [quantity, casketTierName]);
 	}
 
 	async k(msg: KlasaMessage, [quantity, name = '']: [null | number | string, string]) {

--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -13,6 +13,7 @@ import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { addBanks, roll, stringMatches, updateGPTrackSetting } from '../../lib/util';
+import { clueScrollinLootShortcut } from '../../lib/util/clueScrollinLootShortcut';
 import { formatOrdinal } from '../../lib/util/formatOrdinal';
 import itemID from '../../lib/util/itemID';
 
@@ -149,14 +150,13 @@ export default class extends BotCommand {
 			msg.author.incrementMonsterScore(MIMIC_MONSTER_ID, mimicNumber);
 		}
 
-		return msg.channel.sendBankImage({
-			bank: loot,
-			content: `You have completed ${nthCasket} ${clueTier.name.toLowerCase()} Treasure Trails.`,
-			title: opened,
-			flags: { showNewCL: 1, ...msg.flagArgs },
-			user: msg.author,
-			cl: previousCL
-		});
+		const { image } = await this.client.tasks
+			.get('bankImage')!
+			.generateBankImage(loot, opened, true, { showNewCL: 1, ...msg.flagArgs }, msg.author, previousCL);
+
+		let content = `You have completed ${nthCasket} ${clueTier.name.toLowerCase()} Treasure Trails.`;
+
+		clueScrollinLootShortcut(this.client, msg.author, msg.channel, loot, content, image);
 	}
 
 	async osjsOpenablesOpen(msg: KlasaMessage, quantity: number, osjsOpenable: Openable) {
@@ -182,14 +182,20 @@ export default class extends BotCommand {
 			updateGPTrackSetting(this.client, ClientSettings.EconomyStats.GPSourceOpen, loot[COINS_ID]);
 		}
 
-		return msg.channel.sendBankImage({
-			bank: loot,
-			content: `You have opened the ${osjsOpenable.name.toLowerCase()} ${score.toLocaleString()} times.`,
-			title: `You opened ${quantity} ${osjsOpenable.name}`,
-			flags: { showNewCL: 1, ...msg.flagArgs },
-			user: msg.author,
-			cl: previousCL
-		});
+		const { image } = await this.client.tasks
+			.get('bankImage')!
+			.generateBankImage(
+				loot,
+				`You opened ${quantity} ${osjsOpenable.name}`,
+				true,
+				{ showNewCL: 1, ...msg.flagArgs },
+				msg.author,
+				previousCL
+			);
+
+		let content = `You have opened the ${osjsOpenable.name.toLowerCase()} ${score.toLocaleString()} times.`;
+
+		clueScrollinLootShortcut(this.client, msg.author, msg.channel, loot, content, image);
 	}
 
 	async botOpenablesOpen(msg: KlasaMessage, quantity: number, name: string) {
@@ -244,15 +250,21 @@ export default class extends BotCommand {
 			updateGPTrackSetting(this.client, ClientSettings.EconomyStats.GPSourceOpen, loot.amount('Coins'));
 		}
 
-		return msg.channel.sendBankImage({
-			bank: loot.values(),
-			content: `You have opened the ${botOpenable.name.toLowerCase()} ${(
-				score + quantity
-			).toLocaleString()} times.`,
-			title: `You opened ${quantity} ${botOpenable.name}`,
-			flags: { showNewCL: 1, ...msg.flagArgs },
-			user: msg.author,
-			cl: previousCL
-		});
+		const { image } = await this.client.tasks
+			.get('bankImage')!
+			.generateBankImage(
+				loot.values(),
+				`You opened ${quantity} ${botOpenable.name}`,
+				true,
+				{ showNewCL: 1, ...msg.flagArgs },
+				msg.author,
+				previousCL
+			);
+
+		let content = `You have opened the ${botOpenable.name.toLowerCase()} ${(
+			score + quantity
+		).toLocaleString()} times.`;
+
+		clueScrollinLootShortcut(this.client, msg.author, msg.channel, loot.values(), content, image);
 	}
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -425,7 +425,7 @@ export const MAX_XP = 200_000_000;
 
 export const MIMIC_MONSTER_ID = 23_184;
 
-export const continuationChars = 'abdefghjkmnoprstuvwxyz123456789'.split('');
+export const continuationChars = 'abdefghjkmnprstuvwxyz123456789'.split('');
 export const CENA_CHARS = ['​', '‎', '‍'];
 export const NIGHTMARES_HP = 2400;
 export const ZAM_HASTA_CRUSH = 65;

--- a/src/lib/util/clueScrollinLootShortcut.ts
+++ b/src/lib/util/clueScrollinLootShortcut.ts
@@ -1,0 +1,72 @@
+import { Channel, Message, MessageCollector } from 'discord.js';
+import { Time } from 'e';
+import { KlasaClient, KlasaMessage, KlasaUser } from 'klasa';
+import { ItemBank } from 'oldschooljs/dist/meta/types';
+
+import MinionCommand from '../../commands/Minion/minion';
+import { Emoji, PerkTier } from '../constants';
+import ClueTiers from '../minions/data/clueTiers';
+import { channelIsSendable } from '../util';
+import getUsersPerkTier from './getUsersPerkTier';
+import { collectors } from './handleTripFinish';
+import { sendToChannelID } from './webhook';
+
+export function clueScrollinLootShortcut(
+	client: KlasaClient,
+	user: KlasaUser,
+	channel: Channel,
+	loot: ItemBank | null,
+	content: string,
+	image: Buffer | null
+) {
+	const perkTier = getUsersPerkTier(user);
+	const clueReceived = loot ? ClueTiers.find(tier => loot[tier.scrollID] > 0) : undefined;
+
+	if (clueReceived) {
+		content += `\n${Emoji.Casket} **You got a ${clueReceived.name} clue scroll** in your loot.`;
+		if (perkTier > PerkTier.One) {
+			content += ` Say \`c\` if you want to complete this ${clueReceived.name} clue now.`;
+		} else {
+			content += 'You can get your minion to complete them using `+minion clue easy/medium/etc`';
+		}
+	}
+
+	if (!image) return;
+	sendToChannelID(client, channel.id, { content, image });
+
+	const existingCollector = collectors.get(user.id);
+
+	if (existingCollector) {
+		existingCollector.stop();
+		collectors.delete(user.id);
+	}
+
+	if (!channelIsSendable(channel)) return;
+	const collector = new MessageCollector(channel, {
+		filter: (mes: Message) => mes.author === user && mes.content.toLowerCase() === 'c',
+		time: perkTier > PerkTier.One ? Time.Minute * 10 : Time.Minute * 2,
+		max: 1
+	});
+
+	collectors.set(user.id, collector);
+
+	collector.on('collect', async (mes: KlasaMessage) => {
+		if (user.minionIsBusy || client.oneCommandAtATimeCache.has(mes.author.id)) {
+			collector.stop();
+			collectors.delete(user.id);
+			return;
+		}
+		client.oneCommandAtATimeCache.add(mes.author.id);
+		try {
+			if (mes.content.toLowerCase() === 'c' && clueReceived && perkTier > PerkTier.One) {
+				(client.commands.get('minion') as unknown as MinionCommand).clue(mes, [1, clueReceived.name]);
+				return;
+			}
+		} catch (err) {
+			console.log({ err });
+			channel.send(err);
+		} finally {
+			setTimeout(() => client.oneCommandAtATimeCache.delete(mes.author.id), 300);
+		}
+	});
+}

--- a/src/tasks/minions/revenantsActivity.ts
+++ b/src/tasks/minions/revenantsActivity.ts
@@ -101,6 +101,7 @@ export default class extends Task {
 			channelID,
 			str,
 			res => {
+				const flags: Record<string, string> = skulled ? { skull: 'skull' } : {};
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				if (!res.prompter) res.prompter = {};


### PR DESCRIPTION
Fixes #2957 

### Description:

Adds some shortcuts for patrons to make doing clue scrolls from openables or opening caskets easier from clue trips.

### Changes:

Adds for patrons:
- Say 'c' for do clue scroll trip after opening things in +open.
- Say 'o' for open reward casket when returning from a clue scroll trip.

### Other checks:

-   [X] I have tested all my changes thoroughly.
