### PR TITLE
Remove direct Bank updates

### DIFF
--- a/src/commands/Minion/poh.ts
+++ b/src/commands/Minion/poh.ts
@@ -205,11 +205,18 @@ export default class POHCommand extends BotCommand {
 		}
 		const currItem = poh.mountedItem === 1112 ? null : poh.mountedItem;
 
-		userBank.remove(item.id);
+		const costBank = new Bank();
+		const lootBank = new Bank();
+
+		costBank.add('Magic stone', 2);
+		costBank.add(item.id);
+
 		if (currItem) {
+			lootBank.add(currItem);
 			userBank.add(item.id);
 		}
-		await msg.author.settings.update(UserSettings.Bank, userBank.bank);
+
+		await msg.author.exchangeItemsFromBank({ costBank, lootBank });
 		poh.mountedItem = item.id;
 		await poh.save();
 		return msg.channel.send({

--- a/src/commands/Minion/tokkulshop.ts
+++ b/src/commands/Minion/tokkulshop.ts
@@ -1,6 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Bank, Monsters } from 'oldschooljs';
-import { addBanks, bankHasAllItemsFromBank, removeBankFromBank } from 'oldschooljs/dist/util';
+import { bankHasAllItemsFromBank } from 'oldschooljs/dist/util';
 
 import TokkulShopItem from '../../lib/data/buyables/tokkulBuyables';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -100,10 +100,7 @@ export default class extends BotCommand {
 			} **${items}** for **${tokkul}**.`
 		);
 
-		await msg.author.settings.update(
-			UserSettings.Bank,
-			addBanks([outItems.bank, removeBankFromBank(userBank, inItems.bank)])
-		);
+		await msg.author.exchangeItemsFromBank({ costBank: inItems, lootBank: outItems });
 
 		return msg.channel.send(`You ${type === 'buy' ? 'bought' : 'sold'} **${items}** for **${tokkul}**.`);
 	}

--- a/src/commands/Minion/unequippet.ts
+++ b/src/commands/Minion/unequippet.ts
@@ -3,7 +3,7 @@ import { CommandStore, KlasaMessage } from 'klasa';
 import { requiresMinion } from '../../lib/minions/decorators';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
-import { addItemToBank, itemNameFromID } from '../../lib/util';
+import { itemNameFromID } from '../../lib/util';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -22,11 +22,7 @@ export default class extends BotCommand {
 		const equippedPet = msg.author.settings.get(UserSettings.Minion.EquippedPet);
 		if (!equippedPet) return msg.channel.send("You don't have a pet equipped.");
 
-		await msg.author.settings.update([
-			[UserSettings.Minion.EquippedPet, null],
-			[UserSettings.Bank, addItemToBank(msg.author.settings.get(UserSettings.Bank), equippedPet)]
-		]);
-
+		await msg.author.petUnequip();
 		msg.author.log(`unequipping ${itemNameFromID(equippedPet)}[${equippedPet}]`);
 
 		return msg.channel.send(

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -159,6 +159,18 @@ declare module 'discord.js' {
 		log(stringLog: string): void;
 		addGP(amount: number): Promise<SettingsUpdateResult>;
 		removeGP(amount: number): Promise<SettingsUpdateResult>;
+		exchangeItemsFromBank({
+			costBank,
+			lootBank,
+			collectionLog
+		}: {
+			costBank: ItemBank | Bank;
+			lootBank: ItemBank | Bank;
+			collectionLog?: boolean;
+			filterLoot?: boolean;
+		}): Promise<SettingsUpdateResult>;
+		petEquip(petID: number): Promise<SettingsUpdateResult>;
+		petUnequip(): Promise<SettingsUpdateResult>;
 		addQP(amount: number): Promise<SettingsUpdateResult>;
 		addXP(params: AddXpParams): Promise<string>;
 		skillLevel(skillName: SkillsEnum): number;


### PR DESCRIPTION
### Description:

Replaced direct updates to the User's Bank with centralized + queue'd versions.

### Changes:

- Added queued Pet Equip, Unequip, and Exchange Bank functions
- Added the augments.d for typescript typing on the User object
- Updated equippet + unequippet.ts
- Updated `agilityarena.ts` `+aa recolor` function
- Updated `tks.ts` (tokkul shop) to use the bank functions
- Updated `farm.ts` to use the bank functions
- Updated 1 location in poh.ts, however it's currently disabled already.


### Other checks:

-   [x] I have tested all my changes thoroughly.
