### PR TITLE
BSO Collect Command Missing Items

### DIFF
--- a/src/mahoji/lib/abstracted_commands/collectCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/collectCommand.ts
@@ -19,6 +19,7 @@ interface Collectable {
 	quantity: number;
 	duration: number;
 	qpRequired?: number;
+	onlyTamesCan?: boolean;
 }
 
 export const collectables: Collectable[] = [
@@ -133,6 +134,27 @@ export const collectables: Collectable[] = [
 		},
 		duration: 10 * Time.Minute,
 		qpRequired: 100
+	},
+	{
+		item: getOSItem('Neem drupe'),
+		quantity: 5,
+		itemCost: new Bank({
+			'Astral rune': 26,
+			'Cosmic rune': 12
+		}),
+		skillReqs: {
+			magic: 82,
+			herblore: 82,
+			agility: 92
+		},
+		duration: 5 * Time.Minute,
+		qpRequired: 82
+	},
+	{
+		item: getOSItem('Orange'),
+		quantity: 1,
+		duration: 2 * Time.Minute,
+		onlyTamesCan: true
 	}
 ];
 
@@ -142,6 +164,10 @@ export async function collectCommand(mahojiUser: User, user: KlasaUser, channelI
 		return `That's not something your minion can collect, you can collect these things: ${collectables
 			.map(i => i.item.name)
 			.join(', ')}.`;
+	}
+
+	if (collectable.onlyTamesCan) {
+		return 'Only Tames can collect this.';
 	}
 
 	const maxTripLength = user.maxTripLength('Collecting');


### PR DESCRIPTION
https://github.com/oldschoolgg/oldschoolbot/issues/3908

### Description:

The Collectables list does not contain the 2 BSO specific commands.

### Changes:

Amended the Collectable interface to add `onlyTamesCan` property
Added Neem Drupe and Orange items to Collectables array
Added code that prevents collection of a `onlyTamesCan` item
All rates/code same as before on BSO, just copied the items over

### Other checks:

-   [x] I have tested all my changes thoroughly.
