### PR TITLE
Fix missing/outdated roles on `+rp roles`

### DIFF
--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -20,7 +20,7 @@ function addToUserMap(userMap: Record<string, string[]>, id: string, reason: str
 
 const minigames = Minigames.map(game => game.column).filter(i => i !== 'tithe_farm');
 
-const collections = ['pets', 'skilling', 'clues', 'bosses', 'minigames', 'cox', 'tob', 'slayer', 'other', 'custom'];
+const collections = ['pets', 'skilling', 'clues', 'bosses', 'minigames', 'raids', 'slayer', 'other', 'custom'];
 
 const mostSlayerPointsQuery = `SELECT id, 'Most Points' as desc
 FROM users
@@ -257,6 +257,14 @@ SELECT id, (cardinality(u.cl_keys) - u.inverse_length) as qty
 			for (let i = 0; i < topIronUsers.length; i++) {
 				const id = topIronUsers[i]?.id;
 				addToUserMap(userMap, id, `Rank ${i + 1} Ironman Collector`);
+				topCollectors.push(id);
+			}
+			const topNormieUsers = (await q<any>(generateQuery(getCollectionItems('overall'), false, 3))).filter(
+				(i: any) => i.qty > 0
+			) as CLUser[];
+			for (let i = 0; i < topNormieUsers.length; i++) {
+				const id = topNormieUsers[i]?.id;
+				addToUserMap(userMap, id, `Rank ${i + 1} Collector`);
 				topCollectors.push(id);
 			}
 


### PR DESCRIPTION
### Description:

Currently rp roles adds 'Top 3 Ironman CL' but doesn't do 'Top 3 Normie CL'
Also since tob + cox are merged into 'raids' now, we've removed cox + tob, and replaced with raids.

### Changes:

- Added 'Top 3 Collectors'
- Replaced cox + tob with 'raids'

### Other checks:

-   [ ] I have tested all my changes thoroughly.
