### PR TITLE
Fix some Nex bugs

### DIFF
--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -55,7 +55,6 @@ export async function setupParty(
 
 	const reactionAwaiter = () =>
 		new Promise<KlasaUser[]>(async (resolve, reject) => {
-			partyLockCache.add(user.id);
 			let partyCancelled = false;
 			const collector = new CustomReactionCollector(confirmMessage, {
 				time: 120_000,
@@ -102,6 +101,7 @@ export async function setupParty(
 			collector.on('remove', (reaction: MessageReaction, user: KlasaUser) => {
 				if (!usersWhoConfirmed.includes(user)) return false;
 				if (reaction.emoji.id !== ReactionEmoji.Join) return false;
+				partyLockCache.delete(user.id);
 				removeUser(user);
 			});
 

--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -26,7 +26,6 @@ import {
 	itemNameFromID,
 	skillsMeetRequirements
 } from '../util';
-import getUsersPerkTier from '../util/getUsersPerkTier';
 import itemID from '../util/itemID';
 import { arrows, bolts, bows, calcMaxTripLength, crossbows } from '../util/minionUtils';
 import resolveItems from '../util/resolveItems';
@@ -167,9 +166,7 @@ export function handleNexKills({ quantity, team }: NexContext) {
 }
 
 export function calculateNexDetails({ team }: { team: User[] }) {
-	let maxTripLength = calcMaxTripLength(
-		[...team].sort((a, b) => getUsersPerkTier(b.bitfield) - getUsersPerkTier(a.bitfield))[0]
-	);
+	let maxTripLength = Math.max(...team.map(u => calcMaxTripLength(u)));
 	let lengthPerKill = Time.Minute * 35;
 	let resultTeam: TeamMember[] = [];
 

--- a/src/mahoji/commands/pay.ts
+++ b/src/mahoji/commands/pay.ts
@@ -43,7 +43,7 @@ export const payCommand: OSBMahojiCommand = {
 		if (user.isIronman) return "Iron players can't send money.";
 		if (recipient.isIronman) return "Iron players can't receive money.";
 		if (GP < amount) return "You don't have enough GP.";
-		if (user.bot) return "You can't send money to a bot.";
+		if (recipient.bot) return "You can't send money to a bot.";
 		if (client.oneCommandAtATimeCache.has(recipient.id)) return 'That user is busy right now.';
 
 		if (amount > 500_000_000) {


### PR DESCRIPTION
### Description:

Fixes some Nex bugs.

NOTE: I tried to fix the problem where when a Mass fails, it doesn't notify everyone, but even when you mention all the members, it doesn't actually send notifications, because it's a deferred response, it acts like an 'edit' which doesn't send new notifications. I still have the code in case Discord changes this in the future, or maybe we can send an additional message directly to the channel.

### Changes:

- Fixes PartyLockCache so it works as intended. It still prevents joining multiple masses, but now it doesn't lock you out if you accidentally double-click or hit one of the other buttons instead. Unjoining also appropriately removes the lock on your account.
- The max trip length for Nex now takes into consideration sac value, not just Patreon Tier. Previously it could choose between 2 people with Tier 3, but it wouldn't take into account their sac value, which is an extra 3 minutes potentially.
- Prevents paying bots. This came from research into the deferred response notifications
(I know it doesn't really fit here, but I hope we can make a small exception here :) )

### Other checks:

-   [x] I have tested all my changes thoroughly.
