### PR TITLE
Fix MegaDuck error in new Guild

### DIFF
--- a/src/commands/bso/megaduck.ts
+++ b/src/commands/bso/megaduck.ts
@@ -154,7 +154,9 @@ WHERE (mega_duck_location->>'usersParticipated')::text != '{}';`);
 
 	async run(msg: KlasaMessage, [direction]: ['up' | 'down' | 'left' | 'right' | undefined]) {
 		const settings = await getGuildSettings(msg.guild!);
-		const location: O.Readonly<MegaDuckLocation> = { ...settings.get(GuildSettings.MegaDuckLocation) };
+		const location: O.Readonly<MegaDuckLocation> = {
+			...(settings.get(GuildSettings.MegaDuckLocation) ?? defaultMegaDuckLocation)
+		};
 		if (msg.flagArgs.reset && msg.member && msg.member.permissions.has('ADMINISTRATOR')) {
 			await msg.confirm(
 				'Are you sure you want to reset your megaduck back to Falador Park? This will reset all data, and where its been, and who has contributed steps.'


### PR DESCRIPTION
### Description:

When running MegaDuck for the first time in a guild, it triggers, 'An error occured.'

### Changes:

Uses the defaultMegaduckLocation object when the settings/db entry is undefined.

### Other checks:

-   [x] I have tested all my changes thoroughly.
