### PR TITLE
Fix birdhouse bug

### DIFF
--- a/src/mahoji/lib/abstracted_commands/birdhousesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/birdhousesCommand.ts
@@ -211,7 +211,7 @@ export async function birdhouseHarvestCommand(
 	let canPay = false;
 	for (const currentSeed of birdhouseSeedReq) {
 		const seedCost = new Bank().add(currentSeed.itemID, currentSeed.amount * 4);
-		if (!userBank.has(seedCost)) {
+		if (userBank.has(seedCost)) {
 			infoStr.push(`You baited the birdhouses with ${seedCost}.`);
 			removeBank.add(seedCost);
 			canPay = true;


### PR DESCRIPTION
### Description:

Birdhouses are currently not usable, because if you have enough seeds, it acts like you don't, and if you don't have enough seeds, then it tries to pull those out later, and you, of course, don't have it, so it fails either way.

### Changes:

Removed erroneous negation operator

### Other checks:

-   [ ] I have tested all my changes thoroughly.
