### PR TITLE
Gloves must be tradeable to alch

### DIFF
--- a/src/lib/customItems.ts
+++ b/src/lib/customItems.ts
@@ -543,7 +543,8 @@ setCustomItem(
 			slot: EquipmentSlot.Hands,
 			requirements: null
 		},
-		highalch: 50_000_000
+		highalch: 50_000_000,
+		tradeable: true
 	},
 	50_000_000
 );
@@ -689,7 +690,8 @@ setCustomItem(
 			slot: EquipmentSlot.Hands,
 			requirements: null
 		},
-		highalch: 50_000_000
+		highalch: 50_000_000,
+		tradeable: true
 	},
 	50_000_000
 );


### PR DESCRIPTION
### Description:

Fixed torva + pernix gloves not being alchable.

### Changes:

Added in "tradeable: true" to each custom item to override "Rune Gloves" default of false.

### Other checks:

-   [x] I have tested all my changes thoroughly.
