### PR TITLE
Updated Youngllef rate in +pet simulation

### DIFF
--- a/src/lib/data/pets.ts
+++ b/src/lib/data/pets.ts
@@ -541,12 +541,12 @@ const pets: Pet[] = [
 	{
 		id: 44,
 		emoji: '<:Youngllef:604670894798798858>',
-		chance: 1000,
+		chance: 800,
 		name: 'Youngllef',
 		type: 'BOSS',
 		altNames: ['GAUNTLET', 'YOUNGLEF'],
 		formatFinish: (num: number) =>
-			`You had to complete the Gauntlet ${fm(
+			`You had to complete the Corrupted Gauntlet ${fm(
 				num
 			)} times to get the Youngllef pet! <:Youngllef:604670894798798858> This took you ${fm(num * 0.15)} hours.`,
 		bossKeys: ['theGauntlet', 'theCorruptedGauntlet']


### PR DESCRIPTION
### Description:

Youngllef was at the incorrect drop rate of 1/1k in the pet simulation command. This has been updated to 800. 
Also made a small change to the text a bit. 
### Changes:

- Updated Youngllef drop rate to 1/800
- Added "Corrupted" to the message, to reflect the pet coming from the Corrupted gauntlet.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
Note: The pet rate for the actual minion is correct and was not changed. This is just for the fun command.