### PR TITLE
config cmd grammar

### DIFF
--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -618,7 +618,7 @@ export const configCommand: OSBMahojiCommand = {
 						{
 							type: ApplicationCommandOptionType.String,
 							name: 'name',
-							description: 'The thing you want to toggle on/off.',
+							description: 'The setting you want to toggle on/off.',
 							required: true,
 							autocomplete: async (value, user) => {
 								const mUser = await prisma.user.findFirst({


### PR DESCRIPTION
changed the word 'thing' to 'setting' on the config cmd