### PR TITLE
Fix `/open` with Seed pack's.

### DIFF
--- a/src/commands/Minion/seedpack.ts
+++ b/src/commands/Minion/seedpack.ts
@@ -80,7 +80,7 @@ const HighSeedPackTable = new LootTable()
 	.add('Spirit seed', 1, 1)
 	.add('Redwood tree seed', 1, 1);
 
-function openSeedPack(seedTier: number): ItemBank {
+export function openSeedPack(seedTier: number): ItemBank {
 	const loot = new Bank();
 
 	const tempTable = new LootTable();
@@ -91,6 +91,7 @@ function openSeedPack(seedTier: number): ItemBank {
 	let low = 0;
 
 	switch (seedTier) {
+		case 0:
 		case 1: {
 			high = 0;
 			medium = rand(1, 3);

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -255,9 +255,8 @@ const osjsOpenables: UnifiedOpenable[] = [
 			message?: string;
 		}> => {
 			const { plantTier } = args.user.settings.get(UserSettings.Minion.FarmingContract) ?? defaultFarmingContract;
-			const realQty = args.quantity;
 			const openLoot = new Bank();
-			for (let i = 0; i < realQty; i++) {
+			for (let i = 0; i < args.quantity; i++) {
 				openLoot.add(openSeedPack(plantTier));
 			}
 			return { bank: openLoot };

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -5,9 +5,11 @@ import { BeginnerClueTable } from 'oldschooljs/dist/simulation/clues/Beginner';
 import { Mimic } from 'oldschooljs/dist/simulation/misc';
 import { Implings } from 'oldschooljs/dist/simulation/openables/Implings';
 
+import { openSeedPack } from '../commands/Minion/seedpack';
 import { Emoji, Events, MIMIC_MONSTER_ID } from './constants';
 import { cluesRaresCL } from './data/CollectionsExport';
 import ClueTiers from './minions/data/clueTiers';
+import { defaultFarmingContract } from './minions/farming';
 import { UserSettings } from './settings/types/UserSettings';
 import {
 	BagFullOfGemsTable,
@@ -246,7 +248,20 @@ const osjsOpenables: UnifiedOpenable[] = [
 		id: 22_993,
 		openedItem: getOSItem(22_993),
 		aliases: ['seed pack'],
-		output: Openables.SeedPack.table,
+		output: async (
+			args: OpenArgs
+		): Promise<{
+			bank: Bank;
+			message?: string;
+		}> => {
+			const { plantTier } = args.user.settings.get(UserSettings.Minion.FarmingContract) ?? defaultFarmingContract;
+			const realQty = args.quantity ?? 1;
+			const openLoot = new Bank();
+			for (let i = 0; i < realQty; i++) {
+				openLoot.add(openSeedPack(plantTier));
+			}
+			return { bank: openLoot };
+		},
 		allItems: Openables.SeedPack.table.allItems
 	},
 	{

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -255,7 +255,7 @@ const osjsOpenables: UnifiedOpenable[] = [
 			message?: string;
 		}> => {
 			const { plantTier } = args.user.settings.get(UserSettings.Minion.FarmingContract) ?? defaultFarmingContract;
-			const realQty = args.quantity ?? 1;
+			const realQty = args.quantity;
 			const openLoot = new Bank();
 			for (let i = 0; i < realQty; i++) {
 				openLoot.add(openSeedPack(plantTier));


### PR DESCRIPTION
### Description:

Fixes Seed packs, because the osjs openable can't possibly work because there are different tiers based on the farming contract, and it just has to be handled in code.

**Note:** Currently it's so broken, you only seed 1 seed roll per open, so this is a medium priority.

### Changes:

- Exports the openSeedPack function
- Adds a lambda function to the 'Seed pack' openable to handle the opening of the seed packs.

### Other checks:

-   [x] I have tested all my changes thoroughly.
