### PR TITLE
Fix DM Return Trips + Buttons

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -57,10 +57,9 @@ export async function interactionHook(data: APIInteraction) {
 	if (data.type !== InteractionType.MessageComponent) return;
 	const id = data.data.custom_id;
 	if (!isValidGlobalInteraction(id)) return;
-	const userID = data.member?.user?.id;
+	const userID = data.member ? data.member.user?.id : data.user?.id;
 	if (!userID) return;
 	const user = await mahojiUsersSettingsFetch(userID);
-
 	const options = {
 		user,
 		member: data.member ?? null,

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -101,7 +101,7 @@ export async function handleTripFinish(
 	const runCmdOptions = {
 		channelID,
 		userID: user.id,
-		guildID: isGuildBasedChannel(channel) ? channel.guild ? channel.guild.id : channel.id : undefined,
+		guildID: isGuildBasedChannel(channel) && channel.guild ? channel.guild.id : undefined,
 		user,
 		member: null
 	};
@@ -126,7 +126,6 @@ export async function handleTripFinish(
 
 	const casketReceived = loot ? ClueTiers.find(i => loot?.has(i.id)) : undefined;
 	if (casketReceived) components[0].push(makeOpenCasketButton(casketReceived));
-	
 	sendToChannelID(channelID, {
 		content: message,
 		image: attachment,


### PR DESCRIPTION
Fixes https://github.com/oldschoolgg/oldschoolbot/issues/4071

### Description:

At present you can interact with the bot using DMs but it fails to send any messages about the completion of trips.
This is happening because it is failing to find `channel.guild.id` in handleTripFinish.ts causing it to break when it is a `DMChannel`. After fixing this I found the repeat/action buttons have a similar problem where it assumes that there will always be a guild, but there isn't in DMs so it fails to identify the user id correctly.

### Changes:

Add in additional checks to make sure `channel.guild` is present before assuming `channel.guild.id` is. (handleTripFinish.ts)
Add in checks for `data.member` to decide whether we should check for a `member` or ` user` to find the users id. (globalInteraction.ts)

### Other checks:
All button options have been checked in both DMs and my test server with the help of Lux and Pum.
-   [x] I have tested all my changes thoroughly.
