### PR TITLE
Fix =buy festive present

### DIFF
--- a/src/lib/settings/prisma.ts
+++ b/src/lib/settings/prisma.ts
@@ -89,9 +89,9 @@ export async function isElligibleForPresent(user: KlasaUser) {
 	if (user.isIronman) return true;
 	if (user.perkTier >= PerkTier.Four) return true;
 	if (user.totalLevel() >= 2000) return true;
-	const totalActivityDuration: [{ sum: number }] = await prisma.$queryRaw`SELECT SUM(duration)
+	const totalActivityDuration: [{ sum: number }] = await prisma.$queryRawUnsafe(`SELECT SUM(duration)
 FROM activity
-WHERE user_id = ${BigInt(user.id)};`;
+WHERE user_id = ${BigInt(user.id)};`);
 	if (totalActivityDuration[0].sum >= Time.Hour * 80) return true;
 	return false;
 }


### PR DESCRIPTION
### Description:

Players who rely on the activity restriction of the Festive present purchase, cannot buy because of a Prisma bug leading to an error.

### Changes:

- Converts the query to a truly raw query, where the parameters data type is not a factor.

### Other checks:

-   [x] I have tested all my changes thoroughly.