### PR TITLE
Rebalance ToB deaths to be more accurate.

### DIFF
--- a/src/commands/Minion/tob.ts
+++ b/src/commands/Minion/tob.ts
@@ -76,7 +76,7 @@ export default class extends BotCommand {
 			});
 
 			let wins = 0;
-			const winRateSampleSize = 50;
+			const winRateSampleSize = 25;
 			for (let o = 0; o < winRateSampleSize; o++) {
 				const sim = createTOBTeam({
 					team: users.map(u => ({
@@ -373,7 +373,11 @@ export default class extends BotCommand {
 **Mage:** <:Kodai_insignia:403018312264712193> ${gear.mage.toFixed(1)}%
 **Total Gear Score:** ${Emoji.Gear} ${gear.total.toFixed(1)}%\n
 **Death Chances:** ${deathChances.deathChances.map(i => `${i.name} ${i.deathChance.toFixed(2)}%`).join(', ')}
+**Wipe Chances:** ${deathChances.wipeDeathChances.map(i => `${i.name} ${i.deathChance.toFixed(2)}%`).join(', ')}
 **Hard Mode Death Chances:** ${hardDeathChances.deathChances
+			.map(i => `${i.name} ${i.deathChance.toFixed(2)}%`)
+			.join(', ')}
+**Hard Mode Wipe Chances:** ${hardDeathChances.wipeDeathChances
 			.map(i => `${i.name} ${i.deathChance.toFixed(2)}%`)
 			.join(', ')}`);
 	}

--- a/src/commands/Testing/hax.ts
+++ b/src/commands/Testing/hax.ts
@@ -37,10 +37,12 @@ export default class extends BotCommand {
 				.add('Cooked karambwan', 1000)
 				.add('Ranging potion(4)', 1000)
 				.add('Death rune', 10_000)
-				.add('Blood rune', 10_000)
+				.add('Blood rune', 100_000)
 				.add('Water rune', 10_000)
 				.add('Coins', 5_000_000)
 				.add('Shark', 5000)
+				.add('Vial of blood', 10_000)
+				.add('Rune pouch', 1)
 				.add('Toxic blowpipe');
 			await msg.author.addItemsToBank(loot);
 			await msg.author.settings.update(UserSettings.Blowpipe, {


### PR DESCRIPTION
### Description:

Currently the death chances are higher than they should be to make the wipe/completion curve accurate.
This update splits that curve after a certain KC, and uses the original curve to determine wipe chance (so completion chance stays the same), but the actual death chance is significantly reduced.

This behavior matches osrs much more accurately, and everyone so far has agreed.


### Changes:

- Makes deaths much less common after 50 normal, 75 hard mode KC
- Wipe / completion chance remains the same
- Hard mode is made slightly easier because it was much too punishing to players with 250 normal KC.
- `+tob` now shows wipe chance in addition to death chance.

### Testing changes:
- Cuts the number of samples for the `+tob graph` command in half to greatly speed it up
- Adds more blood runes, a rune pouch, and vials of blood to `+hax --tob` to power the scythe it equips.

### Other checks:

-   [x] I have tested all my changes thoroughly.
