### PR TITLE
BSO - Increase quantity compost bin allows

### DIFF
--- a/src/mahoji/commands/farming.ts
+++ b/src/mahoji/commands/farming.ts
@@ -281,7 +281,7 @@ export const farmingCommand: OSBMahojiCommand = {
 					description: 'The quantity you want to put in.',
 					required: false,
 					min_value: 1,
-					max_value: 200
+					max_value: 10_000
 				}
 			]
 		}


### PR DESCRIPTION
Increase the quantity of crops you can change into supercompost.
Prior to slash there was no limit afaik, and this makes it very tedious now compared to before.

-   [ ] I have tested all my changes thoroughly.
