### PR TITLE
[BSO] Fix =price command

### DIFF
--- a/src/commands/bso/price.ts
+++ b/src/commands/bso/price.ts
@@ -28,7 +28,7 @@ export default class extends BotCommand {
 			)
 			.setDescription(
 				`**Price:** ${Util.toKMB(priceOfItem)} 
-**Sell price:** ${sellPriceOfItem(this.client, item)}
+**Sell price:** ${sellPriceOfItem(this.client, item).price}
 **Alch value:** ${Util.toKMB(item.highalch)}`
 			);
 


### PR DESCRIPTION
### Description:

![image](https://user-images.githubusercontent.com/10122432/163651284-4269634c-e8d4-4b7f-80e8-b53a00e6112b.png)
Currently price is showing [object Object] because this BSO-only call to get the item price wasn't updated with the function

### Changes:

- Adds .price to the end of the returned object so show the price accordingly.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
