### PR TITLE
Fix food sorting when Anglerfish are involved

### DIFF
--- a/src/lib/minions/functions/getUserFoodFromBank.ts
+++ b/src/lib/minions/functions/getUserFoodFromBank.ts
@@ -3,6 +3,13 @@ import { Bank } from 'oldschooljs';
 
 import { Eatables } from '../../data/eatables';
 
+function getRealHealAmount(user: KlasaUser, healAmount: ((user: KlasaUser) => number) | number) {
+	if (typeof healAmount === 'number') {
+		return healAmount;
+	}
+	return healAmount(user);
+}
+
 export default function getUserFoodFromBank(
 	user: KlasaUser,
 	totalHealingNeeded: number,
@@ -13,7 +20,7 @@ export default function getUserFoodFromBank(
 	let foodToRemove = new Bank();
 
 	const sorted = [...Eatables]
-		.sort((i, j) => (i.healAmount > j.healAmount ? 1 : -1))
+		.sort((i, j) => (getRealHealAmount(user, i.healAmount) > getRealHealAmount(user, j.healAmount) ? 1 : -1))
 		.sort((a, b) => {
 			if (!userBank.has(a.id)) return 1;
 			if (!userBank.has(b.id)) return -1;


### PR DESCRIPTION
### Description:

- Since Anglerfish was moved to a function for healAmount, it always sorts to the top of the list, (unless foods are favorited)
- This fixes it so it uses the actual heal amount value. 
- Not ideal if someone has low HP, but it's still better than always using Anglerfish first.


### Changes:

Added a new function that processes the function if it's not a numerical value and returns the function result to be sorted against.

### Other checks:

-   [x] I have tested all my changes thoroughly.
