### PR TITLE
Fix one annoying deepscan issue

### DIFF
--- a/src/lib/settings/prisma.ts
+++ b/src/lib/settings/prisma.ts
@@ -39,7 +39,7 @@ export async function countUsersWithItemInCl(itemID: number, ironmenOnly: boolea
 				   AND ("collectionLogBank"->>'${itemID}')::int >= 1
 				   ${ironmenOnly ? 'AND "minion.ironman" = true' : ''};`;
 	const result = parseInt(((await prisma.$queryRawUnsafe(query)) as any)[0].count);
-	if (isNaN(result) || typeof result !== 'number') {
+	if (isNaN(result)) {
 		throw new Error(`countUsersWithItemInCl produced invalid number '${result}' for ${itemID}`);
 	}
 	return result;


### PR DESCRIPTION
### Description:

This redundant piece of code triggers deepscan frequently, causing errors to appear on code checks that shouldn't exist.

### Changes:

Removes a piece of code that always equates to `false` and is therefor not needed in the `or` check.

parseInt() always returns a number [NaN is a [floating point] number]
![image](https://user-images.githubusercontent.com/10122432/166665948-65fd4506-066b-4805-8279-311732ae5869.png)

### Other checks:

-   [ ] I have tested all my changes thoroughly.
