### PR TITLE
Fix minion_is_busy check on new Farming tasks

### DIFF
--- a/src/lib/minions/functions/autoFarm.ts
+++ b/src/lib/minions/functions/autoFarm.ts
@@ -9,6 +9,9 @@ import { plants } from '../../skilling/skills/farming';
 import { IPatchDataDetailed } from '../farming/types';
 
 export async function autoFarm(user: KlasaUser, patchesDetailed: IPatchDataDetailed[], channelID: bigint) {
+	if (user.minionIsBusy) {
+		return 'Your minion must not be busy to use this command.';
+	}
 	const userBank = user.bank();
 	const farmingLevel = user.skillLevel(SkillsEnum.Farming);
 	const elligible = [...plants]

--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -38,6 +38,9 @@ export async function harvestCommand({
 	channelID: bigint;
 	seedType: string;
 }) {
+	if (user.minionIsBusy) {
+		return 'Your minion must not be busy to use this command.';
+	}
 	const GP = user.settings.get(UserSettings.GP);
 	const currentWoodcuttingLevel = user.skillLevel(SkillsEnum.Woodcutting);
 	const currentDate = new Date().getTime();
@@ -134,6 +137,9 @@ export async function farmingPlantCommand({
 	pay: boolean;
 }): Promise<string> {
 	await user.settings.sync(true);
+	if (user.minionIsBusy) {
+		return 'Your minion must not be busy to use this command.';
+	}
 	const userBank = user.bank();
 	const alwaysPay = user.settings.get(UserSettings.Minion.DefaultPay);
 	const questPoints = user.settings.get(UserSettings.QP);

--- a/src/mahoji/lib/abstracted_commands/titheFarmCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/titheFarmCommand.ts
@@ -40,6 +40,9 @@ function determineDuration(user: KlasaUser): [number, string[]] {
 }
 
 export async function titheFarmCommand(user: KlasaUser, channelID: bigint) {
+	if (user.minionIsBusy) {
+		return 'Your minion must not be busy to use this command.';
+	}
 	if (user.skillLevel(SkillsEnum.Farming) < 34) {
 		return `${user.minionName} needs 34 Farming to use the Tithe Farm!`;
 	}


### PR DESCRIPTION
### Description:

Fixes the `busy` check on the /farming command wherever a new task would be generated.

### Changes:

Adds `busy` checks on the following abstracted_commands:
- auto_farm
- tithe_farm  [shop excluded]
- harvest
- plant


### Other checks:

-   [x] I have tested all my changes thoroughly.
