### PR TITLE
Add Neitiznot Shield

### DIFF
--- a/src/lib/skilling/skills/crafting/craftables/misc.ts
+++ b/src/lib/skilling/skills/crafting/craftables/misc.ts
@@ -89,6 +89,16 @@ const Misc: Craftable[] = [
 		tickRate: 3
 	},
 	{
+		name: 'Neitiznot shield',
+		id: itemID('Neitiznot shield'),
+		level: 1,
+		xp: 34,
+		inputItems: new Bank({ 'Arctic pine logs': 2, 'Bronze nails': 1 }),
+		tickRate: 3,
+		qpRequired: 4,
+		wcLvl: 56
+	},
+	{
 		name: 'Water battlestaff',
 		id: itemID('Water battlestaff'),
 		level: 54,

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -146,6 +146,8 @@ export interface Craftable {
 	crushChance?: number[];
 	bankChest?: boolean;
 	outputMultiple?: number;
+	qpRequired?: number;
+	wcLvl?: number;
 }
 
 export interface Fletchable {

--- a/src/mahoji/commands/craft.ts
+++ b/src/mahoji/commands/craft.ts
@@ -3,6 +3,7 @@ import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
 import { FaladorDiary, userhasDiaryTier } from '../../lib/diaries';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { Craftables } from '../../lib/skilling/skills/crafting/craftables';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { CraftingActivityTaskOptions } from '../../lib/types/minions';
@@ -57,6 +58,17 @@ export const craftCommand: OSBMahojiCommand = {
 		let sets = 'x';
 		if (craftable.outputMultiple) {
 			sets = ' sets of';
+		}
+
+		const userQP = user.settings.get(UserSettings.QP);
+		const currentWoodcutLevel = user.skillLevel(SkillsEnum.Woodcutting);
+
+		if (craftable.qpRequired && userQP < craftable.qpRequired) {
+			return `${user.minionName} needs ${craftable.qpRequired} QP to craft ${craftable.name}.`;
+		}
+
+		if (craftable.wcLvl && currentWoodcutLevel < craftable.wcLvl) {
+			return `${user.minionName} needs ${craftable.wcLvl} Woodcutting Level to craft ${craftable.name}.`;
 		}
 
 		if (user.skillLevel(SkillsEnum.Crafting) < craftable.level) {


### PR DESCRIPTION
Add Neitiznot Shield to craftables, add an optional QP checker for craftables along with a Woodcutting Level checker.

As there is a 7% boost for Ice Trolls when using this shield already coded, it makes sense to add it.

-   [x] I have tested all my changes thoroughly.
