### PR TITLE
Achievement Diary Cape - boost from bank

### DIFF
--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -99,7 +99,7 @@ export default class extends BotCommand {
 			duration *= 0.9;
 		}
 
-		if (msg.author.hasItemEquippedAnywhere(['Achievement diary cape', 'Achievement diary cape(t)'], false)) {
+		if (msg.author.hasItemEquippedOrInBank('Achievement diary cape')) {
 			boosts.push('10% for Achievement diary cape');
 			duration *= 0.9;
 		}

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -163,6 +163,7 @@ const source: [string, (string | number)[]][] = [
 	["Ava's accumulator", ['Accumulator max cape']],
 	["Ava's assembler", ['Assembler max cape', 'Assembler max cape (l)']],
 	['Mythical cape', ['Mythical max cape']],
+	['Achievement diary cape', ['Achievement diary cape(t)']],
 	[
 		'Imbued guthix cape',
 		[


### PR DESCRIPTION
Allow the achievement diary cape to boost clues equipped or in the bank, you'd never need it equipped in game as it would just sit in inventory normally.

Adds the trimmed variant to similar items.

-   [x] I have tested all my changes thoroughly.
