### PR TITLE
Fix CoX Boost for BSO

### DIFF
--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -412,7 +412,7 @@ const itemBoosts: ItemBoost[][] = [
 	[
 		{
 			item: getOSItem('Sanguinesti staff'),
-			boost: 6,
+			boost: 7,
 			mustBeEquipped: false,
 			setup: 'mage',
 			mustBeCharged: true,

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -160,7 +160,7 @@ const source: [string, (string | number)[]][] = [
 	['Graceful cape', gracefulCapes],
 	['Agility cape', ['Agility cape(t)']],
 	['Fire cape', ['Fire max cape', 'Fire max cape (l)']],
-	['Infernal cape', ['Infernal max cape', 'Infernal max cape (l)']],
+	['Infernal cape', ['Infernal max cape', 'Infernal max cape (l)', 'TzKal cape']],
 	['Ardougne cloak 4', ['Ardougne max cape']],
 	["Ava's accumulator", ['Accumulator max cape']],
 	["Ava's assembler", ['Assembler max cape', 'Assembler max cape (l)']],


### PR DESCRIPTION
### Description:

This fixes CoX so the max boost is identical to pre-ToB changes

### Changes:

Changed sanguinesti staff to 7%
Makes Tzkal cape also count as infernal cape.

### Other checks:

-   [x] I have tested all my changes thoroughly.
