### PR TITLE
Fix pesky DB constraint conflicts

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -544,6 +544,8 @@ Type \`confirm\` if you understand the above information, and want to become an 
 			minion_hasBought: true,
 			minion_bought_date: new Date()
 		});
+		await msg.author.settings.sync(true);
+
 		return msg.channel.send({
 			embeds: [
 				new MessageEmbed().setTitle('Your minion is now ready to use!').setDescription(

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -544,8 +544,6 @@ Type \`confirm\` if you understand the above information, and want to become an 
 			minion_hasBought: true,
 			minion_bought_date: new Date()
 		});
-		await msg.author.settings.sync(true);
-
 		return msg.channel.send({
 			embeds: [
 				new MessageEmbed().setTitle('Your minion is now ready to use!').setDescription(

--- a/src/tasks/dailyReminder.ts
+++ b/src/tasks/dailyReminder.ts
@@ -31,7 +31,17 @@ export default class extends Task {
 					const user = await globalClient.fetchUser(row.id);
 					if (user.settings.get(UserSettings.LastDailyTimestamp) === -1) continue;
 
-					await user.settings.update(UserSettings.LastDailyTimestamp, -1);
+					try {
+						await user.settings.update(UserSettings.LastDailyTimestamp, -1);
+					} catch (e) {
+						logError(e, {
+							msg: 'Unable to update settings, syncing user first.',
+							user_id: user.id,
+							context: 'dailyReminder.ts'
+						});
+						await user.settings.sync(true);
+						await user.settings.update(UserSettings.LastDailyTimestamp, -1);
+					}
 					await user.send('Your daily is ready!').catch(noOp);
 				}
 			} catch (err) {


### PR DESCRIPTION
### Description:

This bug seems to be related to SG not knowing the user exists and attempting to create the row even after it's been created.

### Changes:

- Adds a try/catch around the dailyReminder settings update to catch when a force sync might be necessary, and then retries.

### Other checks:

-   [] I have tested all my changes thoroughly.
