### PR TITLE
Fix Nex Unique Weightings

### DIFF
--- a/src/lib/simulation/misc.ts
+++ b/src/lib/simulation/misc.ts
@@ -181,8 +181,8 @@ export const BuildersSupplyCrateTable = new LootTable()
 
 export const NexUniqueTable = new LootTable()
 	.add('Nihil horn', 1, 2)
-	.add('Zaryte vambraces', 1, 2)
-	.add('Ancient hilt', 1, 2)
+	.add('Zaryte vambraces', 1, 3)
+	.add('Ancient hilt', 1, 1)
 	.add('Torva full helm (damaged)', 1, 2)
 	.add('Torva platebody (damaged)', 1, 2)
 	.add('Torva platelegs (damaged)', 1, 2);


### PR DESCRIPTION

### Description:

The original Nex unique weightings were all set to be the same, resulting in all uniques having the same chance of dropping.

This adjusts the weightings to be consistent with those in OSRS, as described below.

Torva Armour: 2/12 for each individual piece of the armour set
Nihil Horn: 2/12
Zaryte Vambraces: 3/12
Ancient Hilt: 1/12

### Changes:

Loot table weightings for Ancient hilt and Zaryte vambraces adjusted. Zaryte vambraces will be 1.5x as common as before, Ancient hilt will be half as common.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
