### PR TITLE
Remove worst player from speed calculation (ToB)

### DIFF
--- a/src/lib/data/tob.ts
+++ b/src/lib/data/tob.ts
@@ -501,7 +501,7 @@ export function createTOBTeam({
 	const maxScaling = 350;
 	assert(teamSize > 1 && teamSize < 6, 'TOB team must be 2-5 users');
 
-	let totalReduction = 0;
+	let individualReductions = [];
 
 	let reductions: Record<string, number> = {};
 
@@ -601,11 +601,21 @@ export function createTOBTeam({
 
 		let reduction = round(userPercentChange / teamSize, 1);
 
-		totalReduction += reduction;
+		individualReductions.push(userPercentChange);
 		reductions[u.user.id] = reduction;
 	}
 	let duration = baseDuration;
 
+	// Get the sum of individualReductions array
+	let totalReduction = individualReductions.reduce((a, c) => a + c);
+
+	// Remove the worst player from speed calculation if team size > 2:
+	if (teamSize > 2) {
+		totalReduction -= Math.min(...individualReductions);
+		totalReduction = round(totalReduction / (teamSize - 1), 2);
+	} else {
+		totalReduction = round(totalReduction / teamSize, 2);
+	}
 	if (hardMode) {
 		duration = baseCmDuration;
 		duration = reduceNumByPercent(duration, totalReduction / 1.3);


### PR DESCRIPTION
### Description:

To remove need for the #tob-hm-wipe channel, this removes the worst players 'boost' from the speed calculation.

**Players don't need to worry about the deaths affecting their unique chance**, because while the group chance does go down, 
your individual item chance stays the same, because the other player's chance to get the unique drops by the same amount.

Imagine you have have a 4-man team, each with 10 points (40 points total).
0 deaths:
  Group has 11% chance at an item. 10/40 (25%) chance in your name, this equals 11% * 25% = **2.75%**
If another player loses 8 points from deaths:
  Group has 32/40 (80%) * 11%  = 8.8% chance at item.  10/32 (31.25%) chance in your name. 8.8% * 31.25* = **2.75%**

### Changes:

When team size is at least 3, remove the worst boost from the equation.

### Other checks:

-   [x] I have tested all my changes thoroughly.
