### PR TITLE
Swap string message for image for offering bird eggs

### DIFF
--- a/src/commands/Minion/offer.ts
+++ b/src/commands/Minion/offer.ts
@@ -142,13 +142,26 @@ export default class extends BotCommand {
 				skillName: SkillsEnum.Prayer,
 				amount: quantity * 100
 			});
-			await msg.author.addItemsToBank(loot, true);
+
+			const { previousCL, itemsAdded } = await msg.author.addItemsToBank(loot, true);
 
 			this.notifyUniques(msg.author, egg.name, evilChickenOutfit, loot.bank, quantity);
 
-			return msg.channel.send(
-				`You offered ${quantity}x ${egg.name} to the Shrine and received ${loot} and ${xpStr}.`
-			);
+			const { image } = await this.client.tasks
+				.get('bankImage')!
+				.generateBankImage(
+					itemsAdded,
+					`${quantity}x ${egg.name}`,
+					true,
+					{ showNewCL: 1 },
+					msg.author,
+					previousCL
+				);
+
+			return msg.channel.send({
+				content: `You offered ${quantity}x ${egg.name} to the Shrine and received the attached loot and ${xpStr}.`,
+				files: [image!]
+			});
 		}
 
 		const specialBone = specialBones.find(bone => stringMatches(bone.item.name, boneName));


### PR DESCRIPTION
### Description:

Closes #3304

Changed the response for offering bird eggs to make it easier to see when uniques are obtained.

### Changes:

Swapped the string response for a bank image for offering eggs. 

### Other checks:

-   [x] I have tested all my changes thoroughly.
