### PR TITLE
Restructure command_usage row insertion code

### DIFF
--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -138,21 +138,23 @@ export async function runCommand(
 		is_continue: isContinue
 	};
 
+	let result = null;
 	try {
 		// @ts-ignore Cant be typechecked
-		const result = await command[method](message, args);
+		result = await command[method](message, args);
 		commandUsage.status = command_usage_status.Success;
-		return result;
 	} catch (err) {
 		commandUsage.status = command_usage_status.Error;
 		message.client.emit('commandError', message, command, args, err);
 	} finally {
 		if (shouldTrackCommand(command, args)) {
-			await prisma.commandUsage.create({
-				data: commandUsage
-			});
+			prisma.commandUsage
+				.create({
+					data: commandUsage
+				})
+				.catch(reason => message.client.emit('wtf', reason));
 		}
 	}
 
-	return null;
+	return result;
 }


### PR DESCRIPTION
### Description:
As described via PM, changed the code so the return is guaranteed to happen after the `finally` block has been executed with all variables intact.

### Changes:
1. Removed `return` from the try and tracked the variable to be returned to pass it after the finally
2. Replaced the `await` with `.catch()` to avoid blocking while waiting for the DB while still forcing the code to execute.

### Other checks:

-   [x] I have tested all my changes thoroughly.
