### PR TITLE
Added reverting Zulrah uniques into 20k scales like in-game

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1070,7 +1070,7 @@ const Createables: Createable[] = [
 		outputItems: {
 			[itemID("Zulrah's scales")]: 20_000
 		}
-   	},
+  	},
 	{
 		name: 'Revert Tanzanite fang',
 		inputItems: {

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1054,6 +1054,33 @@ const Createables: Createable[] = [
 		}
 	},
 	{
+		name: 'Serpentine visage',
+		inputItems: {
+			[itemID('Serpentine visage')]: 1
+		},
+		outputItems: {
+			[itemID("Zulrah's scales")]: 20000
+		}
+	},
+	{
+		name: 'Magic fang',
+		inputItems: {
+			[itemID('Magic fang')]: 1
+		},
+		outputItems: {
+			[itemID("Zulrah's scales")]: 20000
+		}
+    	},
+		{
+		name: 'Tanzanite fang',
+		inputItems: {
+			[itemID('Tanzanite fang')]: 1
+		},
+		outputItems: {
+			[itemID("Zulrah's scales")]: 20000
+		}
+	},
+	{
 		name: 'Hell cat ears',
 		inputItems: {
 			[itemID('Cat ears')]: 1,

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1054,30 +1054,30 @@ const Createables: Createable[] = [
 		}
 	},
 	{
-		name: 'Serpentine visage',
+		name: 'Revert Serpentine visage',
 		inputItems: {
 			[itemID('Serpentine visage')]: 1
 		},
 		outputItems: {
-			[itemID("Zulrah's scales")]: 20000
+			[itemID("Zulrah's scales")]: 20_000
 		}
 	},
 	{
-		name: 'Magic fang',
+		name: 'Revert Magic fang',
 		inputItems: {
 			[itemID('Magic fang')]: 1
 		},
 		outputItems: {
-			[itemID("Zulrah's scales")]: 20000
+			[itemID("Zulrah's scales")]: 20_000
 		}
-    	},
-		{
-		name: 'Tanzanite fang',
+   	},
+	{
+		name: 'Revert Tanzanite fang',
 		inputItems: {
 			[itemID('Tanzanite fang')]: 1
 		},
 		outputItems: {
-			[itemID("Zulrah's scales")]: 20000
+			[itemID("Zulrah's scales")]: 20_000
 		}
 	},
 	{

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1070,7 +1070,7 @@ const Createables: Createable[] = [
 		outputItems: {
 			[itemID("Zulrah's scales")]: 20_000
 		}
-  	},
+	},
 	{
 		name: 'Revert Tanzanite fang',
 		inputItems: {


### PR DESCRIPTION
### Description:

In game, you can break down Zulrah uniques (Serp. visage, Tanz & Magic fang) into 20k zulrah scales. This has been added to the bot using the `revert` command. IE: `+revert Tanzanite fang` gives 20k Zulrah scales. This process CANNOT be reversed.
This will be especially helpful to players who are preparing for the Inferno or herblore training, as they can now have more sources of Scales.

I didn't know where to put the items though, so I tossed them under Graceful set reversion because that section has miscellaneous items.

### Changes:

- Added Serpentine visage, Tanz. Fang and Magic fang to revertables, allowing them to breakdown into 20k scales

### Other checks:

-   [ ] I have tested all my changes thoroughly.
