### PR TITLE
Fixes revert command for holy rapier

### DIFF
--- a/src/lib/data/creatables/tob.ts
+++ b/src/lib/data/creatables/tob.ts
@@ -166,11 +166,11 @@ export const tobCreatables: Createable[] = [
 	{
 		name: 'Revert holy ghrazi rapier',
 		inputItems: resolveNameBank({
-			'Holy ghrazi rapier': 1,
-			'Holy ornament kit': 1
+			'Holy ghrazi rapier': 1
 		}),
 		outputItems: resolveNameBank({
-			'Ghrazi rapier': 1
+			'Ghrazi rapier': 1,
+			'Holy ornament kit': 1
 		})
 	}
 ];


### PR DESCRIPTION
Currently a bug that consumes a kit to revert the holy rapier 

Partially closes the first issue raised in #3417 Will look at the other part later

-   [ ] I have tested all my changes thoroughly.
