### PR TITLE
Fix some floating point errors in BSO

### DIFF
--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -1,5 +1,5 @@
 import { MessageCollector } from 'discord.js';
-import { round, Time } from 'e';
+import { increaseNumByPercent, round, Time } from 'e';
 import { KlasaMessage, KlasaUser } from 'klasa';
 import { Bank, Items, Monsters } from 'oldschooljs';
 import { Item, ItemBank } from 'oldschooljs/dist/meta/types';
@@ -287,7 +287,7 @@ export async function runTameTask(activity: TameActivity, tame: Tame) {
 			// If less than 8 kills, roll 25% chance per kill
 			if (hasOri) {
 				if (killQty >= 8) {
-					killQty = Math.ceil(killQty * 1.25);
+					killQty = Math.ceil(increaseNumByPercent(killQty, 25));
 				} else {
 					for (let i = 0; i < quantity; i++) {
 						if (roll(4)) killQty++;

--- a/src/tasks/minions/craftingActivity.ts
+++ b/src/tasks/minions/craftingActivity.ts
@@ -1,3 +1,4 @@
+import { increaseNumByPercent } from 'e';
 import { Task } from 'klasa';
 import { Bank } from 'oldschooljs';
 
@@ -38,7 +39,7 @@ export default class extends Task {
 		const hasScroll = await user.hasItem(itemID('Scroll of dexterity'));
 		if (hasScroll) {
 			let _qty = quantityToGive - crushed;
-			_qty = Math.floor(_qty * 1.15);
+			_qty = Math.floor(increaseNumByPercent(_qty, 15));
 			loot.add(item.id, _qty);
 		} else {
 			loot.add(item.id, quantityToGive - crushed);

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -1,4 +1,4 @@
-import { calcWhatPercent, randArrItem, reduceNumByPercent, Time } from 'e';
+import { calcWhatPercent, increaseNumByPercent, randArrItem, reduceNumByPercent, Time } from 'e';
 import { Task } from 'klasa';
 import { MonsterKillOptions, Monsters } from 'oldschooljs';
 import { MonsterAttribute } from 'oldschooljs/dist/meta/monsterData';
@@ -45,7 +45,7 @@ export default class extends Task {
 			oriBoost = true;
 			if (duration > Time.Minute * 5) {
 				// Original boost for 5+ minute task:
-				boostedQuantity = Math.ceil(quantity * 1.25);
+				boostedQuantity = Math.ceil(increaseNumByPercent(quantity, 25));
 			} else {
 				// 25% chance at extra kill otherwise:
 				for (let i = 0; i < quantity; i++) {


### PR DESCRIPTION
### Description:

Some places in BSO rely on floating point math when they shouldn't be. I scanned over the entire code base (using regex searches for "x.xx *" or "* x.xx") and it's fine to use that for time, xp, etc, but especially for smaller numbers, and specifically ITEMS we can't use floating point math, because:
`Math.floor(100 * 1.15) === 114`

So you only get 114 pieces of jewelry with scroll of dexterity when you craft 100 bracelets, etc.

### Changes:

Changed floating point math to increaseNumByPercent() in 3 places

### Other checks:

-   [x] I have tested all my changes thoroughly.
