### PR TITLE
Prevent dwwh 'saving' and doubling

### DIFF
--- a/src/commands/Minion/smith.ts
+++ b/src/commands/Minion/smith.ts
@@ -14,6 +14,7 @@ import { SmithingActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, itemNameFromID, stringMatches, updateBankSetting } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { hasItemsEquippedOrInBank } from '../../lib/util/minionUtils';
+import resolveItems from '../../lib/util/resolveItems';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -121,9 +122,20 @@ export default class extends BotCommand {
 
 		const hasScroll = msg.author.owns('Scroll of efficiency');
 		if (hasScroll) {
+			const itemsThatCanBeSaved = resolveItems([
+				'Bronze bar',
+				'Iron bar',
+				'Steel bar',
+				'Mithril bar',
+				'Adamantite bar',
+				'Runite bar',
+				'Dwarven bar'
+			]);
 			for (const [item, qty] of baseCost.items()) {
-				const saved = Math.floor(calcPercentOfNum(15, qty));
-				cost.remove(item.id, saved);
+				if (itemsThatCanBeSaved.includes(item.id)) {
+					const saved = Math.floor(calcPercentOfNum(15, qty));
+					cost.remove(item.id, saved);
+				}
 			}
 		}
 
@@ -147,7 +159,8 @@ export default class extends BotCommand {
 			channelID: msg.channel.id,
 			quantity,
 			duration,
-			type: 'Smithing'
+			type: 'Smithing',
+			cantBeDoubled: smithedItem.cantBeDoubled
 		});
 
 		let str = `${msg.author.minionName} is now smithing ${quantity * smithedItem.outputMultiple}x ${

--- a/src/commands/Minion/smith.ts
+++ b/src/commands/Minion/smith.ts
@@ -126,6 +126,8 @@ export default class extends BotCommand {
 				'Bronze bar',
 				'Iron bar',
 				'Steel bar',
+				'Gold bar',
+				'Silver bar',
 				'Mithril bar',
 				'Adamantite bar',
 				'Runite bar',

--- a/src/lib/skilling/skills/smithing/smithables/dwarven.ts
+++ b/src/lib/skilling/skills/smithing/smithables/dwarven.ts
@@ -12,7 +12,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 3 },
 		timeToUse: Time.Second * 3.4,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven knife',
@@ -22,7 +23,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 2 },
 		timeToUse: Time.Second * 3.4,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven gauntlets',
@@ -32,7 +34,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 3 },
 		timeToUse: Time.Second * 3.4,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven greathammer',
@@ -42,7 +45,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 4 },
 		timeToUse: Time.Second * 3.4,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven pickaxe',
@@ -52,7 +56,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 3 },
 		timeToUse: Time.Second * 3.4,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven warhammer',
@@ -62,7 +67,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 3, [itemID('Broken dwarven warhammer')]: 1 },
 		timeToUse: Time.Minute * 3,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven full helm',
@@ -72,7 +78,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 2 },
 		timeToUse: Time.Minute * 3,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven platebody',
@@ -82,7 +89,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 5 },
 		timeToUse: Time.Minute * 3,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven platelegs',
@@ -92,7 +100,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 4 },
 		timeToUse: Time.Minute * 3,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven gloves',
@@ -102,7 +111,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 2 },
 		timeToUse: Time.Minute * 3,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	},
 	{
 		name: 'Dwarven boots',
@@ -112,7 +122,8 @@ const Dwarven: SmithedItem[] = [
 		inputBars: { [itemID('Dwarven bar')]: 2 },
 		timeToUse: Time.Minute * 3,
 		outputMultiple: 1,
-		requiresBlacksmith: true
+		requiresBlacksmith: true,
+		cantBeDoubled: true
 	}
 ];
 

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -134,8 +134,9 @@ export interface SmithedItem {
 	inputBars: ItemBank;
 	timeToUse: number;
 	outputMultiple: number;
-	requiresBlacksmith?: boolean;
 	qpRequired?: number;
+	requiresBlacksmith?: boolean;
+	cantBeDoubled?: boolean;
 }
 
 export interface Craftable {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -18,6 +18,7 @@ export interface ActivityTaskOptions {
 	id: number;
 	finishDate: number;
 	channelID: string;
+	cantBeDoubled?: boolean;
 }
 
 export interface KibbleOptions extends ActivityTaskOptions {

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -60,6 +60,7 @@ export async function handleTripFinish(
 
 	if (
 		loot &&
+		!data.cantBeDoubled &&
 		!['GroupMonsterKilling', 'KingGoldemar', 'Ignecarus', 'Inferno', 'Alching', 'Agility'].includes(data.type) &&
 		data.duration > Time.Minute * 20 &&
 		roll(pet === itemID('Mr. E') ? 12 : 15)


### PR DESCRIPTION
### Description:

Prevents `Broken dwarven warhammer` from being 'saved' by the DG Scroll of efficiency, and allows any activity to disable the Global 2x without blacklisting the entire activity.

### Changes:

- Any activity can have 2x disabled by setting `ActivityTaskOptions.cantBeDoubled = true;`
- Only bars will be saved from the DG Scroll of efficiency, as it says on the tin.
- Adds fully implemented `cantBeDoubled` flag to `SmithedItem` interface.
- Disables global 2x on all dwarven equipment.

### Other checks:

-   [x] I have tested all my changes thoroughly.
