### PR TITLE
Add Custom monsters to `drystreak` command 

### DIFF
--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -19,7 +19,7 @@ import { SILENT_ERROR } from '../lib/constants';
 import { baseFilters, filterableTypes } from '../lib/data/filterables';
 import { evalMathExpression } from '../lib/expressionParser';
 import { defaultGear } from '../lib/gear';
-import killableMonsters from '../lib/minions/data/killableMonsters';
+import { effectiveMonsters } from '../lib/minions/data/killableMonsters';
 import { prisma } from '../lib/settings/prisma';
 import { UserSettings } from '../lib/settings/types/UserSettings';
 import { Gear } from '../lib/structures/Gear';
@@ -80,7 +80,7 @@ export const monsterOption: CommandOption = {
 	description: 'The monster you want to pick.',
 	required: true,
 	autocomplete: async value => {
-		return killableMonsters
+		return effectiveMonsters
 			.filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())))
 			.map(i => ({ name: i.name, value: i.name }));
 	}


### PR DESCRIPTION
### Description:

Changes the Monster dropdown [in BSO] to use the entire list of monsters, including custom ones.
Works for DryStreak and KC_Gains

### Changes:

- Swaps effectiveMonsters for killableMonsters in the Monster drop down generator.

### Other checks:

-   [x] I have tested all my changes thoroughly.
