### PR TITLE
Removed "cl slayer" from the Top collector role - BSO only!

### DIFF
--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -27,7 +27,6 @@ const collections = [
 	'bosses',
 	'minigames',
 	'raids',
-	'slayer',
 	'Dyed Items',
 	'other',
 	'custom'


### PR DESCRIPTION
BSO ONLY! OSB has a lengthy grind for completing this log.

### Description:

The Slayer collection log used to be nearly 100 items, ensuring that a grind would be involved in some way. Now, it is only 65 items, all of which are passively obtained from TMBS or UMBs. 
      This means that completing the Slayer CL isn't very prestigious, in fact 17 players have completed this log, with MANY being only 1-2 items off from completion. 

tl;dr: its not a special log anymore, and RP roles does a random roll of who receives the role. Feels appropriate to remove, so the bso top collector role is a bit more special.
### Changes:

<!-- Write a comprehensive list of changes here. -->
- Removed "slayer" from BSO top collector check.
### Other checks:

-   [ ] I have tested all my changes thoroughly.
