### PR TITLE
Fix more nex bugs (Nex wipes totally broken)

### DIFF
--- a/src/commands/rp.ts
+++ b/src/commands/rp.ts
@@ -41,6 +41,7 @@ import {
 	getSupportGuild,
 	getUsername,
 	isGroupActivity,
+	isNexActivity,
 	isRaidsActivity,
 	isTobActivity,
 	itemNameFromID,
@@ -81,9 +82,10 @@ async function checkMassesCommand(msg: KlasaMessage) {
 	const now = Date.now();
 	const massStr = masses
 		.map(m => {
-			const remainingTime = isTobActivity(m)
-				? m.finishDate - m.duration + m.fakeDuration - now
-				: m.finishDate - now;
+			const remainingTime =
+				isTobActivity(m) || isNexActivity(m)
+					? m.finishDate - m.duration + m.fakeDuration - now
+					: m.finishDate - now;
 			if (isGroupActivity(m)) {
 				return [
 					remainingTime,

--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -23,6 +23,7 @@ import {
 	formatDuration,
 	formatSkillRequirements,
 	itemNameFromID,
+	randomVariation,
 	skillsMeetRequirements
 } from '../util';
 import itemID from '../util/itemID';
@@ -286,7 +287,7 @@ export function calculateNexDetails({ team }: { team: User[] }) {
 	return {
 		team: resultTeam,
 		quantity,
-		duration: wipedKill ? wipedKill * lengthPerKill : duration,
+		duration: wipedKill ? wipedKill * lengthPerKill - randomVariation(lengthPerKill / 2, 90) : duration,
 		fakeDuration: duration,
 		wipedKill,
 		deaths

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -33,7 +33,12 @@ import { POHBoosts } from './poh';
 import { Rune } from './skilling/skills/runecraft';
 import { SkillsEnum } from './skilling/types';
 import { ArrayItemsResolved, Skills } from './types';
-import { GroupMonsterActivityTaskOptions, RaidsOptions, TheatreOfBloodTaskOptions } from './types/minions';
+import {
+	GroupMonsterActivityTaskOptions,
+	NexTaskOptions,
+	RaidsOptions,
+	TheatreOfBloodTaskOptions
+} from './types/minions';
 import getUsersPerkTier from './util/getUsersPerkTier';
 import itemID from './util/itemID';
 import resolveItems from './util/resolveItems';
@@ -263,6 +268,10 @@ export function isRaidsActivity(data: any): data is RaidsOptions {
 
 export function isTobActivity(data: any): data is TheatreOfBloodTaskOptions {
 	return 'wipedRoom' in data;
+}
+
+export function isNexActivity(data: any): data is NexTaskOptions {
+	return 'wipedKill' in data;
 }
 
 export function sha256Hash(x: string) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -271,7 +271,7 @@ export function isTobActivity(data: any): data is TheatreOfBloodTaskOptions {
 }
 
 export function isNexActivity(data: any): data is NexTaskOptions {
-	return 'wipedKill' in data;
+	return 'wipedKill' in data && 'userDetails' in data && 'leader' in data;
 }
 
 export function sha256Hash(x: string) {

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -97,9 +97,9 @@ export async function nexCommand(interaction: SlashCommandInteraction, user: Kla
 
 	let str = `${user.username}'s party (${usersWhoConfirmed.map(u => u.username).join(', ')}) is now off to kill ${
 		details.quantity
-	}x Nex! (${calcPerHour(details.quantity, details.duration).toFixed(
+	}x Nex! (${calcPerHour(details.quantity, details.fakeDuration).toFixed(
 		1
-	)}/hr) - the total trip will take ${formatDuration(details.duration)}.
+	)}/hr) - the total trip will take ${formatDuration(details.fakeDuration)}.
 
 ${details.team
 	.map(i => {

--- a/src/tasks/minions/nexActivity.ts
+++ b/src/tasks/minions/nexActivity.ts
@@ -14,8 +14,9 @@ export default class extends Task {
 		const { quantity, channelID, users, wipedKill, duration, userDetails } = data;
 		const allMention = userDetails.map(t => userMention(t[0])).join(' ');
 
+		const survivedQuantity = wipedKill ? wipedKill - 1 : quantity;
 		const loot = handleNexKills({
-			quantity,
+			quantity: survivedQuantity,
 			team: userDetails.map(u => ({
 				id: u[0],
 				contribution: u[1],


### PR DESCRIPTION
### Description:

Fixed a bunch of Nex bugs related to Nex wipes

### Changes:

- Fixes `+rp checkmasses` not showing the 'fake duration' when a wipe happens
- Now will only give loot for successful kills, instead of all kills in a fraction of the time.
- Now trip will end at a random point in the middle of the Wiped kill, instead of at the very end. (Between 5-95%)
- Fixes the initial mass-send messaging so it uses 'fake duration' for both Kills/hr and duration text.

### Other checks:

-   [x] I have tested all my changes thoroughly.
