### PR TITLE
Don't exclude all Openables drops from Mystery boxes

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1976,7 +1976,13 @@ export const kingGoldemarCL = resolveItems([
 
 export const abyssalDragonCL = resolveItems(['Abyssal thread', 'Abyssal cape', 'Dragon hunter lance', 'Ori']);
 
-export const vasaMagusCL = resolveItems(['Tattered robes of Vasa', 'Jar of magic', 'Voidling', 'Magus scroll']);
+export const vasaMagusCL = resolveItems([
+	'Tattered robes of Vasa',
+	'Jar of magic',
+	'Voidling',
+	'Magus scroll',
+	'Magical artifact'
+]);
 
 export const torvaOutfit = resolveItems([
 	'Torva full helm',

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -1096,13 +1096,13 @@ export const filterableTypes: Filterable[] = [
 		items: [...new Set([...cluesHardRareCL, ...cluesEliteRareCL, ...cluesMasterRareCL])]
 	},
 	{
-		name: 'Untradeables',
-		aliases: ['untradeables', 'umb'],
+		name: 'umb',
+		aliases: ['umb'],
 		items: umbTable
 	},
 	{
-		name: 'Tradeables',
-		aliases: ['tradeables', 'tmb'],
+		name: 'tmb',
+		aliases: ['tmb'],
 		items: tmbTable
 	},
 	{

--- a/src/lib/data/openables.ts
+++ b/src/lib/data/openables.ts
@@ -27,6 +27,7 @@ interface Openable {
 	aliases: string[];
 	table: (() => number) | LootTable;
 	emoji: Emoji | string;
+	excludeFromBoxes?: boolean;
 }
 
 const MR_E_DROPRATE_FROM_UMB_AND_TMB = 5000;
@@ -239,7 +240,8 @@ const Openables: Openable[] = [
 		itemID: 11_918,
 		aliases: ['present', 'birthday present'],
 		table: BirthdayPresentTable,
-		emoji: Emoji.BirthdayPresent
+		emoji: Emoji.BirthdayPresent,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Casket',
@@ -267,14 +269,16 @@ const Openables: Openable[] = [
 		itemID: 3713,
 		aliases: ['holiday mystery box', 'hmb', 'holiday', 'holiday item mystery box', 'himb'],
 		table: baseHolidayItems,
-		emoji: Emoji.MysteryBox
+		emoji: Emoji.MysteryBox,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Pet Mystery box',
 		itemID: 3062,
 		aliases: ['pet mystery box', 'pmb'],
 		table: PMBTable,
-		emoji: Emoji.MysteryBox
+		emoji: Emoji.MysteryBox,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Untradeables Mystery box',
@@ -295,7 +299,8 @@ const Openables: Openable[] = [
 		itemID: itemID('Christmas cracker'),
 		aliases: ['cracker', 'christmas cracker'],
 		table: PartyhatTable,
-		emoji: Emoji.BirthdayPresent
+		emoji: Emoji.BirthdayPresent,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Dwarven crate',
@@ -337,7 +342,8 @@ const Openables: Openable[] = [
 			.add('Sparkler', [2, 10])
 			.add('Party music box')
 			.tertiary(20, 'Cake hat'),
-		emoji: Emoji.BirthdayPresent
+		emoji: Emoji.BirthdayPresent,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Spoils of war',
@@ -358,14 +364,16 @@ const Openables: Openable[] = [
 			.add('12 sided die', 1, 3)
 			.add('20 sided die', 1, 3)
 			.add('100 sided die'),
-		emoji: Emoji.BirthdayPresent
+		emoji: Emoji.BirthdayPresent,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Royal mystery box',
 		itemID: itemID('Royal mystery box'),
 		aliases: ['royal mystery box', 'rmb'],
 		table: new LootTable().add('Diamond crown', 1, 2).add('Diamond sceptre', 1, 2).add('Corgi'),
-		emoji: Emoji.BirthdayPresent
+		emoji: Emoji.BirthdayPresent,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Equippable mystery box',
@@ -384,14 +392,16 @@ const Openables: Openable[] = [
 			.add('Water balloon')
 			.add('Ice cream')
 			.add('Crab hat'),
-		emoji: Emoji.BirthdayPresent
+		emoji: Emoji.BirthdayPresent,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Independence box',
 		itemID: itemID('Independence box'),
 		aliases: ['independence box'],
 		table: new LootTable().add('Fireworks').add('Fireworks').add('Liber tea').add("Sam's hat"),
-		emoji: Emoji.BirthdayPresent
+		emoji: Emoji.BirthdayPresent,
+		excludeFromBoxes: true
 	},
 	{
 		name: 'Magic crate',
@@ -433,9 +443,9 @@ export function getRandomMysteryBox() {
 	return MysteryBoxes.roll().items()[0][0].id;
 }
 
-let allItemsIDs = Openables.map(i => (typeof i.table !== 'function' && i.table.allItems) || []).flat(
-	Infinity
-) as number[];
+let allItemsIDs = Openables.filter(o => o.excludeFromBoxes)
+	.map(i => (typeof i.table !== 'function' && i.table.allItems) || [])
+	.flat(Infinity) as number[];
 allItemsIDs = uniqueArr(allItemsIDs);
 const cantBeDropped = [
 	...chambersOfXericCL,

--- a/tests/parseStringBank.test.ts
+++ b/tests/parseStringBank.test.ts
@@ -80,13 +80,13 @@ describe('Bank Parsers', () => {
 			inputBank: bank,
 			flags: { tradeables: '' }
 		});
-		expect(res2.length).toEqual(1);
+		expect(res2.length).toEqual(3);
 
 		const res3 = parseBank({
 			inputBank: bank,
 			flags: { untradeables: '' }
 		});
-		expect(res3.length).toEqual(0);
+		expect(res3.length).toEqual(1);
 	});
 
 	test('parseBank - filters', async () => {

--- a/tests/sanity.test.ts
+++ b/tests/sanity.test.ts
@@ -62,6 +62,45 @@ describe('Sanity', () => {
 			}
 		}
 	});
+	test('exclude certain openables from mystery boxes', () => {
+		// These items appear in some Openables but should still also appear in Mystery boxes:
+		const shouldBeIn = resolveItems([
+			'Coal',
+			'Blacksmith helmet',
+			'Blacksmith boots',
+			'Blacksmith gloves',
+			'Uncut sapphire',
+			'Oak plank',
+			'Pure essence',
+			'Runite bolts'
+		]);
+		// These items should all still excluded by the 'Openables' rule. Some items are also excluded by other means.
+		const shouldntBeIn = resolveItems([
+			'Christmas cracker',
+			'White partyhat',
+			'Corgi',
+			'Beach ball',
+			'Glass of bubbly',
+			'Sparkler',
+			'Liber tea',
+			'Party music box',
+			'6 sided die'
+		]);
+		for (const i of shouldntBeIn) {
+			if (allMbTables.includes(i)) {
+				console.error('wtf');
+				throw new Error(`Item ${itemNameFromID(i)} shouldn't be in Mystery Boxes, but is.`);
+			}
+		}
+		for (const i of shouldBeIn) {
+			if (!allMbTables.includes(i)) {
+				console.error('wtf');
+				throw new Error(`Item ${itemNameFromID(i)} should be in Mystery Boxes, but isn't.`);
+			}
+		}
+		expect(shouldBeIn.every(ss => allMbTables.includes(ss))).toEqual(true);
+		expect(shouldntBeIn.some(ss => allMbTables.includes(ss))).toEqual(false);
+	});
 	test('custom monsters', () => {
 		expect(killableMonsters.some(m => m.name === 'Frost Dragon')).toBeTruthy();
 		expect(killableMonsters.some(m => m.name === 'Sea Kraken')).toBeTruthy();


### PR DESCRIPTION
### Description:
Currently, there's some code that removes ALL openables loot tables from the mystery box tables. This seeks to improve that by only selectively removing openables drops.

### Changes:

1. Add `excludeFromBoxes?` to Openable interface.
2. Apply this new setting to the Openables with exclusive drops.
3. Added "Magical artifact" to Vasa short-CL which removes it from the TMB table.
4. Removed 'tradeables' and 'untradeables' as aliases from the filterables, because they conflict with the flags of the same name and led to incorrect results.
5. Updated the parseStringBank tests to reflect the correctly filtered bank values.
  (ie: Steel arrow, Coal, Bones,  Clue scroll (easy) => tradeables filter => Steel arrow, Coal, Bones)
6. Added sanity tests



### Other checks:

-   [x] I have tested all my changes thoroughly.

### Examples:
[New list of TMB items](https://github.com/oldschoolgg/oldschoolbot/files/7648140/tmb-list.txt
100k TMB sample
![100k-tmbs](https://user-images.githubusercontent.com/10122432/144576616-d72514ae-6976-41bb-bc47-cd87ebb5b217.png)
)
