### PR TITLE
10% boost for Zul-andra teleports when killing Zulrah

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -449,6 +449,17 @@ export default class extends BotCommand {
 		}
 
 		// Boosts that don't affect quantity:
+
+		// Zulrah can use Zul-andra Teleports if there are enough for 1 per kill
+		if ( monster.name.toLowerCase() === "zulrah" ) {
+			const enoughTeleports = await msg.author.hasItem(itemID("Zul-andra teleport"), quantity);
+			if ( enoughTeleports ) {
+				lootToRemove.addItem(itemID("Zul-andra teleport"), quantity);
+				boosts.push("10% for Zul-andra Teleports");
+				duration = reduceNumByPercent(duration, 10);
+			};
+		};
+
 		duration = randomVariation(duration, 3);
 
 		if (isWeekend()) {


### PR DESCRIPTION
Unsure if this was the best way to do it, I couldn't see any examples of consumableCosts to speed up kills that were optional. Happy to re-write if an example can be provided.

### Description:

Added in a case for using zul-andra teleports to speed up Zulrah kills. Only used if there are enough to cover all kills. 10% was found from 25s of travel time (house/quest cape -> fairy ring) compared to 1s from teleport.

### Changes:

Added clause in k.ts to check if the target monster is Zulrah and if the user has enough teleports to cover the kills.

### Other checks:

-   [x] I have tested all my changes thoroughly.
