### PR TITLE
Make Gorajan bonecrusher toggleable.

### DIFF
--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -827,6 +827,7 @@ setCustomItem(
 setCustomItem(48_012, 'Gorajan shards', 'Coal', {}, 1_000_000);
 setCustomItem(48_013, 'Gorajan bonecrusher', 'Coal', {}, 20_000_000);
 setCustomItem(48_014, 'Gorajan bonecrusher (u)', 'Coal', {}, 20_000_000);
+setCustomItem(50_118, 'Gorajan bonecrusher (disabled)', 'Coal', {}, 20_000_000);
 /**
  * END DUNGEONEERING
  */

--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -182,6 +182,24 @@ const chaoticCreatables: Createable[] = [
 			[itemID('Gorajan bonecrusher')]: 1
 		},
 		requiredSkills: { crafting: 120 }
+	},
+	{
+		name: 'Disable Gorajan bonecrusher',
+		inputItems: {
+			[itemID('Gorajan bonecrusher')]: 1
+		},
+		outputItems: {
+			[itemID('Gorajan bonecrusher (disabled)')]: 1
+		}
+	},
+	{
+		name: 'Enable Gorajan bonecrusher',
+		inputItems: {
+			[itemID('Gorajan bonecrusher (disabled)')]: 1
+		},
+		outputItems: {
+			[itemID('Gorajan bonecrusher')]: 1
+		}
 	}
 ];
 


### PR DESCRIPTION
### Description:

Adds `disabled` variant of Gorajan bonecrusher so it can be easily toggled without requiring a settings change.e

### Changes:

- Adds disasbled version of Gorajan bonecrusher
- Adds enable/disable `Createable`s for the bonecrusher
- tested all changes

### Other checks:

-   [x] I have tested all my changes thoroughly.
