### PR TITLE
Updated monster.qp requirements message for /k

### DIFF
--- a/src/extendables/User/User.ts
+++ b/src/extendables/User/User.ts
@@ -40,7 +40,7 @@ export default class extends Extendable {
 		if (monster.qpRequired && this.settings.get(UserSettings.QP) < monster.qpRequired) {
 			return [
 				false,
-				`You need ${monster.qpRequired} QP to kill ${monster.name}. You can get Quest Points through questing with \`+quest\``
+				`You need ${monster.qpRequired} QP to kill ${monster.name}. You can get Quest Points through questing with \`/minion quest\``
 			];
 		}
 


### PR DESCRIPTION
### Description:

The command `+quest` was changed to a slash command `/minion quest`. This has now been reflected in the message that returns if a player does not have monster.qpRequired.

### Changes:

- Updated the help message for `/k` command to make consistent with `/minion quest` if player does not have required quest points.

### Other checks:

-   [x] I have tested all my changes thoroughly.
