### PR TITLE
Change +kcgains to use last 24 hours

### DIFF
--- a/src/commands/Minion/kcgains.ts
+++ b/src/commands/Minion/kcgains.ts
@@ -35,7 +35,7 @@ export default class extends BotCommand {
 
 		const query = `SELECT user_id AS user, SUM(("data"->>'quantity')::int) AS qty, MAX(finish_date) AS lastDate FROM activity
 WHERE type = 'MonsterKilling' AND ("data"->>'monsterID')::int = ${monster.id}
-AND finish_date >= current_date - interval '${interval === 'day' ? 1 : 7}' day AND completed = true
+AND finish_date >= now() - interval '${interval === 'day' ? 1 : 7}' day AND completed = true
 GROUP BY 1
 ORDER BY qty DESC, lastDate ASC
 LIMIT 10`;


### PR DESCRIPTION
### Description:

`+kcgains` command currently uses 'Yesterday at 00:00' through 'Current time today' instead of last 24 hours.

### Changes:

1. Change Base time to use now() instead of `current_date` so that the timestamp is included properly.

### Other checks:

-   [x] I have tested all my changes thoroughly. (Database testing only, don't have full log to test command in bot)
