### PR TITLE
Remove lamps from Mystery boxes

### DIFF
--- a/src/lib/customItems.ts
+++ b/src/lib/customItems.ts
@@ -198,11 +198,61 @@ setCustomItem(19_567, 'Cob', 'Herbi', {}, 1_000_000);
 
 setCustomItem(22_949, 'Takon', 'Herbi', {}, 1_000_000);
 
-setCustomItem(6796, 'Tiny lamp', 'Lamp', {}, 3_000_000);
-setCustomItem(21_642, 'Small lamp', 'Lamp', {}, 6_000_000);
-setCustomItem(23_516, 'Average lamp', 'Lamp', {}, 15_000_000);
-setCustomItem(22_320, 'Large lamp', 'Lamp', {}, 100_000_000);
-setCustomItem(11_157, 'Huge lamp', 'Lamp', {}, 500_000_000);
+setCustomItem(
+	6796,
+	'Tiny lamp',
+	'Lamp',
+	{
+		customItemData: {
+			cantDropFromMysteryBoxes: true
+		}
+	},
+	3_000_000
+);
+setCustomItem(
+	21_642,
+	'Small lamp',
+	'Lamp',
+	{
+		customItemData: {
+			cantDropFromMysteryBoxes: true
+		}
+	},
+	6_000_000
+);
+setCustomItem(
+	23_516,
+	'Average lamp',
+	'Lamp',
+	{
+		customItemData: {
+			cantDropFromMysteryBoxes: true
+		}
+	},
+	15_000_000
+);
+setCustomItem(
+	22_320,
+	'Large lamp',
+	'Lamp',
+	{
+		customItemData: {
+			cantDropFromMysteryBoxes: true
+		}
+	},
+	100_000_000
+);
+setCustomItem(
+	11_157,
+	'Huge lamp',
+	'Lamp',
+	{
+		customItemData: {
+			cantDropFromMysteryBoxes: true
+		}
+	},
+	500_000_000
+);
 
 setCustomItem(1808, 'Peky', 'Herbi', {}, 1_000_000);
 

--- a/tests/sanity.test.ts
+++ b/tests/sanity.test.ts
@@ -84,7 +84,8 @@ describe('Sanity', () => {
 			'Sparkler',
 			'Liber tea',
 			'Party music box',
-			'6 sided die'
+			'6 sided die',
+			'Huge lamp'
 		]);
 		for (const i of shouldntBeIn) {
 			if (allMbTables.includes(i)) {


### PR DESCRIPTION
### Description:

Removed lamps from being droppable from mystery boxes

### Changes:

- Added the custom item data to make them not droppable.
- Added test just to be sure

### Other checks:

-   [x] I have tested all my changes thoroughly.
