### PR TITLE
Make osbs ironman command bypassage

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -442,7 +442,8 @@ Type \`confirm\` if you understand the above information, and want to become an 
 
 			await msg.author.settings.update([
 				[UserSettings.Minion.Ironman, true],
-				[UserSettings.Minion.HasBought, true]
+				[UserSettings.Minion.HasBought, true],
+				[UserSettings.BitField, BitField.BypassAgeRestriction]
 			]);
 			return msg.channel.send('You are now an ironman.');
 		} catch (err) {


### PR DESCRIPTION
### Description:
Currently when a user makes a new ironman alt, they have to perform many steps:
0. Ask a mod to give them bronze role so they can talk in server.
1. Ask a mod to bypassage command them
2. Run +m ironman, and confirm
3. Ask a mod to be bypassed again, because +m ironman resets everyting
4. Run +m ironman --permanent. (--permanent flag only works if you're already iron)
5. Ask mod to link accounts.



### Changes
- Adds BypassAge account bitfield when an OSB (+) user runs `+m ironman`

### Other checks:

-   Copy/pasted working and tested code.
