### PR TITLE
Phosani Missing Requirement Clarity

### DIFF
--- a/src/commands/Minion/nightmare.ts
+++ b/src/commands/Minion/nightmare.ts
@@ -105,17 +105,16 @@ export default class extends BotCommand {
 			}
 
 			if (isPhosani) {
-				if (
-					!user.hasSkillReqs({
-						prayer: 70,
-						attack: 90,
-						strength: 90,
-						defence: 90,
-						magic: 90,
-						hitpoints: 90
-					})[0]
-				) {
-					throw `${user.username} doesn't have 70 Prayer`;
+				const requirements = user.hasSkillReqs({
+					prayer: 70,
+					attack: 90,
+					strength: 90,
+					defence: 90,
+					magic: 90,
+					hitpoints: 90
+				});
+				if (!requirements[0]) {
+					throw `${user.username} doesn't meet the requirements: ${requirements[1]}`;
 				}
 				if (user.getKC(NightmareMonster.id) < 50) {
 					throw "You need to have killed The Nightmare atleast 50 times before you can face the Phosani's Nightmare.";


### PR DESCRIPTION
Previously it always stated that the user didn't have 70 prayer even if it wasn't the 70 prayer req they were missing.

### Description:

This is a bug fix to change the missing skill requirement message for Phosani. 
Changed nightmare file to return all skill requirements for Phosani when one of the skill requirements aren't met.
Reported in Issue https://github.com/oldschoolgg/oldschoolbot/issues/3098

### Changes:

Changed fixed string response of "doesn't have 70 prayer" to "doesn't meet the requirements: " and return the skill requirements.

### Other checks:

-   [x] I have tested all my changes thoroughly.
