### PR TITLE
BSO questing patch -Max QP bypass for irons (Zippy)

### DIFF
--- a/src/mahoji/lib/abstracted_commands/questCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/questCommand.ts
@@ -9,7 +9,7 @@ import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask
 
 export async function questCommand(user: KlasaUser, channelID: bigint) {
 	const currentQP = user.settings.get(UserSettings.QP);
-	if (currentQP >= MAX_QP) {
+	if (currentQP >= MAX_QP && !user.isIronman) {
 		return 'You already have the maximum amount of Quest Points.';
 	}
 


### PR DESCRIPTION
### Description:

Reinstates the ironman check to allow ironmen to get zippy post 5k qp

### Changes:

add is not ironman check

### Other checks:

-   [x] I have tested all my changes thoroughly.
![image](https://user-images.githubusercontent.com/12814878/155442789-1b1e32f7-4541-4945-87d4-0675ad770389.png)
