### PR TITLE
Allow raw 'favfood' for tames.

### DIFF
--- a/src/commands/Minion/favfood.ts
+++ b/src/commands/Minion/favfood.ts
@@ -31,7 +31,7 @@ export default class extends BotCommand {
 
 		const [item] = items;
 
-		if (!Eatables.some(eatable => item.id === eatable.id)) {
+		if (!Eatables.some(eatable => item.id === eatable.id || item.id === eatable.raw)) {
 			return msg.channel.send("That item isn't a valid food.");
 		}
 


### PR DESCRIPTION
### Description:

- Currently Raw food cannot be added to the favfood AND regular food doesn't count when sorting which food to use. 
- Instead of making raw food compare the same as cooked, this allows tames to essentially have different favfood than the minion.

### Changes:

- Add an `OR` check in favfood.ts to see if the specified item is a raw `Eatable`

(The `getUserFoodFromBank` function already has code that will sort raw food by favfood, as long as it's in the list)

### Other checks:

-   [x] I have tested all my changes thoroughly.
