### PR TITLE
Replaced Treebeard Master clue drop with GM clue

### DIFF
--- a/src/lib/minions/data/killableMonsters/custom/Treebeard.ts
+++ b/src/lib/minions/data/killableMonsters/custom/Treebeard.ts
@@ -61,7 +61,7 @@ const DeadLumberjackTable = new LootTable().every('Lumberjack hat').every('Bones
 
 export const TreebeardLootTable = new LootTable()
 	.tertiary(1200, TanglerootTable)
-	.tertiary(150, 'Clue scroll (master)')
+	.tertiary(150, 'Clue scroll (grandmaster)')
 	.tertiary(300, DeadLumberjackTable)
 	.tertiary(100, 'Mysterious seed')
 	.tertiary(100, 'Ent hide')


### PR DESCRIPTION
### Description:

Treebeard is the only custom boss that doesnt drop Gm clues. Replaced 1/150 Master clue with a 1/150 Grandmaster instead to be in-line with others. Considering the generous drop table, this is a fair rate.

### Changes:

- Replaced 1/150 Master clue with Grandmaster clue

### Other checks:

-   [ ] I have tested all my changes thoroughly.
