### PR TITLE
Fix lottery bug that deletes GP.

### DIFF
--- a/src/commands/Minion/buy.ts
+++ b/src/commands/Minion/buy.ts
@@ -162,6 +162,17 @@ export default class extends BotCommand {
 		}
 
 		await msg.confirm(str);
+		if (buyable.name === 'Bank lottery ticket') {
+			delete msg.flagArgs.cf;
+			delete msg.flagArgs.confirm;
+			await msg.confirm(
+				'**WARNING: This lottery, has only ONE item that will be given out, a Smokey. Everything else (GP/Items) will be deleted as an item/GP sink, and not given to anyone.**'
+			);
+			await this.client.settings.update(
+				ClientSettings.BankLottery,
+				new Bank(this.client.settings.get(ClientSettings.BankLottery)).add(995, buyable.gpCost! * quantity).bank
+			);
+		}
 
 		const econBankChanges = new Bank();
 
@@ -182,16 +193,6 @@ export default class extends BotCommand {
 		}
 
 		updateBankSetting(this.client, ClientSettings.EconomyStats.BuyCostBank, econBankChanges);
-
-		if (buyable.name === 'Bank lottery ticket') {
-			await msg.confirm(
-				'**WARNING: This lottery, has only ONE item that will be given out, a Smokey. Everything else (GP/Items) will be deleted as an item/GP sink, and not given to anyone.**'
-			);
-			await this.client.settings.update(
-				ClientSettings.BankLottery,
-				new Bank(this.client.settings.get(ClientSettings.BankLottery)).add(995, buyable.gpCost! * quantity).bank
-			);
-		}
 
 		await msg.author.addItemsToBank(outItems, true);
 


### PR DESCRIPTION
### Description:

With the new Smokey lottery, there is a 2nd confirmation message when buying lottery tickets.
If you say yes/confirm the first message, at this point, your GP is removed. But if you cancel  on the 2nd message, you don't get the lottery tickets, leading to incorrectly deleted GP.

### Changes:

Fixed order of actions so it works as intended.

### Other checks:

-   [x] I have tested all my changes thoroughly.
