### PR TITLE
Previous Score for Tempoross points to chompy minigame

### DIFF
--- a/src/tasks/minions/minigames/temporossActivity.ts
+++ b/src/tasks/minions/minigames/temporossActivity.ts
@@ -15,7 +15,7 @@ export default class extends Task {
 		const { userID, channelID, quantity, rewardBoost, duration } = data;
 		const user = await this.client.fetchUser(userID);
 		const currentLevel = user.skillLevel(SkillsEnum.Fishing);
-		const previousScore = (await getMinigameEntity(user.id)).big_chompy_bird_hunting;
+		const previousScore = (await getMinigameEntity(user.id)).tempoross;
 		const { newScore } = await incrementMinigameScore(userID, 'tempoross', quantity);
 		const kcForPet = randInt(previousScore, newScore);
 


### PR DESCRIPTION

### Description:

Means that the "you got a pet" message was rolling a number between their Chompy minigame score and their new Tempoross score. Not between their old tempoross and new.

### Changes:

Pointed the previousScore variable for tempoross activity to tempoross instead of chompy hunting.

### Other checks:

-   [x] I have tested all my changes thoroughly.
