### PR TITLE
Add smithable gold items

### DIFF
--- a/src/commands/Minion/smith.ts
+++ b/src/commands/Minion/smith.ts
@@ -5,6 +5,7 @@ import { Bank } from 'oldschooljs';
 
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Smithing from '../../lib/skilling/skills/smithing';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
@@ -65,6 +66,14 @@ export default class extends BotCommand {
 		if (msg.author.skillLevel(SkillsEnum.Smithing) < smithedItem.level) {
 			return msg.channel.send(
 				`${msg.author.minionName} needs ${smithedItem.level} Smithing to smith ${smithedItem.name}s.`
+			);
+		}
+
+		const userQP = msg.author.settings.get(UserSettings.QP);
+
+		if (smithedItem.qpRequired && userQP < smithedItem.qpRequired) {
+			return msg.channel.send(
+				`${msg.author.minionName} needs ${smithedItem.qpRequired} QP to smith ${smithedItem.name}`
 			);
 		}
 

--- a/src/lib/skilling/skills/smithing/smithables/gold.ts
+++ b/src/lib/skilling/skills/smithing/smithables/gold.ts
@@ -1,0 +1,29 @@
+import { Time } from 'e';
+
+import itemID from '../../../../util/itemID';
+import { SmithedItem } from '../../../types';
+
+const Gold: SmithedItem[] = [
+	{
+		name: 'Gold helmet',
+		level: 50,
+		xp: 30,
+		id: itemID('Gold helmet'),
+		inputBars: { [itemID('Gold bar')]: 3 },
+		timeToUse: Time.Second * 4,
+		outputMultiple: 1,
+		qpRequired: 4
+	},
+	{
+		name: 'Gold bowl',
+		level: 50,
+		xp: 30,
+		id: itemID('Gold bowl'),
+		inputBars: { [itemID('Gold bar')]: 2 },
+		timeToUse: Time.Second * 3.7,
+		outputMultiple: 1,
+		qpRequired: 111
+	}
+];
+
+export default Gold;

--- a/src/lib/skilling/skills/smithing/smithables/index.ts
+++ b/src/lib/skilling/skills/smithing/smithables/index.ts
@@ -1,8 +1,9 @@
 import Adamant from './adamant';
 import Bronze from './bronze';
+import Gold from './gold';
 import Iron from './iron';
 import Mithril from './mithril';
 import Rune from './rune';
 import Steel from './steel';
 
-export default [...Adamant, ...Bronze, ...Iron, ...Mithril, ...Rune, ...Steel];
+export default [...Adamant, ...Bronze, ...Gold, ...Iron, ...Mithril, ...Rune, ...Steel];

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -141,6 +141,7 @@ export interface SmithedItem {
 	inputBars: ItemBank;
 	timeToUse: number;
 	outputMultiple: number;
+	qpRequired?: number;
 }
 
 export interface Craftable {


### PR DESCRIPTION
Adds Gold Helmet and Gold Bowl to the smithables, checking they have the required quest points needed to complete the relevant quests.

Closes #3410 

-   [x] I have tested all my changes thoroughly.
