### PR TITLE
Missing Torva Boosts/Requirements

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -243,10 +243,12 @@ const killableBosses: KillableMonster[] = [
 			{ [itemID('Spectral spirit shield')]: 10 },
 			{
 				[itemID('Bandos chestplate')]: 5,
+				[itemID("Torva platebody")]: 6,
 				[itemID("Inquisitor's hauberk")]: 8
 			},
 			{
 				[itemID('Bandos tassets')]: 5,
+				[itemID("Torva platelegs")]: 6,
 				[itemID("Inquisitor's plateskirt")]: 8
 			},
 			{

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -243,12 +243,12 @@ const killableBosses: KillableMonster[] = [
 			{ [itemID('Spectral spirit shield')]: 10 },
 			{
 				[itemID('Bandos chestplate')]: 5,
-				[itemID("Torva platebody")]: 6,
+				[itemID('Torva platebody')]: 6,
 				[itemID("Inquisitor's hauberk")]: 8
 			},
 			{
 				[itemID('Bandos tassets')]: 5,
-				[itemID("Torva platelegs")]: 6,
+				[itemID('Torva platelegs')]: 6,
 				[itemID("Inquisitor's plateskirt")]: 8
 			},
 			{

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -159,12 +159,11 @@ const killableMonsters: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Bandos chestplate')]: 2,
-				[itemID("Torva platebody")]: 2
-				
+				[itemID('Torva platebody')]: 2
 			},
 			{
 				[itemID('Bandos tassets')]: 2,
-				[itemID("Torva platelegs")]: 2
+				[itemID('Torva platelegs')]: 2
 			},
 			{
 				[itemID('Saradomin godsword')]: 4,

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -151,17 +151,20 @@ const killableMonsters: KillableMonster[] = [
 			"Guthan's chainskirt",
 			"Guthan's helm",
 			"Guthan's warspear",
-			['Bandos chestplate', "Torag's platebody"],
-			['Bandos tassets', "Torag's platelegs"]
+			['Bandos chestplate', "Torag's platebody", 'Torva platebody'],
+			['Bandos tassets', "Torag's platelegs", 'Torva platelegs']
 		]),
 		notifyDrops: resolveItems(['Pet dagannoth supreme']),
 		qpRequired: 0,
 		itemInBankBoosts: [
 			{
-				[itemID('Bandos chestplate')]: 2
+				[itemID('Bandos chestplate')]: 2,
+				[itemID("Torva platebody")]: 2
+				
 			},
 			{
-				[itemID('Bandos tassets')]: 2
+				[itemID('Bandos tassets')]: 2,
+				[itemID("Torva platelegs")]: 2
 			},
 			{
 				[itemID('Saradomin godsword')]: 4,

--- a/src/lib/minions/data/killableMonsters/turaelMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/turaelMonsters.ts
@@ -269,7 +269,7 @@ export const turaelMonsters: KillableMonster[] = [
 		difficultyRating: 7,
 		itemsRequired: deepResolveItems([
 			['Torva platebody', 'Bandos chestplate'],
-			["Verac's plateskirt", 'Bandos tassets'],
+			["Verac's plateskirt", 'Bandos tassets', 'Torva platelegs'],
 			['Arclight', 'Abyssal whip', 'Dragon scimitar'],
 			['Rune crossbow', "Karil's crossbow", 'Armadyl crossbow'],
 			['Armadyl chestplate', "Karil's leathertop"],


### PR DESCRIPTION
Adds a boost to Cerberus for Torva in-between Bandos and Inquisitor's.
Allows the use of Torva at dagannoth supreme instead of just bandos/torag's also adds a boost at the same rate as bandos.
Allows the use of torva platelegs at Demonic Gorilla's. 

-   [ ] I have tested all my changes thoroughly.
