### PR TITLE
Add Mr. E to tame feedables for 2x loot chance

### DIFF
--- a/src/commands/bso/tames.ts
+++ b/src/commands/bso/tames.ts
@@ -93,6 +93,12 @@ const feedableItems: FeedableItem[] = [
 		description: '30% faster PvM',
 		tameSpeciesCanBeFedThis: [TameType.Combat],
 		announcementString: "Your tame can now kill 30% faster! It's holding the Dwarven warhammer in its claws..."
+	},
+	{
+		item: getOSItem('Mr. E'),
+		description: 'Chance to get 2x loot',
+		tameSpeciesCanBeFedThis: [TameType.Combat, TameType.Gatherer, TameType.Artisan, TameType.Support],
+		announcementString: "With Mr. E's energy absorbed, your tame now has a chance at 2x loot!"
 	}
 ];
 

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -179,6 +179,17 @@ export async function addDurationToTame(tame: Tame, duration: number) {
 	return `Your tame has grown ${percentToAdd.toFixed(2)}%!`;
 }
 
+function doubleLootCheck(tame: Tame, loot: Bank) {
+	const hasMrE = tameHasBeenFed(tame, 'Mr. E');
+	let doubleLootMsg = '';
+	if (hasMrE && roll(12)) {
+		loot.multiply(2);
+		doubleLootMsg = '\n**2x Loot from Mr. E**';
+	}
+
+	return { loot, doubleLootMsg };
+}
+
 export interface Species {
 	id: number;
 	type: TameType;
@@ -305,6 +316,8 @@ export async function runTameTask(activity: TameActivity, tame: Tame) {
 			if (boosts.length > 0) {
 				str += `\n\n**Boosts:** ${boosts.join(', ')}.`;
 			}
+			const { doubleLootMsg } = doubleLootCheck(tame, loot);
+			str += doubleLootMsg;
 			const { itemsAdded } = await user.addItemsToBank({ items: loot, collectionLog: false });
 			await trackLoot({
 				duration: activity.duration,
@@ -331,6 +344,8 @@ export async function runTameTask(activity: TameActivity, tame: Tame) {
 			let str = `${user}, ${tameName(tame)} finished collecting ${totalQuantity}x ${
 				collectable.item.name
 			}. (${Math.round((totalQuantity / (activity.duration / Time.Minute)) * 60).toLocaleString()}/hr)`;
+			const { doubleLootMsg } = doubleLootCheck(tame, loot);
+			str += doubleLootMsg;
 			const { itemsAdded } = await user.addItemsToBank({ items: loot, collectionLog: false });
 			handleFinish({
 				loot: itemsAdded,


### PR DESCRIPTION
### Description:

Added ability to feed `Mr. E` to tames for a chance (1 in 12) to get 2x loot.

### Changes:

- Adds Mr. E to the feedables list so people know they can feed it
- Adds `doubleLootCheck()` function to centralize the 2x code to easily add to all tames 
-  (Can't use handle trip finish because items are already added to bank + tracked before then)

### Other checks:

-   [x] I have tested all my changes thoroughly.
