### PR TITLE
Update simulation pet for phoenix

### DIFF
--- a/src/lib/data/pets.ts
+++ b/src/lib/data/pets.ts
@@ -306,7 +306,7 @@ const pets: Pet[] = [
 		type: 'SPECIAL',
 		altNames: ['PHOENIX', 'PHEONIX', 'WINTERTODT', 'FM'],
 		formatFinish: (num: number) =>
-			`You had to open ${fm(num)} Wintertodt Supply Crates to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
+			`It took you ${fm(num)} Wintertodt Supply Crate rolls to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
 		bossKeys: ['wintertodt']
 	},
 	{

--- a/src/lib/data/pets.ts
+++ b/src/lib/data/pets.ts
@@ -306,7 +306,9 @@ const pets: Pet[] = [
 		type: 'SPECIAL',
 		altNames: ['PHOENIX', 'PHEONIX', 'WINTERTODT', 'FM'],
 		formatFinish: (num: number) =>
-			`It took you ${fm(num)} Wintertodt Supply Crate rolls to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
+			`It took you ${fm(
+				num
+			)} Wintertodt Supply Crate rolls to get the Phoenix Pet! <:Phoenix:324127378223792129>`,
 		bossKeys: ['wintertodt']
 	},
 	{


### PR DESCRIPTION
Change the return message for phoenix pet simulation to say crate rolls instead of crates opened which would have been incorrect. 

Closes #3332

-   [x] I have tested all my changes thoroughly.
