### PR TITLE
Add pineapple buyable

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -706,7 +706,7 @@ const Buyables: Buyable[] = [
 	},
 	{
 		name: 'Pineapple',
-		gpCost: 5
+		gpCost: 500
 	},
 
 	...sepulchreBuyables,

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -704,6 +704,10 @@ const Buyables: Buyable[] = [
 		name: 'Sandworms',
 		gpCost: 500
 	},
+	{
+		name: 'Pineapple',
+		gpCost: 5
+	},
 
 	...sepulchreBuyables,
 	...constructionBuyables,

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -706,7 +706,8 @@ const Buyables: Buyable[] = [
 	},
 	{
 		name: 'Pineapple',
-		gpCost: 500
+		gpCost: 1350,
+		ironmanPrice: 5
 	},
 
 	...sepulchreBuyables,


### PR DESCRIPTION
Issue: https://github.com/oldschoolgg/oldschoolbot/issues/2686

### Description:

Add pineapple to the buyables list as it is purchasable at the Charter Ships in game.

### Changes:

Add pineapple buyable to buyable list, costing 5 gp like in game.

### Other checks:

-   [x] I have tested all my changes thoroughly.
