### PR TITLE
Fix `+rp ping NUMBER`

### DIFF
--- a/src/commands/rp.ts
+++ b/src/commands/rp.ts
@@ -258,7 +258,7 @@ export default class extends BotCommand {
 				if (!msg.guild || msg.guild.id !== SupportServer) return;
 				if (!input || typeof input !== 'string') return;
 				const roles = await prisma.pingableRole.findMany();
-				const roleToPing = roles.find(i => i.id === Number(str) || stringMatches(i.name, input));
+				const roleToPing = roles.find(i => i.id === Number(input) || stringMatches(i.name, input));
 				if (!roleToPing) {
 					return msg.channel.send('No role with that name found.');
 				}


### PR DESCRIPTION
### Description:

Fixes `+rp ping` command so it works with the numbers again

### Changes:

- Changes check to look at the 1st argument instead of the 2nd which doesn't apply to this command.

### Other checks:

-   [x] I have tested all my changes thoroughly.
