### PR TITLE
Warriors Guild check for equipped defender

### DIFF
--- a/src/tasks/minions/minigames/warriorsGuild/cyclopsActivity.ts
+++ b/src/tasks/minions/minigames/warriorsGuild/cyclopsActivity.ts
@@ -54,7 +54,9 @@ export default class extends Task {
 		let loot = new Bank();
 
 		for (let i = 0; i < quantity; i++) {
-			const highestDefenderOwned = defenders.find(def => userBank.has(def.itemID) || loot.has(def.itemID));
+			const highestDefenderOwned = defenders.find(
+				def => userBank.has(def.itemID) || user.hasItemEquippedAnywhere(def.itemID) || loot.has(def.itemID)
+			);
 			const possibleDefenderToDrop =
 				defenders[
 					Math.max(


### PR DESCRIPTION
Adds a check for the user having a defender equipped rather than just the bank before issuing the next defender.

Closes #3646 

-   [ ] I have tested all my changes thoroughly.
