### PR TITLE
Fix /sell selling favorites

### DIFF
--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -115,7 +115,7 @@ export function parseBankFromFlags({
 
 		const qty = Math.min(maxQuantity, quantity === 0 ? Math.max(1, bank.amount(item.id)) : quantity);
 		if (filter && !filter.items(user).includes(item.id)) continue;
-		if ((filter || flagsKeys.length) && excludeItems.includes(item.id)) continue;
+		if (excludeItems.includes(item.id)) continue;
 
 		newBank.add(item.id, qty);
 	}

--- a/tests/parseStringBank.test.ts
+++ b/tests/parseStringBank.test.ts
@@ -503,8 +503,8 @@ describe('Bank Parsers', () => {
 			flags: {},
 			excludeItems: resolveItems(['Fire rune'])
 		});
-		expect(result16.bank.length).toStrictEqual(1);
-		expect(result16.bank.has('Fire rune')).toEqual(true);
+		expect(result16.bank.length).toStrictEqual(0);
+		expect(result16.bank.has('Fire rune')).toEqual(false);
 
 		//
 		const result17 = parseInputBankWithPrice({


### PR DESCRIPTION
### Description:

Currently, running /sell without arguments will sell your favorites. Same happens to /sacrifice.

### Changes:

- Changes the excludeFavorites `if` because at this point in the code, if we have excludedItems specified, we want them excluded. Item's specified by name are handled in a different section of code. 
- Had to change the relevant test, because the functionality is different now. (See Help wanted at the end)

### Other checks:

-   [x] I have tested all my changes thoroughly.

@gc 
### Help wanted:
I tested everything I could think of, included -sellto, which doesn't really apply since it doesn't pass `excludedItems` otherwise they would be filtered, but would appreciate any input you might have here.

Alternatively, we could try passing a non-null filter/flag to `parseBankFromFlags` somewhere along the path from /sell, but this doesn't seem right to do because it wouldn't actually do anything. I believe the logic was faulty, at least in the context of all the modern code.