### PR TITLE
Prevent negative sell prices

### DIFF
--- a/src/commands/Minion/sell.ts
+++ b/src/commands/Minion/sell.ts
@@ -37,7 +37,7 @@ export default class extends BotCommand {
 		const hasSkipper = msg.author.usingPet('Skipper') || msg.author.bank().amount('Skipper') > 0;
 		const taxRate = hasSkipper ? 0.15 : 0.25;
 		const tax = Math.ceil(totalPrice * taxRate);
-		totalPrice = Math.floor(totalPrice - tax);
+		totalPrice = Math.max(0, Math.floor(totalPrice - tax));
 
 		await msg.confirm(
 			`${


### PR DESCRIPTION
### Description:

Because tax is rounded up, if you sell 1x Mind rune, for example (worth 0.24 bot price), then 0.24 - 1 = -.76, which is rounded down to -1.

### Changes:

Math.max(0, sellPrice); to make 0 the absolute floor sell price.

### Other checks:

-   [x] I have tested all my changes thoroughly.
