### PR TITLE
[BSO] Fix Gorajan Shard rates, and make messaging more clear.

### DIFF
--- a/src/commands/Minion/dung.ts
+++ b/src/commands/Minion/dung.ts
@@ -194,10 +194,11 @@ export default class extends BotCommand {
 			.get(UserSettings.DungeoneeringTokens)
 			.toLocaleString()}
 **Max floor:** ${maxFloorUserCanDo(msg.author)}`;
-		const { boosts } = gorajanShardChance(msg.author);
+		const { chance, boosts } = gorajanShardChance(msg.author);
 		if (boosts.length > 0) {
-			str += `\n**Gorajan shard boosts:** ${boosts.join(', ')}`;
+			str += `\n**Gorajan shards rate boost${boosts.length > 1 ? 's' : ''}:** ${boosts.join(', ')}`;
 		}
+		str += `\n(Gorajan shards rate: 1 in ${chance} minutes)`;
 		return msg.channel.send(str);
 	}
 

--- a/src/tasks/minions/dungeoneeringActivity.ts
+++ b/src/tasks/minions/dungeoneeringActivity.ts
@@ -16,11 +16,11 @@ export function gorajanShardChance(user: KlasaUser) {
 	let goraShardBoosts = [];
 	let baseRate = 2000;
 	if (user.hasItemEquippedAnywhere('Dungeoneering master cape')) {
-		baseRate /= 2;
-		goraShardBoosts.push('2x for Dung. mastery');
+		baseRate = reduceNumByPercent(baseRate, 75);
+		goraShardBoosts.push('75% for Dung. mastery');
 	} else if (user.skillLevel(SkillsEnum.Dungeoneering) >= 99) {
-		baseRate = reduceNumByPercent(baseRate, 30);
-		goraShardBoosts.push('30% for 99+ Dungeoneering');
+		baseRate = reduceNumByPercent(baseRate, 40);
+		goraShardBoosts.push('40% for 99+ Dungeoneering');
 	}
 
 	if (user.hasItemEquippedAnywhere('Ring of luck')) {


### PR DESCRIPTION
### Description:

When adding the G.Shard boost messaging, the rates were inadvertently changed. 

This code replaces the previous rates ( 2,000 base, 1,200 @ 99, 500 @ 500m ), and also makes the messaging clearer, with the actual rate shown.

### Changes:

- Fixes the rates to match the published rates in #bso-news
- Makes the messaging clearer
- Use the actual item name, 'Gorajan shards' as it's always plural.

### Other checks:

-   [x] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/10122432/138659077-c71f3e45-9414-411a-802c-8dae8abfabfc.png)

