### PR TITLE
Black d'hide for Cave Horrors

### DIFF
--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -76,8 +76,8 @@ export const chaeldarMonsters: KillableMonster[] = [
 
 		difficultyRating: 2,
 		itemsRequired: deepResolveItems([
-			["Karil's leathertop", 'Armadyl chestplate'],
-			["Karil's leatherskirt", 'Armadyl chainskirt']
+			["Karil's leathertop", 'Armadyl chestplate', "Black d'hide body"],
+			["Karil's leatherskirt", 'Armadyl chainskirt', "Black d'hide chaps"]
 		]),
 		qpRequired: 20,
 		levelRequirements: {


### PR DESCRIPTION
Allow black d'hide for the killing of cave horrors to help early accounts (which probably need cave horrors more than the rest of us)

Closes #3354

-   [ ] I have tested all my changes thoroughly.
