### PR TITLE
Increase Random Event Response Wait Time

### DIFF
--- a/src/lib/randomEvents.ts
+++ b/src/lib/randomEvents.ts
@@ -163,7 +163,7 @@ async function finalizeEvent(event: RandomEvent, user: KlasaUser, ch: TextChanne
 
 const options = {
 	max: 1,
-	time: 30_000,
+	time: 60_000,
 	errors: ['time']
 };
 


### PR DESCRIPTION
Closes https://github.com/oldschoolgg/oldschoolbot/issues/3766

### Description:

The bot currently waits 30s for a response, the wiki states the in-game events despawn in 60s.

### Changes:

Increasing wait to match in-game (60s)

### Other checks:

-   [x] I have tested all my changes thoroughly.
