### PR TITLE
Fix Falador elite diary (Cape of Accomplishment requirement)

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -630,11 +630,12 @@ const noveltyFood: Buyable[] = [
 
 const Buyables: Buyable[] = [
 	{
-		name: 'Quest Cape',
+		name: 'Quest point cape',
 		outputItems: {
 			[itemID('Quest point cape')]: 1,
 			[itemID('Quest point hood')]: 1
 		},
+		aliases: ['quest cape'],
 		qpRequired: MAX_QP,
 		gpCost: 99_000
 	},

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -485,7 +485,7 @@ export const FaladorDiary: Diary = {
 					return [true];
 				}
 			}
-			return [false, 'you need a Quest point or Skill cape'];
+			return [false, 'you need a Quest point cape or Skill cape'];
 		}
 	}
 };

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -6,6 +6,7 @@ import { Item } from 'oldschooljs/dist/meta/types';
 import { MAX_QP } from './constants';
 import { getAllMinigameScores, MinigameName } from './settings/settings';
 import { UserSettings } from './settings/types/UserSettings';
+import Skillcapes from './skilling/skillcapes';
 import { courses } from './skilling/skills/agility';
 import { Skills } from './types';
 import { formatSkillRequirements, itemNameFromID } from './util';
@@ -475,8 +476,17 @@ export const FaladorDiary: Diary = {
 			thieving: 13,
 			woodcutting: 75
 		},
-		qp: MAX_QP,
-		collectionLogReqs: resolveItems(['Air rune', 'Saradomin brew(3)'])
+		collectionLogReqs: resolveItems(['Air rune', 'Saradomin brew(3)']),
+		customReq: async user => {
+			const userBank = user.bank();
+			if (userBank.has('Quest point cape') && user.settings.get(UserSettings.QP) >= MAX_QP) return [true];
+			for (const cape of Skillcapes) {
+				if ((userBank.has(cape.trimmed) || userBank.has(cape.untrimmed)) && user.skillLevel(cape.skill) >= 99) {
+					return [true];
+				}
+			}
+			return [false, 'you need a Quest point or Skill cape'];
+		}
 	}
 };
 


### PR DESCRIPTION
### Description:

The Falador elite diary requirement is to perform any, 'Cape of Accomplishment,' emote on the top of the castle. This includes the Quest point cape, any 99 Skill cape, and the Music cape (N/A).

### Changes:

- Updates the Fally elite diary with a `customReq` that checks for the cape, AND the requirements to equip said cape.
- Fixes the +buy'able name for Quest point cape, and adds, 'Quest cape' as an alias.

### Other checks:

-   [x] I have tested all my changes thoroughly.
