### PR TITLE
Allow Mysterious pages to drop multiple times

### DIFF
--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -1,4 +1,5 @@
 import { randInt, Time } from 'e';
+import { KlasaUser } from 'klasa';
 import { Bank } from 'oldschooljs';
 import LootTable from 'oldschooljs/dist/structures/LootTable';
 import { resolveNameBank } from 'oldschooljs/dist/util';
@@ -135,7 +136,7 @@ const pages = resolveItems([
 	'Mysterious page 5'
 ]);
 
-export function openCoffin(floor: number, cl: Bank): ItemBank {
+export function openCoffin(floor: number, user: KlasaUser): ItemBank {
 	const loot = new Bank();
 	const floorObj = sepulchreFloors[floor - 1];
 	if (roll(floorObj.lockpickCoffinChance)) {
@@ -145,8 +146,12 @@ export function openCoffin(floor: number, cl: Bank): ItemBank {
 	loot.add('Hallowed mark', randInt(floorObj.marksRange[0], floorObj.marksRange[1]));
 
 	const page = pages[floor - 1];
-	if (!cl.has(page) && roll(10)) {
-		loot.add(page);
+
+	if (roll(10)) {
+		const bank = user.allItemsOwned();
+		if (!bank.has(page)) {
+			loot.add(page);
+		}
 	}
 	return loot.bank;
 }

--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -31,7 +31,7 @@ export default class extends Task {
 				const numCoffinsToOpen = 1;
 				numCoffinsOpened += numCoffinsToOpen;
 				for (let i = 0; i < numCoffinsToOpen; i++) {
-					loot.add(openCoffin(floor.number, user.cl()));
+					loot.add(openCoffin(floor.number, user));
 				}
 
 				agilityXP += floor.xp;


### PR DESCRIPTION
Adds a bank check for the mysterious pages so that the user can get it again if they have previously sacrificed the pages.
(needed in order to get the hallowed tome to sacrifice that etc)

Provided #4150 gets merged.
This closes #4082 

-   [x] I have tested all my changes thoroughly.
