### PR TITLE
Fixes a few bugs in BSO minigames that eat your supplies.

### DIFF
--- a/src/lib/baxtorianBathhouses.ts
+++ b/src/lib/baxtorianBathhouses.ts
@@ -296,6 +296,9 @@ export async function baxtorianBathhousesStartCommand({
 	ore?: string;
 	mixture?: string;
 }) {
+	if (klasaUser.minionIsBusy) {
+		return 'Your minion is busy.';
+	}
 	const userBank = new Bank(user.bank as ItemBank);
 	const maxTripLength = calcMaxTripLength(user);
 	const durationPerPath = Time.Minute * 10;

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -35,7 +35,9 @@ export async function fishingContestStartCommand(user: KlasaUser, channelID: big
 	if (!['Contest rod', "Beginner's tackle box"].every(i => user.hasItemEquippedOrInBank(i))) {
 		return 'You need to buy a Contest rod and a tackle box to compete in the Fishing contest.';
 	}
-
+	if (user.minionIsBusy) {
+		return 'Your minion is busy.';
+	}
 	let quantity = 1;
 	let duration = Math.floor(quantity * Time.Minute * 1.69);
 	let quantityBoosts = [];

--- a/src/mahoji/lib/abstracted_commands/ironmanCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/ironmanCommand.ts
@@ -12,7 +12,7 @@ import { handleMahojiConfirmation, mahojiUserSettingsUpdate, mahojiUsersSettings
 export async function ironmanCommand(user: KlasaUser, interaction: SlashCommandInteraction) {
 	if (minionIsBusy(user.id)) return 'Your minion is busy.';
 	if (user.isIronman) {
-		return 'You are akrady an ironman.';
+		return 'You are alrady an ironman.';
 	}
 
 	const existingGiveaways = await prisma.giveaway.findMany({

--- a/src/mahoji/lib/abstracted_commands/monkeyRumbleCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/monkeyRumbleCommand.ts
@@ -60,6 +60,10 @@ export async function monkeyRumbleCommand(user: KlasaUser, channelID: bigint): C
 		};
 	}
 
+	if (user.minionIsBusy) {
+		return 'Your minion is busy.';
+	}
+
 	const boosts = [];
 
 	let fightDuration = Time.Minute * 9;

--- a/src/mahoji/lib/abstracted_commands/odsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/odsCommand.ts
@@ -72,6 +72,9 @@ export async function odsBuyCommand(user: User, klasaUser: KlasaUser, name: stri
 }
 
 export async function odsStartCommand(klasaUser: KlasaUser, channelID: bigint) {
+	if (klasaUser.minionIsBusy) {
+		return 'Your minion is busy.';
+	}
 	const boosts = [];
 
 	let waveTime = randomVariation(Time.Minute * 4, 10);


### PR DESCRIPTION
### Description:

If you try to run one of the following activities while your minion is busy, it throws a few errors, eats your supplies, and of course, doesn't let you create the activity.

### Changes:

- Adds busy checks to the following BSO minigames:
- Baxtorian bathouses
- ODS
- Fishing contest
- Monkey rumble
- Also corrects a simple typo in the ironman command.

### Other checks:

-   [x] I have tested all my changes thoroughly.
