### PR TITLE
Allow access to individual DK CLs

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -176,12 +176,7 @@ export const allCollectionLogs: ICollection = {
 				items: crazyArchaeologistCL
 			},
 			'Dagannoth Kings': {
-				alias: [
-					'dagannoth kings',
-					'kings',
-					'dagga',
-					'dks'
-				],
+				alias: ['dagannoth kings', 'kings', 'dagga', 'dks'],
 				kcActivity: {
 					Default: [Monsters.DagannothSupreme.name, Monsters.DagannothRex.name, Monsters.DagannothPrime.name],
 					Rex: Monsters.DagannothRex.name,

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -180,13 +180,7 @@ export const allCollectionLogs: ICollection = {
 					'dagannoth kings',
 					'kings',
 					'dagga',
-					'dks',
-					'prime',
-					'rex',
-					'supreme',
-					'dagannoth rex',
-					'dagannoth supreme',
-					'dagannoth prime'
+					'dks'
 				],
 				kcActivity: {
 					Default: [Monsters.DagannothSupreme.name, Monsters.DagannothRex.name, Monsters.DagannothPrime.name],


### PR DESCRIPTION
### Description:

Removing some aliases from the DKs collection log which will allow users to access individual DK logs in a similar manner to +cl man or +cl goblin.

Currently it will show the dks collection log:
![image](https://user-images.githubusercontent.com/32879863/153509491-6839a4db-9bc9-490b-815d-05cd5fc1f240.png)

This changes to:
![image](https://user-images.githubusercontent.com/32879863/153509554-d6ff077d-6b95-44c9-8a47-3ab520d1a0b9.png)

Short names for each DK also direct to the new version. (+cl rex, +cl supreme, +cl prime)

### Changes:

Removed aliases that related to individual DKs

### Other checks:

-   [x] I have tested all my changes thoroughly.
