### PR TITLE
Tidy monster.ts and raid.ts

### DIFF
--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -198,7 +198,7 @@ export default class MinionCommand extends BotCommand {
 		}
 		if (totalBoost.length > 0) {
 			str.push(
-				`**Boosts**\nAvalible Boosts: ${totalBoost.join(',')}\n${
+				`**Boosts**\nAvailable Boosts: ${totalBoost.join(',')}\n${
 					ownedBoostItems.length > 0
 						? `Your boosts: ${ownedBoostItems.join(', ')} for ${totalItemBoost}%`
 						: ''

--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -42,7 +42,7 @@ const uniques = [
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			usage: '[mass|solo|gear]',
+			usage: '[mass|solo]',
 			usageDelim: ' ',
 			oneAtTime: true,
 			altProtection: true,
@@ -83,7 +83,7 @@ export default class extends BotCommand {
 			return msg.channel.send({ files: [new MessageAttachment(Buffer.from(normalTable), 'cox-sim.txt')] });
 		}
 
-		if (!type || type === 'gear') {
+		if (!type) {
 			const [normal, cm] = await Promise.all([
 				msg.author.getMinigameScore('raids'),
 				msg.author.getMinigameScore('raids_challenge_mode')


### PR DESCRIPTION
Fixes a typo on monster.ts

Also tidied raid.ts as inputting anything other than solo/mass will show the gear now. So "+raid gear" will still work.

-   [x] I have tested all my changes thoroughly.
