### PR TITLE
Fix Tame boost message to show item name

### DIFF
--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -756,7 +756,7 @@ export default class extends BotCommand {
 		for (const item of resolveItems(['Voidling', 'Ring of endurance'])) {
 			if (tameHasBeenFed(selectedTame, item)) {
 				speed = reduceNumByPercent(speed, 10);
-				boosts.push(`10% for ${item}`);
+				boosts.push(`10% for ${itemNameFromID(item)}`);
 			}
 		}
 


### PR DESCRIPTION
### Description:
After Prisma merge, Monkey tame boost shows 'x% from 12345' instead of the item name.

### Changes:

Convert item ID to name with `itemNameFromID`

### Other checks:

-   [ ] I have tested all my changes thoroughly. Not tested
