### PR TITLE
Fix spawnlamp so it requires T3

### DIFF
--- a/src/commands/bso/spawnlamp.ts
+++ b/src/commands/bso/spawnlamp.ts
@@ -7,16 +7,11 @@ import { BitField, Channel, Color, PerkTier, spawnLampResetTime, SupportServer }
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { formatDuration } from '../../lib/util';
-import { isPrimaryPatron } from '../../lib/util/getUsersPerkTier';
 import { LampTable } from '../../lib/xpLamps';
 
 export default class extends BotCommand {
 	async run(msg: KlasaMessage) {
-		if (
-			!isPrimaryPatron(msg.author) &&
-			!msg.author.bitfield.includes(BitField.HasPermanentSpawnLamp) &&
-			msg.author.perkTier < PerkTier.Four
-		) {
+		if (!msg.author.bitfield.includes(BitField.HasPermanentSpawnLamp) && msg.author.perkTier < PerkTier.Four) {
 			return msg.channel.send('You need to be a Tier 3 patron to use this command.');
 		}
 


### PR DESCRIPTION
### Description:

Fixes =spawnlamp so it requires Tier 3 as advertised.

### Changes:

- Does what it says on the tin.
- Removes some logic that was causing all Tiers to be allowed to spawnlamp.

### Other checks:

-   [x] I have tested all my changes thoroughly.
