### PR TITLE
Add revert neitiznot faceguard to slayer creatables

### DIFF
--- a/src/lib/data/creatables/slayer.ts
+++ b/src/lib/data/creatables/slayer.ts
@@ -59,6 +59,15 @@ export const slayerCreatables: Createable[] = [
 		GPCost: 0
 	},
 	{
+		name: 'Revert neitiznot faceguard',
+		inputItems: resolveNameBank({ 'Neitiznot faceguard': 1 }),
+		outputItems: resolveNameBank({ 
+			'Basilisk jaw': 1,
+			'Helm of neitiznot': 1 
+		}),
+		GPCost: 0
+	},
+	{
 		name: 'Arclight',
 		inputItems: resolveNameBank({
 			Darklight: 1,

--- a/src/lib/data/creatables/slayer.ts
+++ b/src/lib/data/creatables/slayer.ts
@@ -61,9 +61,9 @@ export const slayerCreatables: Createable[] = [
 	{
 		name: 'Revert neitiznot faceguard',
 		inputItems: resolveNameBank({ 'Neitiznot faceguard': 1 }),
-		outputItems: resolveNameBank({ 
+		outputItems: resolveNameBank({
 			'Basilisk jaw': 1,
-			'Helm of neitiznot': 1 
+			'Helm of neitiznot': 1
 		}),
 		GPCost: 0
 	},


### PR DESCRIPTION
Addresses issue https://github.com/oldschoolgg/oldschoolbot/issues/2149

### Description:

Added "Revert neitiznot faceguard" recipe to slayer createables, it is free to do at any time in OSRS with no penalty.

### Changes:

Added "Revert neitiznot faceguard" definition to slayer createables

### Other checks:

-   [x] I have tested all my changes thoroughly.
