### PR TITLE
Fix Farming bug with potatos

### DIFF
--- a/src/commands/Minion/farm.ts
+++ b/src/commands/Minion/farm.ts
@@ -107,11 +107,8 @@ export default class extends BotCommand {
 
 		const storeHarvestablePlant = patchType.lastPlanted;
 		const planted = storeHarvestablePlant
-			? Farming.Plants.find(
-					plants =>
-						stringMatches(plants.name, storeHarvestablePlant) ||
-						stringMatches(plants.name.split(' ')[0], storeHarvestablePlant)
-			  )
+			? Farming.Plants.find(plants => stringMatches(plants.name, storeHarvestablePlant)) ??
+			  Farming.Plants.find(plants => stringMatches(plants.name.split(' ')[0], storeHarvestablePlant))
 			: null;
 
 		const lastPlantTime: number = patchType.plantTime;


### PR DESCRIPTION
### Description:
Currently, there's a bug when trying to harvest potatoes. Because the  code that looks up the Plant based on the 'last planted crop' checks for both name + partial alias matches at the same time, the FIRST result in the Plants array is chosen, regardless what order you put the predicates because they're all evaluated on each array item individually.

The result is harvesting potatoes will error out if they haven't been planted long enough for `Potato cactus` to grow, even though you planted potatoes.

### Changes:

Separates the search into 2 stages to ensure that a full string match takes priority.

### Other checks:

-   [x] I have tested all my changes thoroughly.
