### PR TITLE
[BSO] Fix bug: Deleting a mass breaks host's minion

### DIFF
--- a/src/lib/structures/Mass.ts
+++ b/src/lib/structures/Mass.ts
@@ -81,6 +81,7 @@ export class Mass {
 					let reason = 'Unknown error';
 					if (e.message && e.message === 'Unknown Message') reason = 'Someone deleted the mass';
 					reject(new Error(reason));
+					return;
 				}
 				for (const user of usersReacted) {
 					if (this.customDenier) {


### PR DESCRIPTION
### Description:
Currently if you host a BossInstance type mass (igne/kg), then the mass message is deleted by someone with MassHoster role, this causes the host's minion to become stuck permanently until the busy cache is cleared, either from a bot-restart, or `rp canceltask`.

### Changes:

Added a try/catch block to detect if the message was deleted, and properly bail out of the mass.

### Other checks:

-   [x] I have tested all my changes thoroughly.
