### PR TITLE
Prevent error when running hax without existing poh

### DIFF
--- a/src/commands/Testing/hax.ts
+++ b/src/commands/Testing/hax.ts
@@ -64,6 +64,7 @@ export default class extends BotCommand {
 		bank.add('Zamorakian spear');
 		bank.add('Dragon warhammer');
 		bank.add('Bandos godsword');
+		await msg.author.getPOH();
 		await prisma.playerOwnedHouse.update({
 			where: {
 				user_id: msg.author.id


### PR DESCRIPTION
### Description:

Currently if you run -hax on a test bot without an existing PoH / or on a new profile, part of the command fails, and it returns, 'An error occured.'

### Changes:

- Adds a call to `user.getPoh()` to ensure the row exists before trying to update it with prisma.

### Other checks:

-   [x] I have tested all my changes thoroughly.
