### PR TITLE
[BSO] Fix new ToB background

### DIFF
--- a/src/lib/minions/data/bankBackgrounds.ts
+++ b/src/lib/minions/data/bankBackgrounds.ts
@@ -201,7 +201,7 @@ const backgroundImages: BankBackground[] = [
 	},
 	{
 		id: 19,
-		name: 'tob',
+		name: 'original tob',
 		image: null,
 		available: false
 	},


### PR DESCRIPTION
### Description:

An old BG image with the name 'tob' is conflicting with the newly released version, preventing users from adopting the new background.

### Changes:

- Renamed the old version to 'original tob'.
- This will prevent anyone who still has the old background from losing it, while still fixing the new one.

### Other checks:

-   [x] I have tested all my changes thoroughly.
