### PR TITLE
Allow Slepey tablet drop if you don't have the CL

### DIFF
--- a/src/tasks/minions/minigames/nightmareActivity.ts
+++ b/src/tasks/minions/minigames/nightmareActivity.ts
@@ -70,7 +70,10 @@ export default class extends Task {
 					deaths[user.id] = deaths[user.id] ? ++deaths[user.id] : 1;
 					kcAmounts[user.id]--;
 				} else {
-					if (user.owns('Slepey tablet') || user.bitfield.includes(BitField.HasSlepeyTablet)) {
+					if (
+						user.cl().has('Slepey tablet') &&
+						(user.owns('Slepey tablet') || user.bitfield.includes(BitField.HasSlepeyTablet))
+					) {
 						loot[user.id].remove('Slepey tablet', loot[user.id].amount('Slepey tablet'));
 					}
 					loot[user.id].bank;


### PR DESCRIPTION
### Description:

This doesn't affect OSB, which is why it's only being merged to BSO.
Currently, if you traded for a slepey tablet to activate it for the boost, you can not obtain it for the CL.

This corrects that problem.

### Changes:

- Allows the Slepey tablet drop if you don't have it on the CL, (along with the exist restrictions)

### Other checks:

-   [ ] I have tested all my changes thoroughly.

Closes #3319 