### PR TITLE
MTA Repeat Trip Bug Fix

### DIFF
--- a/src/tasks/minions/minigames/mageTrainingArenaActivity.ts
+++ b/src/tasks/minions/minigames/mageTrainingArenaActivity.ts
@@ -44,7 +44,7 @@ export default class extends Task {
 			user,
 			channelID,
 			str,
-			['minigames', { mage_arena: {} }, true, 'train'],
+			['mta', [], true, 'train'],
 			undefined,
 			data,
 			loot

--- a/src/tasks/minions/minigames/mageTrainingArenaActivity.ts
+++ b/src/tasks/minions/minigames/mageTrainingArenaActivity.ts
@@ -39,15 +39,6 @@ export default class extends Task {
 
 		let str = `${user}, ${user.minionName} finished completing ${quantity}x Magic Training Arena rooms. You received **${pizazzPoints} Pizazz points**. ${xpRes}`;
 
-		handleTripFinish(
-			this.client,
-			user,
-			channelID,
-			str,
-			['mta', [], true, 'train'],
-			undefined,
-			data,
-			loot
-		);
+		handleTripFinish(this.client, user, channelID, str, ['mta', [], true, 'train'], undefined, data, loot);
 	}
 }


### PR DESCRIPTION
### Description:

MTA continue parameters currently send the minion on a Mage Arena 1 trip. This PR reverts this back to invoking the MTA command again.


### Other checks:

-   [x] I have tested all my changes thoroughly.
