### PR TITLE
Create Ecumenical Key from Shards

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1762,7 +1762,7 @@ const Createables: Createable[] = [
 	{
 		name: 'Ecumenical key',
 		inputItems: new Bank({
-			'Ecumenical key shard': 50,
+			'Ecumenical key shard': 50
 		}),
 		outputItems: {
 			[itemID('Ecumenical key')]: 1

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1759,6 +1759,15 @@ const Createables: Createable[] = [
 			[itemID('Frozen key')]: 1
 		}
 	},
+	{
+		name: 'Ecumenical key',
+		inputItems: new Bank({
+			'Ecumenical key shard': 50,
+		}),
+		outputItems: {
+			[itemID('Ecumenical key')]: 1
+		}
+	},
 	...Reverteables,
 	...crystalTools,
 	...ornamentKits,


### PR DESCRIPTION
Closes https://github.com/oldschoolgg/oldschoolbot/issues/3767

### Description:

With the addition of Nex, ecumenical key shards are available but there is no way to convert them to keys for both sacrifice and alching.

### Changes:

Add create option for ecumenical keys that uses 50 shards, as per wiki.

### Other checks:

-   [x] I have tested all my changes thoroughly.
