### PR TITLE
Add Debug code to investigate 'Unknown error' during BSO Mass start.

### DIFF
--- a/src/lib/structures/Mass.ts
+++ b/src/lib/structures/Mass.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 /* eslint-disable prefer-promise-reject-errors */
+import * as Sentry from '@sentry/node';
 import { MessageReaction, TextChannel, User } from 'discord.js';
 import { debounce, sleep, Time } from 'e';
 import { KlasaMessage, KlasaUser } from 'klasa';
@@ -79,7 +80,11 @@ export class Mass {
 					usersReacted = tryGetReactions;
 				} catch (e) {
 					let reason = 'Unknown error';
-					if (e.message && e.message === 'Unknown Message') reason = 'Someone deleted the mass';
+					if (e.message && e.message === 'Unknown Message') {
+						reason = 'Someone deleted the mass';
+					} else {
+						Sentry.captureException(e);
+					}
 					reject(new Error(reason));
 					return;
 				}


### PR DESCRIPTION
### Description:

- When starting Igne masses, it's frequently failing with, 'Unknown error.' 
- This is related to the reaction collector, but I cannot see anything else without adding some logging.
- I was unable to get access to the KlasaClient object, which is why I used Sentry directly.

### Changes:

Added a `Sentry.captureException()` to the exception  handler in Mass.ts 's try/catch block.

### Other checks:

-   [ ] I have tested all my changes thoroughly. (Did not test this, don't [yet] know how to test interactions with Sentry beyond using the web interface)
