### PR TITLE
Removes minionIsBusy check in a few places

### DIFF
--- a/src/mahoji/commands/drop.ts
+++ b/src/mahoji/commands/drop.ts
@@ -14,7 +14,6 @@ export const dropCommand: OSBMahojiCommand = {
 	description: 'Drop items from your bank.',
 	attributes: {
 		requiresMinion: true,
-		requiresMinionNotBusy: true,
 		examples: ['/drop items:10 trout, 5 coal']
 	},
 	options: [

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -38,8 +38,8 @@ export async function duelCommand(
 	if (duelSourceUser.id === duelTargetUser.id) return 'You cant duel yourself.';
 	if (!(duelTargetUser instanceof User)) return "You didn't mention a user to duel.";
 	if (duelTargetUser.bot) return 'You cant duel a bot.';
-	if (duelSourceUser.minionIsBusy) return `${duelSourceUser.minionName} is busy.`;
-	if (duelTargetUser.minionIsBusy) return 'That user is busy right now.';
+	if (duelSourceUser.isBusy) return `${duelSourceUser.minionName} is busy.`;
+	if (duelTargetUser.isBusy) return 'That user is busy right now.';
 
 	if (!(await checkBal(duelSourceUser, amount))) {
 		return 'You dont have have enough GP to duel that much.';

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -76,45 +76,51 @@ export async function duelCommand(
 
 	async function confirm(amount: number) {
 		duelMessage.edit({ components: [] }).catch(noOp);
+		duelTargetUser.toggleBusy(true);
+		duelSourceUser.toggleBusy(true);
 		if (!(await checkBal(duelSourceUser, amount)) || !(await checkBal(duelTargetUser, amount))) {
 			duelMessage.delete().catch(noOp);
+			duelTargetUser.toggleBusy(false);
+			duelSourceUser.toggleBusy(false);
 			return 'User appears to be less wealthy than expected (they lost some money before accepting...).';
 		}
-
-		const b = new Bank().add('Coins', amount);
-		await duelSourceUser.removeItemsFromBank(b);
-		await duelTargetUser.removeItemsFromBank(b);
-
-		await duelMessage
-			.edit(`${duelTargetUser.username} accepted the duel. You both enter the duel arena...`)
-			.catch(noOp);
-
-		await sleep(2000);
-		await duelMessage
-			.edit(`${duelSourceUser.username} and ${duelTargetUser.username} begin fighting...`)
-			.catch(noOp);
-
 		const [winner, loser] =
 			Math.random() > 0.5 ? [duelSourceUser, duelTargetUser] : [duelTargetUser, duelSourceUser];
-
-		await sleep(2000);
-		await duelMessage.edit('The fight is almost over...').catch(noOp);
-		await sleep(2000);
-
 		const winningAmount = amount * 2;
 		const tax = winningAmount - winningAmount * 0.95;
 
-		const dividedAmount = tax / 1_000_000;
-		updateGPTrackSetting('duelTaxBank', Math.floor(Math.round(dividedAmount * 100) / 100));
+		try {
+			const b = new Bank().add('Coins', amount);
+			await duelSourceUser.removeItemsFromBank(b);
+			await duelTargetUser.removeItemsFromBank(b);
 
-		const winsOfWinner = winner.settings.get(UserSettings.Stats.DuelWins) as number;
-		winner.settings.update(UserSettings.Stats.DuelWins, winsOfWinner + 1);
+			await duelMessage
+				.edit(`${duelTargetUser.username} accepted the duel. You both enter the duel arena...`)
+				.catch(noOp);
 
-		const lossesOfLoser = loser.settings.get(UserSettings.Stats.DuelLosses) as number;
-		loser.settings.update(UserSettings.Stats.DuelLosses, lossesOfLoser + 1);
+			await sleep(2000);
+			await duelMessage
+				.edit(`${duelSourceUser.username} and ${duelTargetUser.username} begin fighting...`)
+				.catch(noOp);
 
-		await winner.addItemsToBank({ items: new Bank().add('Coins', winningAmount - tax), collectionLog: false });
+			await sleep(2000);
+			await duelMessage.edit('The fight is almost over...').catch(noOp);
+			await sleep(2000);
 
+			const dividedAmount = tax / 1_000_000;
+			updateGPTrackSetting('duelTaxBank', Math.floor(Math.round(dividedAmount * 100) / 100));
+
+			const winsOfWinner = winner.settings.get(UserSettings.Stats.DuelWins) as number;
+			winner.settings.update(UserSettings.Stats.DuelWins, winsOfWinner + 1);
+
+			const lossesOfLoser = loser.settings.get(UserSettings.Stats.DuelLosses) as number;
+			loser.settings.update(UserSettings.Stats.DuelLosses, lossesOfLoser + 1);
+
+			await winner.addItemsToBank({ items: new Bank().add('Coins', winningAmount - tax), collectionLog: false });
+		} finally {
+			duelTargetUser.toggleBusy(false);
+			duelSourceUser.toggleBusy(false);
+		}
 		if (amount >= 1_000_000_000) {
 			globalClient.emit(
 				Events.ServerNotification,

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -38,8 +38,6 @@ export async function duelCommand(
 	if (duelSourceUser.id === duelTargetUser.id) return 'You cant duel yourself.';
 	if (!(duelTargetUser instanceof User)) return "You didn't mention a user to duel.";
 	if (duelTargetUser.bot) return 'You cant duel a bot.';
-	if (duelSourceUser.isBusy) return `${duelSourceUser.minionName} is busy.`;
-	if (duelTargetUser.isBusy) return 'That user is busy right now.';
 
 	if (!(await checkBal(duelSourceUser, amount))) {
 		return 'You dont have have enough GP to duel that much.';


### PR DESCRIPTION
### Description:

When +duel was migrated to a slash command, the wrong busy toggle was used. This corrects that issue, as well as removes the minionIsBusy check from the /drop command.

The minionIsBusy check doesn't protect against anything in these cases.

### Changes:

- Removes minionIsBusy check from `/gamble duel` and `/drop`

### Other checks:

-   [x] I have tested all my changes thoroughly.

The user.isBusy() check doesn't work here anymore because it's always 'busy' while the slash command is running.
Because the GP is removed up front before any sleeps() happen, it shouldn't be necessary anyway.