### PR TITLE
Add Drygore boost to igne and configurable boosts to BossInstance class

### DIFF
--- a/src/commands/bso/igne.ts
+++ b/src/commands/bso/igne.ts
@@ -30,9 +30,12 @@ export default class extends BotCommand {
 				slayer: 110
 			},
 			itemBoosts: [
+				['Drygore longsword', 15],
 				['Ignis ring(i)', 10],
-				['TzKal cape', 6]
+				['TzKal cape', 6],
+				["Brawler's hook necklace", 4]
 			],
+			speedMaxReduction: 40,
 			customDenier: async () => {
 				return [false];
 			},

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -110,6 +110,7 @@ export interface BossOptions {
 	id: number;
 	baseDuration: number;
 	skillRequirements: Skills;
+	// The total combined values for item boosts equal their relative contribution to the speed, see `speedMaxReduction`
 	itemBoosts: [string, number][];
 	customDenier: (user: KlasaUser) => Promise<UserDenyResult>;
 	bisGear: Gear;
@@ -131,6 +132,12 @@ export interface BossOptions {
 	allowMoreThan1Group?: boolean;
 	quantity?: number;
 	automaticStartTime?: number;
+	// The total % reduction that perfect gear/kc/boosts nets:
+	speedMaxReduction?: number;
+	// The relative weight that gear score contributes to the speed:
+	speedGearWeight?: number;
+	// The relative weight that KC contributes to the speed:
+	speedKcWeight?: number;
 }
 
 export interface BossUser {
@@ -174,6 +181,9 @@ export class BossInstance {
 	boosts: string[] = [];
 	automaticStartTime?: number;
 	maxSize: number;
+	speedMaxReduction: number = 40;
+	speedGearWeight: number = 25;
+	speedKcWeight: number = 35;
 
 	constructor(options: BossOptions) {
 		this.baseDuration = options.baseDuration;
@@ -194,6 +204,9 @@ export class BossInstance {
 		this.minSize = options.minSize;
 		this.solo = options.solo;
 		this.canDie = options.canDie;
+		this.speedKcWeight = options.speedKcWeight ?? 35;
+		this.speedGearWeight = options.speedGearWeight ?? 25;
+		this.speedMaxReduction = options.speedMaxReduction ?? 40;
 		this.kcLearningCap = options.kcLearningCap ?? 250;
 		this.customDeathChance = options.customDeathChance ?? null;
 		this.allowMoreThan1Solo = options.allowMoreThan1Solo ?? false;
@@ -310,10 +323,13 @@ export class BossInstance {
 	}
 
 	async calculateBossUsers() {
-		const maxReduction = 40;
-		const speedReductionForGear = 25;
-		const speedReductionForKC = 35;
-		let speedReductionForBoosts = sumArr(this.itemBoosts.map(i => i[1]));
+		const {
+			speedMaxReduction: maxReduction,
+			speedGearWeight: speedReductionForGear,
+			speedKcWeight: speedReductionForKC
+		} = this;
+		// The total combined values for item boosts equal their relative contribution to the speed
+		const speedReductionForBoosts = sumArr(this.itemBoosts.map(i => i[1]));
 		const totalSpeedReduction = speedReductionForGear + speedReductionForKC + speedReductionForBoosts;
 
 		const bossUsers: BossUser[] = [];


### PR DESCRIPTION
**Sorry this is so long, the code changes are very small, but have several implications:**

### Description:

This is a simple update which does a fair few things as I mentioned via direct message on Discord:
- Gives a boost to Ignecarus for Drygore longsword and Brawler's hook necklace 
- This distinguishes Drygore longsword as being superior to the Chaotic longsword
- And also balances the item boosts against the KC and Gear factors to be in line with other bosses. (35% max item boost)

**Important: This does not actually increase Igne kill speed at all,** but it would be easy to do that now, with the further addition of the new configurable options on the BossInstance class, by setting speedMaxReduction to a value higher than 40. (%)

### Changes:

**Ignecarus:**
- Adds boost for Drygore longsword and Brawler's hooknecklace
- This bring's the ItemBoost weight to 35, which is equal to KG and Vasa, so item boosts will count for a bigger share of the total speed reduction.

- Basically this just means that if you already have BIS gear, nothing will change, but if you were using Chaotic longsword instead of Drygore longsword, you will now incur a small penalty until you upgrade to the Drygore longsword.

**BossInstance Class**
- Adds 3 new customizable variables to the `BossInstance` class:
- `speedMaxReduction` - The total reduction that occurs when a player has 100% all max boosts.
- `speedGearWeight` / `speedKcWeight` - The relative weight of Gear / KC vs ItemBoosts.
- Example: If the total ItemBoosts are only 10% then Gear/KC weights should be close to 10-15 each themselves to properly balance the weights.

### Other checks:

-   [x] I have tested all my changes thoroughly.
