### PR TITLE
BSO - Dwarven Gloves BF Gold

### DIFF
--- a/src/commands/Minion/blastfurnace.ts
+++ b/src/commands/Minion/blastfurnace.ts
@@ -91,7 +91,7 @@ export default class extends BotCommand {
 			timeToSmithSingleBar *= 0.625;
 		}
 
-		if (msg.author.hasItemEquippedAnywhere(itemID('Dwarven gauntlets')) && bar.id !== itemID('Gold bar')) {
+		if (msg.author.hasItemEquippedAnywhere(itemID('Dwarven gauntlets'))) {
 			boosts.push('100% for having a Dwarven gauntlets equipped.');
 			timeToSmithSingleBar /= 2;
 		}

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -132,6 +132,9 @@ export default class extends Task {
 					break;
 				}
 			}
+		} else if (user.equippedPet() === itemID('Doug')) {
+			loot.add(ore.id, quantity * 4);
+			str += '\n<:doug:748892864813203591> Doug helps you gather 4x as many ores!';
 		} else {
 			loot.add(ore.id, quantity);
 		}

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -132,9 +132,6 @@ export default class extends Task {
 					break;
 				}
 			}
-		} else if (user.equippedPet() === itemID('Doug')) {
-			loot.add(ore.id, quantity * 4);
-			str += '\n<:doug:748892864813203591> Doug helps you gather 4x as many ores!';
 		} else {
 			loot.add(ore.id, quantity);
 		}


### PR DESCRIPTION
Allow the dwarven gloves to work for blast furnacing gold, there was a poll on this back in September 2021.

-   [x] I have tested all my changes thoroughly.
