### PR TITLE
Only show available bankbgs.

### DIFF
--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -1,7 +1,7 @@
 import { FormattedCustomEmoji } from '@sapphire/discord.js-utilities';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
-import { MAX_LEVEL, PerkTier } from '../../lib/constants';
+import { BitField, MAX_LEVEL, PerkTier } from '../../lib/constants';
 import { degradeableItems } from '../../lib/degradeableItems';
 import { diaries } from '../../lib/diaries';
 import { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
@@ -100,10 +100,12 @@ export const minionCommand: OSBMahojiCommand = {
 					type: ApplicationCommandOptionType.String,
 					name: 'name',
 					description: 'The name of the bank background you want.',
-					autocomplete: async value => {
+					autocomplete: async (value, user) => {
+						const mahojiUser = await mahojiUsersSettingsFetch(user.id);
+						const isMod = mahojiUser.bitfield.includes(BitField.isModerator);
 						const bankImages = (globalClient.tasks.get('bankImage') as BankImageTask).backgroundImages;
 						return bankImages
-							.filter(bg => (!value ? true : bg.available))
+							.filter(bg => isMod || bg.available)
 							.filter(bg => (!value ? true : bg.name.toLowerCase().includes(value.toLowerCase())))
 							.map(i => {
 								const name = i.perkTierNeeded

--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -101,7 +101,7 @@ export const minionCommand: OSBMahojiCommand = {
 					name: 'name',
 					description: 'The name of the bank background you want.',
 					autocomplete: async (value, user) => {
-						const mahojiUser = await mahojiUsersSettingsFetch(user.id);
+						const mahojiUser = await mahojiUsersSettingsFetch(user.id, { bitfield: true });
 						const isMod = mahojiUser.bitfield.includes(BitField.isModerator);
 						const bankImages = (globalClient.tasks.get('bankImage') as BankImageTask).backgroundImages;
 						return bankImages


### PR DESCRIPTION
### Description:

Removes Bank BG's the user can't use from the menu (not including Patron tiers, I left those visible as an up-sell)


### Changes:

- Removes disabled backgrounds from the /bankbg option.

### Important:
 When merging to BSO, the first filter should be changed to:
`.filter(bg => isMod || bg.available || bg.owners?.includes(user.id))`

This will allow the filter to show the user's custom bg.

### Other checks:

-   [x] I have tested all my changes thoroughly.
