### PR TITLE
Fix broken webhooks

### DIFF
--- a/src/lib/util/webhook.ts
+++ b/src/lib/util/webhook.ts
@@ -118,15 +118,16 @@ async function webhookSend(channel: WebhookClient, input: MessageOptions) {
 		const split = Util.splitMessage(input.content, { maxLength });
 		const newPayload = { ...input };
 		// Separate files and components from payload for interactions
-		const { files, embeds } = newPayload;
+		const { files, embeds, components } = newPayload;
 		delete newPayload.files;
 		delete newPayload.embeds;
+		delete newPayload.components;
 		await webhookSend(channel, { ...newPayload, content: split[0] });
 
 		for (let i = 1; i < split.length; i++) {
 			if (i + 1 === split.length) {
 				// Add files to last msg, and components for interactions to the final message.
-				await webhookSend(channel, { files, embeds, content: split[i] });
+				await webhookSend(channel, { files, embeds, content: split[i], components });
 			} else {
 				await webhookSend(channel, { content: split[i] });
 			}

--- a/src/lib/util/webhook.ts
+++ b/src/lib/util/webhook.ts
@@ -80,7 +80,7 @@ export async function sendToChannelID(
 		if (data.embed) embeds.push(data.embed);
 		if (channel instanceof WebhookClient) {
 			try {
-				return webhookSend(channel, {
+				await webhookSend(channel, {
 					content: data.content,
 					files,
 					embeds,
@@ -99,7 +99,7 @@ export async function sendToChannelID(
 				}
 			}
 		} else {
-			return channel.send({
+			await channel.send({
 				content: data.content,
 				files,
 				embeds,


### PR DESCRIPTION
### Description:

If a channels webhooks were removed, often from the bot being removed+readded, [or could be manually ofc], then the bot can no longer send replies whenever it uses sendToChannelId().

This is because the code catching the error is never run since `return` leaves the function too soon.

Also there is no reason to `return` because the function in question is in a PQueue, so it doesn't actually return anything to the caller anyway

### Changes:

- Replaces `return` with `await` in 2 places in the webhookSend() code.
- Adds `components` to the list of items moved to the end of a multi-part message

### Other checks:

-   [x] I have tested all my changes thoroughly.
