### PR TITLE
Fix KK scaling for 4+ people.

### DIFF
--- a/src/commands/bso/kk.ts
+++ b/src/commands/bso/kk.ts
@@ -36,7 +36,7 @@ function calcFood(user: KlasaUser, teamSize: number, quantity: number) {
 	else if (kc > 10) healAmountNeeded *= 0.8;
 	else if (kc > 5) healAmountNeeded *= 0.9;
 	healAmountNeeded /= (teamSize + 1) / 1.5;
-	let brewsNeeded = Math.ceil(healAmountNeeded / 16) * quantity;
+	let brewsNeeded = Math.ceil((healAmountNeeded * quantity) / 16);
 	if (teamSize === 1) brewsNeeded += 2;
 	const restoresNeeded = Math.ceil(brewsNeeded / 3);
 	const items = new Bank({
@@ -264,11 +264,16 @@ export default class extends BotCommand {
 			effectiveTime = reduceNumByPercent(effectiveTime, 20);
 		}
 
+		let minDuration = 2;
+		if (users.length === 4) minDuration = 1.5;
+		if (users.length === 5) minDuration = 1.2;
+		if (users.length >= 6) minDuration = 1;
+
 		let [quantity, duration, perKillTime] = await calcDurQty(
 			users,
 			{ ...KalphiteKingMonster, timeToFinish: effectiveTime },
 			undefined,
-			Time.Minute * 2,
+			Time.Minute * minDuration,
 			Time.Minute * 30
 		);
 		this.checkReqs(users, KalphiteKingMonster, quantity);


### PR DESCRIPTION
### Description:

Right now there's a couple issues with Kalphite King. 
1. The META for KK is 3-man trips by a significant margin. This is because there is a hard limit of 2 minutes per kill for KK, which means you get the same number of kills per trip in 3 mans, and 4, 5, 6-mans. 
2. Brew usage is calculated for 1 KC and then multiplied by # of kills, so you end up using 40, 80, or even 120+ brews per trip sometimes.

### Changes:

- Calculates Brew usage for the entire trip instead of for 1 kill at a time
- Scales 4, 5, and 6 mans so they average the same number of kills per player as 3-mans.

### Other checks:

-   [x] I have tested all my changes thoroughly.
