### PR TITLE
Fix =mypets error => Replace nexling to =mypets

### DIFF
--- a/src/lib/data/pets.ts
+++ b/src/lib/data/pets.ts
@@ -598,6 +598,16 @@ const pets: Pet[] = [
 		formatFinish: (num: number) =>
 			`You had to spend ${fm(num)} Permits to get the Tiny Tempor! <:TinyTempor:824483631694217277>`,
 		bossKeys: ['tempoross']
+	},
+	{
+		id: 49,
+		emoji: '<:Nexling:931565564151869460>',
+		chance: 500,
+		name: 'Nexling',
+		type: 'SPECIAL',
+		altNames: ['NEXLING'],
+		formatFinish: (num: number) =>
+			`You had to kill Nex ${fm(num)} times to get Nexling! <:Nexling:931565564151869460>`
 	}
 ];
 


### PR DESCRIPTION
### Description:

Replaces the Nexling pet to pets.ts for the =mypets command.
OSB was not affected by this.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
