### PR TITLE
RC Dark Altar Message Redirect

### DIFF
--- a/src/commands/Minion/darkaltar.ts
+++ b/src/commands/Minion/darkaltar.ts
@@ -56,7 +56,7 @@ export default class extends BotCommand {
 		const [hasSkillReqs, neededReqs] = msg.author.hasSkillReqs(skillReqs);
 		if (!hasSkillReqs) {
 			return msg.channel.send(
-				`You can't craft Blood runes at the Dark Altar, because you don't have these required stats: ${neededReqs}.`
+				`You can't craft runes at the Dark Altar, because you don't have these required stats: ${neededReqs}.`
 			);
 		}
 		const [hasFavour, requiredPoints] = gotFavour(msg.author, Favours.Arceuus, 100);

--- a/src/commands/Minion/rc.ts
+++ b/src/commands/Minion/rc.ts
@@ -38,10 +38,8 @@ export default class extends BotCommand {
 		if (name.toLowerCase() !== 'chaos') {
 			if (name.endsWith('s') || name.endsWith('S')) name = name.slice(0, name.length - 1);
 		}
-		if ( name.toLowerCase().includes('blood') || name.toLowerCase().includes('soul')) {
-			return msg.channel.send(
-				`Blood/Soul runes can be crafted using \`${msg.cmdPrefix}darkaltar blood|soul\`.`
-			);
+		if (name.toLowerCase().includes('blood') || name.toLowerCase().includes('soul')) {
+			return msg.channel.send(`Blood/Soul runes can be crafted using \`${msg.cmdPrefix}darkaltar blood|soul\`.`);
 		}
 		const rune = Runecraft.Runes.find(
 			_rune => stringMatches(_rune.name, name) || stringMatches(_rune.name.split(' ')[0], name)

--- a/src/commands/Minion/rc.ts
+++ b/src/commands/Minion/rc.ts
@@ -38,6 +38,11 @@ export default class extends BotCommand {
 		if (name.toLowerCase() !== 'chaos') {
 			if (name.endsWith('s') || name.endsWith('S')) name = name.slice(0, name.length - 1);
 		}
+		if ( name.toLowerCase().includes('blood') || name.toLowerCase().includes('soul')) {
+			return msg.channel.send(
+				`Blood/Soul runes can be crafted using \`${msg.cmdPrefix}darkaltar blood|soul\`.`
+			);
+		}
 		const rune = Runecraft.Runes.find(
 			_rune => stringMatches(_rune.name, name) || stringMatches(_rune.name.split(' ')[0], name)
 		);


### PR DESCRIPTION
Closes https://github.com/oldschoolgg/oldschoolbot/issues/3545

### Description:

Send a message back to the user to direct them to the darkaltar command if they try to RC blood or soul using the rc command.

### Changes:

Added message that returns if "blood" or "soul" is in the rune name being runecrafted. Directs them to the darkaltar command instead.
Darkaltar skill requirements apply to both blood and soul so removed reference to just "blood" runes in the "you don't have the skills" message.

### Other checks:

No runes have "blood" or "soul" in them so doing .includes() should be fine and doesn't break anything.
-   [x] I have tested all my changes thoroughly.
