### PR TITLE
Stop giving double xp for smithing

### DIFF
--- a/src/tasks/minions/smithingActivity.ts
+++ b/src/tasks/minions/smithingActivity.ts
@@ -20,10 +20,6 @@ export default class extends Task {
 			xpReceived *= 1.1;
 		}
 
-		await user.addXP({
-			skillName: SkillsEnum.Smithing,
-			amount: xpReceived
-		});
 		const xpRes = await user.addXP({
 			skillName: SkillsEnum.Smithing,
 			amount: xpReceived,


### PR DESCRIPTION
### Description:

This one looks to be my fault via git blame. Seems like a merge error. 

Oops.

### Changes:

Stop giving XP twice in Smith activity.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
