### PR TITLE
Adding of charging orbs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,7 +153,7 @@ model Giveaway {
 
 model Guild {
   id                String   @id @db.VarChar(19)
-  prefix            String   @default(",")
+  prefix            String   @default("+")
   language          String   @default("en-US") @db.VarChar(5)
   disabledCommands  String[]
   jmodComments      String?  @db.VarChar(19)

--- a/src/commands/Minion/cast.ts
+++ b/src/commands/Minion/cast.ts
@@ -58,6 +58,13 @@ export default class extends BotCommand {
 			return msg.channel.send(`${msg.author.minionName} needs ${spell.qpRequired} QP to cast ${spell.name}.`);
 		}
 
+		if (spell.agilityLevel && msg.author.skillLevel(SkillsEnum.Agility) < spell.agilityLevel) {
+			return msg.channel.send(
+				`${msg.author.minionName} needs ${spell.agilityLevel} Agility to cast ${spell.name}.`
+			);
+			
+		}
+		
 		await msg.author.settings.sync(true);
 		const userBank = msg.author.bank();
 

--- a/src/commands/Minion/cast.ts
+++ b/src/commands/Minion/cast.ts
@@ -59,7 +59,6 @@ export default class extends BotCommand {
 		if (spell.qpRequired && msg.author.settings.get(UserSettings.QP) < spell.qpRequired) {
 			return msg.channel.send(`${msg.author.minionName} needs ${spell.qpRequired} QP to cast ${spell.name}.`);
 		}
-		
 		await msg.author.settings.sync(true);
 		const userBank = msg.author.bank();
 

--- a/src/commands/Minion/cast.ts
+++ b/src/commands/Minion/cast.ts
@@ -63,39 +63,40 @@ export default class extends BotCommand {
 		const userBank = msg.author.bank();
 
 		let castTimeMilliSeconds = spell.ticks * Time.Second * 0.6 + Time.Second / 4;
-		
-		if ( spell.travelTime ) {
-			let travelTime = spell.travelTime;
-			if ( msg.author.hasGracefulEquipped() ) {
+
+		if (spell.travelTime) {
+			let { travelTime } = spell;
+			if (msg.author.hasGracefulEquipped()) {
 				travelTime = reduceNumByPercent(travelTime, 20); // 20% boost for having graceful
-				boosts.push(`20% for Graceful outfit`);
+				boosts.push('20% for Graceful outfit');
 			} else {
-				missedBoosts.push(`20% for Graceful outfit`);
+				missedBoosts.push('20% for Graceful outfit');
 			}
 
-			if ( spell.agilityBoost ) {
-				const boostLevels = spell.agilityBoost.map((boost) => boost[0]);
-				const boostPercentages = spell.agilityBoost.map((boost) => boost[1]);
-				
-				const availableBoost = boostLevels.find((boost) => msg.author.skillLevel(SkillsEnum.Agility) >= boost);
-				if ( availableBoost ) {
+			if (spell.agilityBoost) {
+				const boostLevels = spell.agilityBoost.map(boost => boost[0]);
+				const boostPercentages = spell.agilityBoost.map(boost => boost[1]);
+
+				const availableBoost = boostLevels.find(boost => msg.author.skillLevel(SkillsEnum.Agility) >= boost);
+				if (availableBoost) {
 					const boostIndex = boostLevels.indexOf(availableBoost);
 
 					travelTime = reduceNumByPercent(travelTime, boostPercentages[boostIndex]); // Apply an agility boost based on tier
 					boosts.push(`${boostPercentages[boostIndex]}% for ${availableBoost}+ Agility`);
 
-					if ( boostIndex > 0 ) {
-						missedBoosts.push(`${boostPercentages[boostIndex-1]}% for ${boostLevels[boostIndex-1]}+ Agility`);
-					};
+					if (boostIndex > 0) {
+						missedBoosts.push(
+							`${boostPercentages[boostIndex - 1]}% for ${boostLevels[boostIndex - 1]}+ Agility`
+						);
+					}
 				} else {
-					const worstBoost = spell.agilityBoost[spell.agilityBoost.length-1];
+					const worstBoost = spell.agilityBoost[spell.agilityBoost.length - 1];
 					missedBoosts.push(`${worstBoost[1]}% for ${worstBoost[0]}+ Agility`);
 				}
-			};
+			}
 
 			castTimeMilliSeconds += travelTime / 27; // One trip holds 27 casts, scale it down
-		};
-
+		}
 
 		const maxTripLength = msg.author.maxTripLength('Casting');
 
@@ -156,25 +157,25 @@ export default class extends BotCommand {
 			((spell.xp * quantity) / (duration / Time.Minute)) * 60
 		).toLocaleString()} Magic XP/Hr`;
 
-		let response = `${msg.author.minionName} is now casting ${quantity}x ${spell.name}, it'll take around ${formatDuration(
-			duration
-		)} to finish. Removed ${cost}${
+		let response = `${msg.author.minionName} is now casting ${quantity}x ${
+			spell.name
+		}, it'll take around ${formatDuration(duration)} to finish. Removed ${cost}${
 			spell.gpCost ? ` and ${gpCost} Coins` : ''
-		} from your bank. **${magicXpHr}**`
+		} from your bank. **${magicXpHr}**`;
 
 		if (spell.craftXp) {
 			response = `and** ${Math.round(
 				((spell.craftXp * quantity) / (duration / Time.Minute)) * 60
 			).toLocaleString()} Crafting XP/Hr**`;
 		}
-		
-		if ( boosts.length > 0 ) {
-			response += `\n**Boosts:** ${boosts.join(', ')}.`
-		};
 
-		if ( missedBoosts.length > 0 ) {
-			response += `\n**Missed boosts:** ${missedBoosts.join(', ')}.`
-		};
+		if (boosts.length > 0) {
+			response += `\n**Boosts:** ${boosts.join(', ')}.`;
+		}
+
+		if (missedBoosts.length > 0) {
+			response += `\n**Missed boosts:** ${missedBoosts.join(', ')}.`;
+		}
 
 		return msg.channel.send(response);
 	}

--- a/src/lib/skilling/skills/magic/castables.ts
+++ b/src/lib/skilling/skills/magic/castables.ts
@@ -350,7 +350,7 @@ export const Castables: Castable[] = [
 		xp: 73,
 		level: 63,
 		ticks: 3,
-		agilityBoost:  [[80,52],[70,45]],
+		agilityBoost:  [[80,52],[70,44]],
 		travelTime: 362_000
 	},
 	{
@@ -371,7 +371,7 @@ export const Castables: Castable[] = [
 		xp: 66,
 		level: 56,
 		ticks: 3,
-		agilityBoost:  [[80,52],[70,45]],
+		agilityBoost:  [[80,52],[70,44]],
 		travelTime: 362_000
 	}
 ];

--- a/src/lib/skilling/skills/magic/castables.ts
+++ b/src/lib/skilling/skills/magic/castables.ts
@@ -350,7 +350,10 @@ export const Castables: Castable[] = [
 		xp: 73,
 		level: 63,
 		ticks: 3,
-		agilityBoost:  [[80,52],[70,44]],
+		agilityBoost: [
+			[80, 52],
+			[70, 44]
+		],
 		travelTime: 362_000
 	},
 	{
@@ -371,7 +374,10 @@ export const Castables: Castable[] = [
 		xp: 66,
 		level: 56,
 		ticks: 3,
-		agilityBoost:  [[80,52],[70,44]],
+		agilityBoost: [
+			[80, 52],
+			[70, 44]
+		],
 		travelTime: 362_000
 	}
 ];

--- a/src/lib/skilling/skills/magic/castables.ts
+++ b/src/lib/skilling/skills/magic/castables.ts
@@ -13,6 +13,8 @@ interface Castable {
 	gpCost?: number;
 	craftLevel?: number;
 	craftXp?: number;
+	agilityLevel?: number;
+	gracefulPenalty?: number;
 }
 
 export const Castables: Castable[] = [
@@ -329,5 +331,47 @@ export const Castables: Castable[] = [
 		qpRequired: 50,
 		craftXp: 130,
 		craftLevel: 61
+	},
+	{
+		id: itemID('Air orb'),
+		name: 'Charge air orb',
+		input: new Bank().add('Cosmic rune', 3).add('Air rune', 30).add('Unpowered orb', 1),
+		output: new Bank().add('Air orb', 1),
+		xp: 76,
+		level: 66,
+		ticks: 12.63,
+		gracefulPenalty: 20
+	},
+	{
+		id: itemID('Fire orb'),
+		name: 'Charge fire orb',
+		input: new Bank().add('Cosmic rune', 3).add('Fire rune', 30).add('Unpowered orb', 1),
+		output: new Bank().add('Fire orb', 1),
+		xp: 73,
+		level: 63,
+		ticks: 13.33,
+		agilityLevel: 70,
+		gracefulPenalty: 20
+	},
+	{
+		id: itemID('Earth orb'),
+		name: 'Charge earth orb',
+		input: new Bank().add('Cosmic rune', 3).add('Earth rune', 30).add('Unpowered orb', 1),
+		output: new Bank().add('Earth orb', 1),
+		xp: 70,
+		level: 60,
+		ticks: 12.63,
+		gracefulPenalty: 20
+	},
+	{
+		id: itemID('Water orb'),
+		name: 'Charge water orb',
+		input: new Bank().add('Cosmic rune', 3).add('Water rune', 30).add('Unpowered orb', 1),
+		output: new Bank().add('Water orb', 1),
+		xp: 66,
+		level: 56,
+		ticks: 13.33,
+		agilityLevel: 70,
+		gracefulPenalty: 20
 	}
 ];

--- a/src/lib/skilling/skills/magic/castables.ts
+++ b/src/lib/skilling/skills/magic/castables.ts
@@ -13,8 +13,8 @@ interface Castable {
 	gpCost?: number;
 	craftLevel?: number;
 	craftXp?: number;
-	agilityLevel?: number;
-	gracefulPenalty?: number;
+	agilityBoost?: number[][];
+	travelTime?: number;
 }
 
 export const Castables: Castable[] = [
@@ -340,7 +340,7 @@ export const Castables: Castable[] = [
 		xp: 76,
 		level: 66,
 		ticks: 12.63,
-		gracefulPenalty: 20
+		travelTime: 20
 	},
 	{
 		id: itemID('Fire orb'),
@@ -350,8 +350,8 @@ export const Castables: Castable[] = [
 		xp: 73,
 		level: 63,
 		ticks: 13.33,
-		agilityLevel: 70,
-		gracefulPenalty: 20
+		agilityBoost:  [[80,45],[70,40]],
+		travelTime: 20
 	},
 	{
 		id: itemID('Earth orb'),
@@ -361,7 +361,7 @@ export const Castables: Castable[] = [
 		xp: 70,
 		level: 60,
 		ticks: 12.63,
-		gracefulPenalty: 20
+		travelTime: 20
 	},
 	{
 		id: itemID('Water orb'),
@@ -371,7 +371,7 @@ export const Castables: Castable[] = [
 		xp: 66,
 		level: 56,
 		ticks: 13.33,
-		agilityLevel: 70,
-		gracefulPenalty: 20
+		agilityBoost:  [[80,45],[70,40]],
+		travelTime: 20
 	}
 ];

--- a/src/lib/skilling/skills/magic/castables.ts
+++ b/src/lib/skilling/skills/magic/castables.ts
@@ -339,8 +339,8 @@ export const Castables: Castable[] = [
 		output: new Bank().add('Air orb', 1),
 		xp: 76,
 		level: 66,
-		ticks: 12.63,
-		travelTime: 20
+		ticks: 3,
+		travelTime: 187_000
 	},
 	{
 		id: itemID('Fire orb'),
@@ -349,9 +349,9 @@ export const Castables: Castable[] = [
 		output: new Bank().add('Fire orb', 1),
 		xp: 73,
 		level: 63,
-		ticks: 13.33,
-		agilityBoost:  [[80,45],[70,40]],
-		travelTime: 20
+		ticks: 3,
+		agilityBoost:  [[80,52],[70,45]],
+		travelTime: 362_000
 	},
 	{
 		id: itemID('Earth orb'),
@@ -360,8 +360,8 @@ export const Castables: Castable[] = [
 		output: new Bank().add('Earth orb', 1),
 		xp: 70,
 		level: 60,
-		ticks: 12.63,
-		travelTime: 20
+		ticks: 3,
+		travelTime: 187_000
 	},
 	{
 		id: itemID('Water orb'),
@@ -370,8 +370,8 @@ export const Castables: Castable[] = [
 		output: new Bank().add('Water orb', 1),
 		xp: 66,
 		level: 56,
-		ticks: 13.33,
-		agilityBoost:  [[80,45],[70,40]],
-		travelTime: 20
+		ticks: 3,
+		agilityBoost:  [[80,52],[70,45]],
+		travelTime: 362_000
 	}
 ];


### PR DESCRIPTION
Added the charging of elemental orbs to the castables. 
Added boosts for having graceful for all four spells.
Added agility boosts for fire and water orbs, as in game you'd use shortcuts. 

Used wiki numbers to get casts per hour.

Tested other castables to check no changes with them.
Tested the four additional spells.
Tested crafting of the battlestaffs.

Closes #2554 
-   [x] I have tested all my changes thoroughly.
