### PR TITLE
Fix leaderboard names

### DIFF
--- a/src/commands/Minion/xpgains.ts
+++ b/src/commands/Minion/xpgains.ts
@@ -32,7 +32,7 @@ export default class extends BotCommand {
 			: undefined;
 
 		const res: any =
-			await prisma.$queryRawUnsafe(`SELECT user_id AS user, sum(xp) AS total_xp, max(date) AS lastDate
+			await prisma.$queryRawUnsafe(`SELECT user_id::text AS user, sum(xp) AS total_xp, max(date) AS lastDate
 FROM xp_gains
 WHERE date > now() - INTERVAL '1 ${interval.toLowerCase() === 'day' ? 'day' : 'week'}'
 ${skillObj ? `AND skill = '${skillObj.id}'` : ''}

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -44,10 +44,19 @@ export async function getNewUser(id: string): Promise<NewUser> {
 }
 
 export async function syncNewUserUsername(message: KlasaMessage) {
-	await prisma.$queryRaw`UPDATE new_users
-SET username = ${cleanUsername(message.author.username)}
-WHERE id = ${message.author.id}
-AND ((username IS NULL) OR (username <> ${cleanUsername(message.author.username)}));`;
+	await prisma.newUser.upsert({
+		where: {
+			id: message.author.id
+		},
+		update: {
+			username: cleanUsername(message.author.username)
+		},
+		create: {
+			id: message.author.id,
+			username: cleanUsername(message.author.username),
+			minigame: {}
+		}
+	});
 }
 
 export async function getMinionName(userID: string): Promise<string> {

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -44,17 +44,18 @@ export async function getNewUser(id: string): Promise<NewUser> {
 }
 
 export async function syncNewUserUsername(message: KlasaMessage) {
+	const cleanedUsername = cleanUsername(message.author.username);
+	const username = cleanedUsername.length > 32 ? cleanedUsername.substring(0, 32) : cleanedUsername;
 	await prisma.newUser.upsert({
 		where: {
 			id: message.author.id
 		},
 		update: {
-			username: cleanUsername(message.author.username)
+			username
 		},
 		create: {
 			id: message.author.id,
-			username: cleanUsername(message.author.username),
-			minigame: {}
+			username
 		}
 	});
 }


### PR DESCRIPTION
### Description:

Fixes leaderboard names and newUser table entries. Currently, the xpgains lookup is broken because it's not using a string for the userId, and 'newUser' table entries are only created when someone does mage training arena (or changes +sls settings). This fixes both of these bugs.

**Important: This does not change the current number of DB calls.**

### Changes:

- Changes the syncNewUsernames() command to an upsert using prisma's OO descriptive syntax.
- Updates xpgains to convert the bigint UserID into a string so the getUsername() function can actually find it.


### Other checks:

-   [x] I have tested all my changes thoroughly.

PS. I want to rewrite the way usernames are handled to make it more efficient, centralized, and reduce the number of DB calls significantly, but that belongs in another PR that I will start soon.