### PR TITLE
Bso mysterious ore

### DIFF
--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -166,7 +166,7 @@ const ores: Ore[] = [
 	},
 	{
 		level: 120,
-		xp: 3_000,
+		xp: 3000,
 		id: 508,
 		name: 'Mysterious ore',
 		respawnTime: 90,

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -19,7 +19,8 @@ const ores: Ore[] = [
 		xp: 5,
 		id: 1436,
 		name: 'Rune essence',
-		respawnTime: 0.5
+		respawnTime: 0.5,
+		loot: new LootTable().add('Rune essence', 1, 100)
 	},
 	{
 		level: 1,
@@ -28,7 +29,8 @@ const ores: Ore[] = [
 		name: 'Copper ore',
 		respawnTime: 0.5,
 		petChance: 750_000,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		loot: new LootTable().add('Copper ore', 1, 100)
 	},
 	{
 		level: 1,
@@ -37,14 +39,16 @@ const ores: Ore[] = [
 		name: 'Tin ore',
 		respawnTime: 0.5,
 		petChance: 750_000,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		loot: new LootTable().add('Tin ore', 1, 100)
 	},
 	{
 		level: 1,
 		xp: 0,
 		id: 13_421,
 		name: 'Saltpetre',
-		respawnTime: 1
+		respawnTime: 1,
+		loot: new LootTable().add('Saltpetre', 1, 100)
 	},
 	{
 		level: 15,
@@ -54,7 +58,8 @@ const ores: Ore[] = [
 		respawnTime: -0.2,
 		petChance: 750_000,
 		minerals: 100,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		loot: new LootTable().add('Iron ore', 1, 100)
 	},
 	{
 		level: 20,
@@ -63,7 +68,8 @@ const ores: Ore[] = [
 		name: 'Silver ore',
 		respawnTime: 3,
 		petChance: 750_000,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		loot: new LootTable().add('Silver ore', 1, 100)
 	},
 	{
 		level: 22,
@@ -71,14 +77,16 @@ const ores: Ore[] = [
 		id: 21_622,
 		name: 'Volcanic ash',
 		respawnTime: 1.9,
-		petChance: 741_600
+		petChance: 741_600,
+		loot: new LootTable().add('Volcanic ash', 1, 100)
 	},
 	{
 		level: 30,
 		xp: 5,
 		id: 7936,
 		name: 'Pure essence',
-		respawnTime: 0.5
+		respawnTime: 0.5,
+		loot: new LootTable().add('Pure essence', 1, 100)
 	},
 	{
 		level: 30,
@@ -88,7 +96,8 @@ const ores: Ore[] = [
 		respawnTime: 2,
 		petChance: 300_000,
 		minerals: 60,
-		clueScrollChance: 296_640
+		clueScrollChance: 296_640,
+		loot: new LootTable().add('Coal', 1, 100)
 	},
 	{
 		level: 40,
@@ -98,7 +107,8 @@ const ores: Ore[] = [
 		respawnTime: 4,
 		petChance: 300_000,
 		nuggets: true,
-		clueScrollChance: 296_640
+		clueScrollChance: 296_640,
+		loot: new LootTable().add('Gold ore', 1, 100)
 	},
 	{
 		level: 40,
@@ -107,7 +117,8 @@ const ores: Ore[] = [
 		name: 'Gem rock',
 		respawnTime: 6,
 		petChance: 211_886,
-		clueScrollChance: 211_886
+		clueScrollChance: 211_886,
+		loot: GemRockTable
 	},
 	{
 		level: 55,
@@ -117,7 +128,8 @@ const ores: Ore[] = [
 		respawnTime: 10,
 		petChance: 150_000,
 		nuggets: true,
-		clueScrollChance: 148_320
+		clueScrollChance: 148_320,
+		loot: new LootTable().add('Mithril ore', 1, 100)
 	},
 	{
 		level: 70,
@@ -127,7 +139,8 @@ const ores: Ore[] = [
 		respawnTime: 18,
 		petChance: 60_000,
 		nuggets: true,
-		clueScrollChance: 59_328
+		clueScrollChance: 59_328,
+		loot: new LootTable().add('Adamantite ore', 1, 100)
 	},
 	{
 		level: 85,
@@ -137,7 +150,8 @@ const ores: Ore[] = [
 		respawnTime: 50,
 		petChance: 45_000,
 		nuggets: true,
-		clueScrollChance: 42_377
+		clueScrollChance: 42_377,
+		loot: new LootTable().add('Runite ore', 1, 100)
 	},
 	{
 		level: 92,
@@ -147,7 +161,8 @@ const ores: Ore[] = [
 		respawnTime: 40,
 		petChance: 50_000,
 		minerals: 20,
-		clueScrollChance: 46_350
+		clueScrollChance: 46_350,
+		loot: new LootTable().add('Amethyst', 1, 100)
 	}
 ];
 

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -163,6 +163,29 @@ const ores: Ore[] = [
 		minerals: 20,
 		clueScrollChance: 46_350,
 		loot: new LootTable().add('Amethyst', 1, 100)
+	},
+	{
+		level: 120,
+		xp: 3_000,
+		id: 508,
+		name: 'Mysterious ore',
+		respawnTime: 90,
+		petChance: 40_000,
+		loot: new LootTable()
+			// Common
+			.add('Coal', [250, 750], 46)
+			.add('Amethyst', [50, 150], 46)
+			.add('Gold ore', [250, 750], 46)
+			.add('Golden nugget', [1, 50], 46)
+			.add('Pure essence', [1000, 5000], 46)
+			.add('Runite ore', [20, 50], 46)
+			// Uncommon - 1/50 (6/300)
+			.add('Runite ore', [50, 120], 6)
+			.add('Tradeable mystery box', 1, 6)
+			.add('Clue scroll (master)', 2, 6)
+			// Rare
+			.add('Clue scroll (grandmaster)', 1, 2) // 1/150 (2/300)
+			.add('Onyx', 1, 3) // 1/100 (3/300)
 	}
 ];
 

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -43,6 +43,7 @@ export interface Ore {
 	nuggets?: boolean;
 	minerals?: number;
 	clueScrollChance?: number;
+	loot: LootTable;
 }
 
 export interface Log {

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -111,12 +111,24 @@ export default class extends Task {
 		}
 
 		// Mysterious Ore, 500m boost
-		if (
-			ore.id === 508 &&
-			user.hasItemEquippedAnywhere('Mining master cape') &&
-			user.settings.get(UserSettings.Skills.Mining) >= 500_000_000
-		) {
-			ore.loot.add('Dwarven ore', 1, 1);
+		if ( ore.id === 508 ) {
+			if (
+				user.hasItemEquippedAnywhere('Mining master cape') &&
+				user.settings.get(UserSettings.Skills.Mining) >= 500_000_000
+			) {
+				ore.loot.add('Dwarven ore', 1, 1);
+			} else {
+				str += "\nMissed out on Dwarven ore chances due to ";
+				if ( !user.hasItemEquippedAnywhere('Mining master cape') ) {
+					str += "no Mining master cape";
+				};
+				if ( user.settings.get(UserSettings.Skills.Mining) < 500_000_000 ) {
+					if ( !user.hasItemEquippedAnywhere('Mining master cape') ) {
+						str += " and ";
+					};
+					str += "<500m mining XP";
+				}
+			}
 		}
 
 		if (ore.id === 21_622) {

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -109,12 +109,7 @@ export default class extends Task {
 			}
 		}
 
-		// Gem rocks roll off the GemRockTable
-		if (ore.id === 1625) {
-			for (let i = 0; i < quantity; i++) {
-				loot.add(Mining.GemRockTable.roll());
-			}
-		} else if (ore.id === 21_622) {
+		if (ore.id === 21_622) {
 			// Volcanic ash
 			const userLevel = user.skillLevel(SkillsEnum.Mining);
 			const tiers = [
@@ -132,7 +127,9 @@ export default class extends Task {
 				}
 			}
 		} else {
-			loot.add(ore.id, quantity);
+			for (let i = 0; i < quantity; i++) {
+				loot.add(ore.loot.roll());
+			}
 		}
 
 		const hasKlik = user.equippedPet() === itemID('Klik');

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -111,22 +111,22 @@ export default class extends Task {
 		}
 
 		// Mysterious Ore, 500m boost
-		if ( ore.id === 508 ) {
+		if (ore.id === 508) {
 			if (
 				user.hasItemEquippedAnywhere('Mining master cape') &&
 				user.settings.get(UserSettings.Skills.Mining) >= 500_000_000
 			) {
 				ore.loot.add('Dwarven ore', 1, 1);
 			} else {
-				str += "\nMissed out on Dwarven ore chances due to ";
-				if ( !user.hasItemEquippedAnywhere('Mining master cape') ) {
-					str += "no Mining master cape";
-				};
-				if ( user.settings.get(UserSettings.Skills.Mining) < 500_000_000 ) {
-					if ( !user.hasItemEquippedAnywhere('Mining master cape') ) {
-						str += " and ";
-					};
-					str += "<500m mining XP";
+				str += '\nMissed out on Dwarven ore chances due to ';
+				if (!user.hasItemEquippedAnywhere('Mining master cape')) {
+					str += 'no Mining master cape';
+				}
+				if (user.settings.get(UserSettings.Skills.Mining) < 500_000_000) {
+					if (!user.hasItemEquippedAnywhere('Mining master cape')) {
+						str += ' and ';
+					}
+					str += '<500m mining XP';
 				}
 			}
 		}

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -5,6 +5,7 @@ import { Bank } from 'oldschooljs';
 import { Emoji, Events, MIN_LENGTH_FOR_PET } from '../../lib/constants';
 import { getRandomMysteryBox } from '../../lib/data/openables';
 import addSkillingClueToLoot from '../../lib/minions/functions/addSkillingClueToLoot';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Mining from '../../lib/skilling/skills/mining';
 import Smithing from '../../lib/skilling/skills/smithing';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -107,6 +108,15 @@ export default class extends Task {
 					break;
 				}
 			}
+		}
+
+		// Mysterious Ore, 500m boost
+		if (
+			ore.id === 508 &&
+			user.hasItemEquippedAnywhere('Mining master cape') &&
+			user.settings.get(UserSettings.Skills.Mining) >= 500_000_000
+		) {
+			ore.loot.add('Dwarven ore', 1, 1);
 		}
 
 		if (ore.id === 21_622) {


### PR DESCRIPTION
Response to https://github.com/oldschoolgg/oldschoolbot/issues/2572

Requires changes found in https://github.com/oldschoolgg/oldschoolbot/pull/3179

### Description:

Added new 120 mining requirement ore which act like geodes, where the ore itself contains many of another mineral or reward.

### Changes:

mining.ts:
Added level 120 Mysterious Ore
Better pet chance than Runite Ore, no clue scroll chance as it has them in rewards.
XP rates are ~550k per hour. Ore per hour is ~30.

miningActivity.ts
Added condition for if the user has 500m+ mining xp and a master mining cape equipped then there is a 1/300 chance to get a Dwarven Ore per roll.
As part of the above, added a return statement to let the user know if they missed out on this chance.

### Other checks:

-   [x] I have tested all my changes thoroughly.
