### PR TITLE
Fix bug while converting to BSO ironman

### DIFF
--- a/src/lib/minions/functions/becomeIronman.ts
+++ b/src/lib/minions/functions/becomeIronman.ts
@@ -51,21 +51,15 @@ Type \`confirm permanent ironman\` if you understand the above information, and 
 
 		await msg.author.settings.reset();
 
-		try {
-			await Promise.all([
-				prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } }),
-				prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }),
-				prisma.minigame.delete({ where: { user_id: msg.author.id } }),
-				prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } }),
-				prisma.newUser.delete({ where: { id: msg.author.id } }),
-				prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } }),
-				prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } }),
-				prisma.tame.deleteMany({ where: { user_id: msg.author.id } }),
-				prisma.fishingContestCatch.deleteMany({ where: { user_id: BigInt(msg.author.id) } })
-			]);
-		} catch (err) {
-			console.log(err);
-		}
+		await prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } });
+		await prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }).catch();
+		await prisma.minigame.delete({ where: { user_id: msg.author.id } });
+		await prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
+		await prisma.newUser.delete({ where: { id: msg.author.id } });
+		await prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
+		await prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } });
+		await prisma.tame.deleteMany({ where: { user_id: msg.author.id } });
+		await prisma.fishingContestCatch.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
 
 		await msg.author.settings.update([
 			[UserSettings.Minion.Ironman, true],

--- a/src/lib/minions/functions/becomeIronman.ts
+++ b/src/lib/minions/functions/becomeIronman.ts
@@ -4,6 +4,7 @@ import { KlasaMessage } from 'klasa';
 import { BitField } from '../../constants';
 import { prisma } from '../../settings/prisma';
 import { UserSettings } from '../../settings/types/UserSettings';
+import { logError } from '../../util/logError';
 
 export async function becomeIronman(msg: KlasaMessage) {
 	/**
@@ -71,10 +72,10 @@ Type \`confirm permanent ironman\` if you understand the above information, and 
 			return msg.channel.send('You are now an ironman.');
 		} catch (e) {
 			// Actual database error
+			logError(e, { command: 'minion ironman', user_id: msg.author.id });
 			return msg.channel.send('We are in an unknown state. Likely inconsistent.');
 		}
 	} catch (err) {
-		console.log(err);
 		return msg.channel.send('Cancelled ironman swap.');
 	}
 }

--- a/src/lib/minions/functions/becomeIronman.ts
+++ b/src/lib/minions/functions/becomeIronman.ts
@@ -1,5 +1,6 @@
 import { KlasaMessage } from 'klasa';
 
+import { BitField } from '../../constants';
 import { prisma } from '../../settings/prisma';
 import { UserSettings } from '../../settings/types/UserSettings';
 
@@ -51,22 +52,25 @@ Type \`confirm permanent ironman\` if you understand the above information, and 
 		await msg.author.settings.reset();
 
 		try {
-			await prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } });
-			await prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } });
-			await prisma.minigame.delete({ where: { user_id: msg.author.id } });
-			await prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
-			await prisma.newUser.delete({ where: { id: msg.author.id } });
-			await prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
-			await prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } });
-			await prisma.tame.deleteMany({ where: { user_id: msg.author.id } });
-			await prisma.fishingContestCatch.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
+			await Promise.all([
+				prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } }),
+				prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }),
+				prisma.minigame.delete({ where: { user_id: msg.author.id } }),
+				prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } }),
+				prisma.newUser.delete({ where: { id: msg.author.id } }),
+				prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } }),
+				prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } }),
+				prisma.tame.deleteMany({ where: { user_id: msg.author.id } }),
+				prisma.fishingContestCatch.deleteMany({ where: { user_id: BigInt(msg.author.id) } })
+			]);
 		} catch (err) {
 			console.log(err);
 		}
 
 		await msg.author.settings.update([
 			[UserSettings.Minion.Ironman, true],
-			[UserSettings.Minion.HasBought, true]
+			[UserSettings.Minion.HasBought, true],
+			[UserSettings.BitField, BitField.BypassAgeRestriction]
 		]);
 		return msg.channel.send('You are now an ironman.');
 	} catch (err) {

--- a/src/lib/minions/functions/becomeIronman.ts
+++ b/src/lib/minions/functions/becomeIronman.ts
@@ -55,10 +55,10 @@ Type \`confirm permanent ironman\` if you understand the above information, and 
 
 		try {
 			await prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } });
-			prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }).catch(noOp);
-			prisma.minigame.delete({ where: { user_id: msg.author.id } }).catch(noOp);
+			await prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }).catch(noOp);
+			await prisma.minigame.delete({ where: { user_id: msg.author.id } }).catch(noOp);
 			await prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
-			prisma.newUser.delete({ where: { id: msg.author.id } }).catch(noOp);
+			await prisma.newUser.delete({ where: { id: msg.author.id } }).catch(noOp);
 			await prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
 			await prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } });
 			await prisma.tame.deleteMany({ where: { user_id: msg.author.id } });
@@ -73,7 +73,7 @@ Type \`confirm permanent ironman\` if you understand the above information, and 
 		} catch (e) {
 			// Actual database error
 			logError(e, { command: 'minion ironman', user_id: msg.author.id });
-			return msg.channel.send('We are in an unknown state. Likely inconsistent.');
+			return msg.channel.send('There was an error in converting to an Ironman. Please contact us for help.');
 		}
 	} catch (err) {
 		return msg.channel.send('Cancelled ironman swap.');

--- a/src/lib/minions/functions/becomeIronman.ts
+++ b/src/lib/minions/functions/becomeIronman.ts
@@ -1,3 +1,4 @@
+import { noOp } from 'e';
 import { KlasaMessage } from 'klasa';
 
 import { BitField } from '../../constants';
@@ -53,10 +54,10 @@ Type \`confirm permanent ironman\` if you understand the above information, and 
 
 		try {
 			await prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } });
-			prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }).catch(_err => null);
-			prisma.minigame.delete({ where: { user_id: msg.author.id } }).catch(_err => null);
+			prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }).catch(noOp);
+			prisma.minigame.delete({ where: { user_id: msg.author.id } }).catch(noOp);
 			await prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
-			prisma.newUser.delete({ where: { id: msg.author.id } }).catch(_err => null);
+			prisma.newUser.delete({ where: { id: msg.author.id } }).catch(noOp);
 			await prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
 			await prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } });
 			await prisma.tame.deleteMany({ where: { user_id: msg.author.id } });

--- a/src/lib/minions/functions/becomeIronman.ts
+++ b/src/lib/minions/functions/becomeIronman.ts
@@ -51,23 +51,29 @@ Type \`confirm permanent ironman\` if you understand the above information, and 
 
 		await msg.author.settings.reset();
 
-		await prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } });
-		await prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }).catch();
-		await prisma.minigame.delete({ where: { user_id: msg.author.id } });
-		await prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
-		await prisma.newUser.delete({ where: { id: msg.author.id } });
-		await prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
-		await prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } });
-		await prisma.tame.deleteMany({ where: { user_id: msg.author.id } });
-		await prisma.fishingContestCatch.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
+		try {
+			await prisma.slayerTask.deleteMany({ where: { user_id: msg.author.id } });
+			prisma.playerOwnedHouse.delete({ where: { user_id: msg.author.id } }).catch(_err => null);
+			prisma.minigame.delete({ where: { user_id: msg.author.id } }).catch(_err => null);
+			await prisma.xPGain.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
+			prisma.newUser.delete({ where: { id: msg.author.id } }).catch(_err => null);
+			await prisma.activity.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
+			await prisma.tameActivity.deleteMany({ where: { user_id: msg.author.id } });
+			await prisma.tame.deleteMany({ where: { user_id: msg.author.id } });
+			await prisma.fishingContestCatch.deleteMany({ where: { user_id: BigInt(msg.author.id) } });
 
-		await msg.author.settings.update([
-			[UserSettings.Minion.Ironman, true],
-			[UserSettings.Minion.HasBought, true],
-			[UserSettings.BitField, BitField.BypassAgeRestriction]
-		]);
-		return msg.channel.send('You are now an ironman.');
+			await msg.author.settings.update([
+				[UserSettings.Minion.Ironman, true],
+				[UserSettings.Minion.HasBought, true],
+				[UserSettings.BitField, BitField.BypassAgeRestriction]
+			]);
+			return msg.channel.send('You are now an ironman.');
+		} catch (e) {
+			// Actual database error
+			return msg.channel.send('We are in an unknown state. Likely inconsistent.');
+		}
 	} catch (err) {
+		console.log(err);
 		return msg.channel.send('Cancelled ironman swap.');
 	}
 }


### PR DESCRIPTION
### Description:

When using the ironman command, under certain circumstances, some data fails to be reset.
This fixes that, and also automatically applies the AgeBypass to irons

### Changes:

- Always processes all Database commands, instead of aborting on fail.
- Adds BypassAge bitfield on the fresh iron
- Logs to Sentry if a DB command actually fails

### Other checks:

-   [x] I have tested all my changes thoroughly.
