### PR TITLE
Fix King Goldemar Solo Trips

### DIFF
--- a/src/commands/bso/kinggoldemar.ts
+++ b/src/commands/bso/kinggoldemar.ts
@@ -16,6 +16,7 @@ export const kgBaseTime = Time.Minute * 45;
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
+			usage: '[solo|mass]',
 			usageDelim: ' ',
 			oneAtTime: true,
 			altProtection: true,
@@ -24,7 +25,8 @@ export default class extends BotCommand {
 		});
 	}
 
-	async run(msg: KlasaMessage) {
+	async run(msg: KlasaMessage, [type]: [string | undefined]) {
+		const checkSolo = type === 'solo' ? true : false;
 		const instance = new BossInstance({
 			leader: msg.author,
 			id: KingGoldemar.id,
@@ -70,7 +72,7 @@ export default class extends BotCommand {
 			activity: Activity.KingGoldemar,
 			massText: `${msg.author.username} is assembling a team to fight King Goldemar! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
 			minSize: 1,
-			solo: false,
+			solo: checkSolo,
 			canDie: true,
 			kcLearningCap: 50
 		});
@@ -81,7 +83,9 @@ export default class extends BotCommand {
 			const { bossUsers } = await instance.start();
 			const embed = new MessageEmbed()
 				.setDescription(
-					`Your group approaches the Kings' chambers, and each of you bribes the Kings Guards with a big bag of gold (${toKMB(
+					`${checkSolo ? 'You approach' : 'Your group approaches'} the Kings' chambers, and ${
+						checkSolo ? 'you bribe' : 'each of you bribes'
+					} the Kings Guards with a big bag of gold (${toKMB(
 						10_000_000
 					)} each) to let you into his chambers. The guards accept the offer and let you in, as they run away. The total trip will take ${formatDuration(
 						instance.duration


### PR DESCRIPTION
### Description:

These changes will make soloing King Goldemar smoother for users, by instantly sending solo trips and by having the ability to have their return trips handled (say 'y' to repeat trip, say 'c' to do clue).

### Changes:

- Added a param to the kg command to differentiate between solo and mass. Example: `=kg solo` vs `=kg mass`.
- If param is solo, trips sends instantly. If param is mass, a mass queue will work as normal. 
- When a solo trip returns it is now handled and shortcuts will be present to either repeat trip or do the clue found in the loot.

### Other checks:

-   [X] I have tested all my changes thoroughly.
