### PR TITLE
Expand Eatables

### DIFF
--- a/src/lib/data/eatables.ts
+++ b/src/lib/data/eatables.ts
@@ -12,19 +12,34 @@ export interface Eatable {
 
 export const Eatables: readonly Eatable[] = [
 	{
-		name: 'Shrimps',
-		id: itemID('Shrimps'),
-		healAmount: 1
-	},
-	{
 		name: 'Anchovies',
 		id: itemID('Anchovies'),
 		healAmount: 1
 	},
 	{
+		name: 'Shrimps',
+		id: itemID('Shrimps'),
+		healAmount: 3
+	},
+	{
+		name: 'Cooked chicken',
+		id: itemID('Cooked chicken'),
+		healAmount: 3
+	},
+	{
+		name: 'Cooked meat',
+		id: itemID('Cooked meat'),
+		healAmount: 3
+	},
+	{
 		name: 'Sardine',
 		id: itemID('Sardine'),
 		healAmount: 4
+	},
+	{
+		name: 'Bread',
+		id: itemID('Bread'),
+		healAmount: 5
 	},
 	{
 		name: 'Herring',

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -39,7 +39,7 @@ describe('util', () => {
 		expect(
 			getUserFoodFromBank(
 				fakeUser(new Bank().add('Shark', 100).add('Lobster', 20).add('Shrimps', 50).add('Coal')),
-				1600,
+				1700,
 				[]
 			)
 		).toStrictEqual(new Bank().add('Lobster', 20).add('Shark', 66).add('Shrimps', 50));


### PR DESCRIPTION
Fixes the heal amount of shrimps, adds chicken, meat and bread to the food minion's can eat. Helps early accounts especially ironmen.

-   [x] I have tested all my changes thoroughly.
