### PR TITLE
Fix CoX Gear score / boost conflict

### DIFF
--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -356,17 +356,17 @@ const itemBoosts: ItemBoost[][] = [
 		{
 			item: getOSItem('Twisted bow'),
 			boost: 8,
-			mustBeEquipped: true
+			mustBeEquipped: false
 		},
 		{
 			item: getOSItem('Bow of faerdhinen (c)'),
 			boost: 6,
-			mustBeEquipped: true
+			mustBeEquipped: false
 		},
 		{
 			item: getOSItem('Dragon hunter crossbow'),
 			boost: 5,
-			mustBeEquipped: true
+			mustBeEquipped: false
 		}
 	],
 	[
@@ -395,14 +395,14 @@ const itemBoosts: ItemBoost[][] = [
 		{
 			item: getOSItem('Abyssal tentacle'),
 			boost: 2,
-			mustBeEquipped: true
+			mustBeEquipped: false
 		}
 	],
 	[
 		{
 			item: getOSItem('Sanguinesti staff'),
 			boost: 6,
-			mustBeEquipped: true,
+			mustBeEquipped: false,
 			setup: 'mage'
 		}
 	]

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -21,7 +21,6 @@ import { Gear } from '../structures/Gear';
 import { Skills } from '../types';
 import { randomVariation, skillsMeetRequirements } from '../util';
 import getOSItem from '../util/getOSItem';
-import { TENTACLE_CHARGES_PER_RAID } from './tob';
 
 export const bareMinStats: Skills = {
 	attack: 80,
@@ -31,6 +30,9 @@ export const bareMinStats: Skills = {
 	magic: 80,
 	prayer: 70
 };
+
+export const SANGUINESTI_CHARGES_PER_COX = 150;
+export const TENTACLE_CHARGES_PER_COX = 200;
 
 export function hasMinRaidsRequirements(user: KlasaUser) {
 	return skillsMeetRequirements(user.rawSkills, bareMinStats);
@@ -278,7 +280,7 @@ export async function checkCoxTeam(users: KlasaUser[], cm: boolean): Promise<str
 		if (user.getGear('melee').hasEquipped('Abyssal tentacle')) {
 			const tentacleResult = checkUserCanUseDegradeableItem({
 				item: getOSItem('Abyssal tentacle'),
-				chargesToDegrade: TENTACLE_CHARGES_PER_RAID,
+				chargesToDegrade: TENTACLE_CHARGES_PER_COX,
 				user
 			});
 			if (!tentacleResult.hasEnough) {
@@ -288,7 +290,7 @@ export async function checkCoxTeam(users: KlasaUser[], cm: boolean): Promise<str
 		if (user.getGear('mage').hasEquipped('Sanguinesti staff')) {
 			const sangResult = checkUserCanUseDegradeableItem({
 				item: getOSItem('Sanguinesti staff'),
-				chargesToDegrade: 250,
+				chargesToDegrade: SANGUINESTI_CHARGES_PER_COX,
 				user
 			});
 			if (!sangResult.hasEnough) {
@@ -349,6 +351,8 @@ interface ItemBoost {
 	boost: number;
 	mustBeEquipped: boolean;
 	setup?: 'mage';
+	mustBeCharged?: boolean;
+	requiredCharges?: number;
 }
 
 const itemBoosts: ItemBoost[][] = [
@@ -395,7 +399,9 @@ const itemBoosts: ItemBoost[][] = [
 		{
 			item: getOSItem('Abyssal tentacle'),
 			boost: 2,
-			mustBeEquipped: false
+			mustBeEquipped: false,
+			mustBeCharged: true,
+			requiredCharges: TENTACLE_CHARGES_PER_COX
 		}
 	],
 	[
@@ -403,7 +409,9 @@ const itemBoosts: ItemBoost[][] = [
 			item: getOSItem('Sanguinesti staff'),
 			boost: 6,
 			mustBeEquipped: false,
-			setup: 'mage'
+			setup: 'mage',
+			mustBeCharged: true,
+			requiredCharges: SANGUINESTI_CHARGES_PER_COX
 		}
 	]
 ];
@@ -411,13 +419,21 @@ const itemBoosts: ItemBoost[][] = [
 export async function calcCoxDuration(
 	_team: KlasaUser[],
 	challengeMode: boolean
-): Promise<{ reductions: Record<string, number>; duration: number; totalReduction: number }> {
+): Promise<{
+	reductions: Record<string, number>;
+	duration: number;
+	totalReduction: number;
+	degradeables: { item: Item; user: KlasaUser; chargesToDegrade: number }[];
+}> {
 	const team = shuffleArr(_team).slice(0, 9);
 	const size = team.length;
 
 	let totalReduction = 0;
 
 	let reductions: Record<string, number> = {};
+
+	// Track degradeable items:
+	const degradeableItems: { item: Item; user: KlasaUser; chargesToDegrade: number }[] = [];
 
 	for (const u of team) {
 		let userPercentChange = 0;
@@ -433,7 +449,21 @@ export async function calcCoxDuration(
 		// Reduce time for item boosts
 		itemBoosts.forEach(set => {
 			for (const item of set) {
-				if (item.mustBeEquipped) {
+				if (item.mustBeCharged && item.requiredCharges) {
+					if (u.hasItemEquippedOrInBank(item.item.id)) {
+						const testItem = {
+							item: item.item,
+							user: u,
+							chargesToDegrade: item.requiredCharges
+						};
+						const canDegrade = checkUserCanUseDegradeableItem(testItem);
+						if (canDegrade.hasEnough) {
+							userPercentChange += item.boost;
+							degradeableItems.push(testItem);
+						}
+						break;
+					}
+				} else if (item.mustBeEquipped) {
 					if (item.setup && u.getGear(item.setup).hasEquipped(item.item.id)) {
 						userPercentChange += item.boost;
 						break;
@@ -463,7 +493,7 @@ export async function calcCoxDuration(
 	duration -= duration * (teamSizeBoostPercent(size) / 100);
 
 	duration = randomVariation(duration, 5);
-	return { duration, reductions, totalReduction: totalSpeedReductions / size };
+	return { duration, reductions, totalReduction: totalSpeedReductions / size, degradeables: degradeableItems };
 }
 
 export async function calcCoxInput(u: KlasaUser, solo: boolean) {

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -460,8 +460,8 @@ export async function calcCoxDuration(
 						if (canDegrade.hasEnough) {
 							userPercentChange += item.boost;
 							degradeableItems.push(testItem);
+							break;
 						}
-						break;
 					}
 				} else if (item.mustBeEquipped) {
 					if (item.setup && u.getGear(item.setup).hasEquipped(item.item.id)) {


### PR DESCRIPTION
### Description:

As we discussed, this is necessary because you can't reach 100% gear score while having most of these items equipped.

The way it is now, it's impossible to reach 100% gear score AND have all boots. And if you bring down the BiS gear to match the boost gear would make it too easy to hit 100% gear score, so I think this is the best solution, though I'm open minded.

### Changes:

- Set mustBeEquipped to `false`
   (Only bso drygores should be `true`, but since they're BIS anyway, it can be removed)
- Changed tentacle charges used to 200 in CoX because you only really use whip for Olm, and very little for vasa/vanguards (but you shouldn't use it for vasa anyway)
- Now the sang/tentacle boosts work from bank, but only under 2 conditions:
- 1) You don't have a higher boost available
- 2) You have enough charges
- If you have tent/sang equipped, it won't let you join the raid if you don't have enough charges
- If they're not equipped, and you don't have enough charges, you just don't get the boost.
- Changed 'check can degrade' for Sang to match the actual charges degraded, 150
- It's the perfect solution :D

### Other checks:

-   [x] I have tested all my changes thoroughly.
