### PR TITLE
Adds ability for Reese to make Crystal stuff

### DIFF
--- a/src/commands/Minion/create.ts
+++ b/src/commands/Minion/create.ts
@@ -17,7 +17,7 @@ export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			usage: '[quantity:int{1}] [itemName:...string]',
-			aliases: ['revert', 'fix', 'unpack'],
+			aliases: ['revert', 'fix', 'unpack', 'reese'],
 			usageDelim: ' ',
 			oneAtTime: true,
 			cooldown: 5,
@@ -83,6 +83,7 @@ export default class extends BotCommand {
 		if (cmd.toLowerCase() === 'revert') itemName = `revert ${itemName}`;
 		if (cmd.toLowerCase() === 'fix') itemName = `fix ${itemName}`;
 		if (cmd.toLowerCase() === 'unpack') itemName = `unpack ${itemName}`;
+		if (cmd.toLowerCase() === 'reese') itemName = `reese ${itemName}`;
 
 		const createableItem = Createables.find(
 			item =>

--- a/src/lib/data/creatables/reese.ts
+++ b/src/lib/data/creatables/reese.ts
@@ -6,7 +6,7 @@ export const reeseCreatables: Createable[] = [
 		name: 'Reese Blade of saeldor (c)',
 		inputItems: resolveNameBank({
 			'Blade of saeldor (inactive)': 1,
-			'Crystal shard': 1500
+			'Crystal shard': 1400
 		}),
 		outputItems: resolveNameBank({ 'Blade of saeldor (c)': 1 }),
 		QPRequired: 150,

--- a/src/lib/data/creatables/reese.ts
+++ b/src/lib/data/creatables/reese.ts
@@ -1,0 +1,77 @@
+import { resolveNameBank } from '../../util';
+import { Createable } from '../createables';
+
+export const reeseCreatables: Createable[] = [
+	{
+		name: 'Reese Blade of saeldor (c)',
+		inputItems: resolveNameBank({
+			'Blade of saeldor (inactive)': 1,
+			'Crystal shard': 1500
+		}),
+		outputItems: resolveNameBank({ 'Blade of saeldor (c)': 1 }),
+		QPRequired: 150
+	},
+	{
+		name: 'Reese Blade of saeldor (inactive)',
+		inputItems: resolveNameBank({
+			'Enhanced crystal weapon seed': 1,
+			'Crystal shard': 150
+		}),
+		outputItems: resolveNameBank({ 'Blade of saeldor (inactive)': 1 }),
+		QPRequired: 150
+	},
+	{
+		name: 'Reese Bow of faerdhinen (c)',
+		inputItems: resolveNameBank({
+			'Bow of faerdhinen (inactive)': 1,
+			'Crystal shard': 1500
+		}),
+		outputItems: resolveNameBank({ 'Bow of faerdhinen (c)': 1 }),
+		QPRequired: 150
+	},
+	{
+		name: 'Reese Bow of faerdhinen (inactive)',
+		inputItems: resolveNameBank({
+			'Enhanced crystal weapon seed': 1,
+			'Crystal shard': 150
+		}),
+		outputItems: resolveNameBank({ 'Bow of faerdhinen (inactive)': 1 }),
+		QPRequired: 150
+	},
+	{
+		name: 'Reese Crystal pickaxe',
+		inputItems: resolveNameBank({
+			'Crystal tool seed': 1,
+			'Crystal shard': 180
+		}),
+		outputItems: resolveNameBank({ 'Crystal pickaxe': 1 }),
+		QPRequired: 150
+	},
+	{
+		name: 'Reese Crystal harpoon',
+		inputItems: resolveNameBank({
+			'Crystal tool seed': 1,
+			'Crystal shard': 180
+		}),
+		outputItems: resolveNameBank({ 'Crystal harpoon': 1 }),
+		QPRequired: 150
+	},
+	{
+		name: 'Reese Crystal axe',
+		inputItems: resolveNameBank({
+			'Crystal tool seed': 1,
+			'Crystal shard': 180
+		}),
+		outputItems: resolveNameBank({ 'Crystal axe': 1 }),
+		QPRequired: 150
+	},
+	{
+		name: 'Reese Enhanced crystal key',
+		inputItems: resolveNameBank({
+			'Crystal key': 1,
+			'Crystal shard': 15
+		}),
+		outputItems: resolveNameBank({ 'Enhanced crystal key': 1 }),
+		QPRequired: 150
+	}
+];

--- a/src/lib/data/creatables/reese.ts
+++ b/src/lib/data/creatables/reese.ts
@@ -44,7 +44,7 @@ export const reeseCreatables: Createable[] = [
 		name: 'Reese Bow of faerdhinen (c)',
 		inputItems: resolveNameBank({
 			'Bow of faerdhinen (inactive)': 1,
-			'Crystal shard': 1500
+			'Crystal shard': 1900
 		}),
 		outputItems: resolveNameBank({ 'Bow of faerdhinen (c)': 1 }),
 		QPRequired: 150,

--- a/src/lib/data/creatables/reese.ts
+++ b/src/lib/data/creatables/reese.ts
@@ -9,7 +9,17 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 1500
 		}),
 		outputItems: resolveNameBank({ 'Blade of saeldor (c)': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	},
 	{
 		name: 'Reese Blade of saeldor (inactive)',
@@ -18,7 +28,17 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 150
 		}),
 		outputItems: resolveNameBank({ 'Blade of saeldor (inactive)': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	},
 	{
 		name: 'Reese Bow of faerdhinen (c)',
@@ -27,7 +47,17 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 1500
 		}),
 		outputItems: resolveNameBank({ 'Bow of faerdhinen (c)': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	},
 	{
 		name: 'Reese Bow of faerdhinen (inactive)',
@@ -36,7 +66,17 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 150
 		}),
 		outputItems: resolveNameBank({ 'Bow of faerdhinen (inactive)': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	},
 	{
 		name: 'Reese Crystal pickaxe',
@@ -45,7 +85,17 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 180
 		}),
 		outputItems: resolveNameBank({ 'Crystal pickaxe': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	},
 	{
 		name: 'Reese Crystal harpoon',
@@ -54,7 +104,17 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 180
 		}),
 		outputItems: resolveNameBank({ 'Crystal harpoon': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	},
 	{
 		name: 'Reese Crystal axe',
@@ -63,7 +123,17 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 180
 		}),
 		outputItems: resolveNameBank({ 'Crystal axe': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	},
 	{
 		name: 'Reese Enhanced crystal key',
@@ -72,6 +142,16 @@ export const reeseCreatables: Createable[] = [
 			'Crystal shard': 15
 		}),
 		outputItems: resolveNameBank({ 'Enhanced crystal key': 1 }),
-		QPRequired: 150
+		QPRequired: 150,
+		requiredSkills: {
+			agility: 70,
+			construction: 70,
+			mining: 70,
+			herblore: 70,
+			farming: 70,
+			woodcutting: 70,
+			hunter: 70,
+			smithing: 70
+		}
 	}
 ];

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -10,6 +10,7 @@ import { capeCreatables } from './creatables/capes';
 import { dragonFireShieldCreatables } from './creatables/dragonfireShields';
 import { gracefulOutfitCreatables } from './creatables/gracefulOutfits';
 import { ornamentKits } from './creatables/ornaments';
+import { reeseCreatables } from './creatables/reese';
 import { slayerCreatables } from './creatables/slayer';
 import { tobCreatables } from './creatables/tob';
 
@@ -1695,7 +1696,8 @@ const Createables: Createable[] = [
 	...revWeapons,
 	...armorAndItemPacks,
 	...gracefulOutfitCreatables,
-	...tobCreatables
+	...tobCreatables,
+	...reeseCreatables
 ];
 
 export default Createables;


### PR DESCRIPTION
### Description:

- Adds ability for Reese to sing Crystal items for the player (at a 50% shard markup)
- Matches OSRS behavior and cost

### Changes:

Adds ability for players with the quest points but not high enough skills to make:

- Blade of saeldor (inactive) - 150 shards (+50)
- Blade of saeldor (c) - 1400 shards
- - Reese fee is 500 shards, and you get credit for existing charges, making 900 + 500 = 1400.
- Bow of faerdhinen (inactive) 150 shards 
- Bow of faerdhinen (c) - 1900 shards
- - Reese fee is 1000 shards, but you get credit for the first 100 shards when making inactive, so 1900 total.
- Crystal axe/pickaxe/harpoon - 180 shards (+60)
- Enhanced crystal key - 15 shards (+5)

(SotE skill requirements are enforced)

### Other checks:

-   [x] I have tested all my changes thoroughly.
