### PR TITLE
Nex - Increase checkNexUser ammo requirement

### DIFF
--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -97,10 +97,10 @@ export function checkNexUser(user: User): [false] | [true, string] {
 	) {
 		return [true, `${tag} is using incorrect ammo for their type of weapon.`];
 	}
-	if (ammo.quantity < 200) {
+	if (ammo.quantity < 600) {
 		return [
 			true,
-			`${tag} has less than 200 ${itemNameFromID(ammo.item)} equipped, they might run out in the fight!`
+			`${tag} has less than 600 ${itemNameFromID(ammo.item)} equipped, they might run out in the fight!`
 		];
 	}
 	const bank = new Bank(user.bank as any);


### PR DESCRIPTION

### Description:

The mass pre-check (checkNexUser) only checks for 200 ammo to let a user in, though the pre-ava's ammo amount can be higher than 200. Maximum possible kills per trip appears to be 9-10 with a maximum ammo/kill of 60. If the total ammo (before ava's) exceeds 200, the mass can still fail upon sending if anyone has less than the pre-ava's amount. See picture below for an example.

![image](https://user-images.githubusercontent.com/59510368/161106101-a7ffb484-bdec-4887-848b-ebccbc11d96c.png)

### Changes:

Increased ammo requirement in checkNexUser from 200 to 600 to accommodate for 10 kills at 60 ammo per kill.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
