### PR TITLE
Fix early fight caves deaths, add +m timer

### DIFF
--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -50,6 +50,7 @@ import {
 	DarkAltarOptions,
 	EnchantingActivityTaskOptions,
 	FarmingActivityTaskOptions,
+	FightCavesActivityTaskOptions,
 	FiremakingActivityTaskOptions,
 	FishingActivityTaskOptions,
 	FletchingActivityTaskOptions,
@@ -298,7 +299,11 @@ export default class extends Extendable {
 			}
 
 			case 'FightCaves': {
-				return `${this.minionName} is currently attempting the ${Emoji.AnimatedFireCape} **Fight caves** ${Emoji.TzRekJad}.`;
+				const data = currentTask as FightCavesActivityTaskOptions;
+				const durationRemaining = data.finishDate - data.duration + data.fakeDuration - Date.now();
+				return `${this.minionName} is currently attempting the ${Emoji.AnimatedFireCape} **Fight caves** ${
+					Emoji.TzRekJad
+				}. If they're successful and don't die, the trip should take ${formatDuration(durationRemaining)}.`;
 			}
 			case 'TitheFarm': {
 				return `${this.minionName} is currently farming at the **Tithe Farm**. ${formattedDuration}`;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -168,6 +168,7 @@ export interface FightCavesActivityTaskOptions extends ActivityTaskOptions {
 	jadDeathChance: number;
 	preJadDeathChance: number;
 	preJadDeathTime: number | null;
+	fakeDuration: number;
 	quantity: number;
 }
 export interface InfernoOptions extends ActivityTaskOptions {

--- a/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
@@ -147,7 +147,7 @@ export async function fightCavesCommand(user: KlasaUser, channelID: bigint): Com
 	const totalDeathChance = (((100 - preJadDeathChance) * (100 - jadDeathChance)) / 100).toFixed(1);
 
 	return {
-		content: `**Duration:** ${formatDuration(duration)} (${(duration / 1000 / 60).toFixed(2)} minutes)
+		content: `**Duration:** ${formatDuration(fakeDuration)} (${(fakeDuration / 1000 / 60).toFixed(2)} minutes)
 **Boosts:** ${debugStr}
 **Range Attack Bonus:** ${usersRangeStats.attack_ranged}
 **Jad KC:** ${jadKC}

--- a/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
@@ -109,9 +109,6 @@ export async function fightCavesCommand(user: KlasaUser, channelID: bigint): Com
 
 	duration += (rand(1, 5) * duration) / 100;
 
-	const diedPreJad = percentChance(preJadDeathChance);
-	const preJadDeathTime = diedPreJad ? rand(Time.Minute * 20, duration) : null;
-
 	await user.removeItemsFromBank(fightCavesCost);
 
 	// Add slayer
@@ -128,6 +125,11 @@ export async function fightCavesCommand(user: KlasaUser, channelID: bigint): Com
 		debugStr += ', 15% on Task with Black mask (i)';
 	}
 
+	const diedPreJad = percentChance(preJadDeathChance);
+	const fakeDuration = duration;
+	duration = diedPreJad ? rand(Time.Minute * 20, duration) : duration;
+	const preJadDeathTime = diedPreJad ? duration : null;
+
 	await addSubTaskToActivityTask<FightCavesActivityTaskOptions>({
 		userID: user.id,
 		channelID: channelID.toString(),
@@ -136,7 +138,8 @@ export async function fightCavesCommand(user: KlasaUser, channelID: bigint): Com
 		type: 'FightCaves',
 		jadDeathChance,
 		preJadDeathChance,
-		preJadDeathTime
+		preJadDeathTime,
+		fakeDuration
 	});
 
 	updateBankSetting(user.client as KlasaClient, ClientSettings.EconomyStats.FightCavesCost, fightCavesCost);

--- a/src/tasks/minions/minigames/fightCavesActivity.ts
+++ b/src/tasks/minions/minigames/fightCavesActivity.ts
@@ -20,7 +20,7 @@ const TokkulID = itemID('Tokkul');
 
 export default class extends Task {
 	async run(data: FightCavesActivityTaskOptions) {
-		const { userID, channelID, jadDeathChance, preJadDeathTime, duration } = data;
+		const { userID, channelID, jadDeathChance, preJadDeathTime, duration, fakeDuration } = data;
 		const user = await this.client.fetchUser(userID);
 
 		const tokkulReward = rand(2000, 6000);
@@ -56,7 +56,7 @@ export default class extends Task {
 			}
 			// Give back supplies based on how far in they died, for example if they
 			// died 80% of the way through, give back approximately 20% of their supplies.
-			const percSuppliesToRefund = 100 - calcWhatPercent(preJadDeathTime, duration);
+			const percSuppliesToRefund = 100 - calcWhatPercent(preJadDeathTime, fakeDuration);
 			const itemLootBank = new Bank();
 
 			for (const [item, qty] of fightCavesCost.items()) {


### PR DESCRIPTION
### Description:

Despite the possibility of dying before Jad in fight caves trips, the trips don't actually return early. Furthermore, the pre-Jad death time is calculated before applying slayer task boosts. This makes it possible for the "early" death time that's shown to be later than the actual trip return if you have a slayer task. Lastly, there is no timer when checking minion status with +m.

### Changes:

- Moved the `preJadDeathTime` calculation after the slayer task boost.
- Redefined `duration` to allow for early trip returns.
- Added a `fakeDuration` variable to mask the real duration from the player and to retain item refund functionality.
- Added a fight caves timer when checking minion status with +m that uses `fakeDuration`.

### Other checks:

-   [X] I have tested all my changes thoroughly.
