### PR TITLE
Adds "sp" alias to Seed packs openable

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -249,7 +249,7 @@ const osjsOpenables: UnifiedOpenable[] = [
 		name: 'Seed pack',
 		id: 22_993,
 		openedItem: getOSItem(22_993),
-		aliases: ['seed pack'],
+		aliases: ['seed pack', 'sp'],
 		output: async (
 			args: OpenArgs
 		): Promise<{


### PR DESCRIPTION
### Description:

What title says. This would be very helpful for contracts, as typing "seed" in the /openable can be annoying when you open multiple in a row. Typing "sp" is much more convenient. 

### Changes:

- Added sp alias to the Seed pack in `openables` file.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
