### PR TITLE
BA Amend Party Size and Message wording

### DIFF
--- a/src/commands/Minion/barbassault.ts
+++ b/src/commands/Minion/barbassault.ts
@@ -113,7 +113,7 @@ export default class extends BotCommand {
 			)} **Honour Level:** ${msg.author.settings.get(
 				UserSettings.HonourLevel
 			)} **High Gambles:** ${msg.author.settings.get(UserSettings.HighGambles)}\n\n` +
-				`You can start a Barbarian Assault party using \`${msg.cmdPrefix}ba start\`, you'll need 2+ people to join to start.` +
+				`You can start a Barbarian Assault party using \`${msg.cmdPrefix}ba start\` which needs 2+ people to join to start or use \`${msg.cmdPrefix}ba start solo\` to go alone.` +
 				' We have a BA channel in our server for finding teams: (discord.gg/ob). \n' +
 				"Barbarian Assault works differently in the bot than ingame, there's only 1 role, no waves, and 1 balance of honour points." +
 				`\n\nYou can buy rewards with \`${msg.cmdPrefix}ba buy\`, level up your Honour Level with \`${msg.cmdPrefix}ba level\`.` +
@@ -232,7 +232,7 @@ export default class extends BotCommand {
 	async start(msg: KlasaMessage, [qty = 0, input]: [number, string]) {
 		const partyOptions: MakePartyOptions = {
 			leader: msg.author,
-			minSize: 1,
+			minSize: 2,
 			maxSize: 4,
 			ironmanAllowed: true,
 			message: `${msg.author.username} has created a Barbarian Assault party${


### PR DESCRIPTION
Closes https://github.com/oldschoolgg/oldschoolbot/issues/3552

### Description:

The +ba start command starts a mass and states that there must be 2 users in the group before it will start but this isn't true.
This PR aims to make this true, and make it clearer how a user can do a solo trip.

### Changes:

Add clarification to the +ba command that lets the user know that they can run a solo trip with {prefix}ba start solo.
Increase the minimum party size to 2 when "solo" isn't specified.

### Other checks:

-   [x] I have tested all my changes thoroughly.
