### PR TITLE
Fix some merge errors in BSO. `Sepulchre` + `K`

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -241,11 +241,11 @@ export async function minionKillCommand(
 			!attackStyles.includes(SkillsEnum.Ranged) &&
 			!attackStyles.includes(SkillsEnum.Magic)
 		) {
-			timeToFinish = reduceNumByPercent(timeToFinish, 15);
-			boosts.push('15% for Dragon hunter lance');
+			timeToFinish = reduceNumByPercent(timeToFinish, 20);
+			boosts.push('20% for Dragon hunter lance');
 		} else if (user.hasItemEquippedOrInBank('Dragon hunter crossbow') && attackStyles.includes(SkillsEnum.Ranged)) {
-			timeToFinish = reduceNumByPercent(timeToFinish, 15);
-			boosts.push('15% for Dragon hunter crossbow');
+			timeToFinish = reduceNumByPercent(timeToFinish, 20);
+			boosts.push('20% for Dragon hunter crossbow');
 		}
 	}
 

--- a/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
@@ -5,7 +5,7 @@ import { addArrayOfNumbers } from 'oldschooljs/dist/util';
 
 import { sepulchreBoosts, sepulchreFloors } from '../../../lib/minions/data/sepulchre';
 import { SepulchreActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, itemNameFromID } from '../../../lib/util';
+import { formatDuration, itemID, itemNameFromID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 
 export async function sepulchreCommand(user: KlasaUser, channelID: bigint) {
@@ -33,6 +33,13 @@ export async function sepulchreCommand(user: KlasaUser, channelID: bigint) {
 	boosts.push(`${percentReduced.toFixed(1)}% for minion learning`);
 
 	lapLength = reduceNumByPercent(lapLength, percentReduced);
+
+	const hasCob = user.equippedPet() === itemID('Cob');
+
+	if (hasCob) {
+		lapLength /= 2;
+		boosts.push("2x boost with Cob's help");
+	}
 
 	for (const [id, percent] of objectEntries(sepulchreBoosts)) {
 		if (user.hasItemEquippedOrInBank(Number(id))) {


### PR DESCRIPTION
### Description:

This fixes 2 small issues where BSO code was overwritten during the merge:
Cob boost @ sepulchre
Dragonbane  boost

This restores the behavior before the recent update.

### Changes:

- Adds cob boost back to /minigame sepulchre
- Brings dragonbane boost on bso back to 20% (it's 15% on osb for balancing)

### Other checks:

-   [ ] I have tested all my changes thoroughly.
