### PR TITLE
Fix items being added to --temp CL from mystery boxes.

### DIFF
--- a/src/mahoji/commands/open.ts
+++ b/src/mahoji/commands/open.ts
@@ -101,7 +101,7 @@ export const openCommand: OSBMahojiCommand = {
 			items: loot.bank,
 			collectionLog: true,
 			filterLoot: false,
-			dontAddToTempCL: !itemsThatDontAddToTempCL.includes(openable.id)
+			dontAddToTempCL: itemsThatDontAddToTempCL.includes(openable.id)
 		});
 
 		const image = await client.tasks.get('bankImage')!.generateBankImage(


### PR DESCRIPTION
### Description:

The logic was bugged in `open.ts` causing openables that should add to temp CL to be ignored, while mystery boxes [that should be ignored]  were actually adding to the CL.

### Changes:

Fixes the broken logic by removing a negation operator `!`

### Other checks:

-   [x] I have tested all my changes thoroughly.
