### PR TITLE
Display 'Challenge mode' on Join for CMs

### DIFF
--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -161,7 +161,9 @@ export default class extends BotCommand {
 			minSize: 2,
 			maxSize: 15,
 			ironmanAllowed: true,
-			message: `${msg.author.username} is hosting a Chambers of Xeric mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
+			message: `${msg.author.username} is hosting a ${
+				isChallengeMode ? '**Challenge mode** ' : ''
+			}Chambers of Xeric mass! Anyone can click the ${Emoji.Join} reaction to join, click it again to leave.`,
 			customDenier: user => {
 				if (!user.hasMinion) {
 					return [true, "you don't have a minion."];


### PR DESCRIPTION
### Description:
Currently, there's no way to tell if a pending raid is a CM or not, without closely examining the command.
Sometimes, simple typos like '-cm' are easy to miss, especially since both --cm and —cm are both valid, but -cm isn't.

There is no other indication that the Raid is a CM until after it's sent, at which point it's too late.

### Changes:
Added some extra text to the Join message that indicates if the raid is a cm or not.
![image](https://user-images.githubusercontent.com/10122432/139913998-baa7e399-7136-4c8d-a176-6e34efa691ad.png)


### Other checks:

-   [x] I have tested all my changes thoroughly.
