### PR TITLE
Remove Tob items from mystery boxes

### DIFF
--- a/src/lib/bsoOpenables.ts
+++ b/src/lib/bsoOpenables.ts
@@ -7,7 +7,8 @@ import {
 	allPetIDs,
 	chambersOfXericCL,
 	cmbClothes,
-	customBossesDropsThatCantBeDroppedInMBs
+	customBossesDropsThatCantBeDroppedInMBs,
+	theatreOfBLoodCL
 } from './data/CollectionsExport';
 import { baseHolidayItems, PartyhatTable } from './data/holidayItems';
 import { FishTable } from './minions/data/killableMonsters/custom/SeaKraken';
@@ -323,7 +324,8 @@ const cantBeDropped = resolveItems([
 	...RoyalMysteryBoxTable.allItems,
 	...BeachMysteryBoxTable.allItems,
 	...IndependenceBoxTable.allItems,
-	...cmbClothes
+	...cmbClothes,
+	...theatreOfBLoodCL
 ]);
 
 export const tmbTable: number[] = [];


### PR DESCRIPTION
### Description:

Stops Tob uniques from appearing in mystery boxes.

The recolored variants etc will still drop, this just prevents the CL from being obtainable by MBs.

### Changes:

Adds tob cl to `cantBeDropped` array.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
