### PR TITLE
Fix /runecraft "no stamina" flag on continue

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -23,6 +23,7 @@ export interface RunecraftActivityTaskOptions extends ActivityTaskOptions {
 	runeID: number;
 	essenceQuantity: number;
 	imbueCasts: number;
+	useStaminas?: boolean;
 }
 
 export interface DarkAltarOptions extends ActivityTaskOptions {

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -225,6 +225,7 @@ export const runecraftCommand: OSBMahojiCommand = {
 			userID: user.id,
 			channelID: channelID.toString(),
 			essenceQuantity: quantity,
+			useStaminas: usestams,
 			duration,
 			imbueCasts,
 			type: 'Runecraft'

--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -10,7 +10,7 @@ import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
 export default class extends Task {
 	async run(data: RunecraftActivityTaskOptions) {
-		const { runeID, essenceQuantity, userID, channelID, imbueCasts, duration } = data;
+		const { runeID, essenceQuantity, userID, channelID, imbueCasts, duration, useStaminas } = data;
 		const user = await this.client.fetchUser(userID);
 
 		const rune = Runecraft.Runes.find(_rune => _rune.id === runeID)!;
@@ -59,7 +59,7 @@ export default class extends Task {
 			user,
 			channelID,
 			str,
-			['runecraft', { quantity: essenceQuantity, rune: rune.name }, true],
+			['runecraft', { quantity: essenceQuantity, rune: rune.name, usestams: useStaminas }, true],
 			undefined,
 			data,
 			loot


### PR DESCRIPTION
### Description:

When continuing a trip of `/runecraft` the `usestams` flag does not persist to continued trips.

### Changes:

- Adds `useStaminas` flag to the runecraft task definition
- Passes along the usestams command arg to the created task

### Other checks:

-   [x] I have tested all my changes thoroughly.
