### PR TITLE
Fix hespori KC tracking

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -382,7 +382,7 @@ export default class extends Task {
 
 			let tangleroot = false;
 			if (plantToHarvest.seedType === 'hespori') {
-				await user.incrementMonsterScore(Monsters.Hespori.id);
+				await user.incrementMonsterScore(Monsters.Hespori.id, patchType.lastQuantity);
 				const hesporiLoot = Monsters.Hespori.kill(patchType.lastQuantity, {
 					farmingLevel: currentFarmingLevel
 				});


### PR DESCRIPTION
### Description:

Hespori only giving 1 kc per harvest, regardless how many are planted.

### Changes:

- Adds patchType.lastQuantity to the numKillsToAdd parameter of incMonsterScore

### Other checks:

-   [ ] I have tested all my changes thoroughly.
