### PR TITLE
Mix Super Combat Potions using Torstol (unf)

### DIFF
--- a/src/commands/Minion/mix.ts
+++ b/src/commands/Minion/mix.ts
@@ -74,12 +74,12 @@ export default class extends BotCommand {
 
 		await msg.author.settings.sync(true);
 		let requiredItems = new Bank(mixableItem.inputItems);
-		if ( msg.flagArgs.unf && mixableItem.name === "Super combat potion (4)" ) {
+		if (msg.flagArgs.unf && mixableItem.name === 'Super combat potion (4)') {
 			requiredItems = new Bank()
 				.add('Super attack(4)')
 				.add('Super strength (4)')
 				.add('Super defence (4)')
-				.add('Torstol potion (unf)')
+				.add('Torstol potion (unf)');
 		}
 
 		// Get the base time to mix the item then add on quarter of a second per item to account for banking/etc.

--- a/src/commands/Minion/mix.ts
+++ b/src/commands/Minion/mix.ts
@@ -74,6 +74,13 @@ export default class extends BotCommand {
 
 		await msg.author.settings.sync(true);
 		let requiredItems = new Bank(mixableItem.inputItems);
+		if ( msg.flagArgs.unf && mixableItem.name === "Super combat potion (4)" ) {
+			requiredItems = new Bank()
+				.add('Super attack(4)')
+				.add('Super strength (4)')
+				.add('Super defence (4)')
+				.add('Torstol potion (unf)')
+		}
 
 		// Get the base time to mix the item then add on quarter of a second per item to account for banking/etc.
 		let timeToMixSingleItem =


### PR DESCRIPTION
### Description:

Currently the bot only allows for super combat potions to be made with a clean Torstol but the wiki lists both the herb and the (unf) as options.
To combat this, the bot allows users to revert (unf) to Torstols, but I thought it'd be better to just let unfinished be used. 
This is basically an if statement to handle this one condition as no other potions in game allow for multiple recipes. Otherwise I'd suggest more elegant code by changing a Mixable to have altInputs or something.
May be worth removing the create option mentioned above if this is approved and merged.

### Changes:

Allow for a --unf flag to be used when creating Super Combat Potions, this changes inputItems to use the unf potion instead of herb.

### Other checks:

-   [x] I have tested all my changes thoroughly.
