### PR TITLE
BSO - Allow Agility master cape with drift net fishing

### DIFF
--- a/src/commands/Minion/driftnet.ts
+++ b/src/commands/Minion/driftnet.ts
@@ -39,9 +39,8 @@ export default class extends BotCommand {
 		}
 
 		if (
-			!msg.author.hasItemEquippedAnywhere('Graceful gloves') ||
-			!msg.author.hasItemEquippedAnywhere('Graceful top') ||
-			!msg.author.hasItemEquippedAnywhere('Graceful legs')
+			!msg.author.hasItemEquippedAnywhere(['Graceful gloves', 'Graceful top', 'Graceful legs'], true) &&
+			!msg.author.hasItemEquippedAnywhere('Agility master cape')
 		) {
 			return msg.channel.send('You need Graceful top, legs and gloves equipped to do Drift net fishing.');
 		}


### PR DESCRIPTION
### Description:

Allow the use of an Agility master cape or Support cape with drift net fishing in place of the graceful pieces. Closes #3449 and closes #3715 

### Other checks:

-   [x] I have tested all my changes thoroughly.
