### PR TITLE
[BSO] Fix use double loot token

### DIFF
--- a/src/mahoji/lib/abstracted_commands/useCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/useCommand.ts
@@ -69,11 +69,6 @@ const usableUnlocks: UsableUnlock[] = [
 		item: getOSItem('Daemonheim agility pass'),
 		bitfield: BitField.HasDaemonheimAgilityPass,
 		resultMessage: 'You show your pass to the Daemonheim guards, and they grant you access to their rooftops.'
-	},
-	{
-		item: getOSItem('Double loot token'),
-		bitfield: BitField.HasDaemonheimAgilityPass,
-		resultMessage: 'You show your pass to the Daemonheim guards, and they grant you access to their rooftops.'
 	}
 ];
 for (const usableUnlock of usableUnlocks) {


### PR DESCRIPTION
### Description:

Currently, Daemonheim agility pass is duplicated, consuming Double loot token without activating the affect.

### Changes:

- removes duplicate entry for daemonheim agility pass

### Other checks:

-   [x] I have tested all my changes thoroughly.
