### PR TITLE
Floor `Ring of Luck` buff so it works for Igne shiny

### DIFF
--- a/src/commands/bso/nursery.ts
+++ b/src/commands/bso/nursery.ts
@@ -22,7 +22,7 @@ export async function generateNewTame(user: KlasaUser, species: Species) {
 	tame.variant = randArrItem(species.variants);
 
 	let shinyChance = user.hasItemEquippedAnywhere('Ring of luck')
-		? Math.ceil(reduceNumByPercent(species.shinyChance, 3))
+		? Math.floor(reduceNumByPercent(species.shinyChance, 3))
 		: species.shinyChance;
 	if (species.shinyVariant && roll(shinyChance)) {
 		tame.variant = species.shinyVariant;


### PR DESCRIPTION
### Description:
Changed the `ceil` to a `floor` in calculate shiny chance algorithm, otherweise Igne chance isn't improved at all.

```
Before:  (1 in X)                           After:
            Igne      Monke             Igne      Monke
RoL         30        59                29        58
Norm        30        60                30        60
```

### Other checks:

-   [x] I have tested all my changes thoroughly. ( actually did test really quick)
