### PR TITLE
Improve Add premium/tier time

### DIFF
--- a/src/commands/rp.ts
+++ b/src/commands/rp.ts
@@ -836,17 +836,17 @@ LIMIT 10;
 					return msg.channel.send(`${input.username} is already a patron of at least that tier.`);
 				}
 				if (currentBalanceTier !== null && currentBalanceTier !== tier) {
-					return msg.channel.send(
+					await msg.confirm(
 						`${input} already has ${formatDuration(
 							currentBalanceTime!
-						)} of Tier ${currentBalanceTier}, you can't add time for a different tier.`
+						)} of Tier ${currentBalanceTier}; this will replace the existing balance entirely, are you sure?`
 					);
 				}
 				await msg.confirm(
 					`Are you sure you want to add ${formatDuration(ms)} of Tier ${tier} patron to ${input.username}?`
 				);
 				await input.settings.update(UserSettings.PremiumBalanceTier, tier);
-				if (currentBalanceTime !== null) {
+				if (currentBalanceTime !== null && tier === currentBalanceTier) {
 					await input.settings.update(UserSettings.PremiumBalanceExpiryDate, currentBalanceTime + ms);
 				} else {
 					await input.settings.update(UserSettings.PremiumBalanceExpiryDate, Date.now() + ms);

--- a/src/commands/rp.ts
+++ b/src/commands/rp.ts
@@ -831,8 +831,9 @@ LIMIT 10;
 				const currentBalanceTier = input.settings.get(UserSettings.PremiumBalanceTier);
 				const currentBalanceTime = input.settings.get(UserSettings.PremiumBalanceExpiryDate);
 
-				if (input.perkTier > 1 && !currentBalanceTier) {
-					return msg.channel.send(`${input.username} is already a patron.`);
+				const oldPerkTier = input.perkTier;
+				if (oldPerkTier > 1 && !currentBalanceTier && oldPerkTier <= tier + 1) {
+					return msg.channel.send(`${input.username} is already a patron of at least that tier.`);
 				}
 				if (currentBalanceTier !== null && currentBalanceTier !== tier) {
 					return msg.channel.send(

--- a/src/commands/rp.ts
+++ b/src/commands/rp.ts
@@ -846,16 +846,19 @@ LIMIT 10;
 					`Are you sure you want to add ${formatDuration(ms)} of Tier ${tier} patron to ${input.username}?`
 				);
 				await input.settings.update(UserSettings.PremiumBalanceTier, tier);
+
+				let newBalanceExpiryTime = 0;
 				if (currentBalanceTime !== null && tier === currentBalanceTier) {
-					await input.settings.update(UserSettings.PremiumBalanceExpiryDate, currentBalanceTime + ms);
+					newBalanceExpiryTime = currentBalanceTime + ms;
 				} else {
-					await input.settings.update(UserSettings.PremiumBalanceExpiryDate, Date.now() + ms);
+					newBalanceExpiryTime = Date.now() + ms;
 				}
+				await input.settings.update(UserSettings.PremiumBalanceExpiryDate, newBalanceExpiryTime);
 
 				return msg.channel.send(
 					`Gave ${formatDuration(ms)} of Tier ${tier} patron to ${input.username}. They have ${formatDuration(
-						input.settings.get(UserSettings.PremiumBalanceExpiryDate)! - Date.now()
-					)} remaning.`
+						newBalanceExpiryTime - Date.now()
+					)} remaining.`
 				);
 			}
 		}


### PR DESCRIPTION
### Description:

Currently there's a few issues with addptime.

1. It won't let you give some ptime if they're already a patron. Even if you try to give a higher tier.
2. If someone has ptime already, you can't do anything except add more of that same tier.

This fixes both issues, and essentially also allows you to remove ptime, but adding a new Tier with duration 1s.

### Changes:

1. Allows adding Ptime even if patron, as long as it's a higher tier
2. Allows adding/changing ptime to a different tier, enabling removal as well.
3. Cleans up the settings code to make it a little easier to implement mahoji and move away from SG.


### Other checks:

-   [x] I have tested all my changes thoroughly.
