### PR TITLE
Fix Double Lil zik drops on hard mode

### DIFF
--- a/src/lib/simulation/tob.ts
+++ b/src/lib/simulation/tob.ts
@@ -95,14 +95,6 @@ export class TheatreOfBloodClass {
 			loot.add(NonUniqueTable.roll());
 		}
 
-		let petChance = isHardMode ? 500 : 650;
-		if (member.numDeaths > 0) {
-			petChance *= member.numDeaths;
-		}
-		if (roll(petChance)) {
-			loot.add("Lil' zik");
-		}
-
 		if (isHardMode) {
 			// Add 15% extra regular loot for hard mode:
 			for (const [itemID] of Object.entries(loot.bank)) {
@@ -110,6 +102,13 @@ export class TheatreOfBloodClass {
 			}
 			// Add HM Tertiary drops: dust / kits
 			loot.add(HardModeExtraTable.roll());
+		}
+		let petChance = isHardMode ? 500 : 650;
+		if (member.numDeaths > 0) {
+			petChance *= member.numDeaths;
+		}
+		if (roll(petChance)) {
+			loot.add("Lil' zik");
 		}
 
 		return loot;


### PR DESCRIPTION
### Description:

Oops, I made a bug with the increased loot  percent, didn't move lil zik down.
This gives 2x lil zik when won in hard mode.

### Changes:
Moves lil zik so you can't get 2x anymore.

### Other checks:

-   [x] I have tested all my changes thoroughly.
