### PR TITLE
Prevent infinite money loophole

### DIFF
--- a/src/lib/data/buyables/tokkulBuyables.ts
+++ b/src/lib/data/buyables/tokkulBuyables.ts
@@ -244,36 +244,36 @@ const TokkulShopItems: TokkulShopItem[] = [
 	{
 		name: 'Fire rune',
 		inputItem: itemID('Fire rune'),
-		tokkulReturn: 1,
+		tokkulReturn: 0,
 		tokkulCost: 6,
-		diaryTokkulReturn: 1,
+		diaryTokkulReturn: 0,
 		diaryTokkulCost: 5,
 		aliases: ['fire']
 	},
 	{
 		name: 'Water rune',
 		inputItem: itemID('Water rune'),
-		tokkulReturn: 1,
+		tokkulReturn: 0,
 		tokkulCost: 6,
-		diaryTokkulReturn: 1,
+		diaryTokkulReturn: 0,
 		diaryTokkulCost: 5,
 		aliases: ['water']
 	},
 	{
 		name: 'Air rune',
 		inputItem: itemID('Air rune'),
-		tokkulReturn: 1,
+		tokkulReturn: 0,
 		tokkulCost: 6,
-		diaryTokkulReturn: 1,
+		diaryTokkulReturn: 0,
 		diaryTokkulCost: 5,
 		aliases: ['air']
 	},
 	{
 		name: 'Earth rune',
 		inputItem: itemID('Earth rune'),
-		tokkulReturn: 1,
+		tokkulReturn: 0,
 		tokkulCost: 6,
-		diaryTokkulReturn: 1,
+		diaryTokkulReturn: 0,
 		diaryTokkulCost: 5,
 		aliases: ['earth']
 	},


### PR DESCRIPTION
### Description:
Currently you can buy elemental runes for 15gp each from the bot, sell for 1 tokkul each, and then buy Tin ore and sell it back to the bot for 10% profit.  (15% on bso with Skipper). 
This can be repeated indefinitely and doesn't require a minion trip.

### Changes:
Changes tokkul shop  so it only pays 0 tokkul for elemental runes. This matches in game behavior because after selling a small number of elemental runes to the tokkul show (1-5) the sell price becomes 0.

Mind/body runes were not changed because their bot purchase price is too high to make it profitable, and tokkul should be obtainable.

(Alternatively, you could change the bot buy price of elemental runes to 25gp each, this would also solve the problem)


### Other checks:

-   [ ] I have tested all my changes thoroughly.
