### PR TITLE
Change order of diaries

### DIFF
--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -1094,8 +1094,8 @@ export const diariesObject = {
 	KourendKebosDiary,
 	LumbridgeDraynorDiary,
 	MorytaniaDiary,
+	VarrockDiary,
 	WesternProv,
-	WildernessDiary,
-	VarrockDiary
+	WildernessDiary
 } as const;
 export const diaries = Object.values(diariesObject);


### PR DESCRIPTION
Issue: https://github.com/oldschoolgg/oldschoolbot/issues/3164

### Description:

Change the order of achievement diaries to alphabetical

### Changes:

Moved VarrockDiary to between LumbridgeDraynor and WesterProv diaries

### Other checks:

-   [x] I have tested all my changes thoroughly.
