### PR TITLE
`+checkmasses` - Only show masses with more than 1 player

### DIFF
--- a/src/commands/Utility/checkmasses.ts
+++ b/src/commands/Utility/checkmasses.ts
@@ -31,7 +31,7 @@ export default class extends BotCommand {
 			})
 		)
 			.map(convertStoredActivityToFlatActivity)
-			.filter(m => isRaidsActivity(m) || isGroupActivity(m));
+			.filter(m => (isRaidsActivity(m) || isGroupActivity(m)) && m.users.length > 1);
 
 		if (masses.length === 0) {
 			return msg.channel.send('There are no active masses in this server.');


### PR DESCRIPTION
### Description:
`+checkmasses` is currently showing activities with 1 or more users, when it should be only be 2+ users.

### Changes:
Added the check to ensure there are multiple people in the mass.

![image](https://user-images.githubusercontent.com/10122432/144039983-e32bed67-89c9-4820-9b15-d1a016117e2c.png)
