### PR TITLE
Runecrafting Souls bug

### DIFF
--- a/src/commands/deprecated/runecraft.ts
+++ b/src/commands/deprecated/runecraft.ts
@@ -1,9 +1,15 @@
-import { KlasaMessage } from 'klasa';
+import { CommandStore, KlasaMessage } from 'klasa';
 
 import { COMMAND_BECAME_SLASH_COMMAND_MESSAGE } from '../../lib/constants';
 import { BotCommand } from '../../lib/structures/BotCommand';
 
 export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			aliases: ['rc', 'da']
+		});
+	}
+
 	async run(msg: KlasaMessage) {
 		return msg.channel.send(COMMAND_BECAME_SLASH_COMMAND_MESSAGE(msg));
 	}

--- a/src/lib/minions/functions/darkAltarCommand.ts
+++ b/src/lib/minions/functions/darkAltarCommand.ts
@@ -62,7 +62,7 @@ export async function darkAltarCommand({
 
 	const boosts = [];
 	const [hasEliteDiary] = await userhasDiaryTier(user, KourendKebosDiary.elite);
-	if (hasEliteDiary) {
+	if (hasEliteDiary && rune === 'blood') {
 		boosts.push('10% additional runes for Kourend/Kebos elite diary');
 	}
 


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/Kourend_%26_Kebos_Diary#Rewards_4

Only blood runes should get the 10% boost for elite diary, currently blood and souls get it.

This PR removes souls from that boost.

Also added aliases to the deprecated commands for "rc" and "da" to help people get used to the change.

-   [x] I have tested all my changes thoroughly.
