### PR TITLE
Fix bug that lets you solo tob

### DIFF
--- a/src/lib/data/tob.ts
+++ b/src/lib/data/tob.ts
@@ -430,6 +430,9 @@ export async function checkTOBTeam(users: KlasaUser[], isHardMode: boolean): Pro
 	if (userWithoutSupplies) {
 		return `${userWithoutSupplies.username} doesn't have enough supplies`;
 	}
+	if (users.length < 2 || users.length > 5) {
+		return 'TOB team must be 2-5 users';
+	}
 
 	for (const user of users) {
 		const checkResult = await checkTOBUser(user, isHardMode, users.length);


### PR DESCRIPTION
### Description:

If you start a tob, and then someone joins, but then that person starts a new task before the raid starts, when the raid does begin, it will start as a solo.

### Changes:

- checkTobTeam fails if there's not 2-5 players

### Other checks:

-   [x] I have tested all my changes thoroughly.
