### PR TITLE
Fix extra message on cancelling party

### DIFF
--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -47,9 +47,9 @@ async function _setup(
 		}
 	};
 
-	let partyCancelled = false;
 	const reactionAwaiter = () =>
 		new Promise<KlasaUser[]>(async (resolve, reject) => {
+			let partyCancelled = false;
 			const collector = new CustomReactionCollector(confirmMessage, {
 				time: 120_000,
 				max: options.usersAllowed?.length ?? options.maxSize,

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -47,6 +47,7 @@ async function _setup(
 		}
 	};
 
+	let partyCancelled = false;
 	const reactionAwaiter = () =>
 		new Promise<KlasaUser[]>(async (resolve, reject) => {
 			const collector = new CustomReactionCollector(confirmMessage, {
@@ -98,7 +99,7 @@ async function _setup(
 			});
 
 			function startTrip() {
-				if (usersWhoConfirmed.length < options.minSize) {
+				if (!partyCancelled && usersWhoConfirmed.length < options.minSize) {
 					msg.channel.send(
 						`${msg.author} Not enough people joined your ${options.party ? 'party' : 'mass'}!`
 					);
@@ -134,6 +135,7 @@ async function _setup(
 
 					case ReactionEmoji.Stop: {
 						if (user === options.leader) {
+							partyCancelled = true;
 							reject(
 								`The leader (${options.leader.username}) cancelled this ${
 									options.party ? 'party' : 'mass'


### PR DESCRIPTION
### Description:

Currently if you cancel a party with the 'Stop' button, it still executes the startTrip() function, which results in sending an extra 'trip failed to start' message even though you cancelled it.

### Changes:

-Adds partyCancelled bool to make sure party awaiter is still valid before sending that message.

### Other checks:

-   [x] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/10122432/153223939-fb80a951-87a9-4302-9325-c9e4f64fa67d.png)
