### PR TITLE
Fix error with sang staff equipped

### DIFF
--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -35,7 +35,7 @@ export const degradeableItems: DegradeableItem[] = [
 		item: getOSItem('Sanguinesti staff'),
 		settingsKey: 'sang_charges',
 		itemsToRefundOnBreak: new Bank().add('Sanguinesti staff (uncharged)'),
-		setup: 'melee',
+		setup: 'mage',
 		aliases: ['sang', 'sang staff', 'sanguinesti staff', 'sanguinesti'],
 		chargeInput: {
 			cost: new Bank().add('Blood rune', 3),


### PR DESCRIPTION
### Description:
Sang staff checks wrong slot when looking to apply boost, causing the check to always fail which throws an error.

### To reproduce: 
Equip sang staff in mage.
Kill a mob who's default attackStyleToUse = 'mage' (like thermy/smoke devils)
This produces, 'an error has occured' via a thrown error.

### Changes:
Changes slot to check for sang from 'melee' to 'mage'

### Other checks:

-   [ ] I have tested all my changes thoroughly.
