### PR TITLE
Remove slayer requirement for charging dfs

### DIFF
--- a/src/lib/data/creatables/dragonfireShields.ts
+++ b/src/lib/data/creatables/dragonfireShields.ts
@@ -47,10 +47,7 @@ export const dragonFireShieldCreatables: Createable[] = [
 		}).bank,
 		outputItems: resolveNameBank({
 			'Dragonfire shield': 1
-		}),
-		requiredSkills: {
-			slayer: 62
-		}
+		})
 	},
 	{
 		name: 'Dragonfire ward',

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1676,9 +1676,6 @@ const Createables: Createable[] = [
 		}),
 		outputItems: {
 			[itemID('Bottled dragonbreath')]: 1
-		},
-		requiredSkills: {
-			slayer: 62
 		}
 	},
 	{


### PR DESCRIPTION
Remove the 62 slayer requirement in order to charge the dfs, not too sure if there was a reason this was added but you can do it with 1 slayer in game?

-   [ ] I have tested all my changes thoroughly.
