### PR TITLE
Sepulchre - Clue scrolls

### DIFF
--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -51,7 +51,11 @@ export const sepulchreFloors = [
 		xp: 500,
 		time: Number(Time.Minute),
 		lockpickCoffinChance: 2000,
-		coffinTable: new LootTable().add(LowTierCoffin, 1, 60).add(MidTierCoffin, 1, 35).add(HighTierCoffin, 1, 5),
+		coffinTable: new LootTable()
+			.add(LowTierCoffin, 1, 60)
+			.add(MidTierCoffin, 1, 35)
+			.add(HighTierCoffin, 1, 5)
+			.tertiary(50, 'Clue scroll (easy)'),
 		numCoffins: 1,
 		marksRange: [1, 1]
 	},
@@ -62,7 +66,11 @@ export const sepulchreFloors = [
 		xp: 850,
 		time: Time.Minute * 1.2,
 		lockpickCoffinChance: 1500,
-		coffinTable: new LootTable().add(LowTierCoffin, 1, 30).add(MidTierCoffin, 1, 60).add(HighTierCoffin, 1, 10),
+		coffinTable: new LootTable()
+			.add(LowTierCoffin, 1, 30)
+			.add(MidTierCoffin, 1, 60)
+			.add(HighTierCoffin, 1, 10)
+			.tertiary(50, 'Clue scroll (medium)'),
 		numCoffins: 2,
 		marksRange: [2, 3]
 	},
@@ -73,7 +81,11 @@ export const sepulchreFloors = [
 		xp: 1425,
 		time: Time.Minute * 1.6,
 		lockpickCoffinChance: 1100,
-		coffinTable: new LootTable().add(LowTierCoffin, 1, 15).add(MidTierCoffin, 1, 65).add(HighTierCoffin, 1, 20),
+		coffinTable: new LootTable()
+			.add(LowTierCoffin, 1, 15)
+			.add(MidTierCoffin, 1, 65)
+			.add(HighTierCoffin, 1, 20)
+			.tertiary(25, 'Clue scroll (medium)'),
 		numCoffins: 2,
 		marksRange: [3, 5]
 	},
@@ -84,7 +96,10 @@ export const sepulchreFloors = [
 		xp: 2625,
 		time: Time.Minute * 2.2,
 		lockpickCoffinChance: 800,
-		coffinTable: new LootTable().add(MidTierCoffin, 1, 60).add(HighTierCoffin, 1, 40),
+		coffinTable: new LootTable()
+			.add(MidTierCoffin, 1, 60)
+			.add(HighTierCoffin, 1, 40)
+			.tertiary(50, 'Clue scroll (hard)'),
 		numCoffins: 2,
 		marksRange: [3, 6]
 	},
@@ -95,7 +110,10 @@ export const sepulchreFloors = [
 		xp: 5850,
 		time: Time.Minute * 3.75,
 		lockpickCoffinChance: 600,
-		coffinTable: new LootTable().add(MidTierCoffin, 1, 20).add(HighTierCoffin, 1, 80),
+		coffinTable: new LootTable()
+			.add(MidTierCoffin, 1, 20)
+			.add(HighTierCoffin, 1, 80)
+			.tertiary(60, 'Clue scroll (elite)'),
 		numCoffins: 3,
 		marksRange: [4, 6]
 	}


### PR DESCRIPTION
Adds the tertiary drops of clue scrolls to the sepulchre floors. 
As per the game update - https://oldschool.runescape.wiki/w/Update:Equipment_Rebalance_Tier_Changes_%26_Poll_76

-   [x] I have tested all my changes thoroughly.
