### PR TITLE
BSO - Smithing QoL Dwarven/Gorajan

### DIFF
--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -86,7 +86,12 @@ export const smithCommand: OSBMahojiCommand = {
 
 		let { quantity } = options;
 		// If no quantity provided, set it to the max.
-		if (!quantity) quantity = Math.floor(maxTripLength / timeToSmithSingleBar);
+		if (!quantity) {
+			quantity = Math.floor(maxTripLength / timeToSmithSingleBar);
+			if (smithedItem.name.includes('Dwarven') || smithedItem.name.includes('Gorajan')) {
+				quantity = 1;
+			}
+		}
 
 		await user.settings.sync(true);
 		const baseCost = new Bank(smithedItem.inputBars);


### PR DESCRIPTION
If no quantity is specified set quantity to be 1 to prevent people accidentally wasting bars.

This was in the previous command but got lost when moved to slash.

-   [ ] I have tested all my changes thoroughly.
