### PR TITLE
Take "m" out of continuation characters

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -369,7 +369,7 @@ export const MAX_XP = 200_000_000;
 
 export const MIMIC_MONSTER_ID = 23_184;
 
-export const continuationChars = 'abdefghjkmnoprstuvwxyz123456789'.split('');
+export const continuationChars = 'abdefghjknoprstuvwxyz123456789'.split('');
 export const CENA_CHARS = ['​', '‎', '‍'];
 export const NIGHTMARES_HP = 2400;
 export const ZAM_HASTA_CRUSH = 65;


### PR DESCRIPTION
Closes #3394

Take "m" out of the possible letters for continuing trips. Resolves bugs around typing +m/=m when trip concludes.

-   [ ] I have tested all my changes thoroughly.
