### PR TITLE
Merge clueScores into openable_scores

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -249,7 +249,6 @@ model User {
   bank                       Json     @default("{}") @db.Json
   collectionLogBank          Json     @default("{}") @db.JsonB
   creatureScores             Json     @default("{}") @db.Json
-  clueScores                 Json     @default("{}") @db.Json
   monsterScores              Json     @default("{}") @db.Json
   lapsScores                 Json     @default("{}") @db.Json
   bankBackground             Int      @default(1)

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -19,7 +19,8 @@ import { getFarmingInfo } from '../../lib/skilling/functions/getFarmingInfo';
 import Agility from '../../lib/skilling/skills/agility';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
-import { convertMahojiResponseToDJSResponse } from '../../lib/util';
+import { ItemBank } from '../../lib/types';
+import { convertLVLtoXP, convertMahojiResponseToDJSResponse, getClueScoresFromOpenables } from '../../lib/util';
 import { calculateBirdhouseDetails } from '../../mahoji/lib/abstracted_commands/birdhousesCommand';
 import { autoContract } from '../../mahoji/lib/abstracted_commands/farmingContractCommand';
 import { minionBuyCommand } from '../../mahoji/lib/abstracted_commands/minionBuyCommand';
@@ -348,13 +349,17 @@ export default class MinionCommand extends BotCommand {
 
 	@requiresMinion
 	async clues(msg: KlasaMessage) {
-		const clueScores = msg.author.settings.get(UserSettings.ClueScores);
-		if (Object.keys(clueScores).length === 0) return msg.channel.send("You haven't done any clues yet.");
+		const userData = await mahojiUsersSettingsFetch(msg.author.id, {
+			openable_scores: true
+		});
+
+		const clueScores = getClueScoresFromOpenables(new Bank(userData.openable_scores as ItemBank));
+		if (clueScores.length === 0) return msg.channel.send("You haven't done any clues yet.");
 
 		let res = `${Emoji.Casket} **${msg.author.minionName}'s Clue Scores:**\n\n`;
-		for (const [clueID, clueScore] of Object.entries(clueScores)) {
+		for (const [clueID, clueScore] of Object.entries(clueScores.bank)) {
 			const clue = ClueTiers.find(c => c.id === parseInt(clueID));
-			res += `**${clue!.name}**: ${clueScore}\n`;
+			res += `**${clue!.name}**: ${clueScore.toLocaleString()}\n`;
 		}
 		return msg.channel.send(res);
 	}

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -20,7 +20,7 @@ import Agility from '../../lib/skilling/skills/agility';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { BotCommand } from '../../lib/structures/BotCommand';
 import { ItemBank } from '../../lib/types';
-import { convertLVLtoXP, convertMahojiResponseToDJSResponse, getClueScoresFromOpenables } from '../../lib/util';
+import { convertMahojiResponseToDJSResponse, getClueScoresFromOpenables } from '../../lib/util';
 import { calculateBirdhouseDetails } from '../../mahoji/lib/abstracted_commands/birdhousesCommand';
 import { autoContract } from '../../mahoji/lib/abstracted_commands/farmingContractCommand';
 import { minionBuyCommand } from '../../mahoji/lib/abstracted_commands/minionBuyCommand';

--- a/src/extendables/User/Minion.ts
+++ b/src/extendables/User/Minion.ts
@@ -868,13 +868,6 @@ export default class extends Extendable {
 		);
 	}
 
-	public async incrementClueScore(this: User, clueID: number, amountToAdd = 1) {
-		await this.settings.sync(true);
-		const currentClueScores = this.settings.get(UserSettings.ClueScores);
-
-		return this.settings.update(UserSettings.ClueScores, addItemToBank(currentClueScores, clueID, amountToAdd));
-	}
-
 	public async incrementCreatureScore(this: User, creatureID: number, amountToAdd = 1) {
 		await this.settings.sync(true);
 		const currentCreatureScores = this.settings.get(UserSettings.CreatureScores);

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -361,7 +361,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['beginner', 'clues beginner', 'clue beginner'],
 				allItems: Clues.Beginner.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[23_245] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[23_245] || 0
 				},
 				items: cluesBeginnerCL,
 
@@ -371,7 +371,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['easy', 'clues easy', 'clue easy'],
 				allItems: Clues.Easy.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_546] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_546] || 0
 				},
 				items: cluesEasyCL,
 
@@ -381,7 +381,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['medium', 'clues medium', 'clue medium'],
 				allItems: Clues.Medium.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_545] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_545] || 0
 				},
 				items: cluesMediumCL,
 				isActivity: true
@@ -390,7 +390,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['hard', 'clues hard', 'clue hard'],
 				allItems: Clues.Hard.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_544] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_544] || 0
 				},
 				items: cluesHardCL,
 				isActivity: true
@@ -399,7 +399,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['elite', 'clues elite', 'clue elite'],
 				allItems: Clues.Elite.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_543] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_543] || 0
 				},
 				items: cluesEliteCL,
 				isActivity: true
@@ -408,7 +408,7 @@ export const allCollectionLogs: ICollection = {
 				alias: ['master', 'clues master', 'clue master'],
 				allItems: Clues.Master.allItems,
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[19_836] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[19_836] || 0
 				},
 				items: cluesMasterCL,
 				isActivity: true
@@ -424,7 +424,7 @@ export const allCollectionLogs: ICollection = {
 					'clues rare hard'
 				],
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_544] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_544] || 0
 				},
 				items: cluesHardRareCL,
 				isActivity: true
@@ -440,7 +440,7 @@ export const allCollectionLogs: ICollection = {
 					'clues rare elite'
 				],
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[20_543] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[20_543] || 0
 				},
 				items: cluesEliteRareCL,
 				isActivity: true
@@ -456,7 +456,7 @@ export const allCollectionLogs: ICollection = {
 					'clues rare master'
 				],
 				kcActivity: {
-					Default: async user => user.settings.get(UserSettings.ClueScores)[19_836] || 0
+					Default: async user => user.settings.get(UserSettings.OpenableScores)[19_836] || 0
 				},
 				items: cluesMasterRareCL,
 				isActivity: true
@@ -464,13 +464,17 @@ export const allCollectionLogs: ICollection = {
 			'Shared Treasure Trail Rewards': {
 				alias: ['shared', 'clues shared', 'clue shared'],
 				kcActivity: {
-					Default: async user =>
-						(user.settings.get(UserSettings.ClueScores)[23_245] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_546] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_545] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_544] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_543] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[19_836] || 0)
+					Default: async user => {
+						const scores = user.settings.get(UserSettings.OpenableScores);
+						return (
+							(scores[23_245] ?? 0) +
+							(scores[20_546] ?? 0) +
+							(scores[20_545] ?? 0) +
+							(scores[20_544] ?? 0) +
+							(scores[20_543] ?? 0) +
+							(scores[19_836] ?? 0)
+						);
+					}
 				},
 				items: cluesSharedCL,
 
@@ -479,10 +483,10 @@ export const allCollectionLogs: ICollection = {
 			'Rare Treasure Trail Rewards': {
 				alias: ['clues rare', 'rares'],
 				kcActivity: {
-					Default: async user =>
-						(user.settings.get(UserSettings.ClueScores)[20_544] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[20_543] || 0) +
-						(user.settings.get(UserSettings.ClueScores)[19_836] || 0)
+					Default: async user => {
+						const scores = user.settings.get(UserSettings.OpenableScores);
+						return (scores[20_544] ?? 0) + (scores[20_543] ?? 0) + (scores[19_836] ?? 0);
+					}
 				},
 				items: [...cluesHardRareCL, ...cluesEliteRareCL, ...cluesMasterRareCL],
 				isActivity: true

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -76,7 +76,7 @@ for (const clueTier of ClueTiers) {
 				mimicNumber > 0 ? `with ${mimicNumber} mimic${mimicNumber > 1 ? 's' : ''}` : ''
 			}`;
 
-			const nthCasket = (user.settings.get(UserSettings.ClueScores)[clueTier.id] ?? 0) + quantity;
+			const nthCasket = (user.settings.get(UserSettings.OpenableScores)[clueTier.id] ?? 0) + quantity;
 
 			// If this tier has a milestone reward, and their new score meets the req, and
 			// they don't own it already, add it to the loot.
@@ -103,8 +103,6 @@ for (const clueTier of ClueTiers) {
 			if (loot.length === 0) {
 				return { bank: loot };
 			}
-
-			await user.incrementClueScore(clueTier.id, quantity);
 
 			if (mimicNumber > 0) {
 				await user.incrementMonsterScore(MIMIC_MONSTER_ID, mimicNumber);

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -26,7 +26,6 @@ Client.defaultUserSchema
 	.add('bank', 'any', { default: {} })
 	.add('collectionLogBank', 'any', { default: {} })
 	.add('creatureScores', 'any', { default: {} })
-	.add('clueScores', 'any', { default: {} })
 	.add('monsterScores', 'any', { default: {} })
 	.add('lapsScores', 'any', { default: {} })
 	.add('bankBackground', 'integer', { default: 1 })

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -28,7 +28,6 @@ export namespace UserSettings {
 	export const CollectionLogBank = T<Readonly<ItemBank>>('collectionLogBank');
 	export const MonsterScores = T<Readonly<ItemBank>>('monsterScores');
 	export const CreatureScores = T<Readonly<ItemBank>>('creatureScores');
-	export const ClueScores = T<Readonly<ItemBank>>('clueScores');
 	export const LapsScores = T<Readonly<ItemBank>>('lapsScores');
 	export const LastDailyTimestamp = T<number>('lastDailyTimestamp');
 	export const LastTearsOfGuthixTimestamp = T<number>('lastTearsOfGuthixTimestamp');

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -133,7 +133,6 @@ declare module 'discord.js' {
 		specialRemoveItems(items: Bank): Promise<{ realCost: Bank }>;
 		addItemsToCollectionLog(options: { items: Bank; dontAddToTempCL?: boolean }): Promise<SettingsUpdateResult>;
 		incrementMonsterScore(monsterID: number, numberToAdd?: number): Promise<SettingsUpdateResult>;
-		incrementClueScore(clueID: number, numberToAdd?: number): Promise<SettingsUpdateResult>;
 		incrementCreatureScore(creatureID: number, numberToAdd?: number): Promise<SettingsUpdateResult>;
 		log(stringLog: string): void;
 		addQP(amount: number): Promise<SettingsUpdateResult>;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -778,3 +778,7 @@ export async function asyncGzip(buffer: Buffer) {
 export function getUsername(id: string | bigint) {
 	return usernameCache.get(id.toString()) ?? 'Unknown';
 }
+
+export function getClueScoresFromOpenables(openableScores: Bank, mutate = false) {
+	return openableScores.filter(item => Boolean(clueTiers.find(ct => ct.id === item.id)), mutate);
+}

--- a/src/lib/util/minionStatsEmbed.ts
+++ b/src/lib/util/minionStatsEmbed.ts
@@ -1,6 +1,7 @@
 import { Embed } from '@discordjs/builders';
 import { shuffleArr } from 'e';
 import { KlasaUser } from 'klasa';
+import { Bank } from 'oldschooljs';
 import { SkillsScore } from 'oldschooljs/dist/meta/types';
 import { convertXPtoLVL, toKMB } from 'oldschooljs/dist/util';
 
@@ -11,8 +12,8 @@ import { getAllMinigameScores } from '../settings/settings';
 import { UserSettings } from '../settings/types/UserSettings';
 import { courses } from '../skilling/skills/agility';
 import creatures from '../skilling/skills/hunter/creatures';
-import { Skills } from '../types';
-import { addArrayOfNumbers, toTitleCase } from '../util';
+import { ItemBank, Skills } from '../types';
+import { addArrayOfNumbers, getClueScoresFromOpenables, toTitleCase } from '../util';
 import { logError } from './logError';
 
 export async function minionStatsEmbed(user: KlasaUser): Promise<Embed> {
@@ -34,7 +35,10 @@ export async function minionStatsEmbed(user: KlasaUser): Promise<Embed> {
 		).toLocaleString()} (${toKMB(skillXP)})`;
 	};
 
-	const clueEntries = Object.entries(user.settings.get(UserSettings.ClueScores));
+	const openableScores = new Bank(user.settings.get(UserSettings.OpenableScores) as ItemBank);
+	getClueScoresFromOpenables(openableScores, true);
+
+	const clueEntries = Object.entries(openableScores.bank);
 	const minigameScores = (await getAllMinigameScores(user.id))
 		.filter(i => i.score > 0)
 		.sort((a, b) => b.score - a.score);

--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -49,7 +49,7 @@ export const clueCommand: OSBMahojiCommand = {
 
 		const [timeToFinish, percentReduced] = reducedClueTime(
 			clueTier,
-			user.settings.get(UserSettings.ClueScores)[clueTier.id] ?? 1
+			user.settings.get(UserSettings.OpenableScores)[clueTier.id] ?? 1
 		);
 
 		if (percentReduced >= 1) boosts.push(`${percentReduced}% for clue score`);

--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -5,7 +5,6 @@ import { ApplicationCommandOptionType, CommandRunOptions, MessageFlags } from 'm
 
 import { badges, Emoji, usernameCache } from '../../lib/constants';
 import { allClNames, getCollectionItems } from '../../lib/data/Collections';
-import ClueTiers from '../../lib/minions/data/clueTiers';
 import { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
 import { allOpenables } from '../../lib/openables';
 import { Minigames } from '../../lib/settings/minigames';
@@ -297,27 +296,15 @@ async function openLb(user: KlasaUser, channelID: bigint, name: string, ironmanO
 	let key = '';
 	let openableName = '';
 
-	const clue = !name
+	const openable = !name
 		? undefined
-		: ClueTiers.find(
-				clue => stringMatches(clue.name, name) || clue.name.toLowerCase().includes(name.toLowerCase())
+		: allOpenables.find(
+				item => stringMatches(item.name, name) || item.name.toLowerCase().includes(name.toLowerCase())
 		  );
-
-	if (clue) {
-		entityID = clue.id;
-		key = 'clueScores';
-		openableName = clue.name;
-	} else {
-		const openable = !name
-			? undefined
-			: allOpenables.find(
-					item => stringMatches(item.name, name) || item.name.toLowerCase().includes(name.toLowerCase())
-			  );
-		if (openable) {
-			entityID = openable.id;
-			key = 'openable_scores';
-			openableName = openable.name;
-		}
+	if (openable) {
+		entityID = openable.id;
+		key = 'openable_scores';
+		openableName = openable.name;
 	}
 
 	if (entityID === -1) {

--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -320,9 +320,9 @@ LIMIT 1;`
 				await Promise.all(
 					ClueTiers.map(t =>
 						q(
-							`SELECT id, '${t.name}' as n, ("clueScores"->>'${t.id}')::int as qty
+							`SELECT id, '${t.name}' as n, (openable_scores->>'${t.id}')::int as qty
 FROM users
-WHERE "clueScores"->>'${t.id}' IS NOT NULL
+WHERE "openable_scores"->>'${t.id}' IS NOT NULL
 ORDER BY qty DESC
 LIMIT 1;`
 						)


### PR DESCRIPTION
### Description:

As discussed, this will merge clueScores into openable_scores.

You have the SQL necessary, or can ask me for it, I have it saved.


### Changes:

- Only updates openable_scores from now on when opening clues
- `+m clues` will read from openable_scores
- `+lb open CLUE TIER` will now read from openable_scores
- Removes ClueScores from UserSettings
- Points collectionlog KC's to openables
- Changes clue opening milestones to check openables
- **Changes collection log functions to only call settings.get once in preparation for mahoji converison.**
- Updates minionStatsembed to look for clue scores in openables
- Removes User.incrementClueScore
- Adds utility function getClueScoresFromOpenables() to convert a Bank of Openable scores to exclusively Clue Scores

### Other checks:

-   [x] I have tested all my changes thoroughly.
