### PR TITLE
modify glory death rates

### DIFF
--- a/src/tasks/minions/gloryChargingActivity.ts
+++ b/src/tasks/minions/gloryChargingActivity.ts
@@ -14,7 +14,7 @@ export default class extends Task {
 		let deaths = 0;
 		let loot = new Bank();
 		for (let i = 0; i < quantity; i++) {
-			if (roll(9)) {
+			if (roll(99)) {
 				deaths++;
 			} else {
 				for (let i = 0; i < gloriesInventorySize; i++) {


### PR DESCRIPTION
at the moment glory death rates are much higher than realistic to ingame rates, both anecdotally in having charged thousands myself only dying a handful of times, and also in a recent video from Torvesta where he only died twice in 56k glories. Instead of a 10% deathchance this modifies to a 1% death chance, so glories are still risked, but at a reasonable rate

video for reference where he discusses his 2 deaths 
https://youtu.be/aUA3VNTT2ck?t=682

### Description:

<!-- What did you change? Describe it here. -->

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

-   [ ] I have tested all my changes thoroughly.
