### PR TITLE
Zulrah zulandra teleports

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -451,7 +451,7 @@ export default class extends BotCommand {
 		// Boosts that don't affect quantity:
 
 		// Zulrah can use Zul-andra Teleports if there are enough for 1 per kill
-		if ( monster.name.toLowerCase() === "zulrah" ) {
+		if ( monster.name.toLowerCase() === "zulrah" && !msg.flagArgs.ntp ) {
 			const enoughTeleports = await msg.author.hasItem(itemID("Zul-andra teleport"), quantity);
 			if ( enoughTeleports ) {
 				lootToRemove.addItem(itemID("Zul-andra teleport"), quantity);

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -449,6 +449,17 @@ export default class extends BotCommand {
 		}
 
 		// Boosts that don't affect quantity:
+
+		// Zulrah can use Zul-andra Teleports if there are enough for 1 per kill
+		if ( monster.name.toLowerCase() === "zulrah" ) {
+			const enoughTeleports = await msg.author.hasItem(itemID("Zul-andra teleport"), quantity);
+			if ( enoughTeleports ) {
+				lootToRemove.addItem(itemID("Zul-andra teleport"), quantity);
+				boosts.push("10% for Zul-andra Teleports");
+				duration = reduceNumByPercent(duration, 10);
+			};
+		};
+
 		duration = randomVariation(duration, 3);
 
 		if (isWeekend()) {

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -455,8 +455,8 @@ export default class extends BotCommand {
 			const enoughTeleports = await msg.author.hasItem(itemID('Zul-andra teleport'), quantity);
 			if (enoughTeleports) {
 				lootToRemove.addItem(itemID('Zul-andra teleport'), quantity);
-				boosts.push('10% for Zul-andra Teleports');
-				duration = reduceNumByPercent(duration, 10);
+				boosts.push('5% for Zul-andra Teleports');
+				duration = reduceNumByPercent(duration, 5);
 			}
 		}
 

--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -451,14 +451,14 @@ export default class extends BotCommand {
 		// Boosts that don't affect quantity:
 
 		// Zulrah can use Zul-andra Teleports if there are enough for 1 per kill
-		if ( monster.name.toLowerCase() === "zulrah" && !msg.flagArgs.ntp ) {
-			const enoughTeleports = await msg.author.hasItem(itemID("Zul-andra teleport"), quantity);
-			if ( enoughTeleports ) {
-				lootToRemove.addItem(itemID("Zul-andra teleport"), quantity);
-				boosts.push("10% for Zul-andra Teleports");
+		if (monster.name.toLowerCase() === 'zulrah' && !msg.flagArgs.ntp) {
+			const enoughTeleports = await msg.author.hasItem(itemID('Zul-andra teleport'), quantity);
+			if (enoughTeleports) {
+				lootToRemove.addItem(itemID('Zul-andra teleport'), quantity);
+				boosts.push('10% for Zul-andra Teleports');
 				duration = reduceNumByPercent(duration, 10);
-			};
-		};
+			}
+		}
 
 		duration = randomVariation(duration, 3);
 


### PR DESCRIPTION
### Description:

Added a opt-out 5% boost for using zul-andra teleports when killing Zulrah.
Will close issue https://github.com/oldschoolgg/oldschoolbot/issues/2550

### Changes:

Added a condition that if the player is killing Zulrah, and has enough teleports to cover all kills, they can use teleports to gain a 5% boost.
This consumes the teleports and is avoided by using --ntp flag (no-teleport).

### Other checks:

-   [x] I have tested all my changes thoroughly.
