### PR TITLE
BSO - Fix DG XP and Rates Displayed on Return

### DIFF
--- a/src/tasks/minions/dungeoneeringActivity.ts
+++ b/src/tasks/minions/dungeoneeringActivity.ts
@@ -44,17 +44,20 @@ export default class extends Task {
 				bonusXP += Math.floor(xp * (gorajanEquipped / 2));
 				xp += bonusXP;
 			}
-			await u.addXP({
+			const xpStr = await u.addXP({
 				skillName: SkillsEnum.Dungeoneering,
 				amount: xp / 5,
-				duration
+				duration,
+				minimal: true
 			});
 			await u.settings.update(
 				UserSettings.DungeoneeringTokens,
 				u.settings.get(UserSettings.DungeoneeringTokens) + tokens
 			);
-			let rawXPHr = (xp / (duration / Time.Minute)) * 60;
-			rawXPHr = Math.floor(xp / 1000) * 1000;
+			let rawXPHr = (xp / minutes) * 60;
+			rawXPHr = Math.floor(rawXPHr / 1000) * 1000;
+			let rawTokenHr = (tokens / minutes) * 60;
+			rawTokenHr = Math.floor(rawTokenHr / 100) * 100;
 
 			// Allow MBs to roll per floor and not trip
 			// This allows people that wants to farm mbs and not xp to do a lot of small floors
@@ -69,13 +72,16 @@ export default class extends Task {
 				}
 			}
 
-			str += `${gotMysteryBox ? Emoji.MysteryBox : ''} ${u} received: ${xp.toLocaleString()} XP (${toKMB(
+			str += `${gotMysteryBox ? Emoji.MysteryBox : ''} ${u} received: ${xpStr} XP (${toKMB(
 				rawXPHr
-			)}/hr) and <:dungeoneeringToken:829004684685606912> ${tokens.toLocaleString()} Dungeoneering tokens (${toKMB(
-				(rawXPHr * 0.1) / 4
+			)}/hr), <:dungeoneeringToken:829004684685606912> ${
+				tokens.toLocaleString()
+			} Dungeoneering tokens (${toKMB(
+				rawTokenHr
 			)}/hr)`;
+
 			if (gorajanEquipped > 0) {
-				str += ` ${bonusXP.toLocaleString()} Bonus XP`;
+				str += `, ${bonusXP.toLocaleString()} Bonus XP from Gorajan`;
 			}
 
 			if (floor >= 5 && roll(Math.floor(gorajanShardChance(user).chance / minutes))) {

--- a/src/tasks/minions/dungeoneeringActivity.ts
+++ b/src/tasks/minions/dungeoneeringActivity.ts
@@ -74,9 +74,7 @@ export default class extends Task {
 
 			str += `${gotMysteryBox ? Emoji.MysteryBox : ''} ${u} received: ${xpStr} XP (${toKMB(
 				rawXPHr
-			)}/hr), <:dungeoneeringToken:829004684685606912> ${
-				tokens.toLocaleString()
-			} Dungeoneering tokens (${toKMB(
+			)}/hr), <:dungeoneeringToken:829004684685606912> ${tokens.toLocaleString()} Dungeoneering tokens (${toKMB(
 				rawTokenHr
 			)}/hr)`;
 


### PR DESCRIPTION
### Description:

Currently the XP, XP rate, and token rate shown on the Dungeoneering trip return message are not correct, as 1. the XP does not account for master cape multiplier and 2. the rates shown were only the XP or tokens from the trip itself instead of an actual rate.

This fixes most said problems, and the end trip message is much more understandable, however the XP *rate* still does not account for the master cape multiplier. To keep the same format as before, you may need some way of returning the raw XP value calculated from addXP(). A change like this would also help fix the incorrect Wintertodt and Farming XP shown too.

### Changes:

- Make use of the addXP return for the XP shown.
- Use the correct variable in rawXPHr calculation so that an actual rate is given.
- Calculate the tokens per hour directly instead of letting Gorajan XP boost influence the result beforehand.

### Other checks:

-   [x] I have tested all my changes thoroughly.
