### PR TITLE
Fix "Mass failed to start, Unknown error" bug.

### DIFF
--- a/src/lib/structures/Mass.ts
+++ b/src/lib/structures/Mass.ts
@@ -173,9 +173,9 @@ export class Mass {
 				}
 			});
 
-			collector.once('end', () => {
+			collector.once('end', async () => {
+				await start();
 				this.message!.removeAllReactions();
-				start();
 			});
 
 			for (const emoji of this.leader === undefined ? [ReactionEmoji.Join] : emojis) {


### PR DESCRIPTION
### Affects:
- King Goldemar
- Ignecarus

### Description:
- Starting a mass sometimes fails with reason, "Unknown error"
- Logging revealed that the ReactionManager.get(ReactionEmojis.Join) was undefined
- Testing hinted that it could be a race condition
- Investigation found some async commands that were not await'ed leading to inconsistent results

### Changes:
- Change the collector.once('end') function to async
- Call start() before removing the emojiis, and await start()

### Other checks:

-   [x] I have tested all my changes thoroughly.
