### PR TITLE
Improve Grand exchange filter response message

### DIFF
--- a/src/monitors/grandExchange.ts
+++ b/src/monitors/grandExchange.ts
@@ -2,6 +2,9 @@ import { KlasaMessage, Monitor, MonitorStore } from 'klasa';
 
 import { Channel, SupportServer } from '../lib/constants';
 
+const filteredCustomEmojis = ['redAlarm', 'blueAlarm'];
+const filteredEmojisRegex = filteredCustomEmojis.map(emoji => new RegExp(`<a?:${emoji}:\\d+>`));
+
 export default class extends Monitor {
 	public constructor(store: MonitorStore, file: string[], directory: string) {
 		super(store, file, directory, { enabled: true, ignoreOthers: false });
@@ -17,6 +20,8 @@ export default class extends Monitor {
 			return;
 		}
 
+		const reasons = [];
+		let failed = false;
 		if (
 			[
 				'seling',
@@ -31,13 +36,33 @@ export default class extends Monitor {
 				'trade',
 				'swap',
 				'swapping'
-			].every(str => !msg.content.toLowerCase().includes(str)) ||
-			msg.content.split(/\r\n|\r|\n/).length > 10 ||
-			msg.cleanContent.length > 450
+			].every(str => !msg.content.toLowerCase().includes(str))
 		) {
+			reasons.push('does not contain the words **buying** or **selling**');
+			failed = true;
+		}
+		if (msg.content.split(/\r\n|\r|\n/).length > 10) {
+			reasons.push('is more than 10 lines long');
+			failed = true;
+		}
+		if (msg.cleanContent.length > 450) {
+			reasons.push(`is more than 450 characters long (message length: ${msg.content.length})`);
+			failed = true;
+		}
+		if (filteredEmojisRegex.some(regex => msg.content.match(regex))) {
+			reasons.push('contains one or more blacklisted emojis');
+			failed = true;
+		}
+		if (failed) {
 			await msg.delete();
 			await msg.author.send(
-				'Your message was automatically removed from the grand exchange channel, because it was either over 10 lines long, over 450 characters long OR does not include the phrase "buying"/"selling". Please take a second to read the rules here: https://discordapp.com/channels/342983479501389826/682996313209831435/706772870923288618'
+				`Your message was automatically removed from the grand exchange channel, because it *${reasons.join(
+					', '
+				)}*.${
+					msg.cleanContent.length > 450
+						? '\n\n**Note:** Custom emojis use up a lot of characters because they are internally represented with their unique ID as well.'
+						: ''
+				}\n\nPlease take a second to read the rules here: https://discordapp.com/channels/342983479501389826/682996313209831435/706772870923288618`
 			);
 		}
 	}

--- a/src/monitors/grandExchange.ts
+++ b/src/monitors/grandExchange.ts
@@ -3,7 +3,10 @@ import { KlasaMessage, Monitor, MonitorStore } from 'klasa';
 import { Channel, SupportServer } from '../lib/constants';
 
 const filteredCustomEmojis = ['redAlarm', 'blueAlarm'];
-const filteredEmojisRegex = filteredCustomEmojis.map(emoji => new RegExp(`<a?:${emoji}:\\d+>`));
+const filteredEmojisRegex = [
+	new RegExp('<a:\\w+:\\d+>'),
+	...filteredCustomEmojis.map(emoji => new RegExp(`(<a?)?:${emoji}:(\\d+>)?`))
+];
 
 export default class extends Monitor {
 	public constructor(store: MonitorStore, file: string[], directory: string) {
@@ -50,7 +53,7 @@ export default class extends Monitor {
 			failed = true;
 		}
 		if (filteredEmojisRegex.some(regex => msg.content.match(regex))) {
-			reasons.push('contains one or more blacklisted emojis');
+			reasons.push('contains one or more animated/blacklisted emojis');
 			failed = true;
 		}
 		if (failed) {


### PR DESCRIPTION
### Description:

Currently, when a message is removed from GE, you get a generic message that isn't always helpful, and doesn't cover all possible reasons the message could be removed.

I initially planned to expand this with mod-enabled commands to blacklist emojis on the fly, but since we're going to lose the readmessage intent in the near future anyway, I figured this was a good solution to hold us over until then.


**Response to criticism:** 450 characters is already generous for GE messages. This limit is intentionally there to make you choose carefully which ads and emojis you want to use in your messaging. There is also a discord character limit that could easily be overrun if emojis didn't count toward the character limit.

### Changes:

 - Restricts usage of the red/blue alarm, and **all** animated emojis.
 - The DM you get from the bot now tells you exactly why your ad was removed.
 - An explanation is now given for long messages that could be from external emojis using a lot of characters.
 - Your message length is now displayed if that was the reason your message was rejected.

### Other checks:

-   [x] I have tested all my changes thoroughly.

Examples: (Users message only shown for example, the DM does not contain this obviously)
![image](https://user-images.githubusercontent.com/10122432/172070323-2e5e605b-10da-467d-b302-eda3d5b6ec79.png)
![image](https://user-images.githubusercontent.com/10122432/172070345-1706e8cc-a661-4e08-9b7a-343a9396b0cc.png)

