### PR TITLE
Fix BSO task extensions

### DIFF
--- a/src/commands/Minion/slayertask.ts
+++ b/src/commands/Minion/slayertask.ts
@@ -1,5 +1,5 @@
 import { MessageButton } from 'discord.js';
-import { randInt, Time } from 'e';
+import { Time } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Monsters } from 'oldschooljs';
 
@@ -9,7 +9,6 @@ import { prisma } from '../../lib/settings/prisma';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { slayerMasters } from '../../lib/slayer/slayerMasters';
-import { SlayerRewardsShop } from '../../lib/slayer/slayerUnlocks';
 import {
 	assignNewSlayerTask,
 	calcMaxBlockedTasks,
@@ -378,25 +377,6 @@ Your current streak is ${msg.author.settings.get(UserSettings.Slayer.TaskStreak)
 		}
 
 		const newSlayerTask = await assignNewSlayerTask(msg.author, slayerMaster);
-		const myUnlocks = (await msg.author.settings.get(UserSettings.Slayer.SlayerUnlocks)) ?? undefined;
-		const extendReward = SlayerRewardsShop.find(
-			srs => srs.extendID && srs.extendID.includes(newSlayerTask.currentTask.monster_id)
-		);
-		if (extendReward && myUnlocks.includes(extendReward.id)) {
-			const quantity = newSlayerTask.assignedTask.extendedAmount
-				? randInt(newSlayerTask.assignedTask.extendedAmount[0], newSlayerTask.assignedTask.extendedAmount[1])
-				: Math.ceil(newSlayerTask.currentTask.quantity * extendReward.extendMult!);
-			newSlayerTask.currentTask.quantity = quantity;
-			await prisma.slayerTask.update({
-				where: {
-					id: newSlayerTask.currentTask.id
-				},
-				data: {
-					quantity: newSlayerTask.currentTask.quantity,
-					quantity_remaining: newSlayerTask.currentTask.quantity
-				}
-			});
-		}
 
 		let commonName = getCommonTaskName(newSlayerTask.assignedTask!.monster);
 		if (commonName === 'TzHaar') {

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -185,6 +185,13 @@ export async function assignNewSlayerTask(_user: KlasaUser, master: SlayerMaster
 
 	let quantity = randInt(assignedTask!.amount[0], assignedTask!.amount[1]);
 
+	const extendReward = SlayerRewardsShop.find(srs => srs.extendID && srs.extendID.includes(assignedTask!.monster.id));
+	if (extendReward && unlocks.includes(extendReward.id)) {
+		quantity = assignedTask.extendedAmount
+			? randInt(assignedTask.extendedAmount[0], assignedTask.extendedAmount[1])
+			: Math.ceil(quantity * extendReward.extendMult!);
+	}
+
 	let messages: string[] = [];
 	if (unlocks.includes(SlayerTaskUnlocksEnum.SizeMatters)) {
 		quantity *= 2;


### PR DESCRIPTION
### Description:
Fix issue with differences between BSO + OSB Slayer task extension handling.

### Changes:
Moved the 'unlocked' task extensiosn to the assignNewTask function to mirror the way BSO was previously working, and implemented the same update as earlier from OSB to BSOI


### Other checks:

-   [x] I have tested all my changes thoroughly.
