### PR TITLE
Give Takon higher priority since it's boost is stronger

### DIFF
--- a/src/commands/Minion/smith.ts
+++ b/src/commands/Minion/smith.ts
@@ -97,10 +97,10 @@ export default class extends BotCommand {
 
 		// Time to smith an item, add on quarter of a second to account for banking/etc.
 		let timeToSmithSingleBar = smithedItem.timeToUse + Time.Second / 4;
-		if (msg.author.hasItemEquippedAnywhere('Dwarven greathammer')) {
-			timeToSmithSingleBar /= 2;
-		} else if (msg.author.usingPet('Takon')) {
+		if (msg.author.usingPet('Takon')) {
 			timeToSmithSingleBar /= 4;
+		} else if (msg.author.hasItemEquippedAnywhere('Dwarven greathammer')) {
+			timeToSmithSingleBar /= 2;
 		}
 
 		let maxTripLength = msg.author.maxTripLength('Smithing');


### PR DESCRIPTION
### Description:

Currently Dwarven greathammer only has 2x boost and Takon is 4x, but if you have both equipped, you get the lesser bonus.

### Changes:

Reorders the if/else block to give Takon higher priority

### Other checks:

-   [ ] I have tested all my changes thoroughly.
