### PR TITLE
Added the ability to cape gamble for Jal-MejJak 

### DIFF
--- a/src/commands/Minion/capegamble.ts
+++ b/src/commands/Minion/capegamble.ts
@@ -19,7 +19,7 @@ export default class extends BotCommand {
 			usage: '[fire|infernal|skin]',
 			description: 'Allows you to gamble fire capes for a chance at the jad pet.'
 		});
-	}	
+	}
 
 	async run(msg: KlasaMessage, [type]: ['fire' | 'infernal' | 'skin' | undefined]) {
 		const firesGambled = msg.author.settings.get(UserSettings.Stats.FireCapesSacrificed);

--- a/src/commands/Minion/capegamble.ts
+++ b/src/commands/Minion/capegamble.ts
@@ -15,40 +15,42 @@ export default class extends BotCommand {
 			altProtection: true,
 			oneAtTime: true,
 			categoryFlags: ['minion'],
-			examples: ['+capegamble infernal', '+capegamble infernal'],
-			usage: '[fire|infernal]',
+			examples: ['+capegamble infernal', '+capegamble infernal', '+capegamble skin'],
+			usage: '[fire|infernal|skin]',
 			description: 'Allows you to gamble fire capes for a chance at the jad pet.'
 		});
 	}
-
-	async run(msg: KlasaMessage, [type]: ['fire' | 'infernal' | undefined]) {
+	
+	async run(msg: KlasaMessage, [type]: ['fire' | 'infernal' | 'skin' | undefined]) {
 		const firesGambled = msg.author.settings.get(UserSettings.Stats.FireCapesSacrificed);
 		const infernalsGambled = msg.author.settings.get(UserSettings.Stats.InfernalCapesSacrificed);
+		const skinsGambled = msg.author.settings.get(UserSettings.Stats.SkinsSacrificed);
 		if (!type) {
 			return msg.channel
-				.send(`You can gamble Fire capes and Infernal capes like this: \`${msg.cmdPrefix}capegamble fire/infernal\`
-
-**Fire Cape's Sacrificed:** ${firesGambled}
-**Infernal Cape's Gambled:** ${infernalsGambled}`);
+				.send(`You can gamble Fire capes and Infernal capes, and Zuk skins like this: \`${msg.cmdPrefix}capegamble fire/infernal/skin\`
+				
+**Fire Cape's Gambled:** ${firesGambled}
+**Infernal Cape's Gambled:** ${infernalsGambled}
+**Skins Gambled:** ${skinsGambled}`);
 		}
-
-		const item = getOSItem(type === 'fire' ? 'Fire cape' : 'Infernal cape');
+		
+		const item = getOSItem(type === 'fire' ? 'Fire cape' : 'Infernal cape' : "TzKal-Zuk's skin");
 		const key =
-			type === 'fire' ? UserSettings.Stats.FireCapesSacrificed : UserSettings.Stats.InfernalCapesSacrificed;
-
+			type === 'fire' ? UserSettings.Stats.FireCapesSacrificed : UserSettings.Stats.InfernalCapesSacrificed : UserSettings.Stats.SkinsSacrificed;
+		
 		const capesOwned = await msg.author.bank().amount(item.id);
-
+		
 		if (capesOwned < 1) return msg.channel.send(`You have no ${item.name}'s' to gamble!`);
-
+		
 		await msg.confirm(`Are you sure you want to gamble a ${item.name}?`);
-
+		
 		const newSacrificedCount = msg.author.settings.get(key) + 1;
 		await msg.author.removeItemsFromBank(new Bank().add(item.id));
 		await msg.author.settings.update(key, newSacrificedCount);
-
-		const chance = type === 'fire' ? 200 : 100;
-		const pet = getOSItem(type === 'fire' ? 'Tzrek-Jad' : 'Jal-nib-rek');
-
+		
+		const chance = type === 'fire' ? 200 : 100 : 175;
+		const pet = getOSItem(type === 'fire' ? 'Tzrek-Jad' : 'Jal-nib-rek' : 'Jal-MejJak');
+		
 		if (roll(chance)) {
 			await msg.author.addItemsToBank(new Bank().add(pet.id), true);
 			this.client.emit(
@@ -64,12 +66,12 @@ export default class extends BotCommand {
 							type === 'fire'
 								? 'You lucky. Better train him good else TzTok-Jad find you, JalYt.'
 								: 'Luck be a TzHaar tonight. Jal-Nib-Rek is yours.',
+								: 'JalYt luck shines today, Jal-MejJak heal you good.',
 						head: type === 'fire' ? 'mejJal' : 'ketKeh'
 					})
 				]
 			});
 		}
-
 		return msg.channel.send({
 			files: [
 				await chatHeadImage({
@@ -79,6 +81,9 @@ export default class extends BotCommand {
 									newSacrificedCount
 							  )} time you gamble cape.`
 							: `No Jal-Nib-Rek for you. This is the ${formatOrdinal(
+									newSacrificedCount
+							  )} time you gamble cape.`,
+							: `Jal-MejJak did not join you. This is the ${formatOrdinal(
 									newSacrificedCount
 							  )} time you gamble cape.`,
 					head: type === 'fire' ? 'mejJal' : 'ketKeh'

--- a/src/commands/Minion/capegamble.ts
+++ b/src/commands/Minion/capegamble.ts
@@ -19,8 +19,8 @@ export default class extends BotCommand {
 			usage: '[fire|infernal|skin]',
 			description: 'Allows you to gamble fire capes for a chance at the jad pet.'
 		});
-	}
-	
+	}	
+
 	async run(msg: KlasaMessage, [type]: ['fire' | 'infernal' | 'skin' | undefined]) {
 		const firesGambled = msg.author.settings.get(UserSettings.Stats.FireCapesSacrificed);
 		const infernalsGambled = msg.author.settings.get(UserSettings.Stats.InfernalCapesSacrificed);
@@ -28,29 +28,29 @@ export default class extends BotCommand {
 		if (!type) {
 			return msg.channel
 				.send(`You can gamble Fire capes and Infernal capes, and Zuk skins like this: \`${msg.cmdPrefix}capegamble fire/infernal/skin\`
-				
+
 **Fire Cape's Gambled:** ${firesGambled}
 **Infernal Cape's Gambled:** ${infernalsGambled}
 **Skins Gambled:** ${skinsGambled}`);
 		}
-		
+
 		const item = getOSItem(type === 'fire' ? 'Fire cape' : 'Infernal cape' : "TzKal-Zuk's skin");
 		const key =
 			type === 'fire' ? UserSettings.Stats.FireCapesSacrificed : UserSettings.Stats.InfernalCapesSacrificed : UserSettings.Stats.SkinsSacrificed;
-		
+
 		const capesOwned = await msg.author.bank().amount(item.id);
-		
+
 		if (capesOwned < 1) return msg.channel.send(`You have no ${item.name}'s' to gamble!`);
-		
+
 		await msg.confirm(`Are you sure you want to gamble a ${item.name}?`);
-		
+
 		const newSacrificedCount = msg.author.settings.get(key) + 1;
 		await msg.author.removeItemsFromBank(new Bank().add(item.id));
 		await msg.author.settings.update(key, newSacrificedCount);
-		
+
 		const chance = type === 'fire' ? 200 : 100 : 175;
 		const pet = getOSItem(type === 'fire' ? 'Tzrek-Jad' : 'Jal-nib-rek' : 'Jal-MejJak');
-		
+
 		if (roll(chance)) {
 			await msg.author.addItemsToBank(new Bank().add(pet.id), true);
 			this.client.emit(


### PR DESCRIPTION
### Description:

Added the ability to cape gamble for Jal-MejJak from emerged inferno

### Changes:
-1/175 pet chance from skin gambles 
-=capegambles shows # of skin gambles
-2 Chatbox messages for either winning or losing the gamble


### Other checks:

-   [ ] I have tested all my changes thoroughly.
