### PR TITLE
Nex Loot Bug Fixes

### DIFF
--- a/src/lib/simulation/misc.ts
+++ b/src/lib/simulation/misc.ts
@@ -211,5 +211,4 @@ const NexNonUniqueBaseTable = new LootTable()
 export const NexNonUniqueTable = new LootTable()
 	.every(NexNonUniqueBaseTable, 2)
 	.oneIn(25, 'Nihil shard', [1, 20])
-	.oneIn(100, 'Rune sword')
-	.tertiary(20, 'Clue scroll (elite)');
+	.oneIn(100, 'Rune sword');

--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -142,23 +142,27 @@ export const purpleNexItems = resolveItems([
 
 export function handleNexKills({ quantity, team }: NexContext) {
 	const teamLoot = new TeamLoot(purpleNexItems);
-	const uniqueDecider = new SimpleTable<string>();
-	for (const user of team) uniqueDecider.add(user.id);
 
 	for (let i = 0; i < quantity; i++) {
-		const uniqueRecipient = roll(43) ? uniqueDecider.roll().item : null;
+		const survivors = team.filter(usr => !usr.deaths.includes(i));
+
+		const uniqueRecipient = roll(43) ? randArrItem(survivors).id : null;
 		const nonUniqueDrop = NexNonUniqueTable.roll();
 
-		for (const teamMember of team) {
-			if (teamMember.deaths.includes(i)) continue;
+		for (const teamMember of survivors) {
 			teamLoot.add(teamMember.id, nonUniqueDrop);
 			if (teamMember.id === uniqueRecipient) {
 				teamLoot.add(teamMember.id, NexUniqueTable.roll());
 			}
 		}
 
+		if (roll(20)) {
+			const recipient = randArrItem(survivors);
+			teamLoot.add(recipient.id, 'Clue scroll (elite)');
+		}
+
 		if (roll(500)) {
-			const recipient = randArrItem(team);
+			const recipient = randArrItem(survivors);
 			teamLoot.add(recipient.id, 'Nexling');
 		}
 	}

--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -13,7 +13,6 @@ import {
 } from 'e';
 import { Bank } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
-import SimpleTable from 'oldschooljs/dist/structures/SimpleTable';
 
 import { getSkillsOfMahojiUser, getUserGear } from '../../mahoji/mahojiSettings';
 import { BitField, NEX_ID } from '../constants';

--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -153,11 +153,9 @@ export function handleNexKills({ quantity, team }: NexContext) {
 			if (teamMember.id === uniqueRecipient) {
 				teamLoot.add(teamMember.id, NexUniqueTable.roll());
 			}
-		}
-
-		if (roll(20)) {
-			const recipient = randArrItem(survivors);
-			teamLoot.add(recipient.id, 'Clue scroll (elite)');
+			if (roll(20)) {
+				teamLoot.add(teamMember.id, 'Clue scroll (elite)');
+			}
 		}
 
 		if (roll(500)) {


### PR DESCRIPTION
### Description:

The handleNexKills function currently does not deal with player deaths for all loot rolls. This means that a player that dies during a kill still has a pet chance. It is also possible for a player to be chosen to receive a unique who had died during the kill. Meaning a unique should have been given out but wasn't because the player was dead.
The kill also gave all members an elite if the 1/20 chance was hit, this changes it so each survivor rolls to receive one.

### Changes:

handleNexKills function now creates a list of surviving team members for each kill. 
This list is then used to:
* Choose a random unique recipient if the 1/43 chance is hit
* Iterate over to distribute loot, including a 1/20 chance for an elite clue
* Choose a random team member to receive the pet, if the 1/500 chance is hit

### Other checks:

Pum helped me test in my private server
* Same non-unique loot is still being allocated to survivors
* Loot is only given to living players (uniques, pets and clues included) - To test this, I gave one person a death for each kill to ensure and no loot was given
* Uniques seemed evenly distributed
-   [x] I have tested all my changes thoroughly.
