### PR TITLE
Add All Minigames to Top Minigame Role

### DIFF
--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -17,20 +17,7 @@ function addToUserMap(userMap: Record<string, string[]>, id: string, reason: str
 	userMap[id].push(reason);
 }
 
-const minigames = [
-	'barb_assault',
-	'agility_arena',
-	'mahogany_homes',
-	'gnome_restaurant',
-	'soul_wars',
-	'castle_wars',
-	'raids',
-	'raids_challenge_mode',
-	'big_chompy_bird_hunting',
-	'rogues_den',
-	'temple_trekking',
-	'volcanic_mine'
-];
+const minigames = Minigames.map(game => game.column);
 
 const collections = [
 	'overall',


### PR DESCRIPTION
Fixes #2974. This would apply to both OSB and BSO.

### Description:

Some minigames (such as mage training arena) were missing from being able to be counted towards the Top Minigames role.

### Changes:

Mapped all minigames to the minigames array in the topMinigamers() function.

### Other checks:

-   [X] I have tested all my changes thoroughly.**

** Although, tithe farm is currently represented in `stats.titheFarnsCompleted` and everyone in the minigame table on postgres will have a '0' for the tithe farm minigame, resulting in a random user given the top minigame role. We should migrate `stats.titheFarnsCompleted` to the minigame score method so we can properly log it as a minigame.