### PR TITLE
Nex item tradeable fix

### DIFF
--- a/src/lib/customItems.ts
+++ b/src/lib/customItems.ts
@@ -397,7 +397,8 @@ setCustomItem(
 			slot: EquipmentSlot.Hands,
 			requirements: null
 		},
-		highalch: 50_000_000
+		highalch: 50_000_000,
+		tradeable: true
 	},
 	50_000_000
 );
@@ -750,7 +751,8 @@ setCustomItem(
 			slot: EquipmentSlot.Weapon,
 			requirements: null
 		},
-		highalch: 50_000_000
+		highalch: 50_000_000,
+		tradeable: true
 	},
 	50_000_000
 );
@@ -779,7 +781,8 @@ setCustomItem(
 			slot: EquipmentSlot.Shield,
 			requirements: null
 		},
-		highalch: 50_000_000
+		highalch: 50_000_000,
+		tradeable: true
 	},
 	50_000_000
 );


### PR DESCRIPTION
### Description:

Add "tradeable: true" flag to Torva Gloves, Virtus Wand and Virtus Book as the items they're based upon are not tradeable.

### Other checks:

-   [x] I have tested all my changes thoroughly.
