### PR TITLE
Fix error with giveaways deleting items.

### DIFF
--- a/src/commands/Minion/giveaway.ts
+++ b/src/commands/Minion/giveaway.ts
@@ -107,9 +107,8 @@ React to this messsage with ${reaction} to enter.`,
 			await message.react(reaction);
 		} catch (err: any) {
 			if (err.code === 10_014) {
-				// Re-fetch emojis for next time, since the cache is obviously invalid.
+				// Unknown emoji: Remove deleted emoji from the cache so it's not tried next time.
 				msg.guild.emojis.cache.delete(reaction.id);
-				await msg.guild.emojis.fetch();
 				return msg.channel.send(
 					'Error starting giveaway, selected emoji no longer exists. You will be refunded when the giveaway ends.'
 				);


### PR DESCRIPTION
### Description:

There's a bug currently where starting a giveaway can delete your items. This fixes that, and adds some additional error logging.

### Changes:

1. Fetches the emoji's first if there aren't any cached emojis for the guild.
2. If no reaction is returned from the cache, abort before removing items.
3. If the DB Insert command fails (which was happening) log the error to sentry, with full details.
4. Don't remove items from the host's bank until after the DB write succeeds
5. When emojis are fetched, deleted emojis are not removed from the cache, so we remove them when we encounter them.

(Alternately, we could remove the items first, then refund on error. OR remove the items first, log the error, and force players to reach out to help n support to get a refund so we can avoid potential dupe glitches, although I feel the risk of a dupe here is small, otherwise I would have written it differently to start with.)

Link to error that causes deleted items:
### Other checks:

-   [x] I have tested all my changes thoroughly.
Sentry event id: f720e969a507492e92f3bb3ce4c92b07  (just pop it in the search)
Closes #3451 