### PR TITLE
Add Black swan to DCP CL to make it equippable

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1965,7 +1965,8 @@ export const discontinuedCustomPetsCL = resolveItems([
 	'Cob',
 	'Gregoyle',
 	'Mini Pumpkinhead',
-	'Seer'
+	'Seer',
+	'Black swan'
 ]);
 
 export const kingGoldemarCL = resolveItems([


### PR DESCRIPTION
### Description:

Black swan pet isn't equippable as it's not on any pet CL

### Changes:

Added 'Black swan' to the Discontinued pets CL to make it equippable.
