### PR TITLE
fixes orn ki amulets/max capes not boosting Pest control

### DIFF
--- a/src/commands/Minion/pestcontrol.ts
+++ b/src/commands/Minion/pestcontrol.ts
@@ -15,8 +15,8 @@ import getOSItem from '../../lib/util/getOSItem';
 let itemBoosts = [
 	[['Abyssal whip', 'Abyssal tentacle'].map(getOSItem), 12],
 	[['Barrows gloves', 'Ferocious gloves'].map(getOSItem), 4],
-	[['Amulet of fury', 'Amulet of torture'].map(getOSItem), 5],
-	[['Fire cape', 'Infernal cape'].map(getOSItem), 6],
+	[['Amulet of fury', 'Amulet of torture', 'Amulet of fury (or)', 'Amulet of torture (or)'].map(getOSItem), 5],
+	[['Fire cape', 'Infernal cape', 'Fire max cape', 'Infernal max cape'].map(getOSItem), 6],
 	[['Dragon claws'].map(getOSItem), 5]
 ] as const;
 


### PR DESCRIPTION
### Description:

Infernal max cape doesn't give a boost at Pest control, where its normal variant does. I assume the same issue applies to: Fire max cape, Amulet of Fury/Torture (or) so included those too.

### Changes:

- Adds Ornament kit variants of the 2 Amulets as a boost item
- Adds Max cape variants of the 2 Capes as a boost item

### Other checks:

-   [ ] I have tested all my changes thoroughly.
