### PR TITLE
Fixed rp roles checking wrong pet collection log

### DIFF
--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -36,7 +36,7 @@ const minigames = [
 
 const collections = [
 	'overall',
-	'pets',
+	'rolepets',
 	'skilling',
 	'clues',
 	'bosses',


### PR DESCRIPTION
### Description:

BSO checked cl pets for the Top collector role, rather than "rolepets" which includes custom pets and is what should have been checked. This PR fixes that.

### Changes:

- Changed "pets" in top collector to "Rolepets"

### Other checks:

-   [ ] I have tested all my changes thoroughly.
