### PR TITLE
Distribute Unique Loot Correctly (Hydra/Totem/Sire)

### DIFF
--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -369,7 +369,6 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 	}
 
 	const combinedBank = new Bank().add(myBank).add(myLoot);
-
 	if (numBludgeonPieces) {
 		for (let x = 0; x < numBludgeonPieces; x++) {
 			const bank: number[] = [];
@@ -378,9 +377,11 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 				bank.push(combinedBank.amount(piece));
 			}
 			const minBank = Math.min(...bank);
+
 			for (let i = 0; i < bank.length; i++) {
 				if (bank[i] === minBank) {
 					myLoot.add(bludgeonPieces[i]);
+					combinedBank.add(bludgeonPieces[i]);
 					myClLoot.add(bludgeonPieces[i]);
 					break;
 				}
@@ -397,6 +398,7 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 			for (let i = 0; i < bank.length; i++) {
 				if (bank[i] === minBank) {
 					myLoot.add(totemPieces[i]);
+					combinedBank.add(totemPieces[i]);
 					myClLoot.add(totemPieces[i]);
 					break;
 				}
@@ -413,6 +415,7 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 			for (let i = 0; i < bank.length; i++) {
 				if (bank[i] === minBank) {
 					myLoot.add(ringPieces[i]);
+					combinedBank.add(ringPieces[i]);
 					myClLoot.add(ringPieces[i]);
 					break;
 				}


### PR DESCRIPTION
### Description:

At present the code correctly identifies which of the 3 possible items (for each scenario) the user has the least of and adds the loot to that one. The code fails to update the data it is using to identify the least had item which means it ends up just adding the same one over and over (only if multiple are obtained in one go).

### Changes:

Update `combinedLoot` with the newly added loot to assist in determining the new lowest value.

### Other checks:

-   [x] I have tested all my changes thoroughly.
