### PR TITLE
Add ability to  equip multiple items at once.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,8 @@ module.exports = {
 	collectCoverageFrom: [
 		"./src/lib/structures/Gear.ts",
 		"./src/lib/util/parseStringBank.ts",
-		"./src/lib/util/buyLimit.ts"
+		"./src/lib/util/buyLimit.ts",
+		"./src/lib/util/equipMulti.ts"
 	],
 	coverageThreshold: {
     	global: {

--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -1,8 +1,10 @@
 import { GearPreset } from '@prisma/client';
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 
+import { PartialGearSetup } from '../../../dist/lib/gear';
 import itemID from '../util/itemID';
 import { DefenceGearStat, GearSetup, GearStat, OffenceGearStat, OtherGearStat } from './types';
+import { constructGearSetup } from './util';
 
 export * from './types';
 export * from './util';
@@ -46,7 +48,14 @@ export const defaultGear: GearSetup = {
 	[EquipmentSlot.Weapon]: null
 };
 Object.freeze(defaultGear);
-
+export function filterGearSetup(gear: undefined | null | GearSetup | PartialGearSetup): GearSetup | undefined {
+	const filteredGear = !gear
+		? undefined
+		: typeof gear.ammo === 'undefined' || typeof gear.ammo === 'string'
+		? constructGearSetup(gear as PartialGearSetup)
+		: (gear as GearSetup);
+	return filteredGear;
+}
 export const globalPresets: GearPreset[] = [
 	{
 		name: 'graceful',

--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -1,10 +1,9 @@
 import { GearPreset } from '@prisma/client';
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 
-import { PartialGearSetup } from '../../../dist/lib/gear';
 import itemID from '../util/itemID';
 import { DefenceGearStat, GearSetup, GearStat, OffenceGearStat, OtherGearStat } from './types';
-import { constructGearSetup } from './util';
+import { constructGearSetup, PartialGearSetup } from './util';
 
 export * from './types';
 export * from './util';

--- a/src/lib/util/equipMulti.ts
+++ b/src/lib/util/equipMulti.ts
@@ -1,0 +1,85 @@
+import { Bank } from 'oldschooljs';
+import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
+
+import { GearSetup } from '../gear';
+import { isValidGearSetup, skillsMeetRequirements } from '../util';
+import { parseStringBank } from './parseStringBank';
+
+export function gearEquipMultiImpl(
+	user: MUser,
+	setup: string,
+	items: string
+): {
+	success: boolean;
+	failMsg?: string;
+	equipBank?: Bank;
+	unequipBank?: Bank;
+	skillFailBank?: Bank;
+	equippedGear?: GearSetup;
+} {
+	if (!isValidGearSetup(setup)) return { success: false, failMsg: 'Invalid gear setup' };
+	const oneItemPerSlot: { [key in EquipmentSlot]?: boolean } = {};
+	const userSkills = user.skillsAsXP;
+	const failedToEquipBank = new Bank();
+	const equipBank = new Bank();
+	for (const [i, _qty] of parseStringBank(items, user.bank, true)) {
+		const qty = i.stackable ? _qty || 1 : 1;
+		if (user.bank.amount(i.id) < qty) continue;
+		// Check skill requirements
+		if (i.equipment?.requirements) {
+			if (!skillsMeetRequirements(userSkills, i.equipment.requirements)) {
+				// Warn only for skill requirements, and conflicting weapon/2h/shield loadouts (below).
+				failedToEquipBank.add(i.id, qty);
+				continue;
+			}
+		}
+		// Make sure it's valid equipment
+		if (i.equipable_by_player && i.equipment && !oneItemPerSlot[i.equipment.slot]) {
+			// Ignore items that conflict with previously specified items:
+			if (
+				(oneItemPerSlot[EquipmentSlot.TwoHanded] &&
+					(i.equipment.slot === EquipmentSlot.Weapon || i.equipment.slot === EquipmentSlot.Shield)) ||
+				((oneItemPerSlot[EquipmentSlot.Shield] || oneItemPerSlot[EquipmentSlot.Weapon]) &&
+					i.equipment.slot === EquipmentSlot.TwoHanded)
+			) {
+				continue;
+			}
+			oneItemPerSlot[i.equipment.slot] = true;
+			equipBank.add(i.id, qty);
+		}
+	}
+
+	const equippedGear = { ...user.gear[setup].raw() };
+
+	const unequipBank = new Bank();
+
+	for (const [item, qty] of equipBank.items()) {
+		const { slot } = item.equipment!;
+		if (slot === EquipmentSlot.TwoHanded && equippedGear[EquipmentSlot.Shield]) {
+			unequipBank.add(equippedGear[EquipmentSlot.Shield]!.item, equippedGear[EquipmentSlot.Shield]!.quantity);
+			equippedGear[EquipmentSlot.Shield] = null;
+		}
+		if (slot === EquipmentSlot.TwoHanded && equippedGear[EquipmentSlot.Weapon]) {
+			unequipBank.add(equippedGear[EquipmentSlot.Weapon]!.item, equippedGear[EquipmentSlot.Weapon]!.quantity);
+			equippedGear[EquipmentSlot.Weapon] = null;
+		}
+		if (equippedGear[EquipmentSlot.TwoHanded] && (slot === EquipmentSlot.Shield || slot === EquipmentSlot.Weapon)) {
+			unequipBank.add(
+				equippedGear[EquipmentSlot.TwoHanded]!.item,
+				equippedGear[EquipmentSlot.TwoHanded]!.quantity
+			);
+			equippedGear[EquipmentSlot.TwoHanded] = null;
+		}
+		if (equippedGear[slot]) {
+			unequipBank.add(equippedGear[slot]!.item, equippedGear[slot]!.quantity);
+		}
+		equippedGear[slot] = { item: item.id, quantity: qty };
+	}
+	return {
+		success: true,
+		equipBank,
+		unequipBank,
+		equippedGear,
+		skillFailBank: failedToEquipBank
+	};
+}

--- a/src/mahoji/commands/gear.ts
+++ b/src/mahoji/commands/gear.ts
@@ -30,14 +30,14 @@ export const gearCommand: OSBMahojiCommand = {
 					required: true
 				},
 				{
-					...ownedItemOption(item => Boolean(item.equipable_by_player) && Boolean(item.equipment)),
-					name: 'item',
-					description: 'The item you want to equip.'
-				},
-				{
 					type: ApplicationCommandOptionType.String,
 					name: 'items',
 					description: 'A list of equippable items to equip.'
+				},
+				{
+					...ownedItemOption(item => Boolean(item.equipable_by_player) && Boolean(item.equipment)),
+					name: 'item',
+					description: 'The item you want to equip.'
 				},
 				{
 					...gearPresetOption,

--- a/src/mahoji/commands/gear.ts
+++ b/src/mahoji/commands/gear.ts
@@ -35,6 +35,11 @@ export const gearCommand: OSBMahojiCommand = {
 					description: 'The item you want to equip.'
 				},
 				{
+					type: ApplicationCommandOptionType.String,
+					name: 'items',
+					description: 'A list of equippable items to equip.'
+				},
+				{
 					...gearPresetOption,
 					required: false,
 					name: 'preset'
@@ -165,7 +170,14 @@ export const gearCommand: OSBMahojiCommand = {
 		interaction,
 		userID
 	}: CommandRunOptions<{
-		equip?: { gear_setup: GearSetupType; item?: string; preset?: string; quantity?: number; auto?: string };
+		equip?: {
+			gear_setup: GearSetupType;
+			item?: string;
+			items?: string;
+			preset?: string;
+			quantity?: number;
+			auto?: string;
+		};
 		unequip?: { gear_setup: GearSetupType; item?: string; all?: boolean };
 		stats?: { gear_setup: string };
 		pet?: { equip?: string; unequip?: string };
@@ -179,6 +191,7 @@ export const gearCommand: OSBMahojiCommand = {
 				userID: user.id,
 				setup: options.equip.gear_setup,
 				item: options.equip.item,
+				items: options.equip.items,
 				preset: options.equip.preset,
 				quantity: options.equip.quantity,
 				unEquippedItem: undefined,

--- a/src/mahoji/commands/gearpresets.ts
+++ b/src/mahoji/commands/gearpresets.ts
@@ -250,6 +250,7 @@ export const gearPresetsCommand: OSBMahojiCommand = {
 				userID: user.id,
 				setup: options.equip.gear_setup,
 				item: undefined,
+				items: undefined,
 				preset: options.equip.preset,
 				quantity: undefined,
 				unEquippedItem: undefined,

--- a/src/mahoji/lib/abstracted_commands/gearCommands.ts
+++ b/src/mahoji/lib/abstracted_commands/gearCommands.ts
@@ -177,7 +177,7 @@ export function gearEquipMultiImpl(
 }
 export async function gearEquipMultiCommand(
 	user: MUser,
-	interaction: SlashCommandInteraction,
+	interaction: ChatInputCommandInteraction,
 	setup: string,
 	items: string
 ) {
@@ -217,7 +217,7 @@ export async function gearEquipMultiCommand(
 	}
 	return {
 		content,
-		attachments: [{ fileName: 'gear.jpg', buffer: image }]
+		files: [{ name: 'gear.jpg', attachment: image }]
 	};
 }
 

--- a/src/mahoji/lib/abstracted_commands/gearCommands.ts
+++ b/src/mahoji/lib/abstracted_commands/gearCommands.ts
@@ -12,18 +12,11 @@ import getUserBestGearFromBank from '../../../lib/minions/functions/getUserBestG
 import { unEquipAllCommand } from '../../../lib/minions/functions/unequipAllCommand';
 import { prisma } from '../../../lib/settings/prisma';
 import { Gear } from '../../../lib/structures/Gear';
-import {
-	assert,
-	formatSkillRequirements,
-	isValidGearSetup,
-	skillsMeetRequirements,
-	stringMatches,
-	toTitleCase
-} from '../../../lib/util';
+import { assert, formatSkillRequirements, isValidGearSetup, stringMatches, toTitleCase } from '../../../lib/util';
+import { gearEquipMultiImpl } from '../../../lib/util/equipMulti';
 import getOSItem, { getItem } from '../../../lib/util/getOSItem';
 import getUsersPerkTier from '../../../lib/util/getUsersPerkTier';
 import { minionIsBusy } from '../../../lib/util/minionIsBusy';
-import { parseStringBank } from '../../../lib/util/parseStringBank';
 import { handleMahojiConfirmation, mahojiParseNumber } from '../../mahojiSettings';
 
 export async function gearPresetEquipCommand(user: MUser, gearSetup: string, presetName: string): CommandResponse {
@@ -97,84 +90,7 @@ export async function gearPresetEquipCommand(user: MUser, gearSetup: string, pre
 		files: [{ name: 'gear.jpg', attachment: image }]
 	};
 }
-export function gearEquipMultiImpl(
-	user: MUser,
-	setup: string,
-	items: string
-): {
-	success: boolean;
-	failMsg?: string;
-	equipBank?: Bank;
-	unequipBank?: Bank;
-	skillFailBank?: Bank;
-	equippedGear?: GearSetup;
-} {
-	if (!isValidGearSetup(setup)) return { success: false, failMsg: 'Invalid gear setup' };
-	const oneItemPerSlot: { [key in EquipmentSlot]?: boolean } = {};
-	const userSkills = user.skillsAsXP;
-	const failedToEquipBank = new Bank();
-	const equipBank = new Bank();
-	for (const [i, _qty] of parseStringBank(items, user.bank, true)) {
-		const qty = i.stackable ? _qty || 1 : 1;
-		if (user.bank.amount(i.id) < qty) continue;
-		// Check skill requirements
-		if (i.equipment?.requirements) {
-			if (!skillsMeetRequirements(userSkills, i.equipment.requirements)) {
-				// Warn only for skill requirements, and conflicting weapon/2h/shield loadouts (below).
-				failedToEquipBank.add(i.id, qty);
-				continue;
-			}
-		}
-		// Make sure it's valid equipment
-		if (i.equipable_by_player && i.equipment && !oneItemPerSlot[i.equipment.slot]) {
-			// Ignore items that conflict with previously specified items:
-			if (
-				(oneItemPerSlot[EquipmentSlot.TwoHanded] &&
-					(i.equipment.slot === EquipmentSlot.Weapon || i.equipment.slot === EquipmentSlot.Shield)) ||
-				((oneItemPerSlot[EquipmentSlot.Shield] || oneItemPerSlot[EquipmentSlot.Weapon]) &&
-					i.equipment.slot === EquipmentSlot.TwoHanded)
-			) {
-				continue;
-			}
-			oneItemPerSlot[i.equipment.slot] = true;
-			equipBank.add(i.id, qty);
-		}
-	}
 
-	const equippedGear = { ...user.gear[setup].raw() };
-
-	const unequipBank = new Bank();
-
-	for (const [item, qty] of equipBank.items()) {
-		const { slot } = item.equipment!;
-		if (slot === EquipmentSlot.TwoHanded && equippedGear[EquipmentSlot.Shield]) {
-			unequipBank.add(equippedGear[EquipmentSlot.Shield]!.item, equippedGear[EquipmentSlot.Shield]!.quantity);
-			equippedGear[EquipmentSlot.Shield] = null;
-		}
-		if (slot === EquipmentSlot.TwoHanded && equippedGear[EquipmentSlot.Weapon]) {
-			unequipBank.add(equippedGear[EquipmentSlot.Weapon]!.item, equippedGear[EquipmentSlot.Weapon]!.quantity);
-			equippedGear[EquipmentSlot.Weapon] = null;
-		}
-		if (equippedGear[EquipmentSlot.TwoHanded] && (slot === EquipmentSlot.Shield || slot === EquipmentSlot.Weapon)) {
-			unequipBank.add(
-				equippedGear[EquipmentSlot.TwoHanded]!.item,
-				equippedGear[EquipmentSlot.TwoHanded]!.quantity
-			);
-			equippedGear[EquipmentSlot.TwoHanded] = null;
-		}
-		if (equippedGear[slot]) {
-			unequipBank.add(equippedGear[slot]!.item, equippedGear[slot]!.quantity);
-		}
-		equippedGear[slot] = { item: item.id, quantity: qty };
-	}
-	return {
-		success: true,
-		equipBank,
-		unequipBank,
-		equippedGear,
-		skillFailBank: failedToEquipBank
-	};
-}
 export async function gearEquipMultiCommand(
 	user: MUser,
 	interaction: ChatInputCommandInteraction,

--- a/tests/gearMultiEquip.test.ts
+++ b/tests/gearMultiEquip.test.ts
@@ -1,0 +1,121 @@
+import { Bank } from 'oldschooljs';
+import { convertLVLtoXP } from 'oldschooljs/dist/util';
+
+import { Gear } from '../dist/lib/structures/Gear';
+import { gearEquipMultiImpl } from '../dist/mahoji/lib/abstracted_commands/gearCommands';
+import { mockMUser } from './utils';
+
+describe('Multi-equip Gear Test', () => {
+	const userBank = new Bank();
+	userBank
+		.add('Elysian spirit shield', 3)
+		.add('Zaryte crossbow', 1)
+		.add('Pegasian boots', 1)
+		.add('Dragon arrow', 1000)
+		.add('Rune arrow', 5000)
+		.add('Twisted bow');
+
+	const testUser = mockMUser({
+		skills_agility: convertLVLtoXP(50),
+		skills_ranged: convertLVLtoXP(99),
+		skills_defence: convertLVLtoXP(99),
+		GP: 100_000,
+		bank: userBank,
+		cl: new Bank().add('Coal'),
+		meleeGear: {
+			'2h': 'Twisted bow',
+			head: 'Armadyl helmet',
+			body: 'Dragon platebody',
+			legs: 'Dragon platelegs'
+		}
+	});
+	test('multi-equip-1', () => {
+		const test1String1 = '2 elysian spirit shield, zaryte crossbow, 500 rune arrow';
+		const result = gearEquipMultiImpl(testUser, 'melee', test1String1);
+		const test1Gear1 = new Gear(result.equippedGear);
+		// console.log(test1Gear1.toString());
+		expect(result.equipBank!.toString()).toEqual('500x Rune arrow, 1x Zaryte crossbow');
+		expect(result.unequipBank!.toString()).toEqual('1x Twisted bow');
+		expect(result.skillFailBank!.toString()).toEqual('1x Elysian spirit shield');
+		expect(test1Gear1.toString()).toEqual(
+			'Rune arrow, Dragon platebody, Armadyl helmet, Dragon platelegs, Zaryte crossbow'
+		);
+		expect(test1Gear1.ammo?.quantity).toEqual(500);
+	});
+
+	const testGear2 = new Gear({
+		weapon: 'Zaryte crossbow',
+		shield: 'Dragonfire shield',
+		head: 'Armadyl helmet',
+		body: 'Dragon platebody',
+		legs: 'Dragon platelegs',
+		ammo: 'Rune arrow'
+	});
+	testGear2.ammo!.quantity = 500;
+
+	const testUser2 = mockMUser({
+		skills_agility: convertLVLtoXP(50),
+		skills_ranged: convertLVLtoXP(99),
+		skills_defence: convertLVLtoXP(99),
+		skills_prayer: convertLVLtoXP(99),
+		GP: 100_000,
+		bank: userBank,
+		cl: new Bank().add('Coal'),
+		meleeGear: testGear2.raw()
+	});
+
+	test('multi-equip-2', () => {
+		const testInput = '3 elysian spirit shield, 2 twisted bow, 999 dragon arrow, primordial boots, robin hood hat';
+		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
+		const resultGear = new Gear(result.equippedGear);
+		// console.log(test1Gear1.toString());
+		expect(result.equipBank!.toString()).toEqual('999x Dragon arrow, 1x Elysian spirit shield');
+		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow, 1x Dragonfire shield');
+		expect(result.skillFailBank!.toString()).toEqual('No items');
+		expect(resultGear.toString()).toEqual(
+			'Dragon arrow, Dragon platebody, Armadyl helmet, Dragon platelegs, Elysian spirit shield, Zaryte crossbow'
+		);
+		expect(resultGear.ammo?.quantity).toEqual(999);
+	});
+	test('multi-equip-2b', () => {
+		const testInput = '2 twisted bow, 999 dragon arrow, primordial boots, robin hood hat';
+		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
+		const resultGear = new Gear(result.equippedGear);
+		// console.log(test1Gear1.toString());
+		expect(result.equipBank!.toString()).toEqual('999x Dragon arrow, 1x Twisted bow');
+		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow, 1x Dragonfire shield, 1x Zaryte crossbow');
+		expect(result.skillFailBank!.toString()).toEqual('No items');
+		expect(resultGear.toString()).toEqual(
+			'Dragon arrow, Dragon platebody, Armadyl helmet, Dragon platelegs, Twisted bow'
+		);
+		expect(resultGear.ammo?.quantity).toEqual(999);
+	});
+
+	test('multi-equip-2c', () => {
+		const testInput = '999 rune arrow';
+		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
+		const resultGear = new Gear(result.equippedGear);
+		// console.log(test1Gear1.toString());
+		expect(result.equipBank!.toString()).toEqual('999x Rune arrow');
+		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow');
+		expect(result.skillFailBank!.toString()).toEqual('No items');
+		expect(resultGear.toString()).toEqual(
+			'Rune arrow, Dragon platebody, Armadyl helmet, Dragon platelegs, Dragonfire shield, Zaryte crossbow'
+		);
+		expect(resultGear.ammo?.quantity).toEqual(999);
+	});
+
+	test('multi-equip-2d', () => {
+		const testInput = '0 rune arrow';
+		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
+		const resultGear = new Gear(result.equippedGear);
+		// console.log(test1Gear1.toString());
+		expect(result.equipBank!.toString()).toEqual('1x Rune arrow');
+		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow');
+		expect(result.skillFailBank!.toString()).toEqual('No items');
+		expect(resultGear.toString()).toEqual(
+			'Rune arrow, Dragon platebody, Armadyl helmet, Dragon platelegs, Dragonfire shield, Zaryte crossbow'
+		);
+		expect(resultGear.ammo?.quantity).toEqual(1);
+	});
+});

--- a/tests/gearMultiEquip.test.ts
+++ b/tests/gearMultiEquip.test.ts
@@ -1,5 +1,6 @@
 import { Bank } from 'oldschooljs';
-import { convertLVLtoXP } from 'oldschooljs/dist/util';
+import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
+import { convertLVLtoXP, itemID } from 'oldschooljs/dist/util';
 
 import { Gear } from '../src/lib/structures/Gear';
 import { gearEquipMultiImpl } from '../src/mahoji/lib/abstracted_commands/gearCommands';
@@ -11,9 +12,12 @@ describe('Multi-equip Gear Test', () => {
 		.add('Elysian spirit shield', 3)
 		.add('Zaryte crossbow', 1)
 		.add('Pegasian boots', 1)
+		.add('Dragon boots')
+		.add('Eternal boots')
 		.add('Dragon arrow', 1000)
 		.add('Rune arrow', 5000)
-		.add('Twisted bow');
+		.add('Twisted bow')
+		.add('Dragon dart', 5000);
 
 	const testUser = mockMUser({
 		skills_agility: convertLVLtoXP(50),
@@ -33,7 +37,6 @@ describe('Multi-equip Gear Test', () => {
 		const test1String1 = '2 elysian spirit shield, zaryte crossbow, 500 rune arrow';
 		const result = gearEquipMultiImpl(testUser, 'melee', test1String1);
 		const test1Gear1 = new Gear(result.equippedGear);
-		// console.log(test1Gear1.toString());
 		expect(result.equipBank!.toString()).toEqual('500x Rune arrow, 1x Zaryte crossbow');
 		expect(result.unequipBank!.toString()).toEqual('1x Twisted bow');
 		expect(result.skillFailBank!.toString()).toEqual('1x Elysian spirit shield');
@@ -64,11 +67,11 @@ describe('Multi-equip Gear Test', () => {
 		meleeGear: testGear2.raw()
 	});
 
+	// Test trying to equip multiple of an item, as well as 2h handling, and conflicting shield/2h combos specified
 	test('multi-equip-2', () => {
 		const testInput = '3 elysian spirit shield, 2 twisted bow, 999 dragon arrow, primordial boots, robin hood hat';
 		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
 		const resultGear = new Gear(result.equippedGear);
-		// console.log(test1Gear1.toString());
 		expect(result.equipBank!.toString()).toEqual('999x Dragon arrow, 1x Elysian spirit shield');
 		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow, 1x Dragonfire shield');
 		expect(result.skillFailBank!.toString()).toEqual('No items');
@@ -77,11 +80,11 @@ describe('Multi-equip Gear Test', () => {
 		);
 		expect(resultGear.ammo?.quantity).toEqual(999);
 	});
+	// Test equipping random items, and 2h item equipping
 	test('multi-equip-2b', () => {
 		const testInput = '2 twisted bow, 999 dragon arrow, primordial boots, robin hood hat';
 		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
 		const resultGear = new Gear(result.equippedGear);
-		// console.log(test1Gear1.toString());
 		expect(result.equipBank!.toString()).toEqual('999x Dragon arrow, 1x Twisted bow');
 		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow, 1x Dragonfire shield, 1x Zaryte crossbow');
 		expect(result.skillFailBank!.toString()).toEqual('No items');
@@ -91,11 +94,11 @@ describe('Multi-equip Gear Test', () => {
 		expect(resultGear.ammo?.quantity).toEqual(999);
 	});
 
+	// Test equipping same ammo type
 	test('multi-equip-2c', () => {
 		const testInput = '999 rune arrow';
 		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
 		const resultGear = new Gear(result.equippedGear);
-		// console.log(test1Gear1.toString());
 		expect(result.equipBank!.toString()).toEqual('999x Rune arrow');
 		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow');
 		expect(result.skillFailBank!.toString()).toEqual('No items');
@@ -105,11 +108,11 @@ describe('Multi-equip Gear Test', () => {
 		expect(resultGear.ammo?.quantity).toEqual(999);
 	});
 
+	// Test with 0 qty:
 	test('multi-equip-2d', () => {
 		const testInput = '0 rune arrow';
 		const result = gearEquipMultiImpl(testUser2, 'melee', testInput);
 		const resultGear = new Gear(result.equippedGear);
-		// console.log(test1Gear1.toString());
 		expect(result.equipBank!.toString()).toEqual('1x Rune arrow');
 		expect(result.unequipBank!.toString()).toEqual('500x Rune arrow');
 		expect(result.skillFailBank!.toString()).toEqual('No items');
@@ -117,5 +120,78 @@ describe('Multi-equip Gear Test', () => {
 			'Rune arrow, Dragon platebody, Armadyl helmet, Dragon platelegs, Dragonfire shield, Zaryte crossbow'
 		);
 		expect(resultGear.ammo?.quantity).toEqual(1);
+	});
+
+	const testUser3 = mockMUser({
+		skills_agility: convertLVLtoXP(50),
+		skills_ranged: convertLVLtoXP(99),
+		skills_defence: convertLVLtoXP(99),
+		skills_magic: convertLVLtoXP(99),
+		GP: 100_000,
+		bank: userBank,
+		cl: new Bank().add('Coal'),
+		meleeGear: {
+			weapon: 'Zaryte crossbow',
+			shield: 'Elysian spirit shield',
+			feet: 'Rune boots'
+		}
+	});
+	// Test equipping multiple items for a single slot + removing both hands for a 2h weapon
+	test('multi-equip-3', () => {
+		const testInput = '0 twisted bow, eternal boots, dragon boots';
+		const result = gearEquipMultiImpl(testUser3, 'melee', testInput);
+		const resultGear = new Gear(result.equippedGear);
+		expect(result.equipBank!.toString()).toEqual('1x Eternal boots, 1x Twisted bow');
+		expect(result.unequipBank!.toString()).toEqual('1x Rune boots, 1x Elysian spirit shield, 1x Zaryte crossbow');
+		expect(resultGear.toString()).toEqual('Eternal boots, Twisted bow');
+	});
+
+	const testUser4 = mockMUser({
+		skills_agility: convertLVLtoXP(50),
+		skills_ranged: convertLVLtoXP(99),
+		skills_defence: convertLVLtoXP(99),
+		skills_magic: convertLVLtoXP(99),
+		GP: 100_000,
+		bank: userBank,
+		cl: new Bank().add('Coal'),
+		meleeGear: {
+			'2h': 'Twisted bow'
+		}
+	});
+	// Test equipping stackable weapon
+	test('multi-equip-4', () => {
+		const testInput = '2222 DragON DART';
+		const result = gearEquipMultiImpl(testUser4, 'melee', testInput);
+		const resultGear = new Gear(result.equippedGear);
+		expect(result.equipBank!.toString()).toEqual('2,222x Dragon dart');
+		expect(result.unequipBank!.toString()).toEqual('1x Twisted bow');
+		expect(resultGear.toString()).toEqual('Dragon dart');
+
+		expect(resultGear.weapon!.quantity).toEqual(2222);
+	});
+
+	const testGear5 = new Gear();
+	testGear5[EquipmentSlot.Weapon] = { item: itemID('Rune dart'), quantity: 500 };
+
+	const testUser5 = mockMUser({
+		skills_agility: convertLVLtoXP(50),
+		skills_ranged: convertLVLtoXP(99),
+		skills_defence: convertLVLtoXP(99),
+		skills_magic: convertLVLtoXP(99),
+		GP: 100_000,
+		bank: userBank,
+		cl: new Bank().add('Coal'),
+		meleeGear: testGear5.raw()
+	});
+	// Test equipping stackable weapon on top of stackable weapon
+	test('multi-equip-5', () => {
+		const testInput = '2222 DragON DART';
+		const result = gearEquipMultiImpl(testUser5, 'melee', testInput);
+		const resultGear = new Gear(result.equippedGear);
+		expect(result.equipBank!.toString()).toEqual('2,222x Dragon dart');
+		expect(result.unequipBank!.toString()).toEqual('500x Rune dart');
+		expect(resultGear.toString()).toEqual('Dragon dart');
+
+		expect(resultGear.weapon!.quantity).toEqual(2222);
 	});
 });

--- a/tests/gearMultiEquip.test.ts
+++ b/tests/gearMultiEquip.test.ts
@@ -1,8 +1,8 @@
 import { Bank } from 'oldschooljs';
 import { convertLVLtoXP } from 'oldschooljs/dist/util';
 
-import { Gear } from '../dist/lib/structures/Gear';
-import { gearEquipMultiImpl } from '../dist/mahoji/lib/abstracted_commands/gearCommands';
+import { Gear } from '../src/lib/structures/Gear';
+import { gearEquipMultiImpl } from '../src/mahoji/lib/abstracted_commands/gearCommands';
 import { mockMUser } from './utils';
 
 describe('Multi-equip Gear Test', () => {

--- a/tests/gearMultiEquip.test.ts
+++ b/tests/gearMultiEquip.test.ts
@@ -3,7 +3,7 @@ import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 import { convertLVLtoXP, itemID } from 'oldschooljs/dist/util';
 
 import { Gear } from '../src/lib/structures/Gear';
-import { gearEquipMultiImpl } from '../src/mahoji/lib/abstracted_commands/gearCommands';
+import { gearEquipMultiImpl } from '../src/lib/util/equipMulti';
 import { mockMUser } from './utils';
 
 describe('Multi-equip Gear Test', () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,8 +2,9 @@ import { Prisma, User } from '@prisma/client';
 import { Bank } from 'oldschooljs';
 import { convertLVLtoXP } from 'oldschooljs/dist/util';
 
+import { GearSetup, PartialGearSetup } from '../dist/lib/gear';
 import { BitField } from '../src/lib/constants';
-import { PartialGearSetup } from '../src/lib/gear';
+import { filterGearSetup } from '../src/lib/gear';
 import { MUserClass } from '../src/lib/MUser';
 import { Gear } from '../src/lib/structures/Gear';
 
@@ -28,8 +29,14 @@ export function mockArgument(arg: any) {
 interface MockUserArgs {
 	bank?: Bank;
 	cl?: Bank;
-	meleeGear?: PartialGearSetup;
+	meleeGear?: GearSetup | PartialGearSetup;
 	skills_agility?: number;
+	skills_attack?: number;
+	skills_strength?: number;
+	skills_ranged?: number;
+	skills_defence?: number;
+	skills_hitpoints?: number;
+	skills_prayer?: number;
 	GP?: number;
 	premium_balance_tier?: number;
 	premium_balance_expiry_date?: number;
@@ -37,10 +44,11 @@ interface MockUserArgs {
 }
 
 export const mockUser = (overrides?: MockUserArgs): User => {
+	const gearMelee = filterGearSetup(overrides?.meleeGear);
 	return {
 		gear_fashion: new Gear().raw() as Prisma.JsonValue,
 		gear_mage: new Gear().raw() as Prisma.JsonValue,
-		gear_melee: new Gear(overrides?.meleeGear).raw() as Prisma.JsonValue,
+		gear_melee: new Gear(gearMelee).raw() as Prisma.JsonValue,
 		gear_misc: new Gear().raw() as Prisma.JsonValue,
 		gear_other: new Gear().raw() as Prisma.JsonValue,
 		gear_range: new Gear().raw() as Prisma.JsonValue,
@@ -57,7 +65,7 @@ export const mockUser = (overrides?: MockUserArgs): User => {
 		skills_firemaking: 0,
 		skills_runecraft: 0,
 		skills_crafting: 0,
-		skills_prayer: 0,
+		skills_prayer: overrides?.skills_prayer ?? 0,
 		skills_fletching: 0,
 		skills_thieving: 0,
 		skills_farming: 0,
@@ -65,12 +73,12 @@ export const mockUser = (overrides?: MockUserArgs): User => {
 		skills_hunter: 0,
 		skills_construction: 0,
 		skills_magic: 0,
-		skills_ranged: 0,
-		skills_attack: 0,
-		skills_strength: 0,
-		skills_defence: 0,
+		skills_ranged: overrides?.skills_ranged ?? 0,
+		skills_attack: overrides?.skills_attack ?? 0,
+		skills_strength: overrides?.skills_strength ?? 0,
+		skills_defence: overrides?.skills_defence ?? 0,
 		skills_slayer: 0,
-		skills_hitpoints: convertLVLtoXP(10),
+		skills_hitpoints: overrides?.skills_hitpoints ?? convertLVLtoXP(10),
 		GP: overrides?.GP,
 		premium_balance_tier: overrides?.premium_balance_tier,
 		premium_balance_expiry_date: overrides?.premium_balance_expiry_date,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -33,6 +33,7 @@ interface MockUserArgs {
 	skills_attack?: number;
 	skills_strength?: number;
 	skills_ranged?: number;
+	skills_magic?: number;
 	skills_defence?: number;
 	skills_hitpoints?: number;
 	skills_prayer?: number;
@@ -71,7 +72,7 @@ export const mockUser = (overrides?: MockUserArgs): User => {
 		skills_herblore: 0,
 		skills_hunter: 0,
 		skills_construction: 0,
-		skills_magic: 0,
+		skills_magic: overrides?.skills_magic ?? 0,
 		skills_ranged: overrides?.skills_ranged ?? 0,
 		skills_attack: overrides?.skills_attack ?? 0,
 		skills_strength: overrides?.skills_strength ?? 0,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,9 +2,8 @@ import { Prisma, User } from '@prisma/client';
 import { Bank } from 'oldschooljs';
 import { convertLVLtoXP } from 'oldschooljs/dist/util';
 
-import { GearSetup, PartialGearSetup } from '../dist/lib/gear';
 import { BitField } from '../src/lib/constants';
-import { filterGearSetup } from '../src/lib/gear';
+import { filterGearSetup, GearSetup, PartialGearSetup } from '../src/lib/gear';
 import { MUserClass } from '../src/lib/MUser';
 import { Gear } from '../src/lib/structures/Gear';
 


### PR DESCRIPTION
### Description:

This is a frequently requested function, and just makes all the sense in the world. We should be able to specify multiple items to equip, just like multiple items in gear stats :) 

### Changes:

- Adds `items` option which takes a bank string and then equips/ unequips items as necessary.

### Other checks:

-   [x] I have tested all my changes thoroughly.

This has been SO thoroughly tested, that I am very confident we found and removed any and all dupes / exploits from the code. We had a great team of testers and everyone was thinking outside the box to completely break the system to reach it's final form.