### PR TITLE
Add a summary for customReqs in AD

### DIFF
--- a/src/commands/Minion/achievementdiary.ts
+++ b/src/commands/Minion/achievementdiary.ts
@@ -97,11 +97,11 @@ export default class extends BotCommand {
 					thisStr += `- Must Have **${score}** KC of ${mon.name}\n`;
 				}
 			}
-		
+
 			if (tier.customReq) {
 				const [hasCustomReq, reason] = await tier.customReq(msg.author, true);
 				if (!hasCustomReq) {
-					thisStr += `- Extra Requirements: ${reason}\n`
+					thisStr += `- Extra Requirements: ${reason}\n`;
 				}
 			}
 

--- a/src/commands/Minion/achievementdiary.ts
+++ b/src/commands/Minion/achievementdiary.ts
@@ -97,6 +97,13 @@ export default class extends BotCommand {
 					thisStr += `- Must Have **${score}** KC of ${mon.name}\n`;
 				}
 			}
+		
+			if (tier.customReq) {
+				const [hasCustomReq, reason] = await tier.customReq(msg.author, true);
+				if (!hasCustomReq) {
+					thisStr += `- Extra Requirements: ${reason}\n`
+				}
+			}
 
 			str += `${thisStr}\n`;
 		}

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -23,7 +23,7 @@ export interface DiaryTier {
 	lapsReqs?: Record<string, number>;
 	qp?: number;
 	monsterScores?: Record<string, number>;
-	customReq?: (user: KlasaUser) => Promise<[true] | [false, string]>;
+	customReq?: (user: KlasaUser, summary: Boolean) => Promise<[true] | [false, string]>;
 }
 interface Diary {
 	name: string;
@@ -109,7 +109,7 @@ export async function userhasDiaryTier(user: KlasaUser, tier: DiaryTier): Promis
 	}
 
 	if (tier.customReq) {
-		const [hasCustomReq, reason] = await tier.customReq(user);
+		const [hasCustomReq, reason] = await tier.customReq(user, false);
 		if (!hasCustomReq) {
 			canDo = false;
 			reasons.push(reason!);
@@ -477,7 +477,8 @@ export const FaladorDiary: Diary = {
 			woodcutting: 75
 		},
 		collectionLogReqs: resolveItems(['Air rune', 'Saradomin brew(3)']),
-		customReq: async user => {
+		customReq: async (user, summary) => {
+			if ( summary ) return [false, 'Quest point cape or Skill cape.']
 			const userBank = user.bank();
 			if (userBank.has('Quest point cape') && user.settings.get(UserSettings.QP) >= MAX_QP) return [true];
 			for (const cape of Skillcapes) {
@@ -648,7 +649,8 @@ export const KandarinDiary: Diary = {
 			smithing: 90
 		},
 		collectionLogReqs: resolveItems(['Grimy dwarf weed', 'Shark']),
-		customReq: async user => {
+		customReq: async (user, summary) => {
+			if ( summary ) return [false, 'Barbarian Assault Honour Level of 5.']
 			const honourLevel = user.settings.get(UserSettings.HonourLevel);
 			if (honourLevel < 5) {
 				return [false, 'your Barbarian Assault Honour Level is less than 5'];

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -478,7 +478,7 @@ export const FaladorDiary: Diary = {
 		},
 		collectionLogReqs: resolveItems(['Air rune', 'Saradomin brew(3)']),
 		customReq: async (user, summary) => {
-			if ( summary ) return [false, 'Quest point cape or Skill cape.']
+			if (summary) return [false, 'Quest point cape or Skill cape.'];
 			const userBank = user.bank();
 			if (userBank.has('Quest point cape') && user.settings.get(UserSettings.QP) >= MAX_QP) return [true];
 			for (const cape of Skillcapes) {
@@ -650,7 +650,7 @@ export const KandarinDiary: Diary = {
 		},
 		collectionLogReqs: resolveItems(['Grimy dwarf weed', 'Shark']),
 		customReq: async (user, summary) => {
-			if ( summary ) return [false, 'Barbarian Assault Honour Level of 5.']
+			if (summary) return [false, 'Barbarian Assault Honour Level of 5.'];
 			const honourLevel = user.settings.get(UserSettings.HonourLevel);
 			if (honourLevel < 5) {
 				return [false, 'your Barbarian Assault Honour Level is less than 5'];


### PR DESCRIPTION
Closes https://github.com/oldschoolgg/oldschoolbot/issues/3551

### Description:

+ad {diary} command isn't able to show the custom requirements. This change adds a way to return the summary from the customReq functions to show in the +ad {diary} command.

### Changes:

Add a summary parameter for the customReq functions in the AD definitions. When this is present, the functions should return a text summary of what they are checking instead of doing the checks.
Add this summary to +ad {diary} command.

### Other checks:

-   [x] I have tested all my changes thoroughly.
