### PR TITLE
[BSO] Spawnbox Grammar Fix

### DIFF
--- a/src/commands/bso/spawnbox.ts
+++ b/src/commands/bso/spawnbox.ts
@@ -29,7 +29,7 @@ export default class extends BotCommand {
 		}
 
 		if (!this.client.owners.has(msg.author) && msg.channel.id !== Channel.BSOChannel) {
-			return msg.channel.send('You can only use this in the BSO channel.');
+			return msg.channel.send('You can only use this in #bso-general or #bot-channel-bso');
 		}
 		const item = randArrItem([
 			itemChallenge,

--- a/src/commands/bso/spawnbox.ts
+++ b/src/commands/bso/spawnbox.ts
@@ -29,7 +29,7 @@ export default class extends BotCommand {
 		}
 
 		if (!this.client.owners.has(msg.author) && msg.channel.id !== Channel.BSOChannel) {
-			return msg.channel.send('You can only use this in #bso-general or #bot-channel-bso');
+			return msg.channel.send('You can only spawn boxes in #bot-channel-bso in the Oldschool.gg support server.');
 		}
 		const item = randArrItem([
 			itemChallenge,


### PR DESCRIPTION
Fixed spawnbox grammar
‘The BSO Channel’ doesnt really tell you where you can actually use it

EDIT: Pleeease could we get a command to disable commands by channel rather than globally
ie: `+rp disable dice #bso-general `