### PR TITLE
Add Defer Reply to Bank Slash Command

### DIFF
--- a/src/mahoji/commands/bank.ts
+++ b/src/mahoji/commands/bank.ts
@@ -39,8 +39,10 @@ export const askCommand: OSBMahojiCommand = {
 	],
 	run: async ({
 		user,
-		options
+		options,
+		interaction
 	}: CommandRunOptions<{ page?: number; format?: BankFormat; search?: string; filter?: string; item?: string }>) => {
+		await interaction.deferReply();
 		const klasaUser = await client.fetchUser(user.id);
 		const baseBank = klasaUser.bank({ withGP: true });
 


### PR DESCRIPTION
Closes https://github.com/oldschoolgg/oldschoolbot/issues/3684

### Description:

Certain filters on the `/bank` command (mainly "Not Sacrificed") take too long to respond so Discord marks the message as failed.

### Changes:

Defer the reply so more time is allowed for calculation on certain filters.

### Other checks:

-   [x] I have tested all my changes thoroughly.
