### PR TITLE
Add mystic robes to buyables

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -274,7 +274,7 @@ const magicBuyables: Buyable[] = [
 		skillsNeeded: {
 			magic: 66
 		}
-	}	
+	}
 ];
 
 const questBuyables: Buyable[] = [


### PR DESCRIPTION
Adds mystic robes to buyables which is needed for the creatables cl, currently there is no possible way to obtain the hat.

-   [x] I have tested all my changes thoroughly.
