### PR TITLE
Add elite clue to cl nex --all

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -256,7 +256,7 @@ export const allCollectionLogs: ICollection = {
 			},
 			Nex: {
 				alias: ['nex'],
-				allItems: [...NexUniqueTable.allItems, ...NexNonUniqueTable.allItems],
+				allItems: [...NexUniqueTable.allItems, ...NexNonUniqueTable.allItems, 12073],
 				items: NexCL
 			},
 			'The Nightmare': {


### PR DESCRIPTION
When the clue scroll drop rate was fixed, it has been removed from the "+cl nex --all" command, this PR adds it back to the cl.

-   [x] I have tested all my changes thoroughly.
