### PR TITLE
MH Repeat Trip Bug Fix

### DIFF
--- a/src/tasks/minions/minigames/mahoganyHomesActivity.ts
+++ b/src/tasks/minions/minigames/mahoganyHomesActivity.ts
@@ -40,7 +40,7 @@ export default class extends Task {
 			user,
 			channelID,
 			str,
-			['minigames', { mahogany_homes: {} }, true],
+			['minigames', { mahogany_homes: { start: {} } }, true],
 			undefined,
 			data,
 			null


### PR DESCRIPTION
### Description:

Add the missing property to the parameters for repeat trip on Mahogany Homes. Without this, "Invalid Command" is sent to the user.

### Other checks:

-   [x] I have tested all my changes thoroughly.
