### PR TITLE
Obis loot return message

### DIFF
--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -58,6 +58,7 @@ export default class extends Task {
 		if (duration >= MIN_LENGTH_FOR_PET) {
 			const minutes = duration / Time.Minute;
 			if (roll(Math.floor(5000 / minutes))) {
+				+				str += "\n<:obis:787028036792614974> An enchantment guardian takes note of your prowess in runecrafting and elects to join you."
 				loot.add('Obis');
 			}
 		}


### PR DESCRIPTION
### Description:

Adds a return message when you receive an obis to make it easier to identify if you obtain one

### Other checks:

-   [x] I have tested all my changes thoroughly.
