### PR TITLE
Adds POH to +monster

### DIFF
--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -94,12 +94,10 @@ export default class MinionCommand extends BotCommand {
 		
 		if (monster.pohBoosts) {
 			const POHBoosts=[];
-			const usedslots=[];
 			for (const [slot, objBoosts] of Object.entries(monster.pohBoosts)) {
 				if (objBoosts === undefined) continue;
 				for (const [name, boostPercent] of Object.entries(objBoosts)) {	
 				POHBoosts.push(`${boostPercent}% for ${name}`);
-				usedslots.push([`${slot}`]);
 			}
 			str.push(`** POH Boosts: **${POHBoosts.join(" or ")} .\n`);
 			if (actPOH == true){

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -7,6 +7,7 @@ import killableMonsters from '../../lib/minions/data/killableMonsters';
 import { requiresMinion } from '../../lib/minions/decorators';
 import calculateMonsterFood from '../../lib/minions/functions/calculateMonsterFood';
 import reducedTimeFromKC from '../../lib/minions/functions/reducedTimeFromKC';
+import { calcPOHBoosts } from '../../lib/poh';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { formatDuration, formatItemBoosts, formatItemCosts, formatItemReqs, itemNameFromID } from '../../lib/util';
@@ -50,14 +51,14 @@ export default class MinionCommand extends BotCommand {
 			totalItemBoost += boostAmount;
 			ownedBoostItems.push(itemNameFromID(parseInt(itemID)));
 		}
-		const OwnedPOHBoost=[];
-		let actPOH=false;
-		if (monster.pohBoosts){
-		const [boostPercent, messages] = calcPOHBoosts(await msg.author.getPOH(), monster.pohBoosts);
+		const OwnedPOHBoost = [];
+		let actPOH = false;
+		if (monster.pohBoosts) {
+			const [boostPercent, messages] = calcPOHBoosts(await msg.author.getPOH(), monster.pohBoosts);
 			if (boostPercent > 0) {
-				timeToFinish *= (100- boostPercent)/100;
-				OwnedPOHBoost.push(`${messages.join(" ")}`);
-				actPOH=true;
+				timeToFinish *= (100 - boostPercent) / 100;
+				OwnedPOHBoost.push(`${messages.join(' ')}`);
+				actPOH = true;
 			}
 		}
 		const maxCanKill = Math.floor(msg.author.maxTripLength(Activity.MonsterKilling) / timeToFinish);
@@ -91,21 +92,21 @@ export default class MinionCommand extends BotCommand {
 				str.push(`You own ${ownedBoostItems.join(', ')} for a total boost of **${totalItemBoost}**%.\n`);
 			}
 		}
-		
 		if (monster.pohBoosts) {
-			const POHBoosts=[];
+			const POHBoosts = [];
+			const usedslots = [];
 			for (const [slot, objBoosts] of Object.entries(monster.pohBoosts)) {
 				if (objBoosts === undefined) continue;
-				for (const [name, boostPercent] of Object.entries(objBoosts)) {	
-				POHBoosts.push(`${boostPercent}% for ${name}`);
+				for (const [name, boostPercent] of Object.entries(objBoosts)) {
+					POHBoosts.push(`${boostPercent}% for ${name}`);
+					usedslots.push([`${slot}`]);
+				}
+				str.push(`** POH Boosts: **${POHBoosts.join(' or ')} .\n`);
+				if (actPOH) {
+					str.push(`**Active POH Boosts: ** ${OwnedPOHBoost}. \n`);
+				}
 			}
-			str.push(`** POH Boosts: **${POHBoosts.join(" or ")} .\n`);
-			if (actPOH == true){
-				str.push(`**Active POH Boosts: ** ${OwnedPOHBoost} .\n`);
-				}	
-			}
-		}
-		
+		}	
 		str.push(`The normal time to kill ${monster.name} is ${formatDuration(monster.timeToFinish)}.`);
 
 		const kcForOnePercent = Math.ceil((Time.Hour * 5) / monster.timeToFinish);

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -94,16 +94,15 @@ export default class MinionCommand extends BotCommand {
 		}
 		if (monster.pohBoosts) {
 			const POHBoosts = [];
-			const usedslots = [];
 			for (const [slot, objBoosts] of Object.entries(monster.pohBoosts)) {
 				if (objBoosts === undefined) continue;
 				for (const [name, boostPercent] of Object.entries(objBoosts)) {
 					POHBoosts.push(`${boostPercent}% for ${name}`);
-					usedslots.push([`${slot}`]);
 				}
-				str.push(`** POH Boosts: **${POHBoosts.join(' or ')} .\n`);
+				str.push(`**POH Slot Used: ** ${slot}.\n`);
+				str.push(`** POH Boosts: **  ${POHBoosts.join(' or ')} .\n`);
 				if (actPOH) {
-					str.push(`**Active POH Boosts: ** ${OwnedPOHBoost}. \n`);
+					str.push(`**Active POH Boosts:  ** ${OwnedPOHBoost}. \n`);
 				}
 			}
 		}	

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -50,14 +50,14 @@ export default class MinionCommand extends BotCommand {
 			totalItemBoost += boostAmount;
 			ownedBoostItems.push(itemNameFromID(parseInt(itemID)));
 		}
-		const OwnedPOHBoost=[]
-		let actPOH=false
+		const OwnedPOHBoost=[];
+		let actPOH=false;
 		if (monster.pohBoosts){
 		const [boostPercent, messages] = calcPOHBoosts(await msg.author.getPOH(), monster.pohBoosts);
 			if (boostPercent > 0) {
 				timeToFinish *= (100- boostPercent)/100;
 				OwnedPOHBoost.push(`${messages.join(" ")}`);
-				actPOH=true
+				actPOH=true;
 			}
 		}
 		const maxCanKill = Math.floor(msg.author.maxTripLength(Activity.MonsterKilling) / timeToFinish);
@@ -99,11 +99,11 @@ export default class MinionCommand extends BotCommand {
 				if (objBoosts === undefined) continue;
 				for (const [name, boostPercent] of Object.entries(objBoosts)) {	
 				POHBoosts.push(`${boostPercent}% for ${name}`);
-				usedslots.push([`${slot}`])
+				usedslots.push([`${slot}`]);
 			}
-			str.push(`** POH Boosts: **${POHBoosts.join(" or ")} .\n`)
+			str.push(`** POH Boosts: **${POHBoosts.join(" or ")} .\n`);
 			if (actPOH == true){
-				str.push(`**Active POH Boosts: ** ${OwnedPOHBoost}. \n`);
+				str.push(`**Active POH Boosts: ** ${OwnedPOHBoost} .\n`);
 				}	
 			}
 		}

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -50,6 +50,16 @@ export default class MinionCommand extends BotCommand {
 			totalItemBoost += boostAmount;
 			ownedBoostItems.push(itemNameFromID(parseInt(itemID)));
 		}
+		const OwnedPOHBoost=[]
+		let actPOH=false
+		if (monster.pohBoosts){
+		const [boostPercent, messages] = calcPOHBoosts(await msg.author.getPOH(), monster.pohBoosts);
+			if (boostPercent > 0) {
+				timeToFinish *= (100- boostPercent)/100;
+				OwnedPOHBoost.push(`${messages.join(" ")}`);
+				actPOH=true
+			}
+		}
 		const maxCanKill = Math.floor(msg.author.maxTripLength(Activity.MonsterKilling) / timeToFinish);
 
 		const QP = msg.author.settings.get(UserSettings.QP);
@@ -81,7 +91,23 @@ export default class MinionCommand extends BotCommand {
 				str.push(`You own ${ownedBoostItems.join(', ')} for a total boost of **${totalItemBoost}**%.\n`);
 			}
 		}
-
+		
+		if (monster.pohBoosts) {
+			const POHBoosts=[]
+			const usedslots=[]
+			for (const [slot, objBoosts] of Object.entries(monster.pohBoosts)) {
+				if (objBoosts === undefined) continue;
+				for (const [name, boostPercent] of Object.entries(objBoosts)) {	
+				POHBoosts.push(`${boostPercent}% for ${name}`);
+				usedslots.push([`${slot}`])
+			}
+			str.push(`** POH Boosts: **${POHBoosts.join(" or ")} .\n`)
+			if (actPOH == true){
+				str.push(`**Active POH Boosts: ** ${OwnedPOHBoost}. \n`);
+				}	
+			}
+		}
+		
 		str.push(`The normal time to kill ${monster.name} is ${formatDuration(monster.timeToFinish)}.`);
 
 		const kcForOnePercent = Math.ceil((Time.Hour * 5) / monster.timeToFinish);

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -105,7 +105,7 @@ export default class MinionCommand extends BotCommand {
 					str.push(`**Active POH Boosts:  ** ${OwnedPOHBoost}. \n`);
 				}
 			}
-		}	
+		}
 		str.push(`The normal time to kill ${monster.name} is ${formatDuration(monster.timeToFinish)}.`);
 
 		const kcForOnePercent = Math.ceil((Time.Hour * 5) / monster.timeToFinish);

--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -93,8 +93,8 @@ export default class MinionCommand extends BotCommand {
 		}
 		
 		if (monster.pohBoosts) {
-			const POHBoosts=[]
-			const usedslots=[]
+			const POHBoosts=[];
+			const usedslots=[];
 			for (const [slot, objBoosts] of Object.entries(monster.pohBoosts)) {
 				if (objBoosts === undefined) continue;
 				for (const [name, boostPercent] of Object.entries(objBoosts)) {	


### PR DESCRIPTION
### Description:

mainly a QOL update to include POH (pools) to be listed as a boost on the +monster command, only runs if the monster has pohboosts attribute

### Changes:

- Adds calculation of POH boosts to the trip timer
- Displays all potential boost (should probably remove similar items eg Variation of Rejuvv Pools)
- Displays current POH boost (Doesn't display anything similar to regular items when blank)
- only runs the commands when pohboosts is populated
- POH Boosts follow item boosts

### Other checks:

-   [x ] I have tested all my changes thoroughly.
