### PR TITLE
Make sacrifice use overridden prices.

### DIFF
--- a/src/commands/Minion/sacrifice.ts
+++ b/src/commands/Minion/sacrifice.ts
@@ -9,6 +9,7 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { updateBankSetting } from '../../lib/util';
 import { parseInputCostBank } from '../../lib/util/parseStringBank';
+import { sellPriceOfItem } from './sell';
 
 async function trackSacBank(user: KlasaUser, bank: Bank) {
 	const currentSacBank = new Bank(user.settings.get(UserSettings.SacrificedBank));
@@ -77,7 +78,10 @@ export default class extends BotCommand {
 			);
 		}
 
-		const totalPrice = bankToSac.value();
+		let totalPrice = 0;
+		for (const [item, qty] of bankToSac.items()) {
+			totalPrice += sellPriceOfItem(item, 0).basePrice * qty;
+		}
 
 		await msg.confirm(
 			`${


### PR DESCRIPTION
### Description:

OSB + BSO both need this update ASAP to re-enable the +sacrifice command.

Currently, sacrifice doesn't use the mod-price-overrides, this will fix that.

### Changes:

- Adds call to sellPriceOfItem();

### Other checks:

-   [x] I have tested all my changes thoroughly.
