### PR TITLE
[BSO ONLY] Replaced "bosses" with "pvm" for Top collector role

### DIFF
--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -19,7 +19,7 @@ function addToUserMap(userMap: Record<string, string[]>, id: string, reason: str
 
 const minigames = Minigames.map(game => game.column).filter(i => i !== 'tithe_farm');
 
-const collections = ['rolepets', 'skilling', 'clues', 'bosses', 'minigames', 'raids', 'Dyed Items', 'other', 'custom'];
+const collections = ['rolepets', 'skilling', 'clues', 'pvm', 'minigames', 'raids', 'Dyed Items', 'other', 'custom'];
 
 const mostSlayerPointsQuery = `SELECT id, 'Most Points' as desc
 FROM users


### PR DESCRIPTION
### Description:

Cl Boss was 'removed' in BSO, so that Cl PvM could take its place. This meant that Top collector role for "Bosses" went to nobody, so I replaced with Pvm so top pvm collection log gets the role now!

### Changes:

- Replaced check for `bosses` with `pvm` in Top collector section of `roles.ts `

### Other checks:

-   [ ] I have tested all my changes thoroughly.
