### PR TITLE
Achievement Diary Shows Completed/Incompleted Incorrect

### DIFF
--- a/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
@@ -38,7 +38,7 @@ export async function achievementDiaryCommand(user: KlasaUser, diaryName: string
 					};
 				})
 			);
-			str += `**${dir.name}:** ${res.map(t => (t.has ? t.name : strikethrough(t.name))).join(' - ')}\n`;
+			str += `**${dir.name}:** ${res.map(t => (t.has ? strikethrough(t.name) : t.name)).join(' - ')}\n`;
 		}
 		return str;
 	}


### PR DESCRIPTION
Fixes: https://github.com/oldschoolgg/oldschoolbot/issues/3858
Not on in BSO, also present in OSB.

### Description:

When doing `/minion achievementdiary` it shows all completed/qualified diaries as incomplete/unqualified and vice versa.

### Changes:

Invert the display logic, strikethrough diaries which the minion has complete/is qualified for not the other way around.

### Other checks:

-   [x] I have tested all my changes thoroughly.
