### PR TITLE
Update of adding Granite Body to buyables

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -704,6 +704,11 @@ const Buyables: Buyable[] = [
 		name: 'Sandworms',
 		gpCost: 500
 	},
+	{
+		name: 'Granite Body',
+		gpCost: 95_000,
+		minigameScoreReq: ['barb_assault', 10]
+	},
 
 	...sepulchreBuyables,
 	...constructionBuyables,


### PR DESCRIPTION
Redo of #2916 since prisma changes
Adding the granite body to buyables after 10 waves so the BA cl can be completed.
Closes #2710

-   [x] I have tested all my changes thoroughly.
