### PR TITLE
Fix 10% Gorajan boosts for the `=k` command

### DIFF
--- a/src/commands/Minion/k.ts
+++ b/src/commands/Minion/k.ts
@@ -78,6 +78,12 @@ const gorajanBoosts = [
 	[gorajanWarriorOutfit, 'melee'],
 	[gorajanOccultOutfit, 'mage']
 ] as const;
+const gearstatToSetup = new Map()
+	.set('attack_stab', 'melee')
+	.set('attack_slash', 'melee')
+	.set('attack_crush', 'melee')
+	.set('attack_magic', 'mage')
+	.set('attack_ranged', 'range');
 const degradeableItemsCanUse = [
 	{
 		item: getOSItem('Sanguinesti staff'),
@@ -376,7 +382,8 @@ export default class extends BotCommand {
 		for (const [outfit, setup] of gorajanBoosts) {
 			if (
 				allGorajan ||
-				(monster.attackStyleToUse?.includes(setup) && msg.author.getGear(setup).hasEquipped(outfit, true))
+				(gearstatToSetup.get(monster.attackStyleToUse) === setup &&
+					msg.author.getGear(setup).hasEquipped(outfit, true))
 			) {
 				boosts.push('10% for gorajan');
 				timeToFinish *= 0.9;


### PR DESCRIPTION
### Description:

This fixes a bug where the 10% gorajan boost for `=k` doesn't work it's expecting the wrong type of data.

This bug cannot be seen when wearing 3 full sets of Gorajan, because that skips the broken code path.

### Changes:

- Adds a small 'GearStat to GearSetup' mapping
- Compares the remapped value to the gear setup

### Other checks:

-   [x] I have tested all my changes thoroughly.
