### PR TITLE
ToB Remove Stamina requirement as you buy from chests.

### DIFF
--- a/src/lib/data/tob.ts
+++ b/src/lib/data/tob.ts
@@ -270,7 +270,6 @@ export function calculateTOBUserGearPercents(user: KlasaUser) {
 }
 
 export const minimumTOBSuppliesNeeded = new Bank({
-	'Stamina potion(4)': 3,
 	'Saradomin brew(4)': 10,
 	'Super restore(4)': 5
 });


### PR DESCRIPTION
### Description:
Removes stamina potion requirement to join raid.
Stams are obtained from chests in raid.
Stams are also not drained from players, because of this fact, so they shouldn't be required to join a party.

### Changes:

Updated tobCheckTeam to stop checking for Staminas by changing the minimuim supplies

### Other checks:

-   [ ] I have tested all my changes thoroughly.
