### PR TITLE
Phosani boosts work equipped

### DIFF
--- a/src/commands/Minion/nightmare.ts
+++ b/src/commands/Minion/nightmare.ts
@@ -256,7 +256,7 @@ export default class extends BotCommand {
 			}
 			if (isPhosani) {
 				effectiveTime = reduceNumByPercent(effectiveTime, 31);
-				if (user.owns('Dragon claws')) {
+				if (user.hasItemEquippedOrInBank('Dragon claws')) {
 					effectiveTime = reduceNumByPercent(effectiveTime, 3);
 					soloBoosts.push('3% for Dragon claws');
 				}
@@ -264,7 +264,7 @@ export default class extends BotCommand {
 					effectiveTime = reduceNumByPercent(effectiveTime, 3);
 					soloBoosts.push('3% for Harmonised nightmare staff');
 				}
-				if (user.owns('Elder maul')) {
+				if (user.hasItemEquippedOrInBank('Elder maul')) {
 					effectiveTime = reduceNumByPercent(effectiveTime, 3);
 					soloBoosts.push('3% for Elder maul');
 				}


### PR DESCRIPTION
Allows the elder maul and dragon claws boosts to work equipped or from bank, rather than just in bank.

-   [ ] I have tested all my changes thoroughly.
