### PR TITLE
Fix merge error in BSO with combat options prevent killing some monsters without 'none' flag.

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -286,7 +286,7 @@ export async function minionKillCommand(
 	let cannonMulti = false;
 	let burstOrBarrage = 0;
 	const hasCannon = user.owns(CombatCannonItemBank);
-	if (!isOnTask && method !== 'none') {
+	if (!isOnTask && method && method !== 'none') {
 		return 'You can only burst/barrage/cannon while on task in BSO.';
 	}
 	if ((method === 'burst' || method === 'barrage') && !monster!.canBarrage) {


### PR DESCRIPTION
### Description:

The BSO code wasn't expecting a null value for method, so this corrects that.

### Changes:

Added a check for non-null `method` parameter.

### Other checks:

-   [x] I have tested all my changes thoroughly.
