### PR TITLE
Fix a NaN (image / item) error, Farming CL

### DIFF
--- a/src/lib/skilling/skills/farming/index.ts
+++ b/src/lib/skilling/skills/farming/index.ts
@@ -52,7 +52,7 @@ export type CompostName = typeof CompostTiers[number]['name'];
 
 for (const plant of plants) {
 	if (plant.outputCrop) allFarmingItems.push(plant.outputCrop);
-	for (const key of Object.keys(plant.inputItems)) {
+	for (const key of Object.keys(plant.inputItems.bank)) {
 		allFarmingItems.push(Number(key));
 	}
 	if (plant.outputLogs) allFarmingItems.push(plant.outputLogs);


### PR DESCRIPTION
### Description:

- Fixes farming CL which was bugged showing 77/78 at max, when it should have ~ 140 something.
- This also fixes [one of?] the NaN errors we've been seeing in the logs.
- The old code was essentially causing lots of NaN's to be added to the `collection` member variable of the allFarmingItems cl object.

### Changes:

- Adds `.bank` to the end of inputItems, as it apparently wasn't updated when that was converted to a Bank object.

### Other checks:

-   [x] I have tested all my changes thoroughly.
