### PR TITLE
Fix mention in mass failure msg.

### DIFF
--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -3,7 +3,7 @@ import { Message, MessageReaction } from 'discord.js';
 import { debounce, sleep } from 'e';
 import { Extendable, ExtendableStore, KlasaMessage, KlasaUser } from 'klasa';
 
-import { ReactionEmoji } from '../../lib/constants';
+import { ReactionEmoji, SILENT_ERROR } from '../../lib/constants';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { CustomReactionCollector } from '../../lib/structures/CustomReactionCollector';
 import { MakePartyOptions } from '../../lib/types';
@@ -99,7 +99,10 @@ async function _setup(
 
 			function startTrip() {
 				if (usersWhoConfirmed.length < options.minSize) {
-					reject(`${msg.author} Not enough people joined your ${options.party ? 'party' : 'mass'}!`);
+					msg.channel.send(
+						`${msg.author} Not enough people joined your ${options.party ? 'party' : 'mass'}!`
+					);
+					reject(new Error(SILENT_ERROR));
 					return;
 				}
 


### PR DESCRIPTION
### Description:

Currently when a mass fails because not enough people joined, the @mention it returns is broken.
This is caused by `postCommand.ts` running `cleanMentions()` on the error string.

An alternative fix for this bug is just to stop running `cleanMentions()` on the error code, but that may have unintended side effects.

### Changes:

1. The PartyAwaiter will now call msg.channel.send() with the appropriate mention + error message
2. PartyAwaiter will `reject()` the Promise with a SILENT_ERROR. 
  -(This is needed to ensure the bot doesn't try to send either an empty message, or a second error message).

### Other checks:

-   [x] I have tested all my changes thoroughly.
