### PR TITLE
Fix +checkmasses again

### DIFF
--- a/src/commands/Utility/checkmasses.ts
+++ b/src/commands/Utility/checkmasses.ts
@@ -51,7 +51,11 @@ export default class extends BotCommand {
 					];
 				}
 			})
-			.sort()
+			.sort((a, b) => {
+				const i = a![0];
+				const j = b![0];
+				return i < j ? -1 : i > j ? 1 : 0;
+			})
 			.map(m => m![1])
 			.join('\n');
 		return msg.channel.send(`**Masses in this server:**

--- a/src/commands/Utility/checkmasses.ts
+++ b/src/commands/Utility/checkmasses.ts
@@ -51,11 +51,7 @@ export default class extends BotCommand {
 					];
 				}
 			})
-			.sort((a, b) => {
-				const i = a![0];
-				const j = b![0];
-				return i < j ? -1 : i > j ? 1 : 0;
-			})
+			.sort((a, b) => (a![0] < b![0] ? -1 : a![0] > b![0] ? 1 : 0))
 			.map(m => m![1])
 			.join('\n');
 		return msg.channel.send(`**Masses in this server:**


### PR DESCRIPTION
### Description:
So I previously fixed it so it would sort based on the 'fake end' time, to prevent people from identifying wipes.

This worked as intended, but unfortunately I didn't realize it was doing an Alphabetic sort, because everything was 20+ minutes in the future.

This fixes that by changing the sort algorithm to work numerically instead of alphabetically.

### Changes:

Adds a custom `sort()` algorithm to sort numerically

### Other checks:

-   [x] I have tested all my changes thoroughly.
