### PR TITLE
Merge clueScores into openable_scores

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -249,7 +249,6 @@ model User {
   bank                       Json     @default("{}") @db.Json
   collectionLogBank          Json     @default("{}") @db.JsonB
   creatureScores             Json     @default("{}") @db.Json
-  clueScores                 Json     @default("{}") @db.Json
   monsterScores              Json     @default("{}") @db.Json
   lapsScores                 Json     @default("{}") @db.Json
   bankBackground             Int      @default(1)

--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -4,7 +4,6 @@ import { CommandStore, KlasaMessage, util } from 'klasa';
 import { production } from '../../config';
 import { badges, Emoji } from '../../lib/constants';
 import { getCollectionItems } from '../../lib/data/Collections';
-import ClueTiers from '../../lib/minions/data/clueTiers';
 import { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
 import { allOpenables } from '../../lib/openables';
 import { prisma } from '../../lib/settings/prisma';
@@ -440,27 +439,15 @@ ORDER BY u.sacbanklength DESC LIMIT 10;`;
 		let key = '';
 		let openableName = '';
 
-		const clue = !name
+		const openable = !name
 			? undefined
-			: ClueTiers.find(
-					clue => stringMatches(clue.name, name) || clue.name.toLowerCase().includes(name.toLowerCase())
+			: allOpenables.find(
+					item => stringMatches(item.name, name) || item.name.toLowerCase().includes(name.toLowerCase())
 			  );
-
-		if (clue) {
-			entityID = clue.id;
-			key = 'clueScores';
-			openableName = clue.name;
-		} else {
-			const openable = !name
-				? undefined
-				: allOpenables.find(
-						item => stringMatches(item.name, name) || item.name.toLowerCase().includes(name.toLowerCase())
-				  );
-			if (openable) {
-				entityID = openable.id;
-				key = 'openable_scores';
-				openableName = openable.name;
-			}
+		if (openable) {
+			entityID = openable.id;
+			key = 'openable_scores';
+			openableName = openable.name;
 		}
 
 		if (entityID === -1) {

--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -58,7 +58,7 @@ export default class extends BotCommand {
 
 		const [timeToFinish, percentReduced] = reducedClueTime(
 			clueTier,
-			msg.author.settings.get(UserSettings.ClueScores)[clueTier.id] ?? 1
+			msg.author.settings.get(UserSettings.OpenableScores)[clueTier.id] ?? 1
 		);
 
 		if (percentReduced >= 1) boosts.push(`${percentReduced}% for clue score`);

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -619,7 +619,7 @@ Type \`confirm\` if you understand the above information, and want to become an 
 		let res = `${Emoji.Casket} **${msg.author.minionName}'s Clue Scores:**\n\n`;
 		for (const [clueID, clueScore] of Object.entries(clueScores.bank)) {
 			const clue = ClueTiers.find(c => c.id === parseInt(clueID));
-			res += `**${clue!.name}**: ${clueScore}\n`;
+			res += `**${clue!.name}**: ${clueScore.toLocaleString()}\n`;
 		}
 		return msg.channel.send(res);
 	}

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -606,17 +606,17 @@ Type \`confirm\` if you understand the above information, and want to become an 
 		const userData = await mahojiUsersSettingsFetch(msg.author.id, {
 			openable_scores: true
 		});
-		const openableScores = userData.openable_scores as ItemBank;
-		if (!openableScores || openableScores.length === 0) return msg.channel.send("You haven't done any clues yet.");
+		const openableScores = new Bank(userData.openable_scores as ItemBank);
+		if (openableScores.length === 0) return msg.channel.send("You haven't done any clues yet.");
+
+		// Make array of [name, score] for each clue that exists in openable_scores:
+		const clueScores = ClueTiers.map(ct => [ct.name, openableScores.bank[String(ct.id)] ?? 0]).filter(
+			score => score[1] > 0
+		);
+		if (clueScores.length === 0) return msg.channel.send("You haven't done any clues yet.");
 
 		let res = `${Emoji.Casket} **${msg.author.minionName}'s Clue Scores:**\n\n`;
-		for (const clue of ClueTiers) {
-			const clueScore = openableScores[String(clue.id)] ?? 0;
-			if (clueScore) {
-				res += `**${clue!.name}**: ${clueScore}\n`;
-			}
-		}
-
+		res += clueScores.map(score => `**${score[0]}**: ${score[1]}`).join('\n');
 		return msg.channel.send(res);
 	}
 

--- a/src/commands/Patrons/botstats.ts
+++ b/src/commands/Patrons/botstats.ts
@@ -120,13 +120,14 @@ GROUP BY "bankBackground";`);
 		const totalBank: { [key: string]: number } = {};
 
 		const res: any = await this._query(
-			'SELECT ARRAY(SELECT "clueScores" FROM users WHERE "clueScores"::text <> \'{}\'::text);'
+			"SELECT ARRAY(SELECT openable_scores FROM users WHERE openable_scores::text <> '{}'::text);"
 		);
 
 		const banks: ItemBank[] = res[0].array;
-
+		console.log(banks);
 		banks.map(bank => {
 			for (const [id, qty] of Object.entries(bank)) {
+				if (!ClueTiers.find(ct => ct.id === Number(id))) continue;
 				if (!totalBank[id]) totalBank[id] = qty;
 				else totalBank[id] += qty;
 			}

--- a/src/commands/Patrons/botstats.ts
+++ b/src/commands/Patrons/botstats.ts
@@ -124,7 +124,7 @@ GROUP BY "bankBackground";`);
 		);
 
 		const banks: ItemBank[] = res[0].array;
-		console.log(banks);
+
 		banks.map(bank => {
 			for (const [id, qty] of Object.entries(bank)) {
 				if (!ClueTiers.find(ct => ct.id === Number(id))) continue;

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -861,13 +861,6 @@ export default class extends Extendable {
 		);
 	}
 
-	public async incrementClueScore(this: User, clueID: number, amountToAdd = 1) {
-		await this.settings.sync(true);
-		const currentClueScores = this.settings.get(UserSettings.ClueScores);
-
-		return this.settings.update(UserSettings.ClueScores, addItemToBank(currentClueScores, clueID, amountToAdd));
-	}
-
 	public async incrementCreatureScore(this: User, creatureID: number, amountToAdd = 1) {
 		await this.settings.sync(true);
 		const currentCreatureScores = this.settings.get(UserSettings.CreatureScores);

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -359,7 +359,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['beginner', 'clues beginner', 'clue beginner'],
 				allItems: Clues.Beginner.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[23_245] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[23_245] || 0
 				},
 				items: cluesBeginnerCL,
 
@@ -369,7 +369,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['easy', 'clues easy', 'clue easy'],
 				allItems: Clues.Easy.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_546] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_546] || 0
 				},
 				items: cluesEasyCL,
 
@@ -379,7 +379,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['medium', 'clues medium', 'clue medium'],
 				allItems: Clues.Medium.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_545] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_545] || 0
 				},
 				items: cluesMediumCL,
 				isActivity: true
@@ -388,7 +388,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['hard', 'clues hard', 'clue hard'],
 				allItems: Clues.Hard.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_544] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_544] || 0
 				},
 				items: cluesHardCL,
 				isActivity: true
@@ -397,7 +397,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['elite', 'clues elite', 'clue elite'],
 				allItems: Clues.Elite.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_543] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_543] || 0
 				},
 				items: cluesEliteCL,
 				isActivity: true
@@ -406,7 +406,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['master', 'clues master', 'clue master'],
 				allItems: Clues.Master.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[19_836] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[19_836] || 0
 				},
 				items: cluesMasterCL,
 				isActivity: true
@@ -422,7 +422,7 @@ export const allCollectionLogs: ICollection = {
 					'clues rare hard'
 				],
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_544] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_544] || 0
 				},
 				items: cluesHardRareCL,
 				isActivity: true
@@ -438,7 +438,7 @@ export const allCollectionLogs: ICollection = {
 					'clues rare elite'
 				],
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_543] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_543] || 0
 				},
 				items: cluesEliteRareCL,
 				isActivity: true
@@ -454,7 +454,7 @@ export const allCollectionLogs: ICollection = {
 					'clues rare master'
 				],
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[19_836] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[19_836] || 0
 				},
 				items: cluesMasterRareCL,
 				isActivity: true
@@ -462,13 +462,17 @@ export const allCollectionLogs: ICollection = {
 			'Shared Treasure Trail Rewards': {
 				alias: ['shared', 'clues shared', 'clue shared'],
 				kcActivity: {
-					Default: async user =>
-						(user.settings.get(UserSettings.ClueScores)[23_245] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_546] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_545] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_544] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_543] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[19_836] || 0)
+					Default: async user => {
+						const scores = user.settings.get(UserSettings.OpenableScores);
+						return (
+							(scores[23_245] ?? 0) +
+							(scores[20_546] ?? 0) +
+							(scores[20_545] ?? 0) +
+							(scores[20_544] ?? 0) +
+							(scores[20_543] ?? 0) +
+							(scores[19_836] ?? 0)
+						);
+					}
 				},
 				items: cluesSharedCL,
 
@@ -477,10 +481,10 @@ export const allCollectionLogs: ICollection = {
 			'Rare Treasure Trail Rewards': {
 				alias: ['clues rare', 'rares'],
 				kcActivity: {
-					Default: async user =>
-						(user.settings.get(UserSettings.ClueScores)[20_544] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_543] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[19_836] || 0)
+					Default: async user => {
+						const scores = user.settings.get(UserSettings.OpenableScores);
+						return (scores[20_544] ?? 0) + (scores[20_543] ?? 0) + (scores[19_836] ?? 0);
+					}
 				},
 				items: [...cluesHardRareCL, ...cluesEliteRareCL, ...cluesMasterRareCL],
 				isActivity: true

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -75,7 +75,7 @@ for (const clueTier of ClueTiers) {
 				mimicNumber > 0 ? `with ${mimicNumber} mimic${mimicNumber > 1 ? 's' : ''}` : ''
 			}`;
 
-			const nthCasket = (user.settings.get(UserSettings.ClueScores)[clueTier.id] ?? 0) + quantity;
+			const nthCasket = (user.settings.get(UserSettings.OpenableScores)[clueTier.id] ?? 0) + quantity;
 
 			// If this tier has a milestone reward, and their new score meets the req, and
 			// they don't own it already, add it to the loot.

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -103,8 +103,6 @@ for (const clueTier of ClueTiers) {
 				return { bank: loot };
 			}
 
-			await user.incrementClueScore(clueTier.id, quantity);
-
 			if (mimicNumber > 0) {
 				await user.incrementMonsterScore(MIMIC_MONSTER_ID, mimicNumber);
 			}

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -26,7 +26,6 @@ Client.defaultUserSchema
 	.add('bank', 'any', { default: {} })
 	.add('collectionLogBank', 'any', { default: {} })
 	.add('creatureScores', 'any', { default: {} })
-	.add('clueScores', 'any', { default: {} })
 	.add('monsterScores', 'any', { default: {} })
 	.add('lapsScores', 'any', { default: {} })
 	.add('bankBackground', 'integer', { default: 1 })

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -28,7 +28,6 @@ export namespace UserSettings {
 	export const CollectionLogBank = T<Readonly<ItemBank>>('collectionLogBank');
 	export const MonsterScores = T<Readonly<ItemBank>>('monsterScores');
 	export const CreatureScores = T<Readonly<ItemBank>>('creatureScores');
-	export const ClueScores = T<Readonly<ItemBank>>('clueScores');
 	export const LapsScores = T<Readonly<ItemBank>>('lapsScores');
 	export const LastDailyTimestamp = T<number>('lastDailyTimestamp');
 	export const LastTearsOfGuthixTimestamp = T<number>('lastTearsOfGuthixTimestamp');

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -147,7 +147,6 @@ declare module 'discord.js' {
 		specialRemoveItems(items: Bank): Promise<{ realCost: Bank }>;
 		addItemsToCollectionLog(options: { items: Bank; dontAddToTempCL?: boolean }): Promise<SettingsUpdateResult>;
 		incrementMonsterScore(monsterID: number, numberToAdd?: number): Promise<SettingsUpdateResult>;
-		incrementClueScore(clueID: number, numberToAdd?: number): Promise<SettingsUpdateResult>;
 		incrementCreatureScore(creatureID: number, numberToAdd?: number): Promise<SettingsUpdateResult>;
 		log(stringLog: string): void;
 		addQP(amount: number): Promise<SettingsUpdateResult>;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -33,7 +33,6 @@ import { getSkillsOfMahojiUser } from '../mahoji/mahojiSettings';
 import { CENA_CHARS, continuationChars, PerkTier, skillEmoji, SupportServer } from './constants';
 import { DefenceGearStat, GearSetupType, GearSetupTypes, GearStat, OffenceGearStat } from './gear/types';
 import clueTiers from './minions/data/clueTiers';
-import ClueTiers from './minions/data/clueTiers';
 import { Consumable } from './minions/types';
 import { POHBoosts } from './poh';
 import { prisma } from './settings/prisma';
@@ -796,5 +795,5 @@ export async function asyncGzip(buffer: Buffer) {
 }
 
 export function getClueScoresFromOpenables(openableScores: Bank, mutate = false) {
-	return openableScores.filter(item => Boolean(ClueTiers.find(ct => ct.id === item.id)), mutate);
+	return openableScores.filter(item => Boolean(clueTiers.find(ct => ct.id === item.id)), mutate);
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -33,6 +33,7 @@ import { getSkillsOfMahojiUser } from '../mahoji/mahojiSettings';
 import { CENA_CHARS, continuationChars, PerkTier, skillEmoji, SupportServer } from './constants';
 import { DefenceGearStat, GearSetupType, GearSetupTypes, GearStat, OffenceGearStat } from './gear/types';
 import clueTiers from './minions/data/clueTiers';
+import ClueTiers from './minions/data/clueTiers';
 import { Consumable } from './minions/types';
 import { POHBoosts } from './poh';
 import { prisma } from './settings/prisma';
@@ -792,4 +793,8 @@ export async function asyncGzip(buffer: Buffer) {
 			resolve(gzipped);
 		});
 	});
+}
+
+export function getClueScoresFromOpenables(openableScores: Bank, mutate = false) {
+	return openableScores.filter(item => Boolean(ClueTiers.find(ct => ct.id === item.id)), mutate);
 }

--- a/src/lib/util/minionStatsEmbed.ts
+++ b/src/lib/util/minionStatsEmbed.ts
@@ -1,6 +1,7 @@
 import { Embed } from '@discordjs/builders';
 import { shuffleArr } from 'e';
 import { KlasaUser } from 'klasa';
+import { Bank } from 'oldschooljs';
 import { SkillsScore } from 'oldschooljs/dist/meta/types';
 import { convertXPtoLVL, toKMB } from 'oldschooljs/dist/util';
 
@@ -11,8 +12,8 @@ import { getAllMinigameScores } from '../settings/settings';
 import { UserSettings } from '../settings/types/UserSettings';
 import { courses } from '../skilling/skills/agility';
 import creatures from '../skilling/skills/hunter/creatures';
-import { Skills } from '../types';
-import { addArrayOfNumbers, toTitleCase } from '../util';
+import { ItemBank, Skills } from '../types';
+import { addArrayOfNumbers, getClueScoresFromOpenables, toTitleCase } from '../util';
 import { logError } from './logError';
 
 export async function minionStatsEmbed(user: KlasaUser): Promise<Embed> {
@@ -34,7 +35,10 @@ export async function minionStatsEmbed(user: KlasaUser): Promise<Embed> {
 		).toLocaleString()} (${toKMB(skillXP)})`;
 	};
 
-	const clueEntries = Object.entries(user.settings.get(UserSettings.ClueScores));
+	const openableScores = new Bank(user.settings.get(UserSettings.OpenableScores) as ItemBank);
+	getClueScoresFromOpenables(openableScores, true);
+
+	const clueEntries = Object.entries(openableScores.bank);
 	const minigameScores = (await getAllMinigameScores(user.id))
 		.filter(i => i.score > 0)
 		.sort((a, b) => b.score - a.score);

--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -321,9 +321,9 @@ LIMIT 1;`
 				await Promise.all(
 					ClueTiers.map(t =>
 						q(
-							`SELECT id, '${t.name}' as n, ("clueScores"->>'${t.id}')::int as qty
+							`SELECT id, '${t.name}' as n, (openable_scores->>'${t.id}')::int as qty
 FROM users
-WHERE "clueScores"->>'${t.id}' IS NOT NULL
+WHERE "openable_scores"->>'${t.id}' IS NOT NULL
 ORDER BY qty DESC
 LIMIT 1;`
 						)


### PR DESCRIPTION
### Description:

As discussed, this will merge clueScores into openable_scores.

You have the SQL necessary, or can ask me for it, I have it saved.


### Changes:

- Only updates openable_scores from now on when opening clues
- `+m clues` will read from openable_scores
- `+lb open CLUE TIER` will now read from openable_scores
- Removes ClueScores from UserSettings
- Points +botstats to openables
- Points collectionlog KC's to openables
- Changes clue opening milestones to check openables
- **Changes collection log functions to only call settings.get once in preparation for mahoji converison.**
- Updates minionStatsembed to look for clue scores in openables
- Removes User.incrementClueScore
- Adds utility function getClueScoresFromOpenables() to convert a Bank of Openable scores to exclusively Clue Scores

### Other checks:

-   [x] I have tested all my changes thoroughly.
