### PR TITLE
Minor fixes with the open_until updated on BSO

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -147,6 +147,9 @@ for (const clueTier of ClueTiers) {
 	});
 }
 
+const masterClue = clueOpenables.find(c => c.name === 'Reward casket (master)');
+masterClue!.allItems.push(itemID('Clue scroll (grandmaster)'));
+
 const osjsOpenables: UnifiedOpenable[] = [
 	{
 		name: 'Brimstone chest',

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -103,7 +103,7 @@ for (const clueTier of ClueTiers) {
 				mimicNumber > 0 ? `with ${mimicNumber} mimic${mimicNumber > 1 ? 's' : ''}` : ''
 			}`;
 			if (extraClueRolls > 0) {
-				message += `${extraClueRolls} extra rolls`;
+				message += `${mimicNumber ? ' ' : ''}${extraClueRolls} extra rolls`;
 			}
 
 			const nthCasket = (user.settings.get(UserSettings.ClueScores)[clueTier.id] ?? 0) + quantity;

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -67,7 +67,8 @@ export async function abstractedOpenUntilCommand(
 		return `That's not a valid item to open until, you can only do it with items that you can get from ${openable.openedItem.name}.`;
 	}
 	if (!openable.allItems.includes(openUntil.id)) {
-		return `${openable.openedItem.name} doesn't drop ${openUntil.name}.`;
+		if (!(openUntil.name === 'Clue scroll (grandmaster)' && openable.name === 'Reward casket (master)'))
+			return `${openable.openedItem.name} doesn't drop ${openUntil.name}.`;
 	}
 	const amountOfThisOpenableOwned = user.bank().amount(openableItem.id);
 	if (amountOfThisOpenableOwned === 0) return "You don't own any of that item.";
@@ -147,7 +148,7 @@ async function finalizeOpening({
 			loot.add((await getOpenableLoot({ user, mahojiUser, openable, quantity: smokeyBonus })).bank);
 			bonuses.push(`${smokeyBonus}x ${openable.name}`);
 		}
-		smokeyMsg = `${Emoji.Smokey} Bonus Rolls: ${messages.join(', ')}`;
+		smokeyMsg = `${Emoji.Smokey} Bonus Rolls: ${bonuses.join(', ')}`;
 	}
 	if (smokeyMsg) messages.push(smokeyMsg);
 

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -67,8 +67,7 @@ export async function abstractedOpenUntilCommand(
 		return `That's not a valid item to open until, you can only do it with items that you can get from ${openable.openedItem.name}.`;
 	}
 	if (!openable.allItems.includes(openUntil.id)) {
-		if (!(openUntil.name === 'Clue scroll (grandmaster)' && openable.name === 'Reward casket (master)'))
-			return `${openable.openedItem.name} doesn't drop ${openUntil.name}.`;
+		return `${openable.openedItem.name} doesn't drop ${openUntil.name}.`;
 	}
 	const amountOfThisOpenableOwned = user.bank().amount(openableItem.id);
 	if (amountOfThisOpenableOwned === 0) return "You don't own any of that item.";
@@ -148,7 +147,7 @@ async function finalizeOpening({
 			loot.add((await getOpenableLoot({ user, mahojiUser, openable, quantity: smokeyBonus })).bank);
 			bonuses.push(`${smokeyBonus}x ${openable.name}`);
 		}
-		smokeyMsg = `${Emoji.Smokey} Bonus Rolls: ${bonuses.join(', ')}`;
+		smokeyMsg = bonuses.length ? `${Emoji.Smokey} Bonus Rolls: ${bonuses.join(', ')}` : null;
 	}
 	if (smokeyMsg) messages.push(smokeyMsg);
 


### PR DESCRIPTION
### Description:

Fixed some minor updates with the open until command on BSO.

### Changes:

- Missing space after mimic rolls
- Unable to open_until Grandmaster when opening masters.
- Smokey message using the wrong variable
- Only show smokey message if smokey gave a bonus.

### Other checks:

-   [x] I have tested all my changes thoroughly.
