### PR TITLE
Remove Hallowed Sack from CL

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1137,7 +1137,6 @@ export const gnomeRestaurantCL = resolveItems(['Grand seed pod', 'Gnome scarf', 
 export const hallowedSepulchreCL = resolveItems([
 	'Hallowed mark',
 	'Hallowed token',
-	'Hallowed sack',
 	'Hallowed grapple',
 	'Hallowed focus',
 	'Hallowed symbol',


### PR DESCRIPTION
Following adding the hallowed sack as an openable and buyable, I incorrectly added it to the CL to. 

This removes it from the CL as per the osrs cl - https://oldschool.runescape.wiki/w/Collection_log#Hallowed_Sepulchre

-   [x] I have tested all my changes thoroughly.
