### PR TITLE
Add Confirmation For Open All

### DIFF
--- a/src/mahoji/commands/open.ts
+++ b/src/mahoji/commands/open.ts
@@ -81,8 +81,8 @@ export const openCommand: OSBMahojiCommand = {
 			return abstractedOpenUntilCommand(interaction, user, mahojiUser, options.name, options.open_until);
 		}
 		if (options.name.toLowerCase() === 'all') {
-			return abstractedOpenCommand(user, mahojiUser, ['all'], 'auto');
+			return abstractedOpenCommand(interaction, user, mahojiUser, ['all'], 'auto');
 		}
-		return abstractedOpenCommand(user, mahojiUser, [options.name], options.quantity);
+		return abstractedOpenCommand(interaction, user, mahojiUser, [options.name], options.quantity);
 	}
 };

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -196,7 +196,6 @@ export async function abstractedOpenCommand(
 
 	if (!openables.length) return "That's not a valid item.";
 
-
 	const cost = new Bank();
 	const kcBank = new Bank();
 	const loot = new Bank();

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -172,6 +172,7 @@ ${messages.join(', ')}`
 }
 
 export async function abstractedOpenCommand(
+	interaction: SlashCommandInteraction,
 	user: KlasaUser,
 	mahojiUser: User,
 	_names: string[],
@@ -186,9 +187,15 @@ export async function abstractedOpenCommand(
 		: names
 				.map(name => allOpenables.find(o => o.aliases.some(alias => stringMatches(alias, name))))
 				.filter(notEmpty);
-	if (names.includes('all') && !openables.length) return 'You have no openable items.';
+
+	if (names.includes('all')) {
+		if (!openables.length) return 'You have no openable items.';
+		if (user.perkTier < PerkTier.Two) return patronMsg(PerkTier.Two);
+		await handleMahojiConfirmation(interaction, 'Are you sure you want to open ALL your items?');
+	}
+
 	if (!openables.length) return "That's not a valid item.";
-	if (openables.length > 1 && user.perkTier < PerkTier.Two) return patronMsg(PerkTier.Two);
+
 
 	const cost = new Bank();
 	const kcBank = new Bank();


### PR DESCRIPTION
### Description:

At present there is no confirmation for opening all items. This adds the confirmation in.

### Changes:

Passed interaction into the `abstractedOpenCommand` to allow for use of `handleMahojiConfirmation`
Consolidated `names.includes('all')` checks into one block
Added use of `handleMahojiConfirmation` at the end of that block

### Other checks:
Tested with and without correct Patreon tier
No openables present
Openables present
-   [x] I have tested all my changes thoroughly.
