### PR TITLE
[Leagues-BSO] Fixes "Unlock all Slayer rewards" bug for leagues

### DIFF
--- a/src/lib/leagues/masterTasks.ts
+++ b/src/lib/leagues/masterTasks.ts
@@ -16,7 +16,7 @@ import {
 import { Inventions } from '../invention/inventions';
 import { dungBuyables } from '../skilling/skills/dung/dungData';
 import Dwarven from '../skilling/skills/smithing/smithables/dwarven';
-import { SlayerTaskUnlocksEnum } from '../slayer/slayerUnlocks';
+import { slayerUnlockableRewards } from '../slayer/slayerUnlocks';
 import { getTameSpecies } from '../tames';
 import { calcTotalLevel } from '../util';
 import resolveItems from '../util/resolveItems';
@@ -744,7 +744,7 @@ export const masterTasks: Task[] = [
 		id: 4103,
 		name: 'Unlock every slayer unlock',
 		has: async ({ mahojiUser }) => {
-			return mahojiUser.slayer_unlocks.length === Object.keys(SlayerTaskUnlocksEnum).length;
+			return mahojiUser.slayer_unlocks.length >= slayerUnlockableRewards.length;
 		}
 	},
 	{

--- a/src/lib/slayer/slayerUnlocks.ts
+++ b/src/lib/slayer/slayerUnlocks.ts
@@ -16,15 +16,26 @@ export interface SlayerTaskUnlocks {
 }
 
 export enum SlayerTaskUnlocksEnum {
-	// Unlockables
-	MalevolentMasquerade = 2,
+	Dummy = 0,
+	// Not in use, but in theory gives 10% boost
+	GargoyleSmasher,
+	// Slayer helm unlock
+	MalevolentMasquerade,
+	// Create slayer rings
 	RingBling,
+	// Unlock Red Dragons (not in use)
 	SeeingRed,
+	// Unlock mith Dragons (not in use)
 	IHopeYouMithMe,
+	// Unlock aviansies (not in use)
 	WatchTheBirdie,
+	// TzHaar unlock (not in use)
 	HotStuff,
+	// Lizardman unlock (not in use)
 	ReptileGotRipped,
+	// Unlock boss tasks. Definitely will use this one for the preroll.
 	LikeABoss,
+	// Unlock superiors
 	BiggerAndBadder,
 	KingBlackBonnet,
 	KalphiteKhat,

--- a/src/lib/slayer/slayerUnlocks.ts
+++ b/src/lib/slayer/slayerUnlocks.ts
@@ -16,26 +16,15 @@ export interface SlayerTaskUnlocks {
 }
 
 export enum SlayerTaskUnlocksEnum {
-	Dummy = 0,
-	// Not in use, but in theory gives 10% boost
-	GargoyleSmasher,
-	// Slayer helm unlock
-	MalevolentMasquerade,
-	// Create slayer rings
+	// Unlockables
+	MalevolentMasquerade = 2,
 	RingBling,
-	// Unlock Red Dragons (not in use)
 	SeeingRed,
-	// Unlock mith Dragons (not in use)
 	IHopeYouMithMe,
-	// Unlock aviansies (not in use)
 	WatchTheBirdie,
-	// TzHaar unlock (not in use)
 	HotStuff,
-	// Lizardman unlock (not in use)
 	ReptileGotRipped,
-	// Unlock boss tasks. Definitely will use this one for the preroll.
 	LikeABoss,
-	// Unlock superiors
 	BiggerAndBadder,
 	KingBlackBonnet,
 	KalphiteKhat,

--- a/src/lib/slayer/slayerUnlocks.ts
+++ b/src/lib/slayer/slayerUnlocks.ts
@@ -555,3 +555,5 @@ export const SlayerRewardsShop: SlayerTaskUnlocks[] = [
 		aliases: ['pore decisions', 'poor decisions']
 	}
 ];
+
+export const slayerUnlockableRewards = SlayerRewardsShop.filter(reward => !reward.item);


### PR DESCRIPTION
### Description:

The enum has a dummy entry to take the place of the '0th' element, as well as includes non-unlockables, such as the herb sack and slayer ring. I probably should have named it `SlayerRewardsEnum` but oh well. 

### Changes:

- Pre-filters a list of just the unlockable Slayer rewards so this doesn't have to be computed every time.
- Updates the task to use the new list for the length check

### Other checks:

-   [x] I have tested all my changes thoroughly.
