### PR TITLE
Add Trailblazer to graceful variants

### DIFF
--- a/src/lib/data/gracefulVariants.ts
+++ b/src/lib/data/gracefulVariants.ts
@@ -7,7 +7,8 @@ export const gracefulHoods = [
 	'Hosidius graceful hood',
 	'Kourend graceful hood',
 	'Brimhaven graceful hood',
-	'Dark graceful hood'
+	'Dark graceful hood',
+	'Trailblazer graceful hood'
 ];
 
 export const gracefulTops = [
@@ -19,7 +20,8 @@ export const gracefulTops = [
 	'Hosidius graceful top',
 	'Kourend graceful top',
 	'Brimhaven graceful top',
-	'Dark graceful top'
+	'Dark graceful top',
+	'Trailblazer graceful top'
 ];
 
 export const gracefulLegs = [
@@ -31,7 +33,8 @@ export const gracefulLegs = [
 	'Hosidius graceful legs',
 	'Kourend graceful legs',
 	'Brimhaven graceful legs',
-	'Dark graceful legs'
+	'Dark graceful legs',
+	'Trailblazer graceful legs'
 ];
 
 export const gracefulFeet = [
@@ -43,7 +46,8 @@ export const gracefulFeet = [
 	'Hosidius graceful boots',
 	'Kourend graceful boots',
 	'Brimhaven graceful boots',
-	'Dark graceful boots'
+	'Dark graceful boots',
+	'Trailblazer graceful boots'
 ];
 
 export const gracefulHands = [
@@ -55,7 +59,8 @@ export const gracefulHands = [
 	'Hosidius graceful gloves',
 	'Kourend graceful gloves',
 	'Brimhaven graceful gloves',
-	'Dark graceful gloves'
+	'Dark graceful gloves',
+	'Trailblazer graceful gloves'
 ];
 
 export const gracefulCapes = [
@@ -68,6 +73,7 @@ export const gracefulCapes = [
 	'Kourend graceful cape',
 	'Brimhaven graceful cape',
 	'Dark graceful cape',
+	'Trailblazer graceful cape',
 	'Agility cape',
 	'Agility cape (t)',
 	'Max cape'


### PR DESCRIPTION
Adds the trailblazer outfit to the graceful variants, to allow you to get the normal boosts when using this outfit. Also adds the trailblazer graceful to the uncounted graceful cl.

-   [x] I have tested all my changes thoroughly.
