### PR TITLE
Fix Combat options - always cannon, and config user combat_options

### DIFF
--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -252,9 +252,7 @@ async function handleCombatOptions(user: KlasaUser, command: 'add' | 'remove' | 
 		settings.combat_options.includes(CombatOptionsEnum.AlwaysIceBurst)
 	) {
 		if (hasCannon) warningMsg = priorityWarningMsg;
-		await mahojiUserSettingsUpdate(user.id, {
-			combat_options: removeFromArr(settings.combat_options, CombatOptionsEnum.AlwaysIceBurst)
-		});
+		settings.combat_options = removeFromArr(settings.combat_options, CombatOptionsEnum.AlwaysIceBurst);
 	}
 	// If enabling Ice Burst, make sure barrage isn't also enabled:
 	if (
@@ -263,17 +261,21 @@ async function handleCombatOptions(user: KlasaUser, command: 'add' | 'remove' | 
 		settings.combat_options.includes(CombatOptionsEnum.AlwaysIceBarrage)
 	) {
 		if (warningMsg === '' && hasCannon) warningMsg = priorityWarningMsg;
-		await mahojiUserSettingsUpdate(user.id, {
-			combat_options: removeFromArr(settings.combat_options, CombatOptionsEnum.AlwaysIceBarrage)
-		});
+		settings.combat_options = removeFromArr(settings.combat_options, CombatOptionsEnum.AlwaysIceBarrage);
 	}
 	// Warn if enabling cannon with ice burst/barrage:
 	if (nextBool && newcbopt.id === CombatOptionsEnum.AlwaysCannon && warningMsg === '' && hasBurstB) {
 		warningMsg = priorityWarningMsg;
 	}
-	await mahojiUserSettingsUpdate(user.id, {
-		combat_options: [...settings.combat_options, newcbopt.id]
-	});
+	if (nextBool && !settings.combat_options.includes(newcbopt.id)) {
+		await mahojiUserSettingsUpdate(user.id, {
+			combat_options: [...settings.combat_options, newcbopt.id]
+		});
+	} else if (!nextBool && settings.combat_options.includes(newcbopt.id)) {
+		await mahojiUserSettingsUpdate(user.id, {
+			combat_options: removeFromArr(settings.combat_options, newcbopt.id)
+		});
+	}
 
 	return `${newcbopt.name} is now ${nextBool ? 'enabled' : 'disabled'} for you.${warningMsg}`;
 }

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -275,6 +275,8 @@ async function handleCombatOptions(user: KlasaUser, command: 'add' | 'remove' | 
 		await mahojiUserSettingsUpdate(user.id, {
 			combat_options: removeFromArr(settings.combat_options, newcbopt.id)
 		});
+	} else {
+		return 'Error processing command. This should never happen, please report bug.';
 	}
 
 	return `${newcbopt.name} is now ${nextBool ? 'enabled' : 'disabled'} for you.${warningMsg}`;

--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -52,6 +52,6 @@ export const killCommand: OSBMahojiCommand = {
 		channelID
 	}: CommandRunOptions<{ name: string; quantity?: number; method?: PvMMethod }>) => {
 		const user = await client.fetchUser(userID);
-		return minionKillCommand(user, channelID, options.name, options.quantity, options.method ?? 'none');
+		return minionKillCommand(user, channelID, options.name, options.quantity, options.method);
 	}
 };

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -103,7 +103,7 @@ export async function minionKillCommand(
 	channelID: bigint,
 	name: string,
 	quantity: number | undefined,
-	method: PvMMethod
+	method: PvMMethod | undefined
 ) {
 	const { minionName } = user;
 
@@ -130,7 +130,7 @@ export async function minionKillCommand(
 		cbOpts: myCBOpts as CombatOptionsEnum[],
 		user,
 		monster,
-		method: method ?? 'none',
+		method,
 		isOnTask
 	});
 


### PR DESCRIPTION
### Description:

Fixed combat options.
1. Combat options will now properly take effect if no method override is specified.
2. Removing combat options no longer adds duplicate entries to the list
3. Adding ice barrage/burst now properly removes the other ice spell.

### Changes:

- Removed the default 'none' value applied to the boost/method override on the k command
- Fixed logic in the `/config user combat_options` command so it properly adds/removes the entries as it should

### Other checks:

-   [x] I have tested all my changes thoroughly.
