### PR TITLE
Allow new TzHaar monsters to be killed on Slayer task

### DIFF
--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -473,7 +473,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		monster: Monsters.TzHaarKet,
 		amount: [90, 150],
 		weight: 8,
-		monsters: [Monsters.TzHaarKet.id],
+		monsters: [Monsters.TzHaarKet.id, Monsters.TzHaarXil.id, Monsters.TzHaarMej.id],
 		unlocked: false
 	},
 	{

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -442,7 +442,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		monster: Monsters.TzHaarKet,
 		amount: [130, 199],
 		weight: 10,
-		monsters: [Monsters.TzHaarKet.id],
+		monsters: [Monsters.TzHaarKet.id, Monsters.TzHaarXil.id, Monsters.TzHaarMej.id],
 		unlocked: false
 	},
 	{

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -424,7 +424,7 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		monster: Monsters.TzHaarKet,
 		amount: [110, 180],
 		weight: 10,
-		monsters: [Monsters.TzHaarKet.id],
+		monsters: [Monsters.TzHaarKet.id, Monsters.TzHaarXil.id, Monsters.TzHaarMej.id],
 		unlocked: false
 	},
 	{


### PR DESCRIPTION
### Description:

Adds the newly added TzHaar monsters to Slayer tasks.

### Changes:

Added `, Monsters.TzHaarXil.id, Monsters.TzHaarMej.id` to each of the TzHaar tasks
