### PR TITLE
Multiline Kill Numbers for Collection Log

### DIFF
--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -480,9 +480,14 @@ export default class CollectionLogTask extends Task {
 			this.drawText(ctx, (drawnSoFar = collectionLog.isActivity ? 'Completions: ' : 'Kills: '), 0, 25);
 			let pixelLevel = 25;
 			for (let [type, value] of objectEntries(collectionLog.completions)) {
-				if ( ctx.measureText(drawnSoFar).width + ctx.measureText(` / ${type}: `).width + ctx.measureText(value.toLocaleString()).width >= 225) {
+				if (
+					ctx.measureText(drawnSoFar).width +
+						ctx.measureText(` / ${type}: `).width +
+						ctx.measureText(value.toLocaleString()).width >=
+					225
+				) {
 					pixelLevel += 10;
-					drawnSoFar = "";
+					drawnSoFar = '';
 				}
 				if (type !== 'Default') {
 					if (value === 0) continue;

--- a/src/tasks/collectionLogTask.ts
+++ b/src/tasks/collectionLogTask.ts
@@ -478,15 +478,20 @@ export default class CollectionLogTask extends Task {
 			ctx.textAlign = 'left';
 			ctx.fillStyle = '#FF981F';
 			this.drawText(ctx, (drawnSoFar = collectionLog.isActivity ? 'Completions: ' : 'Kills: '), 0, 25);
+			let pixelLevel = 25;
 			for (let [type, value] of objectEntries(collectionLog.completions)) {
+				if ( ctx.measureText(drawnSoFar).width + ctx.measureText(` / ${type}: `).width + ctx.measureText(value.toLocaleString()).width >= 225) {
+					pixelLevel += 10;
+					drawnSoFar = "";
+				}
 				if (type !== 'Default') {
 					if (value === 0) continue;
 					ctx.fillStyle = '#FF981F';
-					this.drawText(ctx, ` / ${type}: `, ctx.measureText(drawnSoFar).width, 25);
+					this.drawText(ctx, ` / ${type}: `, ctx.measureText(drawnSoFar).width, pixelLevel);
 					drawnSoFar += ` / ${type}: `;
 				}
 				ctx.fillStyle = '#FFFFFF';
-				this.drawText(ctx, value.toLocaleString(), ctx.measureText(drawnSoFar).width, 25);
+				this.drawText(ctx, value.toLocaleString(), ctx.measureText(drawnSoFar).width, pixelLevel);
 				drawnSoFar += value.toLocaleString();
 			}
 		}


### PR DESCRIPTION
### Description:

A user can have so many kills for bosses that the text overlaps the Value section of the Collection Log image:
![image](https://user-images.githubusercontent.com/32879863/153504067-29b84a7a-64d7-451b-aab7-c763ae8a73dc.png)

I added code to check if the text has run too far and to move it down a line if needs be:
![image](https://user-images.githubusercontent.com/32879863/153504162-c5f41bf4-d8ef-40a1-8bae-6285a57ac33f.png)

### Changes:

Updated collectionLogTask.ts to check whether the text will run past a certain point and to move the text further down the image.

### Other checks:

-   [x] I have tested all my changes thoroughly.
