### PR TITLE
[BSO] Fix Seed Pack and Make Farming Contract Changes

### DIFF
--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -185,8 +185,8 @@ export default class extends BotCommand {
 	}
 
 	async osjsOpenablesOpen(msg: KlasaMessage, quantity: number, osjsOpenable: Openable) {
-		if (osjsOpenable.name === 'seed pack') {
-			return msg.channel.send('In order to open your seed pack, please use the command `=sp`');
+		if (osjsOpenable.name === 'Seed pack') {
+			return this.client.commands.get('sp')!.run(msg, []);
 		}
 
 		if (msg.author.bank().amount(osjsOpenable.id) < quantity) {

--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -185,7 +185,7 @@ export default class extends BotCommand {
 	}
 
 	async osjsOpenablesOpen(msg: KlasaMessage, quantity: number, osjsOpenable: Openable) {
-		if ((osjsOpenable.name = 'seed pack')) {
+		if (osjsOpenable.name === 'seed pack') {
 			return msg.channel.send('In order to open your seed pack, please use the command `=sp`');
 		}
 

--- a/src/commands/Minion/open.ts
+++ b/src/commands/Minion/open.ts
@@ -185,6 +185,10 @@ export default class extends BotCommand {
 	}
 
 	async osjsOpenablesOpen(msg: KlasaMessage, quantity: number, osjsOpenable: Openable) {
+		if ((osjsOpenable.name = 'seed pack')) {
+			return msg.channel.send('In order to open your seed pack, please use the command `=sp`');
+		}
+
 		if (msg.author.bank().amount(osjsOpenable.id) < quantity) {
 			return msg.channel.send(
 				`You don't have enough ${osjsOpenable.name} to open!\n\n However... ${await this.showAvailable(msg)}`

--- a/src/commands/Minion/seedpack.ts
+++ b/src/commands/Minion/seedpack.ts
@@ -176,6 +176,6 @@ export default class extends BotCommand {
 		await msg.author.removeItemsFromBank(new Bank().add('Seed pack'));
 		await msg.author.addItemsToBank(loot.bank, true);
 
-		return msg.channel.send(`You opened a seed pack and received: ${loot}.`);
+		return msg.channel.send(`You opened 1x seed pack and received: ${loot}.`);
 	}
 }

--- a/src/lib/skilling/functions/calcFarmingContracts.ts
+++ b/src/lib/skilling/functions/calcFarmingContracts.ts
@@ -76,7 +76,12 @@ const hardPlants: PlantsList = [
 	[85, 'Dragonfruit tree', 5],
 	[85, 'Celastrus tree', 5],
 	[85, 'Torstol', 4],
-	[90, 'Redwood tree', 5]
+	[90, 'Redwood tree', 5],
+	[99, 'Athelas', 5],
+	[99, 'Avocado bush', 5],
+	[105, 'Mango bush', 5],
+	[111, 'Lychee bush', 5],
+	[120, 'Mysterious tree', 5]
 ];
 
 export function getPlantToGrow(


### PR DESCRIPTION
### Description:

Seed packs from =open were not working as intended so I made it only openable from `=sp` and also adds bso plants to farming contracts.

### Changes:

- Removed the ability to `=open seed pack`. Command now tells you to do `=sp` instead.
- Added the following plants to farming contracts hard tier with tier 5 rewards: 
	[99, 'Athelas', 5],
	[99, 'Avocado bush', 5],
	[105, 'Mango bush', 5],
	[111, 'Lychee bush', 5],
	[120, 'Mysterious tree', 5]

### Other checks:

-   [X] I have tested all my changes thoroughly.
