### PR TITLE
BSO - Smithing QoL Dwarven/Gorajan

### DIFF
--- a/src/commands/Minion/smith.ts
+++ b/src/commands/Minion/smith.ts
@@ -110,10 +110,9 @@ export default class extends BotCommand {
 		// If no quantity provided, set it to the max.
 		if (quantity === null) {
 			quantity = Math.floor(maxTripLength / timeToSmithSingleBar);
-		}
-
-		if (smithedItem.name.includes('Gorajan')) {
-			quantity = 1;
+			if (smithedItem.name.includes('Dwarven') || smithedItem.name.includes('Gorajan')) {
+				quantity = 1;
+			}
 		}
 
 		await msg.author.settings.sync(true);


### PR DESCRIPTION
If no quantity is specified set quantity to be 1 to prevent people accidentally wasting bars.

This was previously the case for Gorajan but they couldn't specify any quantity at all and would have to spam the command if they wanted to smith more than one item.

-   [x] I have tested all my changes thoroughly.
