### PR TITLE
Update scythe of vitur similarItems

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -264,7 +264,7 @@ const source: [string, (string | number)[]][] = [
 	['Salve amulet', ['Salve amulet(ei)', 'Salve amulet(i)', 'Salve amulet (e)']],
 	['Salve amulet (e)', ['Salve amulet(ei)']],
 	['Salve amulet (i)', ['Salve amulet(ei)']],
-	['Scythe of vitur', [...scytheChargedSimilar, ...scytheUnchargedSimilar]],
+	['Scythe of vitur', [...scytheChargedSimilar]],
 	['Scythe of vitur (uncharged)', [...scytheUnchargedSimilar]],
 	['Sanguinesti staff', ['Holy sanguinesti staff']],
 	['Sanguinesti staff (uncharged)', ['Holy sanguinesti staff (uncharged)']]


### PR DESCRIPTION
Updates the scythe of vitur charged similaritems to only be other charged scythes

closes #3509 

-   [ ] I have tested all my changes thoroughly.
