### PR TITLE
Fix continue autofarm trip

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -458,7 +458,7 @@ export default class extends Task {
 				autoFarmed
 					? res => {
 							user.log('continued trip of autofarming');
-							return this.client.commands.get('autofarm')!.run(res, []);
+							return this.client.commands.get('m')!.run(res, ['autofarm']);
 					  }
 					: undefined,
 				janeMessage


### PR DESCRIPTION
### Description:

This fixes `press y to continue` for autofarming.

### Changes:

Change called command from 'autofarm' to 'm autofarm'

### Other checks:

-   [x] I have tested all my changes thoroughly.
