### PR TITLE
[ToB] Remove Vial of blood cost from creating charged variants

### DIFF
--- a/src/lib/data/creatables/tob.ts
+++ b/src/lib/data/creatables/tob.ts
@@ -41,9 +41,7 @@ export const tobCreatables: Createable[] = [
 	{
 		name: 'Holy scythe of vitur',
 		inputItems: resolveNameBank({
-			'Holy scythe of vitur (uncharged)': 1,
-			'Blood rune': 100,
-			'Vial of blood': 1
+			'Holy scythe of vitur (uncharged)': 1
 		}),
 		outputItems: resolveNameBank({
 			'Holy scythe of vitur': 1
@@ -71,9 +69,7 @@ export const tobCreatables: Createable[] = [
 	{
 		name: 'Sanguine scythe of vitur',
 		inputItems: resolveNameBank({
-			'Sanguine scythe of vitur (uncharged)': 1,
-			'Blood rune': 100,
-			'Vial of blood': 1
+			'Sanguine scythe of vitur (uncharged)': 1
 		}),
 		outputItems: resolveNameBank({
 			'Sanguine scythe of vitur': 1


### PR DESCRIPTION
### Description:
Removed the vial of blood + blood rune cost to 'charge' the holy/sanguine scythes.
This is because you charge the scythe separately.

### Changes:
Removed vial of blood/ blood rune cost to 'charge' holy/sang scythes

### Other checks:

-   [ ] I have tested all my changes thoroughly.
