### PR TITLE
Add revenants timer

### DIFF
--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -545,9 +545,9 @@ export default class extends Extendable {
 				const durationRemaining = data.finishDate - data.duration + data.fakeDuration - Date.now();
 				return `${data.skulled ? `${Emoji.OSRSSkull} ` : ''} ${this.minionName} is currently killing ${
 					data.quantity
-				}x ${Monsters.get(data.monsterID)!.name} in the wilderness. If they don't die, the trip should take ${formatDuration(
-					durationRemaining
-				)}.`;
+				}x ${
+					Monsters.get(data.monsterID)!.name
+				} in the wilderness. If they don't die, the trip should take ${formatDuration(durationRemaining)}.`;
 			}
 			case 'PestControl': {
 				const data = currentTask as MinigameActivityTaskOptions;

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -542,9 +542,12 @@ export default class extends Extendable {
 			}
 			case 'Revenants': {
 				const data = currentTask as RevenantOptions;
+				const durationRemaining = data.finishDate - data.duration + data.fakeDuration - Date.now();
 				return `${data.skulled ? `${Emoji.OSRSSkull} ` : ''} ${this.minionName} is currently killing ${
 					data.quantity
-				}x ${Monsters.get(data.monsterID)!.name} in the wilderness.`;
+				}x ${Monsters.get(data.monsterID)!.name} in the wilderness. If they don't die, the trip should take ${formatDuration(
+					durationRemaining
+				)}.`;
 			}
 			case 'PestControl': {
 				const data = currentTask as MinigameActivityTaskOptions;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -63,6 +63,7 @@ export interface RevenantOptions extends ActivityTaskOptions {
 	monsterID: number;
 	quantity: number;
 	died: boolean;
+	fakeDuration: number;
 	usingPrayerPots: boolean;
 	skulled: boolean;
 	style: 'melee' | 'range' | 'mage';

--- a/src/mahoji/lib/abstracted_commands/revsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/revsCommand.ts
@@ -107,6 +107,7 @@ export async function revsCommand(
 		userID: user.id,
 		channelID: channelID.toString(),
 		quantity,
+		fakeDuration: duration,
 		duration: died ? randInt(Math.min(Time.Minute * 3, duration), duration) : duration,
 		type: 'Revenants',
 		died,


### PR DESCRIPTION
### Description:

When killing revenants, no timer is given when checking your minion status with +m. A fake duration can be added in order to have an estimate on your trip time without revealing if you died, similar to inferno/tob/nex.

### Changes:

Added a fakeDuration variable to RevenantOptions
Added a revenant trip timer to +m that uses fakeDuration

### Other checks:

-   [X] I have tested all my changes thoroughly.
