### PR TITLE
Stop penalizing patrons with fewer Marks of grace per hour.

### DIFF
--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -32,7 +32,7 @@ export default class extends Task {
 		// Calculate marks of grace
 		let totalMarks = 0;
 		const timePerLap = course.lapTime * Time.Second;
-		const maxQuantity = Math.floor(user.maxTripLength('Agility') / timePerLap);
+		const maxQuantity = Math.floor((Time.Minute * 30) / timePerLap);
 		if (course.marksPer60) {
 			for (let i = 0; i < Math.floor(course.marksPer60 * (quantity / maxQuantity)); i++) {
 				if (roll(2)) {


### PR DESCRIPTION
### Description:

Currently Marks of grace per hour are determined by the ratio of Laps quantity divided by the max possible Laps determined by `maxTripLength()`. This means Patrons (or zak users on BSO) are at a disadvantage because their trip length is 40 minutes for example, but they get the same amount of marks as someone doing 30 minutes trips if they're not a patron.

This changes the algorithm to use a constant of 30 minutes instead of `user.maxTripLength()`.

### Changes:
**This works out to the following change in rates:**
Patron Status: (0 means no Patron)
0 - No change
1 - 10% increase
2 - 20% increase
3 - 33% increase

**IMPORTANT**!  This means the Marks per hour will be the SAME regardless of Patron status. Previously Patrons got fewer marks per hour, so the increase above just brings Patrons to be on par with non-patrons.

### Other checks:

-   [x] I have tested all my changes thoroughly.
