### PR TITLE
[Prisma update bug] Fix `+gearpresets update`

### DIFF
--- a/src/commands/Minion/gearpresets.ts
+++ b/src/commands/Minion/gearpresets.ts
@@ -190,6 +190,16 @@ export default class extends BotCommand {
 
 		let gearSetup = msg.author.rawGear()[setup];
 
+		if (update) {
+			await prisma.gearPreset.delete({
+				where: {
+					user_id_name: {
+						user_id: msg.author.id,
+						name
+					}
+				}
+			});
+		}
 		const preset = await prisma.gearPreset.create({
 			data: {
 				head: gearSetup.head?.item ?? null,

--- a/src/commands/Minion/gearpresets.ts
+++ b/src/commands/Minion/gearpresets.ts
@@ -190,31 +190,32 @@ export default class extends BotCommand {
 
 		let gearSetup = msg.author.rawGear()[setup];
 
-		if (update) {
-			await prisma.gearPreset.delete({
-				where: {
-					user_id_name: {
-						user_id: msg.author.id,
-						name
-					}
+		const gearData = {
+			head: gearSetup.head?.item ?? null,
+			neck: gearSetup.neck?.item ?? null,
+			body: gearSetup.body?.item ?? null,
+			legs: gearSetup.legs?.item ?? null,
+			cape: gearSetup.cape?.item ?? null,
+			two_handed: gearSetup['2h']?.item ?? null,
+			hands: gearSetup.hands?.item ?? null,
+			feet: gearSetup.feet?.item ?? null,
+			shield: gearSetup.shield?.item ?? null,
+			weapon: gearSetup.weapon?.item ?? null,
+			ring: gearSetup.ring?.item ?? null,
+			ammo: gearSetup.ammo?.item ?? null,
+			ammo_qty: gearSetup.ammo?.quantity ?? null
+		};
+
+		const preset = await prisma.gearPreset.upsert({
+			where: {
+				user_id_name: {
+					user_id: msg.author.id,
+					name
 				}
-			});
-		}
-		const preset = await prisma.gearPreset.create({
-			data: {
-				head: gearSetup.head?.item ?? null,
-				neck: gearSetup.neck?.item ?? null,
-				body: gearSetup.body?.item ?? null,
-				legs: gearSetup.legs?.item ?? null,
-				cape: gearSetup.cape?.item ?? null,
-				two_handed: gearSetup['2h']?.item ?? null,
-				hands: gearSetup.hands?.item ?? null,
-				feet: gearSetup.feet?.item ?? null,
-				shield: gearSetup.shield?.item ?? null,
-				weapon: gearSetup.weapon?.item ?? null,
-				ring: gearSetup.ring?.item ?? null,
-				ammo: gearSetup.ammo?.item ?? null,
-				ammo_qty: gearSetup.ammo?.quantity ?? null,
+			},
+			update: gearData,
+			create: {
+				...gearData,
 				name,
 				user_id: msg.author.id
 			}


### PR DESCRIPTION
### Description:
Running `=gearpresets update coxmelee melee` returns 'An error has occured'

### Changes:
Changed the gearpresets script to first delete the existing row before creating the new one.


### Other checks:

-   [x] I have tested all my changes thoroughly.
