### PR TITLE
Added dragonbone mage gloves to createables

### DIFF
--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -872,6 +872,16 @@ const dragonBoneCreatables: Createable[] = [
 		})
 	},
 	{
+		name: 'Dragonbone mage gloves',
+		inputItems: resolveNameBank({
+			'Dragonbone upgrade kit': 1,
+			'Infinity gloves': 1
+		}),
+		outputItems: resolveNameBank({
+			'Dragonbone mage gloves': 1
+		})
+	},
+	{
 		name: 'Dragonbone mage top',
 		inputItems: resolveNameBank({
 			'Dragonbone upgrade kit': 1,


### PR DESCRIPTION
### Description:

Dragonbone mage gloves are in the itembase, but was missing from the createables. This fixes that.

### Changes:

- Added `create dragonbone mage gloves` with cost of Dbone upgrade kit+Infin gloves

### Other checks:

-   [ ] I have tested all my changes thoroughly.
