### PR TITLE
Fix Deathtouched Dart's using entire stack when equipped.

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -636,7 +636,11 @@ export default class extends BotCommand {
 		let usedDart = false;
 		if (rangeSetup.weapon?.item === itemID('Deathtouched dart')) {
 			duration = 1;
-			rangeSetup.weapon = null;
+			if (rangeSetup.weapon.quantity > 1) {
+				rangeSetup.weapon.quantity--;
+			} else {
+				rangeSetup.weapon = null;
+			}
 			await msg.author.settings.update(UserSettings.Gear.Range, rangeSetup);
 			if (monster.name === 'Koschei the deathless') {
 				return msg.channel.send(


### PR DESCRIPTION
### Description:

Regardless how many darts you have equipped, it always consumes the entire stack when used. This would fix that to only use 1 dart if more than 1 are equipped.

### Changes:

If more than 1 DTD is equipped, simply subtract one and update, instead of setting weapon to null.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
