### PR TITLE
Agility Arena XP purchase clarification

### DIFF
--- a/src/commands/Minion/agilityarena.ts
+++ b/src/commands/Minion/agilityarena.ts
@@ -134,9 +134,9 @@ export default class extends BotCommand {
 
 Alternatively, you can convert tickets to XP (+10% XP for Karamja Medium Diary) using \`${
 					msg.cmdPrefix
-				}agilityarena buy xp 5\`, or recolor a set of plain Graceful using \`${
-					msg.cmdPrefix
-				}agilityarena buy recolor\`.`
+				}agilityarena buy xp ${Object.keys(ticketQuantities).join(
+					'|'
+				)}\`, or recolor a set of plain Graceful using \`${msg.cmdPrefix}agilityarena buy recolor\`.`
 			);
 		}
 


### PR DESCRIPTION
Closes #3283 

### Description:

Example used to be -agilityarena buy xp 5, but 5 is not a valid choice.

### Changes:

Replaced the fixed value of 5 with a pipe-delimited list of available options.

### Other checks:

-   [x] I have tested all my changes thoroughly.
