### PR TITLE
Fix BSO Farming - merge error and mushroom

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -237,6 +237,7 @@ export default class extends Task {
 				} else if (plantToHarvest.fixedOutput) {
 					if (!plantToHarvest.fixedOutputAmount) return;
 					cropYield = plantToHarvest.fixedOutputAmount;
+					if (plantToHarvest.seedType === 'mushroom') cropYield *= alivePlants;
 				} else {
 					const plantChanceFactor =
 						Math.floor(
@@ -383,7 +384,9 @@ export default class extends Task {
 			let tangleroot = false;
 			if (plantToHarvest.seedType === 'hespori') {
 				await user.incrementMonsterScore(Monsters.Hespori.id);
-				const hesporiLoot = Monsters.Hespori.kill(1, { farmingLevel: currentFarmingLevel });
+				const hesporiLoot = Monsters.Hespori.kill(patchType.lastQuantity, {
+					farmingLevel: currentFarmingLevel
+				});
 				loot = hesporiLoot;
 				if (hesporiLoot.amount('Tangleroot')) tangleroot = true;
 				if (roll((plantToHarvest.petChance - currentFarmingLevel * 25) / patchType.lastQuantity / 5)) {


### PR DESCRIPTION
### Description:

Currently, Mushrooms + Hespori only give loot for 1 plant/kill.

Mushrooms I think we fixed before, but can't find the exact merge error, so it may be an older break.

Hespori was recently broken this last master=>bso merge.

### Changes:

1. If plantType == mushroom, * by alivePlants
2. hespori.kill(patchType.lastQuantity)

### Other checks:

-   [ ] I have tested all my changes thoroughly.

### Other
The farming code DESPERATELY needs to be re-written, but I don't want to do it, hah. I think someone redid farming a few months back, in a really nice system (from the frontend, i didn't see the code)