### PR TITLE
Fix error when buying Festive Presents

### DIFF
--- a/src/lib/settings/prisma.ts
+++ b/src/lib/settings/prisma.ts
@@ -89,7 +89,7 @@ export async function isElligibleForPresent(user: KlasaUser) {
 	if (user.totalLevel() >= 2000) return true;
 	const totalActivityDuration: [{ sum: number }] = await prisma.$queryRaw`SELECT SUM(duration)
 FROM activity
-WHERE user_id = ${user.id};`;
+WHERE user_id = ${BigInt(user.id)};`;
 	if (totalActivityDuration[0].sum >= Time.Hour * 80) return true;
 	return false;
 }


### PR DESCRIPTION
### Description:

Because user_id in Activity table is a Bigint, user.id must be cast to a bigint before being passed to the prepared statement/prisma queryRaw function.

### Changes:

Adds BigInt() around user.id in the location in question.

### Other checks:

-   [x] I have tested all my changes thoroughly.
