### PR TITLE
Fix bug with buyables taht include a GPCost and an itemCost

### DIFF
--- a/src/commands/Minion/buy.ts
+++ b/src/commands/Minion/buy.ts
@@ -128,7 +128,8 @@ export default class extends BotCommand {
 		const gpCost =
 			msg.author.isIronman && buyable.ironmanPrice !== undefined ? buyable.ironmanPrice : buyable.gpCost;
 
-		const singleCost: Bank = buyable.itemCost ?? new Bank();
+		// If itemCost is undefined, it creates a new empty Bank, like we want:
+		const singleCost: Bank = new Bank(buyable.itemCost);
 		if (gpCost) singleCost.add('Coins', gpCost);
 
 		const totalCost = singleCost.clone().multiply(quantity);


### PR DESCRIPTION
### Description:

When trying to buy  an item with a GPCost and an itemCost, the gpCost get's reapplied everytime the command is run, whether a purchase is made or not.

### Changes:

- Clones the itemCost bank before gpCost is added

### Other checks:

-   [x] I have tested all my changes thoroughly.
