### PR TITLE
BSO - Include Doug and Dwarven Pickaxe Messages to VM

### DIFF
--- a/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
@@ -150,6 +150,10 @@ export async function volcanicMineCommand(user: KlasaUser, channelID: bigint, ga
 
 	await user.removeItemsFromBank(suppliesUsage);
 
+	if (user.usingPet('Doug')) {
+		boosts.push('20% more Mining XP for having Doug helping you!');
+	}
+
 	let duration = VolcanicMineGameTime * gameQuantity;
 
 	const str = `${

--- a/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
@@ -114,7 +114,9 @@ export async function volcanicMineCommand(user: KlasaUser, channelID: bigint, ga
 		.add('Numulite', 30);
 
 	// Activity boosts
-	if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {
+	if (userMiningLevel >= 99 && userSkillingGear.hasEquipped('Dwarven pickaxe')) {
+		boosts.push(`3x boost for having a ${userSkillingGear.equippedWeapon()?.name ?? 'Dwarven pickaxe'} equipped.`);
+	} else if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {
 		boosts.push(`50% boost for having a ${userSkillingGear.equippedWeapon()?.name ?? 'Crystal pickaxe'} equipped.`);
 	} else if (userMiningLevel >= 61 && userSkillingGear.hasEquipped('Dragon pickaxe')) {
 		boosts.push(`30% boost for having a ${userSkillingGear.equippedWeapon()?.name ?? 'Dragon pickaxe'} equipped.`);


### PR DESCRIPTION
### Description:

Adds Doug and Dwarven Pickaxe boosts to the Volcanic Mine trip start message if they are equipped.

Closes #3938 

### Other checks:

-   [x] I have tested all my changes thoroughly.
