### PR TITLE
Fixes Twisted bow, Zaryte bow, Hellfire bow requirement for Cox CM party

### DIFF
--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -181,7 +181,7 @@ export default class extends BotCommand {
 				if (
 					isChallengeMode &&
 					!user.hasItemEquippedOrInBank('Dragon hunter crossbow') &&
-					!['Twisted bow', 'Hellfire bow', 'Zaryte bow'].some(i => user.hasItemEquippedOrInBank(i))
+					!['Twisted bow', 'Zaryte bow'].some(i => user.hasItemEquippedOrInBank(i))
 				) {
 					return [
 						true,

--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -23,7 +23,6 @@ import { MakePartyOptions } from '../../lib/types';
 import { RaidsOptions } from '../../lib/types/minions';
 import { formatDuration, updateBankSetting } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
-import resolveItems from '../../lib/util/resolveItems';
 
 const uniques = [
 	'Dexterous prayer scroll',

--- a/src/commands/Minion/raid.ts
+++ b/src/commands/Minion/raid.ts
@@ -181,13 +181,11 @@ export default class extends BotCommand {
 				if (
 					isChallengeMode &&
 					!user.hasItemEquippedOrInBank('Dragon hunter crossbow') &&
-					resolveItems(['Twisted bow', 'Hellfire bow', 'Zaryte bow']).every(
-						i => !user.hasItemEquippedAnywhere(i) && user.owns(i)
-					)
+					!['Twisted bow', 'Hellfire bow', 'Zaryte bow'].some(i => user.hasItemEquippedOrInBank(i))
 				) {
 					return [
 						true,
-						'You need either a Dragon hunter crossbow or Twisted bow to attempt Challenge Mode Chambers of Xeric.'
+						'You need either a Dragon hunter crossbow, Zaryte bow, or Twisted bow to attempt Challenge Mode Chambers of Xeric.'
 					];
 				}
 

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -265,9 +265,9 @@ export async function checkCoxTeam(users: KlasaUser[], cm: boolean): Promise<str
 			if (
 				users.length > 1 &&
 				!user.hasItemEquippedOrInBank('Dragon hunter crossbow') &&
-				!user.hasItemEquippedOrInBank('Twisted bow')
+				!['Twisted bow', 'Zaryte bow'].some(i => user.hasItemEquippedOrInBank(i))
 			) {
-				return `${user.username} doesn't own a Twisted bow or Dragon hunter crossbow, which is required for Challenge Mode.`;
+				return `${user.username} doesn't own a Twisted bow, Zaryte bow, or Dragon hunter crossbow, which is required for Challenge Mode.`;
 			}
 			const kc = await user.getMinigameScore('raids');
 			if (kc < 200) {


### PR DESCRIPTION
### Description:

This does not affect OSB.
Currently, the bot lets you join a CM party without a Tbow/zbow/hellfire bow because the logic is bugged.
This fixes that, and cleans up the logic to make it a little more efficient.

### Changes:

- Fixes logic in the Party awaiter when joining a CM raid without a proper bow
- Changes from `.every()` to `.some()` because we can abort as soon as we have any match, no need to check for all 3 every time.
- Removes explicit `Hellfire bow` check because `User.hasItemEquippedOrInBank()` already checks for similar items, so the hellfire bow is included in the search space already.
- Fixed the actual send-off code to allow Zaryte bow, which was intended but not implemented.

### Other checks:

-   [x] I have tested all my changes thoroughly.
