### PR TITLE
Add ring of suffering (ri) variation as similar to (i)

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -315,7 +315,8 @@ const source: [string, (string | number)[]][] = [
 	['Twisted bow', ['Hellfire bow']],
 	['Gorajan archer helmet', ['Infernal slayer helmet(i)']],
 	['Gorajan occult helmet', ['Infernal slayer helmet(i)']],
-	['Gorajan warrior helmet', ['Infernal slayer helmet(i)']]
+	['Gorajan warrior helmet', ['Infernal slayer helmet(i)']],
+	['Ring of suffering (i)', ['Ring of suffering (ri)']]
 ];
 
 for (const { baseItem, dyedVersions } of dyedItems) {


### PR DESCRIPTION
Issue: https://github.com/oldschoolgg/oldschoolbot/issues/3161

Description:

Added new similar items entry to allow for ring of suffering (ri) to be used in place of ring of suffering(i)

Changes:

Added ring of suffering (i) similar item

Other checks:

[x]    I have tested all my changes thoroughly.
