### PR TITLE
Fix bugs with Easter update

### DIFF
--- a/src/commands/Minion/sell.ts
+++ b/src/commands/Minion/sell.ts
@@ -22,7 +22,7 @@ const specialSoldItems = new Map([
 ]);
 
 export function sellPriceOfItem(client: KlasaClient, item: Item, taxRate = 20): { price: number; basePrice: number } {
-	if (!item.price || !item.tradeable) return { price: 0, basePrice: 0 };
+	if (!item.price) return { price: 0, basePrice: 0 };
 	const customPrices = client.settings.get(ClientSettings.CustomPrices);
 	let basePrice = customPrices[item.id] ?? item.price;
 	let price = basePrice;

--- a/src/commands/Minion/sell.ts
+++ b/src/commands/Minion/sell.ts
@@ -21,7 +21,7 @@ const specialSoldItems = new Map([
 	[id('Ancient relic'), 16_000_000]
 ]);
 
-export function sellPriceOfItem(client: KlasaClient, item: Item, taxRate = 20): { price: number; basePrice: number } {
+export function sellPriceOfItem(client: KlasaClient, item: Item, taxRate = 25): { price: number; basePrice: number } {
 	if (!item.price) return { price: 0, basePrice: 0 };
 	const customPrices = client.settings.get(ClientSettings.CustomPrices);
 	let basePrice = customPrices[item.id] ?? item.price;

--- a/src/mahoji/commands/easter.ts
+++ b/src/mahoji/commands/easter.ts
@@ -42,7 +42,7 @@ export const easterCommand: OSBMahojiCommand = {
 
 		const eggsGivenOut = user.settings.get(UserSettings.EggsDelivered);
 		const cl = user.cl();
-		if (cl.has(UniqueTable.allItems)) {
+		if (cl.has(DeliverRewardTable.allItems)) {
 			return "I don't have anything left to give you!";
 		}
 
@@ -56,7 +56,7 @@ export const easterCommand: OSBMahojiCommand = {
 			let loot = DeliverRewardTable.roll(eggsGivenOut);
 
 			// Can't get more than one of each unique.
-			for (const item of UniqueTable.allItems) {
+			for (const item of DeliverRewardTable.allItems) {
 				if (!loot.has(item)) continue;
 				if (cl.has(item)) {
 					loot.remove(item, loot.amount(item));

--- a/src/mahoji/commands/easter.ts
+++ b/src/mahoji/commands/easter.ts
@@ -3,6 +3,7 @@ import { Bank, LootTable } from 'oldschooljs';
 import { client } from '../..';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { newChatHeadImage } from '../../lib/util/chatHeadImage';
+import itemID from '../../lib/util/itemID';
 import { OSBMahojiCommand } from '../lib/util';
 import { mahojiUserSettingsUpdate } from '../mahojiSettings';
 
@@ -38,11 +39,14 @@ export const easterCommand: OSBMahojiCommand = {
 	},
 	options: [],
 	run: async ({ userID }) => {
+		const uniquesToCheck = [...UniqueTable.allItems];
+		uniquesToCheck.push(itemID('Decorative easter eggs'));
+
 		const user = await client.fetchUser(userID.toString());
 
 		const eggsGivenOut = user.settings.get(UserSettings.EggsDelivered);
 		const cl = user.cl();
-		if (cl.has(DeliverRewardTable.allItems)) {
+		if (cl.has(uniquesToCheck)) {
 			return "I don't have anything left to give you!";
 		}
 
@@ -56,7 +60,7 @@ export const easterCommand: OSBMahojiCommand = {
 			let loot = DeliverRewardTable.roll(eggsGivenOut);
 
 			// Can't get more than one of each unique.
-			for (const item of DeliverRewardTable.allItems) {
+			for (const item of uniquesToCheck) {
 				if (!loot.has(item)) continue;
 				if (cl.has(item)) {
 					loot.remove(item, loot.amount(item));

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -74,7 +74,7 @@ describe('util', () => {
 		const clientMock = { settings: { get: () => ({}) } } as any as KlasaClient;
 		const item = getOSItem('Dragon pickaxe');
 		const { price } = item;
-		let expected = Math.floor(reduceNumByPercent(price, 20));
+		let expected = Math.floor(reduceNumByPercent(price, 25));
 		expect(sellPriceOfItem(clientMock, item)).toEqual({ price: expected, basePrice: price });
 		expect(sellPriceOfItem(clientMock, getOSItem('A yellow square'))).toEqual({ price: 0, basePrice: 0 });
 


### PR DESCRIPTION
### Easter
- Fixes bug where you couldn't get any more loot after you got Chickaxe and Leia
- Fixes bug where you can get more than one of the loots beside Chickaxe and Leia

### Update
- Fixes bug where sell price for items based on untradeables was 0
-     Include all lamps, hellfire arrows, abyssal thread, etc
- Set default tax rate for =price command to 25% [bso tax rate]

### Other checks:

-   [x] I have tested all my changes thoroughly.
