### PR TITLE
Fix create command with `cantHaveItems`

### DIFF
--- a/src/mahoji/commands/create.ts
+++ b/src/mahoji/commands/create.ts
@@ -172,7 +172,7 @@ export const createCommand: OSBMahojiCommand = {
 		if (createableItem.cantHaveItems) {
 			const allItemsOwned = user.allItemsOwned();
 			for (const [itemID, qty] of Object.entries(createableItem.cantHaveItems)) {
-				const numOwned = allItemsOwned.amount(itemID);
+				const numOwned = allItemsOwned.amount(Number(itemID));
 				if (numOwned >= qty) {
 					return `You can't ${action} this item, because you have ${new Bank(
 						createableItem.cantHaveItems


### PR DESCRIPTION
### Description:

Fixes bug with `/create` that doesn't allow creation of items that have a `cantHaveItems` variable. Such as only allowing 1 of the rune pouches (ie. Giant pouch). 

Object keys are always strings in javascript, so must be converted to `Number`s when a number is required.

### Changes:

- Adds a `Number()` conversion to the /create command

### Other checks:

-   [ ] I have tested all my changes thoroughly.
