### PR TITLE
Allow changing Reaction emojiis

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -142,11 +142,11 @@ export const enum Emoji {
 	SOTWTrophy = '<:SOTWtrophy:842938096097820693>'
 }
 
-export const enum ReactionEmoji {
-	Join = '705971600956194907',
-	Stop = '705972260950769669',
-	Start = '705973302719414329'
-}
+export const ReactionEmoji = {
+	Join: DISCORD_SETTINGS.Emojis?.ReactionJoin ?? '705971600956194907',
+	Stop: DISCORD_SETTINGS.Emojis?.ReactionStop ?? '705972260950769669',
+	Start: DISCORD_SETTINGS.Emojis?.ReactionStart ?? '705973302719414329'
+};
 
 export const enum Image {
 	DiceBag = 'https://i.imgur.com/sySQkSX.png'

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -94,6 +94,7 @@ export type CategoryFlag =
 export interface IDiscordSettings {
 	Roles: Record<string, string>;
 	Channels: Record<string, string>;
+	Emojis: Record<string, string>;
 	SupportServer: string;
 	BotID: string;
 }


### PR DESCRIPTION
### Description:

With this PR, you can add this to your DISCORD_SETTINGS in config.ts to setup your reactions to the test servers IDs.

Or use your own local servers emojiis.

`	Emojis: {
		ReactionStart: '951309579302604880',
		ReactionJoin: '951309579302604900',
		ReactionStop: '951309579248091166'
	}
`
### Changes:

Added Emojis member to IDiscordSettings interface
Added null coalesce operator to the reaction emojis to use the overrides, or defaults when null/undefined.

### Other checks:

-   [x] I have tested all my changes thoroughly.
