### PR TITLE
Fix torva gloves not being tradeable and therefore not alchable

### DIFF
--- a/src/lib/customItems.ts
+++ b/src/lib/customItems.ts
@@ -397,7 +397,8 @@ setCustomItem(
 			slot: EquipmentSlot.Hands,
 			requirements: null
 		},
-		highalch: 50_000_000
+		highalch: 50_000_000,
+		tradeable: true
 	},
 	50_000_000
 );


### PR DESCRIPTION
### Description:

Fix torva gloves not being tradeable and therefore not alchable

### Changes:

Added tradeable: true to torva gloves custom item. Made this change to Virtus and Pernix yesterday but missed these.

### Other checks:

-   [x] I have tested all my changes thoroughly.
