### PR TITLE
Reduce antidote requirement to antipoison for easier sea snakes

### DIFF
--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -1035,7 +1035,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		levelRequirements: {
 			slayer: 40
 		},
-		itemsRequired: resolveItems(['Antidote++(4)']),
+		itemsRequired: resolveItems(['Antipoison(4)']),
 		qpRequired: 57,
 		healAmountNeeded: 20,
 		attackStyleToUse: GearStat.AttackSlash,
@@ -1054,7 +1054,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		levelRequirements: {
 			slayer: 40
 		},
-		itemsRequired: resolveItems(['Antidote++(4)']),
+		itemsRequired: resolveItems(['Antipoison(4)']),
 		qpRequired: 57,
 		healAmountNeeded: 30,
 		attackStyleToUse: GearStat.AttackSlash,


### PR DESCRIPTION
Getting a antidote++ at the expected level to be getting vannaka tasks seems harsh. Addresses issue https://github.com/oldschoolgg/oldschoolbot/issues/3040

### Description:

Reduce the requirements for consumables on young and hatchling sea snakes. Vannaka is a low-level slayer master and can give these tasks out. Users getting tasks from Vannaka are unlikely to have the requirements to make antidote++(4), or money to buy.
### Changes:

Change antidote++(4) requirement to antipoison(4) for young and hatchling sea snakes.

### Other checks:

-   [x] I have tested all my changes thoroughly.
