### PR TITLE
Daeyalt Essence - Runecrafting/Mining

### DIFF
--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -120,6 +120,13 @@ const ores: Ore[] = [
 		clueScrollChance: 148_320
 	},
 	{
+		level: 60,
+		xp: 5,
+		id: 24_704,
+		name: 'Daeyalt shard',
+		respawnTime: 0.5
+	},
+	{
 		level: 70,
 		xp: 95,
 		id: 449,

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -24,6 +24,7 @@ export interface RunecraftActivityTaskOptions extends ActivityTaskOptions {
 	essenceQuantity: number;
 	imbueCasts: number;
 	useStaminas?: boolean;
+	daeyaltEssence?: boolean;
 }
 
 export interface DarkAltarOptions extends ActivityTaskOptions {

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -50,16 +50,23 @@ export const runecraftCommand: OSBMahojiCommand = {
 			name: 'usestams',
 			description: 'Set this to false to not use stamina potions (default true)',
 			required: false
+		},
+		{
+			type: ApplicationCommandOptionType.Boolean,
+			name: 'daeyalt_essence',
+			description: 'Set this to true to use daeyalt essence (default false)',
+			required: false
 		}
 	],
 	run: async ({
 		userID,
 		options,
 		channelID
-	}: CommandRunOptions<{ rune: string; quantity?: number; usestams?: boolean }>) => {
+	}: CommandRunOptions<{ rune: string; quantity?: number; usestams?: boolean; daeyalt_essence?: boolean }>) => {
 		const user = await client.fetchUser(userID.toString());
-		let { rune, quantity, usestams } = options;
+		let { rune, quantity, usestams, daeyalt_essence } = options;
 		if (usestams === undefined) usestams = true;
+		if (daeyalt_essence === undefined) daeyalt_essence = false;
 		rune = rune.toLowerCase().replace('rune', '').trim();
 
 		if (rune !== 'chaos' && rune.endsWith('s')) {
@@ -89,6 +96,7 @@ export const runecraftCommand: OSBMahojiCommand = {
 
 		const bank = user.bank();
 		const numEssenceOwned = bank.amount('Pure essence');
+		const daeyaltEssenceOwned = bank.amount('Daeyalt essence');
 
 		let { tripLength } = runeObj;
 		const boosts = [];
@@ -137,10 +145,17 @@ export const runecraftCommand: OSBMahojiCommand = {
 		const maxCanDo = Math.floor(maxTripLength / tripLength) * inventorySize;
 
 		// If no quantity provided, set it to the max.
-		if (!quantity) quantity = Math.min(numEssenceOwned, maxCanDo);
+		if (daeyalt_essence) {
+			if (!quantity) quantity = Math.min(daeyaltEssenceOwned, maxCanDo);
+			if (daeyaltEssenceOwned === 0 || quantity === 0 || daeyaltEssenceOwned < quantity) {
+				return "You don't have enough Daeyalt Essence to craft these runes. You can acquire some through Mining.";
+			}
+		} else {
+			if (!quantity) quantity = Math.min(numEssenceOwned, maxCanDo);
 
-		if (numEssenceOwned === 0 || quantity === 0 || numEssenceOwned < quantity) {
-			return "You don't have enough Pure Essence to craft these runes. You can acquire some through Mining, or purchasing from other players.";
+			if (numEssenceOwned === 0 || quantity === 0 || numEssenceOwned < quantity) {
+				return "You don't have enough Pure Essence to craft these runes. You can acquire some through Mining, or purchasing from other players.";
+			}
 		}
 
 		const numberOfInventories = Math.max(Math.ceil(quantity / inventorySize), 1);
@@ -213,8 +228,10 @@ export const runecraftCommand: OSBMahojiCommand = {
 			}
 			totalCost.add(removeTalismanAndOrRunes);
 		}
-
-		totalCost.add('Pure essence', quantity);
+		if (daeyalt_essence) {
+			totalCost.add('Daeyalt essence', quantity);
+			if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
+		} else totalCost.add('Pure essence', quantity);
 		if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
 
 		await user.removeItemsFromBank(totalCost);
@@ -226,6 +243,7 @@ export const runecraftCommand: OSBMahojiCommand = {
 			channelID: channelID.toString(),
 			essenceQuantity: quantity,
 			useStaminas: usestams,
+			daeyaltEssence: daeyalt_essence,
 			duration,
 			imbueCasts,
 			type: 'Runecraft'

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -82,6 +82,8 @@ export default class extends Task {
 			}
 		}
 
+		let daeyaltQty = 0;
+
 		// Gem rocks roll off the GemRockTable
 		if (ore.id === 1625) {
 			for (let i = 0; i < quantity; i++) {
@@ -104,6 +106,11 @@ export default class extends Task {
 					break;
 				}
 			}
+		} else if (ore.id === 24_704) {
+			for (let i = 0; i < quantity; i++) {
+				daeyaltQty += rand(2, 3);
+			}
+			loot.add(ore.id, daeyaltQty);
 		} else {
 			loot.add(ore.id, quantity);
 		}

--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -10,7 +10,7 @@ import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
 export default class extends Task {
 	async run(data: RunecraftActivityTaskOptions) {
-		const { runeID, essenceQuantity, userID, channelID, imbueCasts, duration, useStaminas } = data;
+		const { runeID, essenceQuantity, userID, channelID, imbueCasts, duration, useStaminas, daeyaltEssence } = data;
 		const user = await this.client.fetchUser(userID);
 
 		const rune = Runecraft.Runes.find(_rune => _rune.id === runeID)!;
@@ -18,7 +18,13 @@ export default class extends Task {
 		const quantityPerEssence = calcMaxRCQuantity(rune, user);
 		const runeQuantity = essenceQuantity * quantityPerEssence;
 
-		const xpReceived = essenceQuantity * rune.xp;
+		let runeXP = rune.xp;
+
+		if (daeyaltEssence) {
+			runeXP = rune.xp * 1.5;
+		}
+
+		const xpReceived = essenceQuantity * runeXP;
 
 		const magicXpReceived = imbueCasts * 86;
 
@@ -59,7 +65,11 @@ export default class extends Task {
 			user,
 			channelID,
 			str,
-			['runecraft', { quantity: essenceQuantity, rune: rune.name, usestams: useStaminas }, true],
+			[
+				'runecraft',
+				{ quantity: essenceQuantity, rune: rune.name, usestams: useStaminas, daeyalt_essence: daeyaltEssence },
+				true
+			],
 			undefined,
 			data,
 			loot


### PR DESCRIPTION
Adds the mining of daeyalt shards to gather daeyalt essence (auto banks the essence instead of the shards as that's their only purpose)
Adds a boolean optional command on the runecrafting command to use daeyalt essence at a 50% increased xp rate. (doesn't work on blood/soul runes)
If the boolean is not selected it defaults to false.

Closes #1017

-   [x] I have tested all my changes thoroughly.
