### PR TITLE
Consistency changes for food boosts

### DIFF
--- a/src/lib/data/eatables.ts
+++ b/src/lib/data/eatables.ts
@@ -130,7 +130,7 @@ export const Eatables: readonly Eatable[] = [
 	{
 		name: 'Monkfish',
 		id: itemID('Monkfish'),
-		healAmount: 16,
+		healAmount: 16
 	},
 	{
 		name: 'Anchovy pizza',
@@ -140,7 +140,7 @@ export const Eatables: readonly Eatable[] = [
 	{
 		name: 'Cooked karambwan',
 		id: itemID('Cooked karambwan'),
-		healAmount: 18
+		healAmount: 18,
 		pvmBoost: 1
 	},
 	{
@@ -156,7 +156,7 @@ export const Eatables: readonly Eatable[] = [
 	{
 		name: 'Mushroom potato',
 		id: itemID('Mushroom potato'),
-		healAmount: 20
+		healAmount: 20,
 		pvmBoost: 2
 	},
 	{
@@ -174,13 +174,13 @@ export const Eatables: readonly Eatable[] = [
 	{
 		name: 'Pineapple pizza',
 		id: itemID('Pineapple pizza'),
-		healAmount: 22
+		healAmount: 22,
 		pvmBoost: 3
 	},
 	{
 		name: 'Summer pie',
 		id: itemID('Summer pie'),
-		healAmount: 22
+		healAmount: 22,
 		pvmBoost: 3
 	},
 	{
@@ -192,7 +192,7 @@ export const Eatables: readonly Eatable[] = [
 	{
 		name: 'Tuna potato',
 		id: itemID('Tuna potato'),
-		healAmount: 22
+		healAmount: 22,
 		pvmBoost: 3
 	},
 	{

--- a/src/lib/data/eatables.ts
+++ b/src/lib/data/eatables.ts
@@ -131,7 +131,6 @@ export const Eatables: readonly Eatable[] = [
 		name: 'Monkfish',
 		id: itemID('Monkfish'),
 		healAmount: 16,
-		pvmBoost: 1
 	},
 	{
 		name: 'Anchovy pizza',
@@ -142,6 +141,7 @@ export const Eatables: readonly Eatable[] = [
 		name: 'Cooked karambwan',
 		id: itemID('Cooked karambwan'),
 		healAmount: 18
+		pvmBoost: 1
 	},
 	{
 		name: 'Curry',
@@ -157,6 +157,7 @@ export const Eatables: readonly Eatable[] = [
 		name: 'Mushroom potato',
 		id: itemID('Mushroom potato'),
 		healAmount: 20
+		pvmBoost: 2
 	},
 	{
 		name: 'Shark',
@@ -174,11 +175,13 @@ export const Eatables: readonly Eatable[] = [
 		name: 'Pineapple pizza',
 		id: itemID('Pineapple pizza'),
 		healAmount: 22
+		pvmBoost: 3
 	},
 	{
 		name: 'Summer pie',
 		id: itemID('Summer pie'),
 		healAmount: 22
+		pvmBoost: 3
 	},
 	{
 		name: 'Manta ray',
@@ -190,6 +193,7 @@ export const Eatables: readonly Eatable[] = [
 		name: 'Tuna potato',
 		id: itemID('Tuna potato'),
 		healAmount: 22
+		pvmBoost: 3
 	},
 	{
 		name: 'Dark crab',

--- a/src/tasks/minions/gloryChargingActivity.ts
+++ b/src/tasks/minions/gloryChargingActivity.ts
@@ -14,13 +14,13 @@ export default class extends Task {
 		let deaths = 0;
 		let loot = new Bank();
 		for (let i = 0; i < quantity; i++) {
-			if (roll(9)) {
+			if (roll(25)) {
 				deaths++;
-			} else {
+			}
 				for (let i = 0; i < gloriesInventorySize; i++) {
 					if (roll(25_000)) {
 						loot.add('Amulet of eternal glory');
-					} else {
+					else {
 						loot.add('Amulet of glory(6)');
 					}
 				}
@@ -35,7 +35,7 @@ export default class extends Task {
 				: `${user}, ${user.minionName} finished charging ${amnt} Amulets of glory.`;
 
 		if (loot.length !== 0 && deaths > 0) {
-			str += ` They died ${deaths}x times, causing the loss of ${gloriesInventorySize * deaths} glories.`;
+			str += ` They died ${deaths}x times, causing the loss of ${(gloriesInventorySize - 3) * deaths} glories.`;
 		}
 
 		if (loot.has('Amulet of eternal glory')) {


### PR DESCRIPTION
Add 3% boost to all "22" healing foods including tuna potatoes, instead of just manta rays, added 2% boost to other "20" healing foods, including mushroom potatoes, rather than just sharks, moved 1% boost from "16" heal monkfish to karambwans "18" heal + 1t less eating delay, and in line with food tiers.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
