### PR TITLE
Fixed wrong enhanced crystal weapon seed requirement on amrod

### DIFF
--- a/src/lib/data/creatables/amrod.ts
+++ b/src/lib/data/creatables/amrod.ts
@@ -5,7 +5,7 @@ import { Createable } from '../createables';
 export const amrodCreatables: Createable[] = [
 	{
 		name: 'Revert crystal weapon seed',
-		inputItems: new Bank().add('Enhanced crystal weapon seed'),
+		inputItems: new Bank().add('Crystal weapon seed'),
 		outputItems: new Bank().add('Crystal shard', 10),
 		QPRequired: 150,
 		noCl: true


### PR DESCRIPTION

Revert crystal weapon seed has a wrong input item as **enhanced** crystal weapon seed

Edit made from github, not tested. But only a rename :shrugge: