### PR TITLE
Fix some BSO-specific inferno bugs

### DIFF
--- a/src/commands/Minion/inferno.ts
+++ b/src/commands/Minion/inferno.ts
@@ -438,7 +438,7 @@ AND (data->>'diedPreZuk')::boolean = false;`)
 		if (!isEmergedZuk) {
 			duration.add(
 				(rangeGear.hasEquipped('Armadyl chestplate') && rangeGear.hasEquipped('Armadyl chainskirt')) ||
-					(rangeGear.hasEquipped('Pernix body') && rangeGear.hasEquipped('Armadyl chaps')),
+					(rangeGear.hasEquipped('Pernix body') && rangeGear.hasEquipped('Pernix chaps')),
 				-3,
 				'Armadyl/Pernix'
 			);
@@ -589,8 +589,8 @@ AND (data->>'diedPreZuk')::boolean = false;`)
 
 		const usingTbow =
 			rangeGear.hasEquipped('Twisted bow', true, true) || rangeGear.hasEquipped('Hellfire bow', true, true);
-		zukDeathChance.add(usingTbow, 1.5, `Zuk with ${rangeGear.equippedWeapon()?.name}`);
-		duration.add(usingTbow, -7.5, `${rangeGear.equippedWeapon()?.name}`);
+		zukDeathChance.add(usingTbow, 1.5, `Zuk with ${usingTbow ? rangeGear.equippedWeapon()?.name : 'Twisted bow'}`);
+		duration.add(usingTbow, -7.5, `${usingTbow ? rangeGear.equippedWeapon()?.name : 'Twisted bow'}`);
 
 		/**
 		 * Emerged


### PR DESCRIPTION
### Description:

1. Currently the Twisted bow boost uses the equipped item name so it can show variants, however this leads to 'missing' boosts showing the equipped item (ie. Armadyle crossbow) instead of Twisted bow when you fail the check.
![image](https://user-images.githubusercontent.com/10122432/141736975-85088974-388a-45cd-a563-f1256e772308.png)
2. Fixed a typo where it checks for 'Armadyl chaps' instead of 'Pernix chaps'


### Changes:

1. Checks if the usingTbow variable is true,, and only then does it use the equipped item, otherwise it uses, 'Twisted bow'
2. Changed 'Armadyl chaps' to 'Pernix chaps'

### Other checks:

-   [ ] I have tested all my changes thoroughly. (Not tested)
