### PR TITLE
Update cl chaos druids

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -630,8 +630,8 @@ export const allCollectionLogs: ICollection = {
 				isActivity: true
 			},
 			'Chaos Druids': {
-				allItems: Monsters.ChaosDruid.allItems,
-				kcActivity: Monsters.ChaosDruid.name,
+				allItems: Monsters.ElderChaosDruid.allItems,
+				kcActivity: Monsters.ElderChaosDruid.name,
 				items: chaosDruisCL
 			},
 			'Chompy Birds': {


### PR DESCRIPTION
Update the "allitems" pulled for chaos druids cl to match the elder chaos druids along with the kc being correct.
Closes #3787

-   [x] I have tested all my changes thoroughly.
