### PR TITLE
BSO - Fixed output crop plants yield fix

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -318,13 +318,9 @@ export default class extends Task {
 					harvestXp = 0;
 				} else if (plantToHarvest.givesCrops && chopped) {
 					if (!plantToHarvest.outputCrop) return;
-					// cropYield already counts each patch if variableYield is true:
-					loot[plantToHarvest.outputCrop] =
-						plantToHarvest.fixedOutput && plantToHarvest.fixedOutputAmount
-							? plantToHarvest.fixedOutputAmount * alivePlants
-							: cropYield;
-
-					harvestXp = cropYield * alivePlants * plantToHarvest.harvestXp;
+					
+					loot[plantToHarvest.outputCrop] = cropYield;
+					harvestXp = cropYield * plantToHarvest.harvestXp;
 				}
 			}
 

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -318,7 +318,7 @@ export default class extends Task {
 					harvestXp = 0;
 				} else if (plantToHarvest.givesCrops && chopped) {
 					if (!plantToHarvest.outputCrop) return;
-					
+
 					loot[plantToHarvest.outputCrop] = cropYield;
 					harvestXp = cropYield * plantToHarvest.harvestXp;
 				}

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -243,7 +243,7 @@ export default class extends Task {
 					);
 				} else if (plantToHarvest.fixedOutput) {
 					if (!plantToHarvest.fixedOutputAmount) return;
-					cropYield = plantToHarvest.fixedOutputAmount;
+					cropYield = plantToHarvest.fixedOutputAmount * alivePlants;
 				} else {
 					const plantChanceFactor =
 						Math.floor(


### PR DESCRIPTION
closes #2967 

### Description:

If a plant has a fixed crop yield (and doesn't require chopping) it will only return the yield of one plant, not the total for each alive plant.

This bug is also present in OSB but the only affected plants (Mushroom and Calquat Tree) only have 1 patch to farm anyway so multiplication isn't an issue. Should probably be fixed too though.

### Changes:

Multiply the fixedOutputAmount by the number of alivePlants

### Other checks:

-   [x] I have tested all my changes thoroughly.
