### PR TITLE
Typo on error occured message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ client.on('raw', async event => {
 		if (result.type === InteractionType.ApplicationCommand) {
 			const ERROR_RESPONSE: SlashCommandResponse = {
 				response: {
-					data: { content: 'Sorry, an errored occured while trying to run this command.' },
+					data: { content: 'Sorry, an error occured while trying to run this command.' },
 					type: InteractionResponseType.ChannelMessageWithSource
 				},
 				interaction: result.interaction,


### PR DESCRIPTION
Fixes a typo on the return message for an error on a slash command

-   [x] I have tested all my changes thoroughly.
