### PR TITLE
Revs death chance bugfix

### DIFF
--- a/src/commands/Minion/revs.ts
+++ b/src/commands/Minion/revs.ts
@@ -4,7 +4,7 @@ import { CommandStore, KlasaMessage } from 'klasa';
 import { Bank, Monsters } from 'oldschooljs';
 
 import { Emoji } from '../../lib/constants';
-import { maxOffenceStats } from '../../lib/gear';
+import { maxDefenceStats, maxOffenceStats } from '../../lib/gear';
 import { generateGearImage } from '../../lib/gear/functions/generateGearImage';
 import { minionNotBusy, requiresMinion } from '../../lib/minions/decorators';
 import { KillableMonster } from '../../lib/minions/types';
@@ -251,8 +251,6 @@ Skulled: \`${skulled}\` - You can choose to go skulled into the Revenants cave. 
 			return msg.channel.send("Your weapon is terrible, you can't kill revenants.");
 		}
 
-		debug.push(`${gearStat} ${key} out of max ${maxOffenceStats[key]}`);
-
 		let timePerMonster = monster.timeToFinish;
 		timePerMonster = reduceNumByPercent(timePerMonster, gearPercent / 4);
 		boosts.push(`${(gearPercent / 4).toFixed(2)}% (out of a possible 25%) for ${key}`);
@@ -288,7 +286,7 @@ Skulled: \`${skulled}\` - You can choose to go skulled into the Revenants cave. 
 		let deathChanceFromDefenceLevel = (100 - (defLvl === 99 ? 100 : defLvl)) / 4;
 		deathChance += deathChanceFromDefenceLevel;
 
-		const defensiveGearPercent = Math.max(0, calcWhatPercent(gear.getStats().defence_magic, maxOffenceStats[key]));
+		const defensiveGearPercent = Math.max(0, calcWhatPercent(gear.getStats().defence_magic, maxDefenceStats["defence_magic"]));
 		let deathChanceFromGear = Math.max(20, 100 - defensiveGearPercent) / 4;
 		deathChance += deathChanceFromGear;
 
@@ -309,7 +307,7 @@ Skulled: \`${skulled}\` - You can choose to go skulled into the Revenants cave. 
 
 		let response = `${msg.author.minionName} is now killing ${quantity}x ${
 			monster.name
-		}, it'll take around ${formatDuration(duration)} to finish. ${debug.join(', ')}
+		}, it'll take around ${formatDuration(duration)} to finish.
 ${Emoji.OSRSSkull} ${skulled ? 'Skulled' : 'Unskulled'}
 **Death Chance:** ${deathChance.toFixed(2)}% (${deathChanceFromGear.toFixed(2)}% from magic def${
 			deathChanceFromDefenceLevel > 0 ? `, ${deathChanceFromDefenceLevel.toFixed(2)}% from defence level` : ''

--- a/src/commands/Minion/revs.ts
+++ b/src/commands/Minion/revs.ts
@@ -285,7 +285,10 @@ Skulled: \`${skulled}\` - You can choose to go skulled into the Revenants cave. 
 		let deathChanceFromDefenceLevel = (100 - (defLvl === 99 ? 100 : defLvl)) / 4;
 		deathChance += deathChanceFromDefenceLevel;
 
-		const defensiveGearPercent = Math.max(0, calcWhatPercent(gear.getStats().defence_magic, maxDefenceStats["defence_magic"]));
+		const defensiveGearPercent = Math.max(
+			0,
+			calcWhatPercent(gear.getStats().defence_magic, maxDefenceStats['defence_magic'])
+		);
 		let deathChanceFromGear = Math.max(20, 100 - defensiveGearPercent) / 4;
 		deathChance += deathChanceFromGear;
 

--- a/src/commands/Minion/revs.ts
+++ b/src/commands/Minion/revs.ts
@@ -235,7 +235,6 @@ Skulled: \`${skulled}\` - You can choose to go skulled into the Revenants cave. 
 				`That's not a valid revenant. The valid revenants are: ${revenantMonsters.map(m => m.name).join(', ')}.`
 			);
 		}
-		let debug = [];
 
 		const gear = msg.author.getGear('wildy');
 		const key = ({ melee: 'attack_crush', mage: 'attack_magic', range: 'attack_ranged' } as const)[style];

--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -10,7 +10,7 @@ export * from './util';
 // https://oldschool.runescape.wiki/w/Armour/Highest_bonuses
 export const maxDefenceStats: { [key in DefenceGearStat]: number } = {
 	[GearStat.DefenceCrush]: 505,
-	[GearStat.DefenceMagic]: 253,
+	[GearStat.DefenceMagic]: 238,
 	[GearStat.DefenceRanged]: 542,
 	[GearStat.DefenceSlash]: 521,
 	[GearStat.DefenceStab]: 519


### PR DESCRIPTION
### Description:

Revs currently compares the magic defence stats of the user to the maximum possible crush attack stat, rather than the max possible magic defence stat, when calculating gear death chance.

Minimum death chance (10%) can be obtained with 99 Defence and 190.4+ magic defence on your wildy gear.

### Changes:

Calculate gear death chance using magic defence compared against the maximum magic defence stats.
Updated the maximum magic defence stats from 253 -> 238. This was reduced due to changes to crystal armour, meaning Halos are now BIS (+11 instead of +26).
Removed debug statements, the information is already included in return messages to the user anyway.

### Other checks:

-   [x] I have tested all my changes thoroughly.
