### PR TITLE
Mix, show what supplies are needed if maxCanDo = 0

### DIFF
--- a/src/mahoji/commands/mix.ts
+++ b/src/mahoji/commands/mix.ts
@@ -108,7 +108,7 @@ export const mineCommand: OSBMahojiCommand = {
 
 		const maxCanDo = user.bank({ withGP: true }).fits(baseCost);
 		if (maxCanDo === 0) {
-			return "You don't have enough supplies to mix even one of this item!";
+			return `You don't have enough supplies to mix even one of this item!\nTo mix/clean a ${mixableItem.name}, you need to have ${baseCost}.`;
 		}
 		if (maxCanDo < quantity) {
 			quantity = maxCanDo;


### PR DESCRIPTION
Shows the base cost of mixing one item is so the user can check the bank for the items, without using wiki or other resources. This will be especially beneficial when making bso custom potions but will benefit osb too imo.

Closes #4156

-   [x] I have tested all my changes thoroughly.
