### PR TITLE
Collecting - Jangerberries

### DIFF
--- a/src/commands/Minion/collect.ts
+++ b/src/commands/Minion/collect.ts
@@ -93,6 +93,17 @@ export const collectables: Collectable[] = [
 		duration: Time.Minute,
 		qpRequired: 30
 	},
+	{
+		item: getOSItem('Jangerberries'),
+		quantity: 224,
+		itemCost: new Bank({
+			'Ring of dueling(8)': 1
+		}),
+		skillReqs: {
+			agility: 10
+		},
+		duration: Time.Minute * 24
+	},
 	// Miniquest to get Tarn's diary for Salve amulet (e)/(ei)
 	{
 		item: getOSItem("Tarn's diary"),


### PR DESCRIPTION
Except through farming there isn't really a viable way of getting jangerberries. Adds the collecting of jangerberries as per the wiki rates - https://oldschool.runescape.wiki/w/Money_making_guide/Collecting_jangerberries
Note the wiki does say it uses ropes too, however until these are under buy I don't see it reasonable to put that into the item cost.

-   [x] I have tested all my changes thoroughly.
