### PR TITLE
BSO - Revert Nex Items for components

### DIFF
--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -53,16 +53,16 @@ const nexCreatables: Createable[] = [
 			[itemID('Armadylean components')]: 1
 		}
 	})),
-	...brokenTorvaOutfit.map(part => ({
-		name: `Revert ${getOSItem(part).name}`,
-		inputItems: new Bank().add(part),
+	...brokenTorvaOutfit.map(piece => ({
+		name: `Revert ${getOSItem(piece).name}`,
+		inputItems: new Bank().add(piece),
 		outputItems: {
 			[itemID('Bandosian components')]: 1
 		}
 	})),
-	...brokenVirtusOutfit.map(part => ({
-		name: `Revert ${getOSItem(part).name}`,
-		inputItems: new Bank().add(part),
+	...brokenVirtusOutfit.map(piece => ({
+		name: `Revert ${getOSItem(piece).name}`,
+		inputItems: new Bank().add(piece),
 		outputItems: {
 			[itemID('Ancestral components')]: 1
 		}

--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -46,22 +46,22 @@ const nexCreatables: Createable[] = [
 		},
 		requiredSkills: { smithing: 80, crafting: 80 }
 	},
-		...brokenPernixOutfit.map(piece => ({
-		name: `Revert ${getOSItem(piece)}`,
+	...brokenPernixOutfit.map(piece => ({
+		name: `Revert ${getOSItem(piece).name}`,
 		inputItems: new Bank().add(piece),
 		outputItems: {
 			[itemID('Armadylean components')]: 1
 		}
 	})),
 	...brokenTorvaOutfit.map(part => ({
-		name: `Revert ${getOSItem(part)}`,
+		name: `Revert ${getOSItem(part).name}`,
 		inputItems: new Bank().add(part),
 		outputItems: {
 			[itemID('Bandosian components')]: 1
 		}
 	})),
 	...brokenVirtusOutfit.map(part => ({
-		name: `Revert ${getOSItem(part)}`,
+		name: `Revert ${getOSItem(part).name}`,
 		inputItems: new Bank().add(part),
 		outputItems: {
 			[itemID('Ancestral components')]: 1

--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -135,143 +135,22 @@ const componentRevertables: Createable[] = [
 		outputItems: {
 			[itemID('Ancestral components')]: 3
 		}
-	},
-	{
-		name: 'Revert torva full helm (broken)',
-		inputItems: {
-			[itemID('Torva full helm (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Bandosian components')]: 1
-		}
-	},
-	{
-		name: 'Revert torva platebody (broken)',
-		inputItems: {
-			[itemID('Torva platebody (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Bandosian components')]: 1
-		}
-	},
-	{
-		name: 'Revert torva platelegs (broken)',
-		inputItems: {
-			[itemID('Torva platelegs (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Bandosian components')]: 1
-		}
-	},
-	{
-		name: 'Revert torva gloves (broken)',
-		inputItems: {
-			[itemID('Torva gloves (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Bandosian components')]: 1
-		}
-	},
-	{
-		name: 'Revert torva boots (broken)',
-		inputItems: {
-			[itemID('Torva boots (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Bandosian components')]: 1
-		}
-	},
-	{
-		name: 'Revert pernix cowl (broken)',
-		inputItems: {
-			[itemID('Pernix cowl (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Armadylean components')]: 1
-		}
-	},
-	{
-		name: 'Revert pernix body (broken)',
-		inputItems: {
-			[itemID('Pernix body (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Armadylean components')]: 1
-		}
-	},
-	{
-		name: 'Revert pernix chaps (broken)',
-		inputItems: {
-			[itemID('Pernix chaps (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Armadylean components')]: 1
-		}
-	},
-	{
-		name: 'Revert pernix gloves (broken)',
-		inputItems: {
-			[itemID('Pernix gloves (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Armadylean components')]: 1
-		}
-	},
-	{
-		name: 'Revert pernix boots (broken)',
-		inputItems: {
-			[itemID('Pernix boots (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Armadylean components')]: 1
-		}
-	},
-	{
-		name: 'Revert virtus mask (broken)',
-		inputItems: {
-			[itemID('Virtus mask (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Ancestral components')]: 1
-		}
-	},
-	{
-		name: 'Revert virtus robe top (broken)',
-		inputItems: {
-			[itemID('Virtus robe top (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Ancestral components')]: 1
-		}
-	},
-	{
-		name: 'Revert virtus robe legs (broken)',
-		inputItems: {
-			[itemID('Virtus robe legs (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Ancestral components')]: 1
-		}
-	},
-	{
-		name: 'Revert virtus gloves (broken)',
-		inputItems: {
-			[itemID('Virtus gloves (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Ancestral components')]: 1
-		}
-	},
-	{
-		name: 'Revert virtus boots (broken)',
-		inputItems: {
-			[itemID('Virtus boots (broken)')]: 1
-		},
-		outputItems: {
-			[itemID('Ancestral components')]: 1
-		}
 	}
 ];
+
+for (const [component, brokenOutfit] of nexBrokenArmorDetails) {
+	for (let i = 0; i < brokenOutfit.length; i++) {
+		componentRevertables.push({
+			name: `Revert ${getOSItem(brokenOutfit[i]).name}`,
+			inputItems: {
+				[brokenOutfit[i]]: 1
+			},
+			outputItems: {
+				[component.id]: 1
+			}
+		});
+	}
+}
 
 const chaoticCreatables: Createable[] = [
 	{

--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -9,6 +9,7 @@ import { assert, resolveNameBank } from '../../util';
 import getOSItem from '../../util/getOSItem';
 import itemID from '../../util/itemID';
 import resolveItems from '../../util/resolveItems';
+import { brokenPernixOutfit, brokenTorvaOutfit, brokenVirtusOutfit } from '../CollectionsExport';
 import { Createable } from '../createables';
 
 const dyeCreatables: Createable[] = [];
@@ -44,7 +45,28 @@ const nexCreatables: Createable[] = [
 			[itemID('Virtus book')]: 1
 		},
 		requiredSkills: { smithing: 80, crafting: 80 }
-	}
+	},
+		...brokenPernixOutfit.map(piece => ({
+		name: `Revert ${getOSItem(piece)}`,
+		inputItems: new Bank().add(piece),
+		outputItems: {
+			[itemID('Armadylean components')]: 1
+		}
+	})),
+	...brokenTorvaOutfit.map(part => ({
+		name: `Revert ${getOSItem(part)}`,
+		inputItems: new Bank().add(part),
+		outputItems: {
+			[itemID('Bandosian components')]: 1
+		}
+	})),
+	...brokenVirtusOutfit.map(part => ({
+		name: `Revert ${getOSItem(part)}`,
+		inputItems: new Bank().add(part),
+		outputItems: {
+			[itemID('Ancestral components')]: 1
+		}
+	}))
 ];
 
 for (const [component, brokenOutfit, repairedOutfit] of nexBrokenArmorDetails) {
@@ -137,20 +159,6 @@ const componentRevertables: Createable[] = [
 		}
 	}
 ];
-
-for (const [component, brokenOutfit] of nexBrokenArmorDetails) {
-	for (let i = 0; i < brokenOutfit.length; i++) {
-		componentRevertables.push({
-			name: `Revert ${getOSItem(brokenOutfit[i]).name}`,
-			inputItems: {
-				[brokenOutfit[i]]: 1
-			},
-			outputItems: {
-				[component.id]: 1
-			}
-		});
-	}
-}
 
 const chaoticCreatables: Createable[] = [
 	{

--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -135,6 +135,141 @@ const componentRevertables: Createable[] = [
 		outputItems: {
 			[itemID('Ancestral components')]: 3
 		}
+	},
+	{
+		name: 'Revert torva full helm (broken)',
+		inputItems: {
+			[itemID('Torva full helm (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Bandosian components')]: 1
+		}
+	},
+	{
+		name: 'Revert torva platebody (broken)',
+		inputItems: {
+			[itemID('Torva platebody (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Bandosian components')]: 1
+		}
+	},
+	{
+		name: 'Revert torva platelegs (broken)',
+		inputItems: {
+			[itemID('Torva platelegs (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Bandosian components')]: 1
+		}
+	},
+	{
+		name: 'Revert torva gloves (broken)',
+		inputItems: {
+			[itemID('Torva gloves (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Bandosian components')]: 1
+		}
+	},
+	{
+		name: 'Revert torva boots (broken)',
+		inputItems: {
+			[itemID('Torva boots (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Bandosian components')]: 1
+		}
+	},
+	{
+		name: 'Revert pernix cowl (broken)',
+		inputItems: {
+			[itemID('Pernix cowl (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Armadylean components')]: 1
+		}
+	},
+	{
+		name: 'Revert pernix body (broken)',
+		inputItems: {
+			[itemID('Pernix body (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Armadylean components')]: 1
+		}
+	},
+	{
+		name: 'Revert pernix chaps (broken)',
+		inputItems: {
+			[itemID('Pernix chaps (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Armadylean components')]: 1
+		}
+	},
+	{
+		name: 'Revert pernix gloves (broken)',
+		inputItems: {
+			[itemID('Pernix gloves (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Armadylean components')]: 1
+		}
+	},
+	{
+		name: 'Revert pernix boots (broken)',
+		inputItems: {
+			[itemID('Pernix boots (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Armadylean components')]: 1
+		}
+	},
+	{
+		name: 'Revert virtus mask (broken)',
+		inputItems: {
+			[itemID('Virtus mask (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral components')]: 1
+		}
+	},
+	{
+		name: 'Revert virtus robe top (broken)',
+		inputItems: {
+			[itemID('Virtus robe top (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral components')]: 1
+		}
+	},
+	{
+		name: 'Revert virtus robe legs (broken)',
+		inputItems: {
+			[itemID('Virtus robe legs (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral components')]: 1
+		}
+	},
+	{
+		name: 'Revert virtus gloves (broken)',
+		inputItems: {
+			[itemID('Virtus gloves (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral components')]: 1
+		}
+	},
+	{
+		name: 'Revert virtus boots (broken)',
+		inputItems: {
+			[itemID('Virtus boots (broken)')]: 1
+		},
+		outputItems: {
+			[itemID('Ancestral components')]: 1
+		}
 	}
 ];
 


### PR DESCRIPTION
Following the positive feedback from the #bso-vote poll.
This now allows you to breakdown the Nex drops for 1 of the relevant component, this makes it so the original way is still the most beneficial and preferred, but gives irons a more realistic way to get components and gives dupes a use. (Especially ancestral components)

-   [x] I have tested all my changes thoroughly.
