### PR TITLE
Added ironmanPrice to MANY items, so it matches in-game cost for ironmen

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -270,19 +270,19 @@ const questBuyables: Buyable[] = [
 		name: 'Black gloves',
 		qpRequired: 35,
 		gpCost: 400_000,
-		ironmanPrice: 1_000
+		ironmanPrice: 1000
 	},
 	{
 		name: 'Mithril gloves',
 		qpRequired: 50,
 		gpCost: 500_000,
-		ironmanPrice: 2_000
+		ironmanPrice: 2000
 	},
 	{
 		name: 'Adamant gloves',
 		qpRequired: 65,
 		gpCost: 600_000,
-		ironmanPrice: 3_250
+		ironmanPrice: 3250
 	},
 	{
 		name: 'Rune gloves',
@@ -291,7 +291,7 @@ const questBuyables: Buyable[] = [
 		},
 		qpRequired: 85,
 		gpCost: 700_000,
-		ironmanPrice: 6_500
+		ironmanPrice: 6500
 	},
 	{
 		name: 'Dragon gloves',
@@ -609,7 +609,7 @@ const questBuyables: Buyable[] = [
 		name: 'Elemental shield',
 		gpCost: 2_500_000,
 		qpRequired: 25,
-		ironmanPrice: 2_000
+		ironmanPrice: 2000
 	}
 ];
 

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -270,13 +270,13 @@ const questBuyables: Buyable[] = [
 		name: 'Black gloves',
 		qpRequired: 35,
 		gpCost: 400_000,
-		ironmanPrice: 1_300
+		ironmanPrice: 1_000
 	},
 	{
 		name: 'Mithril gloves',
 		qpRequired: 50,
 		gpCost: 500_000,
-		ironmanPrice: 1_950
+		ironmanPrice: 2_000
 	},
 	{
 		name: 'Adamant gloves',

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -228,12 +228,14 @@ const questBuyables: Buyable[] = [
 			[itemID('Goldsmith gauntlets')]: 1
 		},
 		qpRequired: 25,
-		gpCost: 1_000_000
+		gpCost: 1_000_000,
+		ironmanPrice: 25_000
 	},
 	{
 		name: 'Cooking gauntlets',
 		qpRequired: 25,
-		gpCost: 1_000_000
+		gpCost: 1_000_000,
+		ironmanPrice: 25_000
 	},
 	{
 		name: 'Anti-dragon shield',
@@ -243,37 +245,44 @@ const questBuyables: Buyable[] = [
 	{
 		name: 'Hardleather gloves',
 		qpRequired: 5,
-		gpCost: 50_000
+		gpCost: 50_000,
+		ironmanPrice: 65
 	},
 	{
 		name: 'Bronze gloves',
 		qpRequired: 10,
-		gpCost: 100_000
+		gpCost: 100_000,
+		ironmanPrice: 130
 	},
 	{
 		name: 'Iron gloves',
 		qpRequired: 20,
-		gpCost: 200_000
+		gpCost: 200_000,
+		ironmanPrice: 325
 	},
 	{
 		name: 'Steel gloves',
 		qpRequired: 25,
-		gpCost: 300_000
+		gpCost: 300_000,
+		ironmanPrice: 650
 	},
 	{
 		name: 'Black gloves',
 		qpRequired: 35,
-		gpCost: 400_000
+		gpCost: 400_000,
+		ironmanPrice: 1_300
 	},
 	{
 		name: 'Mithril gloves',
 		qpRequired: 50,
-		gpCost: 500_000
+		gpCost: 500_000,
+		ironmanPrice: 1_950
 	},
 	{
 		name: 'Adamant gloves',
 		qpRequired: 65,
-		gpCost: 600_000
+		gpCost: 600_000,
+		ironmanPrice: 3_250
 	},
 	{
 		name: 'Rune gloves',
@@ -281,27 +290,32 @@ const questBuyables: Buyable[] = [
 			[itemID('Rune gloves')]: 1
 		},
 		qpRequired: 85,
-		gpCost: 700_000
+		gpCost: 700_000,
+		ironmanPrice: 6_500
 	},
 	{
 		name: 'Dragon gloves',
 		qpRequired: 107,
-		gpCost: 850_000
+		gpCost: 850_000,
+		ironmanPrice: 130_000
 	},
 	{
 		name: 'Barrows gloves',
 		qpRequired: 175,
-		gpCost: 1_000_000
+		gpCost: 1_000_000,
+		ironmanPrice: 130_000
 	},
 	{
 		name: 'Helm of neitiznot',
 		qpRequired: 75,
-		gpCost: 500_000
+		gpCost: 500_000,
+		ironmanPrice: 50_000
 	},
 	{
 		name: 'Magic secateurs',
 		qpRequired: 40,
-		gpCost: 2_500_000
+		gpCost: 2_500_000,
+		ironmanPrice: 40_000
 	},
 	{
 		name: "Iban's staff",
@@ -318,7 +332,8 @@ const questBuyables: Buyable[] = [
 	{
 		name: 'Mythical cape',
 		gpCost: 1_000_000,
-		qpRequired: 205
+		qpRequired: 205,
+		ironmanPrice: 10_000
 	},
 	{
 		name: 'Mind shield',
@@ -472,22 +487,26 @@ const questBuyables: Buyable[] = [
 	{
 		name: 'Warrior helm',
 		gpCost: 780_000,
-		qpRequired: 60
+		qpRequired: 60,
+		ironmanPrice: 78_000
 	},
 	{
 		name: 'Berserker helm',
 		gpCost: 780_000,
-		qpRequired: 60
+		qpRequired: 60,
+		ironmanPrice: 78_000
 	},
 	{
 		name: 'Archer helm',
 		gpCost: 780_000,
-		qpRequired: 60
+		qpRequired: 60,
+		ironmanPrice: 78_000
 	},
 	{
 		name: 'Farseer helm',
 		gpCost: 780_000,
-		qpRequired: 60
+		qpRequired: 60,
+		ironmanPrice: 78_000
 	},
 	{
 		name: "Doctor's hat",
@@ -589,7 +608,8 @@ const questBuyables: Buyable[] = [
 	{
 		name: 'Elemental shield',
 		gpCost: 2_500_000,
-		qpRequired: 25
+		qpRequired: 25,
+		ironmanPrice: 2_000
 	}
 ];
 


### PR DESCRIPTION
### Description:

Many relevant items, mostly ones that starting ironmen would want, were very expensive to the point that it'd be near impossible to buy them at the start due to the relatively very high cost. 
     Therefore, I updated the price of important items by adding the ironmanPrice function to them. This makes the price for items such as Magic secs & Barrow gloves match their in-game price for *ironman only*, the original cost is unchanged for mains. 
  

### Changes:

Added an `ironmanPrice` function to the following items, so they match their in-game cost. The Osrs Wiki was used for references. 

- Goldsmith gauntlets
- Cooking gauntlets
- RFD Gloves (Hardleather > Barrows)
- Helm of Neitiznot
- Magic Secateurs
- Mythical cape
- Warrior/Berserker/Farseer/Archer helms
- Elemental shield (For this one, there is no in-game cost since you smith it during quest. However, 2.5m is too much for ironmen. Made it 2,000 since thats reasonable)

### Other checks:

-   [ ] I have tested all my changes thoroughly.


