### PR TITLE
Fix `=b --hmb` after removal of Christmas cracker openable

### DIFF
--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -35,6 +35,7 @@ import {
 	wintertodtCL
 } from './CollectionsExport';
 import { Eatables } from './eatables';
+import { PartyhatTable } from './holidayItems';
 
 export const warmGear = resolveItems([
 	'Staff of fire',
@@ -1118,10 +1119,7 @@ export const baseFilters: Filterable[] = [
 	{
 		name: 'Holiday',
 		aliases: ['holiday', 'hmb', 'rare', 'rares'],
-		items: () => [
-			...allOpenables.find(o => o.name === 'Holiday Mystery box')!.allItems,
-			...allOpenables.find(o => o.name === 'Christmas cracker')!.allItems
-		]
+		items: () => [...allOpenables.find(o => o.name === 'Holiday Mystery box')!.allItems, ...PartyhatTable.allItems]
 	},
 	{
 		name: 'Custom Items',


### PR DESCRIPTION
### Description:

After removing the Christmas cracker from openables, the filterables wasn't updated, no error was raised during transpilation because it used openables.find()

### Changes:

- Replaced the Christmas cracker openable with the PartyHat loot table.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
