### PR TITLE
Fix max slash + crush offence stats (BSO)

### DIFF
--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -16,7 +16,7 @@ export const maxDefenceStats: { [key in DefenceGearStat]: number } = {
 };
 
 export const maxOffenceStats: { [key in OffenceGearStat]: number } = {
-	[GearStat.AttackCrush]: 352,
+	[GearStat.AttackCrush]: 360,
 	[GearStat.AttackMagic]: 459,
 	[GearStat.AttackRanged]: 431,
 	[GearStat.AttackSlash]: 295,

--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -19,7 +19,7 @@ export const maxOffenceStats: { [key in OffenceGearStat]: number } = {
 	[GearStat.AttackCrush]: 352,
 	[GearStat.AttackMagic]: 459,
 	[GearStat.AttackRanged]: 431,
-	[GearStat.AttackSlash]: 288,
+	[GearStat.AttackSlash]: 295,
 	[GearStat.AttackStab]: 361
 };
 


### PR DESCRIPTION
![osbot](https://user-images.githubusercontent.com/79149170/154747100-c5c9770e-7191-4af4-9157-617709d9958c.png)
![osbot-1](https://user-images.githubusercontent.com/79149170/154753035-d8c6e580-d825-4cdb-8891-bdb5f5f3f1a9.png)

Closes #3585 

The stab can be updated too:
offhand drygore/chaotic rapier gives 358 stab, 
363 is obtainable with offhand dragon claw, 
361 is not obtainable

-   [ ] I have tested all my changes thoroughly.
