### PR TITLE
TOG - Trip length based on QP of user

### DIFF
--- a/src/commands/Minion/tearsofguthix.ts
+++ b/src/commands/Minion/tearsofguthix.ts
@@ -50,7 +50,8 @@ export default class extends BotCommand {
 		}
 
 		// 43 QP for the quest
-		if (msg.author.settings.get(UserSettings.QP) < 43) {
+		const userQP = msg.author.settings.get(UserSettings.QP);
+		if (userQP < 43) {
 			return msg.channel.send(
 				`**${Emoji.Snake} Juna says...** You can drink from the Tears of Guthix when you have 43+ QP.`
 			);
@@ -94,7 +95,10 @@ export default class extends BotCommand {
 			);
 		}
 
-		const duration = Time.Minute * 8;
+		let duration = Time.Minute * 2;
+		duration += Time.Second * 0.6 * userQP;
+		if (duration > Time.Minute * 30) duration = Time.Minute * 30;
+
 		await addSubTaskToActivityTask<TearsOfGuthixActivityTaskOptions>({
 			minigameID: 'tears_of_guthix',
 			userID: msg.author.id,


### PR DESCRIPTION
Closes https://github.com/oldschoolgg/oldschoolbot/issues/3420

### Description:

Make it so that ToG trips are based on the number of QP of the user. This is capped at 30minutes since BSO can have 5k QP.
This would mean minimum trip length is 2 minutes 25 seconds, max for OSB is 4 minutes 50 seconds. BSO would be 30 minutes at 2800+ QP.

### Changes:

Change duration of ToG based on user's QP

### Other checks:

-   [x] I have tested all my changes thoroughly.
