### PR TITLE
Fix trips failing to repeat when pressing button too fast

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -120,7 +120,8 @@ export async function handleTripFinish(
 					commandName: onContinue[0],
 					args: onContinue[1],
 					isContinue: onContinue[2],
-					method: onContinue[3]
+					method: onContinue[3],
+					bypassInhibitors: true
 				})
 		: onContinue;
 


### PR DESCRIPTION
### Description:

Fixes  `+m` so clicking the 'Repeat X trip' button without waiting approx 3 seconds doesn't just fail silently, but instead works as intended.

### Changes:

- Added `bypassInhibitors: true` to the `onContinueFn` lamba function in handleTripFinish.ts

### Other checks:

-   [x] I have tested all my changes thoroughly.

I verified the pressing the button immediately after `+m` does not work, (used gauntlet as an example), and after this fix, it does work as intended. 