### PR TITLE
Fix /bsominigames fishing_contest fish when no location specified

### DIFF
--- a/src/mahoji/commands/bsominigames.ts
+++ b/src/mahoji/commands/bsominigames.ts
@@ -222,10 +222,10 @@ export const minigamesCommand: OSBMahojiCommand = {
 		if (ourania_delivery_service?.stats) return odsStatsCommand(user);
 		if (ourania_delivery_service?.start) return odsStartCommand(klasaUser, channelID);
 
-		if (fishing_contest?.stats_info) return fishingContestStatsCommand(klasaUser);
-		if (fishing_contest?.fish) {
+		if (fishing_contest?.fish && fishing_contest.fish.location) {
 			return fishingContestStartCommand(klasaUser, channelID, fishing_contest.fish.location);
 		}
+		if (fishing_contest?.stats_info || fishing_contest) return fishingContestStatsCommand(klasaUser);
 
 		return 'Invalid command.';
 	}

--- a/src/mahoji/commands/bsominigames.ts
+++ b/src/mahoji/commands/bsominigames.ts
@@ -222,10 +222,10 @@ export const minigamesCommand: OSBMahojiCommand = {
 		if (ourania_delivery_service?.stats) return odsStatsCommand(user);
 		if (ourania_delivery_service?.start) return odsStartCommand(klasaUser, channelID);
 
-		if (fishing_contest?.fish && fishing_contest.fish.location) {
+		if (fishing_contest?.stats_info) return fishingContestStatsCommand(klasaUser);
+		if (fishing_contest?.fish) {
 			return fishingContestStartCommand(klasaUser, channelID, fishing_contest.fish.location);
 		}
-		if (fishing_contest?.stats_info || fishing_contest) return fishingContestStatsCommand(klasaUser);
 
 		return 'Invalid command.';
 	}

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -17,6 +17,7 @@ import { formatDuration, stringMatches, updateBankSetting } from '../../../lib/u
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 
 export async function fishingContestStartCommand(user: KlasaUser, channelID: bigint, loc: string) {
+	if (!loc) return fishingContestStatsCommand(user);
 	const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc));
 	if (!fishingLocation) {
 		return `That's not a valid location to fish at, you can fish at these locations: ${fishingLocations


### PR DESCRIPTION
### Description:

Currently, location is optional, and keeping it that way, and merging this PR best preserves the existing behavior to make the switch to slash commands as non-invasive as possible.

With this change, not specifying a location on the `fish` subcommand, is the same as choosing `stats_info`

**Currently, choosing `fish` without a location causing an Exception and error.**

### Changes:
- Handle missing location as a stats_info request.


### Other checks:

-   [x] I have tested all my changes thoroughly.
