### PR TITLE
Removed Ely from Corp BankBG cost

### DIFF
--- a/src/lib/minions/data/bankBackgrounds.ts
+++ b/src/lib/minions/data/bankBackgrounds.ts
@@ -96,8 +96,7 @@ const backgroundImages: BankBackground[] = [
 		}),
 		itemCost: resolveNameBank({
 			'Spectral spirit shield': 1,
-			'Arcane spirit shield': 1,
-			'Elysian spirit shield': 1
+			'Arcane spirit shield': 1
 		}),
 		gpCost: 100_000_000
 	},


### PR DESCRIPTION
### Description:

As title says, the Ely shield cost to unlock the Corp bank bg is removed with this PR. Currently, to unlock the BG you need a full corp log completed, which takes a TON of time to get done. After such a long grind, you need to pay a Spectral, Arcane AND Elysian shield to unlock it *until you switch to a different background*, where you then need to repay this cost again!

While the Sigil shields are a reasonable cost, consider that the Elysian is 1b+ in the market and is generally a must-have items for end-game players in general. Adding it as a cost makes a simple background become *very* expensive and not worth it, even if you spent over a thousand hours grinding corp! By making it just the Arcane & spectral shields, this background becomes more reasonable to purchase. 

tldr: ely inflates corp bg cost by a ton, even when the bg requires a massive grind to even purchase it. 

### Changes:

- Removed ely shield requirement from corp background cost

### Other checks:

-   [ ] I have tested all my changes thoroughly.
