### PR TITLE
BSO - KG BiS gear text

### DIFF
--- a/src/commands/bso/kinggoldemar.ts
+++ b/src/commands/bso/kinggoldemar.ts
@@ -55,7 +55,7 @@ export default class extends BotCommand {
 				legs: 'Gorajan warrior legs',
 				hands: 'Gorajan warrior gloves',
 				feet: 'Gorajan warrior boots',
-				cape: 'Abyssal cape',
+				cape: 'TzKal cape',
 				ring: 'Warrior ring(i)',
 				weapon: 'Drygore longsword',
 				shield: 'Offhand drygore longsword',


### PR DESCRIPTION
Updates the king goldemar bis gear to the TzKal cape, which will then change the trip message to the correct cape.

-   [ ] I have tested all my changes thoroughly.
