### PR TITLE
Changed phoenix rate in +pet simulator

### DIFF
--- a/src/lib/data/pets.ts
+++ b/src/lib/data/pets.ts
@@ -301,7 +301,7 @@ const pets: Pet[] = [
 	{
 		id: 24,
 		emoji: '<:Phoenix:324127378223792129>',
-		chance: 5000,
+		chance: 2500,
 		name: 'Phoenix',
 		type: 'SPECIAL',
 		altNames: ['PHOENIX', 'PHEONIX', 'WINTERTODT', 'FM'],

--- a/src/lib/data/pets.ts
+++ b/src/lib/data/pets.ts
@@ -306,7 +306,7 @@ const pets: Pet[] = [
 		type: 'SPECIAL',
 		altNames: ['PHOENIX', 'PHEONIX', 'WINTERTODT', 'FM'],
 		formatFinish: (num: number) =>
-			`You had to open ${fm(num)} Wintertodt Supply Crates to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
+			`You had to open ${fm(num)} Wintertodt Supply Crates with 2 rolls each to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
 		bossKeys: ['wintertodt']
 	},
 	{

--- a/src/lib/data/pets.ts
+++ b/src/lib/data/pets.ts
@@ -306,7 +306,7 @@ const pets: Pet[] = [
 		type: 'SPECIAL',
 		altNames: ['PHOENIX', 'PHEONIX', 'WINTERTODT', 'FM'],
 		formatFinish: (num: number) =>
-			`You had to open ${fm(num)} Wintertodt Supply Crates with 2 rolls each to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
+			`You had to open ${fm(num)} Wintertodt Supply Crates with two rolls each to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
 		bossKeys: ['wintertodt']
 	},
 	{


### PR DESCRIPTION
### Description:

Old rate was 1/5k, which is inaccurate as you get 2 rolls minimum per crate. Making the pet at least 1/2.5k.

### Changes:

- Phoenix rate in pet.ts is 1/2.5k
- Updated the bot text to reflect it does 2 pet rolls per kc
### Other checks:

-   [ ] I have tested all my changes thoroughly.
This does NOT have anything to do with minions. Just the fun commands.
