### PR TITLE
Fix schema error preventing new users

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -346,7 +346,7 @@ model User {
   farmingPatches_flower      Json?    @map("farmingPatches.flower") @db.Json
   farmingPatches_mushroom    Json?    @map("farmingPatches.mushroom") @db.Json
   farmingPatches_belladonna  Json?    @map("farmingPatches.belladonna") @db.Json
-  kourend_favour             Json     @map("kourend_favour") @db.Json
+  kourend_favour             Json?    @map("kourend_favour") @db.Json
 
   @@map("users")
 }


### PR DESCRIPTION
### Important
See PM For more details.

### Description:

So there's a problem right now where new users cannot buy minions or play because the database table user creation fails. 

This fixes the only current problem in schema.prisma that's preventing a fresh-DB install from working.

HOWEVER: The production database still has other issues. The only problem in the4 schema is `kourend_favour` column, however in the production database, `badges` (and probably bitfield and several other `String[]`/`Integer[]` datatypes) have no default value but are set `not null`

A clean prisma DB install doesn't set default values on list/array types (unsupported), but it also shouldn't be setting 'not null' on the column. 

TLDR: This will fix the schema, but the production DB needs to either remove the 'not null' from several columns in multiple tables, or add defaults to match the old behavior.

### Changes:

Set kourend_favour column in schema.prisma to be optional, thus allowing null values.

### Other checks:

-   [x] I have tested all my changes thoroughly.
