### PR TITLE
adjust clueFilter minion buttons

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -216,7 +216,10 @@ export default class MinionCommand extends BotCommand {
 		}
 
 		const bank = msg.author.bank();
-		for (const tier of ClueTiers.filter(t => bank.has(t.scrollID) && ClueTiers.indexOf(t) > 2)) {
+
+		for (const tier of ClueTiers.filter(t => bank.has(t.scrollID))
+			.reverse()
+			.slice(0, 3)) {
 			dynamicButtons.add({
 				name: `Do ${tier.name} Clue`,
 				fn: () => {


### PR DESCRIPTION
### Description:

Changed so that it creates up to 3 buttons for the highest tiered clue scrolls that are owned.

### Changes:

Adjusted the filter for ClueTiers on the minion command.

### Other checks:

-   [X] I have tested all my changes thoroughly.
