### PR TITLE
Replace Sinhaza shrouds into UMBs

### DIFF
--- a/src/lib/bsoOpenables.ts
+++ b/src/lib/bsoOpenables.ts
@@ -8,7 +8,8 @@ import {
 	chambersOfXericCL,
 	cmbClothes,
 	customBossesDropsThatCantBeDroppedInMBs,
-	theatreOfBLoodCL
+	theatreOfBloodHardUniques,
+	theatreOfBloodNormalUniques
 } from './data/CollectionsExport';
 import { baseHolidayItems, PartyhatTable } from './data/holidayItems';
 import { FishTable } from './minions/data/killableMonsters/custom/SeaKraken';
@@ -325,7 +326,8 @@ const cantBeDropped = resolveItems([
 	...BeachMysteryBoxTable.allItems,
 	...IndependenceBoxTable.allItems,
 	...cmbClothes,
-	...theatreOfBLoodCL
+	...theatreOfBloodHardUniques,
+	...theatreOfBloodNormalUniques
 ]);
 
 export const tmbTable: number[] = [];

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -368,7 +368,15 @@ export const chambersOfXericCL = resolveItems([
 	"Xeric's general",
 	"Xeric's champion"
 ]);
-export const theatreOfBLoodCL = resolveItems([
+const theatreOfBloodCapes = resolveItems([
+	'Sinhaza shroud tier 1',
+	'Sinhaza shroud tier 2',
+	'Sinhaza shroud tier 3',
+	'Sinhaza shroud tier 4',
+	'Sinhaza shroud tier 5'
+]);
+
+export const theatreOfBloodNormalUniques = resolveItems([
 	"Lil' zik",
 	'Scythe of vitur (uncharged)',
 	'Ghrazi rapier',
@@ -377,17 +385,14 @@ export const theatreOfBLoodCL = resolveItems([
 	'Justiciar chestguard',
 	'Justiciar legguards',
 	'Avernic defender hilt',
-	'Vial of blood',
-	'Sinhaza shroud tier 1',
-	'Sinhaza shroud tier 2',
-	'Sinhaza shroud tier 3',
-	'Sinhaza shroud tier 4',
-	'Sinhaza shroud tier 5',
-	'Sanguine dust',
-	'Holy ornament kit',
-	'Sanguine ornament kit'
+	'Vial of blood'
 ]);
-
+export const theatreOfBloodHardUniques = resolveItems(['Sanguine dust', 'Holy ornament kit', 'Sanguine ornament kit']);
+export const theatreOfBLoodCL = resolveItems([
+	...theatreOfBloodNormalUniques,
+	...theatreOfBloodCapes,
+	...theatreOfBloodHardUniques
+]);
 export const cluesBeginnerCL = resolveItems([
 	'Mole slippers',
 	'Frog slippers',


### PR DESCRIPTION
### Description:

After receiving numerous complaints about removal of the Sinhaza shroud capes from the UMBs because they require 2,000 completions and some people already got them from UMBs while several others didn't, replacing just the capes back into UMBs seems to be the most fair solution.

### Changes:
- Only add the normal + hard mode uniques to the 'CantBeDropped' in MBox's list

### Other checks:

-   [x] I have tested all my changes thoroughly.
