### PR TITLE
Fix open bugs

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -103,8 +103,6 @@ for (const clueTier of ClueTiers) {
 				return { bank: loot };
 			}
 
-			await user.incrementClueScore(clueTier.id, quantity);
-
 			if (mimicNumber > 0) {
 				await user.incrementMonsterScore(MIMIC_MONSTER_ID, mimicNumber);
 			}

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -194,7 +194,13 @@ export async function abstractedOpenCommand(
 	}
 
 	if (!openables.length) return "That's not a valid item.";
-
+	// This code will only execute if we're not in auto/all mode:
+	if (typeof _quantity === 'number') {
+		for (const openable of openables) {
+			const tmpCost = new Bank().add(openable.id, _quantity);
+			if (!bank.has(tmpCost)) return `You don't own ${tmpCost}`;
+		}
+	}
 	const cost = new Bank();
 	const kcBank = new Bank();
 	const loot = new Bank();


### PR DESCRIPTION
### Description
People are able to open any amount of caskets they don't have, and the loot is processed, shows up in the notitfications, AND counts to their openable scores.
Also all clues are being counted twice.
![image](https://user-images.githubusercontent.com/10122432/170157116-91a1eee2-a1d3-4696-bd95-b2fe716ff76c.png)


### Changes:

- Stop double counting clue opens
- Don't process the openable if they don't have the quantity

### Other checks:

-   [x] I have tested all my changes thoroughly.
