### PR TITLE
Stats optional type - patch

### DIFF
--- a/src/mahoji/commands/stats.ts
+++ b/src/mahoji/commands/stats.ts
@@ -42,7 +42,7 @@ export const statsCommand: OSBMahojiCommand = {
 	run: async ({ options }: CommandRunOptions<{ username: string; type?: AccountType; virtual?: boolean }>) => {
 		try {
 			if (!options.type) {
-				options.type = AccountType.Normal
+				options.type = AccountType.Normal;
 			}
 			const player = await Hiscores.fetch(options.username, {
 				type: options.type,

--- a/src/mahoji/commands/stats.ts
+++ b/src/mahoji/commands/stats.ts
@@ -41,6 +41,9 @@ export const statsCommand: OSBMahojiCommand = {
 	],
 	run: async ({ options }: CommandRunOptions<{ username: string; type?: AccountType; virtual?: boolean }>) => {
 		try {
+			if (!options.type) {
+				options.type = AccountType.Normal
+			}
 			const player = await Hiscores.fetch(options.username, {
 				type: options.type,
 				virtualLevels: Boolean(options.virtual)


### PR DESCRIPTION
Makes it so if no optional account type is selected it defaults to a normal account.
Closes #3797

-   [x] I have tested all my changes thoroughly.
