### PR TITLE
[BSO] Add more invention toggles from Player Feedback

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -348,7 +348,10 @@ export const enum BitField {
 	HasScrollOfTheHunt = 204,
 	HasBananaEnchantmentScroll = 205,
 	HasDaemonheimAgilityPass = 206,
-	DisabledGorajanBoneCrusher = 207
+	DisabledGorajanBoneCrusher = 207,
+	DisabledClueUpgrader = 208,
+	DisabledDwarvenToolkit = 209,
+	DisabledMasterHammerAndChisel = 210
 }
 
 interface BitFieldData {
@@ -405,6 +408,21 @@ export const BitFieldData: Record<BitField, BitFieldData> = {
 	[BitField.DisabledRandomEvents]: { name: 'Disabled Random Events', protected: false, userConfigurable: true },
 	[BitField.DisabledGorajanBoneCrusher]: {
 		name: 'Disabled Gorajan Bonecrusher',
+		protected: false,
+		userConfigurable: true
+	},
+	[BitField.DisabledClueUpgrader]: {
+		name: 'Disabled Clue Upgrader',
+		protected: false,
+		userConfigurable: true
+	},
+	[BitField.DisabledDwarvenToolkit]: {
+		name: 'Disabled Dwarven Toolkit',
+		protected: false,
+		userConfigurable: true
+	},
+	[BitField.DisabledMasterHammerAndChisel]: {
+		name: 'Disabled Master Hammer And Chisel',
 		protected: false,
 		userConfigurable: true
 	}

--- a/src/lib/invention/disassemble.ts
+++ b/src/lib/invention/disassemble.ts
@@ -13,7 +13,7 @@ import {
 	mahojiClientSettingsFetch,
 	mahojiUsersSettingsFetch
 } from '../../mahoji/mahojiSettings';
-import { Emoji } from '../constants';
+import { BitField, Emoji } from '../constants';
 import Skillcapes from '../skilling/skillcapes';
 import { SkillsEnum } from '../skilling/types';
 import { ItemBank } from '../types';
@@ -201,7 +201,7 @@ export async function handleDisassembly({
 	let timePer = Time.Second * 0.33;
 
 	let messages: string[] = [];
-	if (bank.has('Dwarven toolkit')) {
+	if (bank.has('Dwarven toolkit') && !user.bitfield.includes(BitField.DisabledDwarvenToolkit)) {
 		const boostRes = await inventionItemBoost({
 			userID: user.id,
 			inventionID: InventionID.DwarvenToolkit,

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -41,6 +41,18 @@ const toggles = [
 	{
 		name: 'Disable Gorajan Bonecrusher',
 		bit: BitField.DisabledGorajanBoneCrusher
+	},
+	{
+		name: 'Disable Clue Upgrader',
+		bit: BitField.DisabledClueUpgrader
+	},
+	{
+		name: 'Disable Dwarven Toolkit',
+		bit: BitField.DisabledDwarvenToolkit
+	},
+	{
+		name: 'Disable Master Hammer and Chisel',
+		bit: BitField.DisabledMasterHammerAndChisel
 	}
 ];
 

--- a/src/mahoji/commands/craft.ts
+++ b/src/mahoji/commands/craft.ts
@@ -1,6 +1,7 @@
 import { reduceNumByPercent, Time } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
+import { BitField } from '../../lib/constants';
 import { FaladorDiary, userhasDiaryTier } from '../../lib/diaries';
 import { inventionBoosts, InventionID, inventionItemBoost } from '../../lib/invention/inventions';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
@@ -88,19 +89,21 @@ export const craftCommand: OSBMahojiCommand = {
 				timeToCraftSingleItem /= 2;
 				boosts.push('2x faster for Dwarven greathammer');
 			}
-			const res = await inventionItemBoost({
-				userID: BigInt(user.id),
-				inventionID: InventionID.MasterHammerAndChisel,
-				duration: quantity ? quantity * timeToCraftSingleItem : maxTripLength
-			});
-			if (res.success) {
-				timeToCraftSingleItem = reduceNumByPercent(
-					timeToCraftSingleItem,
-					inventionBoosts.masterHammerAndChisel.speedBoostPercent
-				);
-				boosts.push(
-					`${inventionBoosts.masterHammerAndChisel.speedBoostPercent}% faster for Master hammer and chisel (${res.messages})`
-				);
+			if (!user.bitfield.includes(BitField.DisabledMasterHammerAndChisel)) {
+				const res = await inventionItemBoost({
+					userID: BigInt(user.id),
+					inventionID: InventionID.MasterHammerAndChisel,
+					duration: quantity ? quantity * timeToCraftSingleItem : maxTripLength
+				});
+				if (res.success) {
+					timeToCraftSingleItem = reduceNumByPercent(
+						timeToCraftSingleItem,
+						inventionBoosts.masterHammerAndChisel.speedBoostPercent
+					);
+					boosts.push(
+						`${inventionBoosts.masterHammerAndChisel.speedBoostPercent}% faster for Master hammer and chisel (${res.messages})`
+					);
+				}
 			}
 		}
 

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -115,6 +115,7 @@ export async function clueUpgraderEffect(
 	type: 'pvm' | 'pickpocketing'
 ) {
 	if (!user.owns('Clue upgrader')) return false;
+	if (user.bitfield.includes(BitField.DisabledClueUpgrader)) return false;
 	const upgradedClues = new Bank();
 	const removeBank = new Bank();
 	let durationForCost = 0;


### PR DESCRIPTION
### Description:

While a case can be made to make all of the non-equip-required inventions toggleable, these 3 are the most important, in my opinion. 

**I used the following criteria when deciding which Inventions should be the first to receive toggles:**
1. Cost/rarity of invention materials
2. Frequency with which you may want to disable said invention
3. Ongoing / usage cost of invention materials based on use-cases.

**Dwarven toolkit**: You want to disassemble many different items, but you are being taxed 2 Dwarven parts for each single disassemble, the same as for an entire trip. This can quickly add up and cost several hundred mil to disassemble all items.

**Clue upgrader**: While the materials aren't nearly as rare/expensive, there are oftentimes when you want to exclusively farm a specific type of clue, and not have a % 'upgraded' **especially when medium=>hard is actually a significant downgrade.**

**Master Hammer and chisel:** It is common when doing skilling activities, especially crafting, that you want to control your trip time for various bonuses, like holiday events, doubles, and pet loot (ie. doug, peky, etc). Since a lot of crafting materials are in short supply, you often don't want to speed up your trip.

### Changes:

- Added toggles for Dwarven toolkit, Clue upgrader, and Master hammer and chisel
- Added the bitfield constants of course
- Added the descriptions for the +rp c / minion info screen
- Added the hooks to disable said inventions when toggles are enabled.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
