### PR TITLE
Allow Zaryte Crossbow to be used where armadyl crossbow is required

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -84,6 +84,7 @@ const source: [string, (string | number)[]][] = [
 	['Necklace of anguish', ['Necklace of anguish (or)']],
 	['Occult necklace', ['Occult necklace (or)']],
 	['Dragon hunter crossbow', ['Dragon hunter crossbow (t)', 'Dragon hunter crossbow (b)']],
+	['Armadyl crossbow', ['Zaryte crossbow']],
 	['Dragon pickaxe', ['Dragon pickaxe(or)', 12_797, '3rd age pickaxe', 'Infernal pickaxe']],
 	['Dragon axe', ['3rd age axe']],
 	['Steam battlestaff', [12_795]],


### PR DESCRIPTION
Adds Zaryte Crossbow to similarItems, making it useable wherever the Armadyl crossbow is used and give the relevant boosts also.
Checked the Armadyl crossbow doesn't gain any boosts the Zaryte has through this.
Checked Zaryte crossbow works on content that Armadyl Crossbow is needed.
Checked it gets the relevant boosts.

-   [x] I have tested all my changes thoroughly.
