### PR TITLE
Add more weapons to Lobstrosities to match OSRS

### DIFF
--- a/src/lib/minions/data/killableMonsters/turaelMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/turaelMonsters.ts
@@ -664,7 +664,8 @@ export const turaelMonsters: KillableMonster[] = [
 		wildy: false,
 
 		difficultyRating: 1,
-		itemsRequired: deepResolveItems([['Trident of the seas', 'Trident of the swamp', 'Brine sabre']]),
+		// Merfolk trident has similar items including all water tridents
+		itemsRequired: deepResolveItems([['Merfolk trident', 'Uncharged trident', 'Brine sabre']]),
 		qpRequired: 10,
 		healAmountNeeded: 22,
 		attackStyleToUse: GearStat.AttackSlash,


### PR DESCRIPTION
### Description:
Allowed more weapons to be used to kill Lobstrosities .

### Changes:
The following weapons are all valid:

- Trident of the seas (and uncharged + e variants)
- Trident of the swamp (and uncharged + e variants)
- Merfolk trident
- Brine sabre

### Other checks:

-   [x] I have tested all my changes thoroughly.

Note: `Uncharged trident` is listed extraneously to make it clear when attempting to kill them that tridents work, as that may not be obvious from 'Merfolk trident'