### PR TITLE
BSO - Dark Relic Dungeoneering

### DIFF
--- a/src/commands/Minion/lamp.ts
+++ b/src/commands/Minion/lamp.ts
@@ -109,7 +109,8 @@ const XPObjects: IXPObject[] = [
 						SkillsEnum.Fishing,
 						SkillsEnum.Thieving,
 						SkillsEnum.Firemaking,
-						SkillsEnum.Agility
+						SkillsEnum.Agility,
+						SkillsEnum.Dungeoneering
 					].includes(skill)
 						? 150
 						: 50) *


### PR DESCRIPTION
As per the #bso-votes poll
adds Dungeoneering to the list of skills that Dark Relic gives ‘bonus’ EXP in (So instead of 50 * Lvl = current exp, its 150 * Dung Level).

-   [x] I have tested all my changes thoroughly.
