### PR TITLE
Fix alching / getUserFavAlchs / agility alching [ ...and Voidling after merge to BSO]

### DIFF
--- a/src/extendables/User/User.ts
+++ b/src/extendables/User/User.ts
@@ -1,5 +1,5 @@
 import { User } from 'discord.js';
-import { objectEntries, Time } from 'e';
+import { objectEntries } from 'e';
 import { Extendable, ExtendableStore, KlasaClient, KlasaUser, SettingsFolder } from 'klasa';
 import { Bank } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
@@ -134,14 +134,12 @@ export default class extends Extendable {
 	}
 
 	public getUserFavAlchs(this: User, duration: number): Item[] {
-		// This absolutely matters because shorter trips can change which stack is the most valuable to alch:
-		const tripLength = duration ?? Time.Minute * 30;
 		const bank = this.bank();
 		return this.settings
 			.get(UserSettings.FavoriteAlchables)
 			.filter(id => bank.has(id))
 			.map(getOSItem)
 			.filter(i => i.highalch > 0 && i.tradeable)
-			.sort((a, b) => alchPrice(bank, b, tripLength) - alchPrice(bank, a, tripLength));
+			.sort((a, b) => alchPrice(bank, b, duration) - alchPrice(bank, a, duration));
 	}
 }

--- a/src/extendables/User/User.ts
+++ b/src/extendables/User/User.ts
@@ -133,14 +133,15 @@ export default class extends Extendable {
 		return createdPoh;
 	}
 
-	public getUserFavAlchs(this: User): Item[] {
+	public getUserFavAlchs(this: User, duration: number): Item[] {
+		// This absolutely matters because shorter trips can change which stack is the most valuable to alch:
+		const tripLength = duration ?? Time.Minute * 30;
 		const bank = this.bank();
 		return this.settings
 			.get(UserSettings.FavoriteAlchables)
 			.filter(id => bank.has(id))
 			.map(getOSItem)
 			.filter(i => i.highalch > 0 && i.tradeable)
-			.filter(i => bank.amount(i.id) >= Math.floor((Time.Minute * 30) / timePerAlch))
-			.sort((a, b) => alchPrice(bank, b, b.highalch) - alchPrice(bank, b, a.highalch));
+			.sort((a, b) => alchPrice(bank, b, tripLength) - alchPrice(bank, a, tripLength));
 	}
 }


### PR DESCRIPTION
### Description:

Fixes some bugs that were breaking the calculation of which stack to alch, and also removed the minimum of 1200 qty stack to alch.

### Changes:

- Removes mandatory minimum quantity of 1200 of an item stack to alch.
- Adds the duration parameter to getUserFavAlchs() which was already expected by calling code [default 30 minutes]
- It's important to know how long the trip is for this calculation because a smaller stack with higher individual alch value could be worth more if the trip length is shorter
- Fixed bug where both sides of the sort algorithm were given the same item (b)
- The code should actually work as intended now :)

### Other checks:

-   [x] I have tested all my changes thoroughly.
