### PR TITLE
Fix bug that deletes equipped items when using gearpresets.

### DIFF
--- a/src/commands/Minion/gearpresets.ts
+++ b/src/commands/Minion/gearpresets.ts
@@ -6,8 +6,8 @@ import { Bank } from 'oldschooljs';
 import { Color } from '../../lib/constants';
 import { defaultGear, gearPresetToString, globalPresets, resolveGearTypeSetting } from '../../lib/gear';
 import { generateGearImage } from '../../lib/gear/functions/generateGearImage';
+import { unEquipAllCommand } from '../../lib/minions/functions/unequipAllCommand';
 import { prisma } from '../../lib/settings/prisma';
-import { runCommand } from '../../lib/settings/settings';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { cleanString, isValidGearSetup } from '../../lib/util';
@@ -113,23 +113,12 @@ export default class extends BotCommand {
 			);
 		}
 
-		try {
-			const unequipAllMessage = await runCommand(msg, 'm', [setup], false, 'unequipall');
-			if (
-				!(unequipAllMessage instanceof KlasaMessage) ||
-				(!(unequipAllMessage as KlasaMessage).content.toLowerCase().includes('you unequipped all items') &&
-					!(unequipAllMessage as KlasaMessage).content.toLowerCase().includes('you have no items in your'))
-			) {
-				return msg.channel.send(
-					`It was not possible to equip your **${preset.name}** preset on your ${setup} gear setup.`
-				);
-			}
-		} catch (err) {
-			// On error do not continue which will overwrite [delete] gear.
-			if (!err.message.includes('command is disabled')) {
-				// Only log to sentry if the error is not from a disabled command.
-				this.client.wtf(err);
-			}
+		const unequipAllMessage = await unEquipAllCommand(msg, setup);
+		if (
+			!(unequipAllMessage instanceof KlasaMessage) ||
+			(!(unequipAllMessage as KlasaMessage).content.toLowerCase().includes('you unequipped all items') &&
+				!(unequipAllMessage as KlasaMessage).content.toLowerCase().includes('you have no items in your'))
+		) {
 			return msg.channel.send(
 				`It was not possible to equip your **${preset.name}** preset on your ${setup} gear setup.`
 			);

--- a/src/commands/Minion/gearpresets.ts
+++ b/src/commands/Minion/gearpresets.ts
@@ -114,17 +114,26 @@ export default class extends BotCommand {
 		}
 
 		try {
-			const unequipAllMessage = await runCommand(msg, 'unequipall', [setup]);
+			const unequipAllMessage = await runCommand(msg, 'm', [setup], false, 'unequipall');
 			if (
 				!(unequipAllMessage instanceof KlasaMessage) ||
 				(!(unequipAllMessage as KlasaMessage).content.toLowerCase().includes('you unequipped all items') &&
 					!(unequipAllMessage as KlasaMessage).content.toLowerCase().includes('you have no items in your'))
 			) {
 				return msg.channel.send(
-					`It was not possible to equip your **${preset.name}** on your ${setup} gear setup.`
+					`It was not possible to equip your **${preset.name}** preset on your ${setup} gear setup.`
 				);
 			}
-		} catch (_) {}
+		} catch (err) {
+			// On error do not continue which will overwrite [delete] gear.
+			if (!err.message.includes('command is disabled')) {
+				// Only log to sentry if the error is not from a disabled command.
+				this.client.wtf(err);
+			}
+			return msg.channel.send(
+				`It was not possible to equip your **${preset.name}** preset on your ${setup} gear setup.`
+			);
+		}
 
 		await msg.author.removeItemsFromBank(toRemove.bank);
 

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -14,6 +14,7 @@ import {
 	MIMIC_MONSTER_ID,
 	PerkTier
 } from '../../lib/constants';
+import { GearSetupType } from '../../lib/gear';
 import ClueTiers from '../../lib/minions/data/clueTiers';
 import { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
 import minionIcons from '../../lib/minions/data/minionIcons';
@@ -23,6 +24,7 @@ import { cancelTaskCommand } from '../../lib/minions/functions/cancelTaskCommand
 import { equipPet } from '../../lib/minions/functions/equipPet';
 import { pastActivities } from '../../lib/minions/functions/pastActivities';
 import { trainCommand } from '../../lib/minions/functions/trainCommand';
+import { unEquipAllCommand } from '../../lib/minions/functions/unequipAllCommand';
 import { unequipPet } from '../../lib/minions/functions/unequipPet';
 import { prisma } from '../../lib/settings/prisma';
 import { runCommand } from '../../lib/settings/settings';
@@ -70,7 +72,8 @@ const subCommands = [
 	'uep',
 	'lapcounts',
 	'cancel',
-	'train'
+	'train',
+	'unequipall'
 ];
 
 export default class MinionCommand extends BotCommand {
@@ -494,5 +497,11 @@ Please click the buttons below for important links.`
 	async opens(msg: KlasaMessage) {
 		const openableScores = new Bank(msg.author.settings.get(UserSettings.OpenableScores));
 		return msg.channel.send(`You've opened... ${openableScores}`);
+	}
+
+	@requiresMinion
+	@minionNotBusy
+	async unequipall(msg: KlasaMessage, [gearType]: [string]) {
+		return unEquipAllCommand(msg, gearType as GearSetupType);
 	}
 }


### PR DESCRIPTION
### Description:
The `unequipall` command was removed, and the `gearpresets` command wasn't properly aborting on failure of `unequipall`, causing the gear to remain equipped, and then overwritten by the `gearpresets` command.

### Changes:

1. Added `+m unequipall`
2. Changed gearpresets to call the new `unEquipAllCommand` instead of using `runCommand`

**Note**: [Click here to see the diff between this commit and my original fix, just in case you prefer the original way](https://github.com/oldschoolgg/oldschoolbot/pull/3282/commits/87eef06e49321adac2b9cf96f4f929eb864911c9)

### Other checks:

-   [x] I have tested all my changes thoroughly.

Closes [3280](https://github.com/oldschoolgg/oldschoolbot/issues/3280)