### PR TITLE
BSO Giveaway Timer Format Change

### DIFF
--- a/src/commands/Minion/giveaway.ts
+++ b/src/commands/Minion/giveaway.ts
@@ -71,10 +71,10 @@ export default class extends BotCommand {
 		}
 
 		const message = await msg.channel.sendBankImage({
-			content: `You created a giveaway that will finish at ${time(
+			content: `You created a giveaway that will finish at ${time(duration.fromNow, 'F')} (${time(
 				duration.fromNow,
-				'F'
-			)}, the winner will receive these items.
+				'R'
+			)}), the winner will receive these items.
 			
 React to this messsage with ${reaction} to enter.`,
 			bank,

--- a/src/commands/Minion/giveaway.ts
+++ b/src/commands/Minion/giveaway.ts
@@ -1,3 +1,4 @@
+import { time } from '@discordjs/builders';
 import { Duration } from '@sapphire/time-utilities';
 import { roll, Time } from 'e';
 import { CommandStore, KlasaMessage } from 'klasa';
@@ -6,7 +7,7 @@ import { Bank } from 'oldschooljs';
 import { ironsCantUse } from '../../lib/minions/decorators';
 import { prisma } from '../../lib/settings/prisma';
 import { BotCommand } from '../../lib/structures/BotCommand';
-import { addToGPTaxBalance, formatDuration, isSuperUntradeable } from '../../lib/util';
+import { addToGPTaxBalance, isSuperUntradeable } from '../../lib/util';
 import { logError } from '../../lib/util/logError';
 
 export default class extends BotCommand {
@@ -70,8 +71,9 @@ export default class extends BotCommand {
 		}
 
 		const message = await msg.channel.sendBankImage({
-			content: `You created a giveaway that will finish in ${formatDuration(
-				duration.offset
+			content: `You created a giveaway that will finish at ${time(
+				duration.fromNow,
+				'F'
 			)}, the winner will receive these items.
 			
 React to this messsage with ${reaction} to enter.`,


### PR DESCRIPTION
https://github.com/oldschoolgg/oldschoolbot/issues/3909

### Description:

The current format involves people having to do maths, and people are lazy.

### Changes:

Use the time builder (similar to check_patches command) to construct both the finishing date/time and the relative finish time when the message is viewed.

Now looks like this:
![image](https://user-images.githubusercontent.com/32879863/168468604-e6a34e52-0521-441f-9f07-bf48e3d86ec6.png)

### Other checks:

-   [x] I have tested all my changes thoroughly.
