### PR TITLE
Add way to revert Ignecarus claw into 100 Igne scales

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -403,7 +403,7 @@ const Reverteables: Createable[] = [
 	{
 		name: 'Revert Ignecarus dragonclaw',
 		outputItems: resolveNameBank({
-			'Ignecarus scales': 100,
+			'Ignecarus scales': 100
 		}),
 		inputItems: resolveNameBank({
 			'Ignecarus dragonclaw': 1

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -401,6 +401,16 @@ const Reverteables: Createable[] = [
 		noCl: true
 	},
 	{
+		name: 'Revert Ignecarus dragonclaw',
+		outputItems: resolveNameBank({
+			'Ignecarus scales': 100,
+		}),
+		inputItems: resolveNameBank({
+			'Ignecarus dragonclaw': 1
+		}),
+		noCl: true
+	},
+	{
 		name: 'Revert red decorative full helm',
 		inputItems: {
 			[itemID('Red decorative full helm')]: 1


### PR DESCRIPTION
### Description:

Per BSO-vote, added a Ignecarus dragonclaw to `revertables`, allowing players to revert it into 100 Ignecarus scales - The equivalent of 500 hellfire arrows. This number can be adjusted, of course.

Furthermore, it gives a consistent value to the claw as it will be tied to hellfire arrow prices. 

### Changes:

- Added Ignecarus dragonclaw to Revertables. Breaks down to 100 scales.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
Below are images of the poll results, showing clear demand for this addition. (Note: 2nd image was due to me forgetting you add scales to arrows directly, so 500 being winner = 100 scales)
![image](https://user-images.githubusercontent.com/63373565/142781963-4c84d240-7410-4b93-9960-7c31fc2c4251.png)
![image](https://user-images.githubusercontent.com/63373565/142781970-09c9ade8-21df-4162-9bca-32f4aa8e7d4c.png)
