### PR TITLE
Update Invite Command

### DIFF
--- a/src/mahoji/commands/invite.ts
+++ b/src/mahoji/commands/invite.ts
@@ -5,6 +5,7 @@ export const inviteCommand: OSBMahojiCommand = {
 	description: 'Shows the invite link for the bot.',
 	options: [],
 	run: async () => {
-		return 'https://www.oldschool.gg/invite/osb';
+		return `OSB - https://www.oldschool.gg/invite/osb
+BSO - https://www.oldschool.gg/invite/bso`;
 	}
 };


### PR DESCRIPTION
Updates the invite command to show both bots link, currently it only shows OSB even if you use the BSO slash command.

-   [x] I have tested all my changes thoroughly.
