### PR TITLE
Capture Users Last Loot

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -247,6 +247,7 @@ model User {
   lastTearsOfGuthixTimestamp BigInt   @default(1)
   sacrificedValue            BigInt   @default(0)
   bank                       Json     @default("{}") @db.Json
+  lastLoot                   Json     @default("{}") @db.Json
   collectionLogBank          Json     @default("{}") @db.JsonB
   creatureScores             Json     @default("{}") @db.Json
   clueScores                 Json     @default("{}") @db.Json

--- a/src/extendables/User/Bank.ts
+++ b/src/extendables/User/Bank.ts
@@ -5,6 +5,7 @@ import { Bank } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 
 import { projectiles } from '../../lib/constants';
+import { implings } from '../../lib/implings';
 import { blowpipeDarts, validateBlowpipeData } from '../../lib/minions/functions/blowpipeCommand';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { filterLootReplace } from '../../lib/slayer/slayerUtil';
@@ -109,6 +110,10 @@ export default class extends Extendable {
 
 			// Re-add the coins to the loot
 			if (coinsInLoot > 0) loot.add('Coins', coinsInLoot);
+
+			// Skip Impling loots
+			if (Object.keys(implings).every(imp => !loot.has(Number(imp))))
+				await this.settings.update(UserSettings.LastLoot, loot.bank);
 
 			return {
 				previousCL,

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -25,6 +25,7 @@ Client.defaultUserSchema
 	.add('lastTearsOfGuthixTimestamp', 'integer', { default: 1 })
 	.add('sacrificedValue', 'integer', { default: 0, minimum: 0, maximum: Number.MAX_SAFE_INTEGER })
 	.add('bank', 'any', { default: {} })
+	.add('lastLoot', 'any', { default: {} })
 	.add('collectionLogBank', 'any', { default: {} })
 	.add('creatureScores', 'any', { default: {} })
 	.add('clueScores', 'any', { default: {} })

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -24,6 +24,7 @@ export namespace UserSettings {
 	export const GP = T<number>('GP');
 	export const QP = T<number>('QP');
 	export const Bank = T<Readonly<ItemBank>>('bank');
+	export const LastLoot = T<Readonly<ItemBank>>('lastLoot');
 	export const BankBackground = T<number>('bankBackground');
 	export const Pets = T<Readonly<ItemBank>>('pets');
 	export const CollectionLogBank = T<Readonly<ItemBank>>('collectionLogBank');

--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -13,6 +13,7 @@ import {
 } from '../lib/abstracted_commands/achievementDiaryCommand';
 import { bankBgCommand } from '../lib/abstracted_commands/bankBgCommand';
 import { crackerCommand } from '../lib/abstracted_commands/crackerCommand';
+import { lastLootCommand } from '../lib/abstracted_commands/lastLootCommand';
 import { questCommand } from '../lib/abstracted_commands/questCommand';
 import { OSBMahojiCommand } from '../lib/util';
 import { MahojiUserOption } from '../mahojiSettings';
@@ -92,6 +93,23 @@ export const minionCommand: OSBMahojiCommand = {
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'quest',
 			description: 'Send your minion to do quests.'
+		},
+		{
+			type: ApplicationCommandOptionType.Subcommand,
+			name: 'last_loot',
+			description: 'See the last loot your minion received',
+			options: [
+				{
+					type: ApplicationCommandOptionType.String,
+					name: 'format',
+					description: 'The format of the data.',
+					autocomplete: async value => {
+						return ['image', 'names', 'text']
+							.filter(format => (!value ? true : format.toLowerCase().includes(value.toLowerCase())))
+							.map(i => ({ name: i, value: i }));
+					}
+				}
+			]
 		}
 	],
 	run: async ({
@@ -106,6 +124,7 @@ export const minionCommand: OSBMahojiCommand = {
 		bankbg?: { name?: string };
 		cracker?: { user: MahojiUserOption };
 		quest?: {};
+		last_loot?: { format?: string };
 	}>) => {
 		const user = await client.fetchUser(userID.toString());
 
@@ -122,6 +141,11 @@ export const minionCommand: OSBMahojiCommand = {
 
 		if (options.stats) {
 			return { embeds: [await minionStatsEmbed(user)] };
+		}
+
+		if (options.last_loot) {
+			const format = options.last_loot.format ? options.last_loot.format : 'text';
+			return lastLootCommand(interaction, user, format);
 		}
 
 		if (options.achievementdiary) {

--- a/src/mahoji/lib/abstracted_commands/lastLootCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lastLootCommand.ts
@@ -37,6 +37,12 @@ export async function lastLootCommand(interaction: SlashCommandInteraction, user
 				]
 			};
 		default:
+			if ( loot.toString().length > 500 ) {
+				return {
+					content: 'Your last received loot was:',
+					attachments:  [{ buffer: Buffer.from(loot.toString()), fileName: 'Loot.txt' }]
+				};
+			}
 			return `Your last received loot was: ${loot}`;
 	}
 }

--- a/src/mahoji/lib/abstracted_commands/lastLootCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lastLootCommand.ts
@@ -37,10 +37,10 @@ export async function lastLootCommand(interaction: SlashCommandInteraction, user
 				]
 			};
 		default:
-			if ( loot.toString().length > 500 ) {
+			if (loot.toString().length > 500) {
 				return {
 					content: 'Your last received loot was:',
-					attachments:  [{ buffer: Buffer.from(loot.toString()), fileName: 'Loot.txt' }]
+					attachments: [{ buffer: Buffer.from(loot.toString()), fileName: 'Loot.txt' }]
 				};
 			}
 			return `Your last received loot was: ${loot}`;

--- a/src/mahoji/lib/abstracted_commands/lastLootCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lastLootCommand.ts
@@ -1,0 +1,42 @@
+import { KlasaUser } from 'klasa';
+import { SlashCommandInteraction } from 'mahoji/dist/lib/structures/SlashCommandInteraction';
+import { Bank } from 'oldschooljs';
+
+import { UserSettings } from '../../../lib/settings/types/UserSettings';
+import { makeBankImage } from '../../../lib/util/makeBankImage';
+
+export async function lastLootCommand(interaction: SlashCommandInteraction, user: KlasaUser, format: string) {
+	await interaction.deferReply();
+
+	const loot = new Bank(user.settings.get(UserSettings.LastLoot));
+
+	switch (format) {
+		case 'image':
+			return {
+				content: 'Your last received loot was:',
+				attachments: [
+					(
+						await makeBankImage({
+							bank: loot,
+							user
+						})
+					).file
+				]
+			};
+		case 'names':
+			return {
+				content: 'Your last received loot was:',
+				attachments: [
+					(
+						await makeBankImage({
+							bank: loot,
+							user,
+							flags: { names: 1 }
+						})
+					).file
+				]
+			};
+		default:
+			return `Your last received loot was: ${loot}`;
+	}
+}


### PR DESCRIPTION
### Description:

When getting loot via bank images, it can be hard to discern what it is that has been received if you don't recognise the item. To combat this I've added a entry in the DB which tracks what the last loot that was added to the users bank was, excluding impling captures. This can be returned by a new `/minion` command `last_loot` in 3 different formats:
* Text - Text string of loot, strings over 500 characters are sent as .txt instead
* Names - Bank image with names
* Image - Bank image as normal

### Changes:

Add lastLoot entry to Prisma Schema and UserSchema
Add LastLoot option for UserSettings
Updated `addItemsToBank` function to track the last received loot in the aforementioned field, only if it's not a impling capture.
Add a command to `/minion` called `last_loot` which returns the loot in 3 different formats mentioned above.

### Other checks:
Checked it with a large amount of commands and all loot seems to be appropriately tracked.
-   [x] I have tested all my changes thoroughly.
