### PR TITLE
Nex Elite Clue CL Entry

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -256,7 +256,11 @@ export const allCollectionLogs: ICollection = {
 			},
 			Nex: {
 				alias: ['nex'],
-				allItems: [...NexUniqueTable.allItems, ...NexNonUniqueTable.allItems],
+				allItems: [
+					...NexUniqueTable.allItems,
+					...NexNonUniqueTable.allItems,
+					...resolveItems(['Clue scroll (elite)'])
+				],
 				items: NexCL
 			},
 			'The Nightmare': {


### PR DESCRIPTION
### Description:

Due to the way elite clues are handled in the nex code, it is not included in the --all version of Nex's collection log.

### Changes:

Add it to the `allItems` list so that it can appear in the --all version of Nex CL

### Other checks:

-   [x] I have tested all my changes thoroughly.
