### PR TITLE
Fix remaining minion busy checks in mahoji commands

### DIFF
--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -24,6 +24,7 @@ export const clueCommand: OSBMahojiCommand = {
 	description: 'Send your minion to complete clue scrolls.',
 	attributes: {
 		requiresMinion: true,
+		requiresMinionNotBusy: true,
 		examples: ['/cl name:Boss']
 	},
 	options: [

--- a/src/mahoji/commands/drop.ts
+++ b/src/mahoji/commands/drop.ts
@@ -13,7 +13,6 @@ export const dropCommand: OSBMahojiCommand = {
 	name: 'drop',
 	description: 'Drop items from your bank.',
 	attributes: {
-		requiresMinion: true,
 		examples: ['/drop items:10 trout, 5 coal']
 	},
 	options: [

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -17,6 +17,8 @@ export const runecraftCommand: OSBMahojiCommand = {
 	name: 'runecraft',
 	description: 'Sends your minion to craft runes with essence.',
 	attributes: {
+		requiresMinion: true,
+		requiresMinionNotBusy: true,
 		categoryFlags: ['minion', 'skilling'],
 		examples: ['/runecraft']
 	},


### PR DESCRIPTION
### Description:

Went through every command in mahohi/commands and checked for correct hasMinion / minionNotBusy settings

These are important because if you try to make a new task that has the wrong setting while you're busy, it will delete your pure essence, clues, etc.

### Changes:

- Removed minion requirement for drop
- Added hasMinion + minion busy check to runecraft
- Added minion busy check to /clue

### Other checks:

-   [ ] I have tested all my changes thoroughly.
