### PR TITLE
Fix most deepscan issues, and related bugs

### DIFF
--- a/src/commands/rp.ts
+++ b/src/commands/rp.ts
@@ -456,7 +456,6 @@ ${
 				const item = getOSItem(itemName);
 				const price = evalMathExpression(rawPrice);
 				if (!price || price < 1 || price > 1_000_000_000) return;
-				if (!price || isNaN(price)) return msg.channel.send('Invalid price');
 				await msg.confirm(
 					`Are you sure you want to set the price of \`${item.name}\`(ID: ${item.id}, Wiki: ${
 						item.wiki_url

--- a/src/lib/util/farmingHelpers.ts
+++ b/src/lib/util/farmingHelpers.ts
@@ -45,7 +45,7 @@ export function findPlant(lastPlanted: IPatchData['lastPlanted']) {
 	const plant = Farming.Plants.find(
 		plants => stringMatches(plants.name, lastPlanted) || plants.aliases.some(a => stringMatches(a, lastPlanted))
 	);
-	if (!plant) null;
+	if (!plant) return null;
 	return plant;
 }
 export function userGrowingProgressStr(patchesDetailed: IPatchDataDetailed[]) {

--- a/src/mahoji/commands/poh.ts
+++ b/src/mahoji/commands/poh.ts
@@ -117,7 +117,7 @@ export const pohCommand: OSBMahojiCommand = {
 		const mahojiUser = await mahojiUsersSettingsFetch(userID);
 		if (!mahojiUser.minion_hasBought) return "You don't own a minion yet, so you have no PoH!";
 		if (options.view) {
-			return makePOHImage(user, options.view?.build_mode);
+			return makePOHImage(user, options.view.build_mode);
 		}
 		if (options.wallkit) {
 			return pohWallkitCommand(user, options.wallkit.name);

--- a/src/mahoji/lib/abstracted_commands/infernoCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/infernoCommand.ts
@@ -455,9 +455,9 @@ export async function infernoStartCommand(user: KlasaUser, channelID: bigint): C
 		realDuration
 	} = res;
 
-	let realCost = new Bank();
+	const realCost = new Bank();
 	try {
-		realCost = (await user.specialRemoveItems(cost)).realCost;
+		realCost.add((await user.specialRemoveItems(cost)).realCost);
 	} catch (err: any) {
 		return {
 			attachments: [

--- a/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
@@ -85,7 +85,7 @@ function checkReqs(
 			}.`;
 		}
 
-		const cost = perUserCost(user, isPhosani, quantity);
+		const cost = perUserCost(isPhosani, quantity);
 		if (!user.owns(cost)) {
 			return `${user.username} doesn't own ${cost}`;
 		}
@@ -109,7 +109,7 @@ function checkReqs(
 	}
 }
 
-function perUserCost(_user: KlasaUser, isPhosani: boolean, quantity: number) {
+function perUserCost(isPhosani: boolean, quantity: number) {
 	const cost = new Bank();
 	if (isPhosani) {
 		cost.add('Super combat potion(4)', Math.max(1, Math.floor(quantity / 2)))
@@ -231,29 +231,27 @@ export async function nightmareCommand(user: KlasaUser, channelID: bigint, name:
 	let soloFoodUsage: Bank | null = null;
 	for (const user of users) {
 		const [healAmountNeeded] = calculateMonsterFood(NightmareMonster, user);
-		const cost = perUserCost(user, isPhosani, quantity);
+		const cost = perUserCost(isPhosani, quantity);
 		if (!user.owns(cost)) {
 			return `${user} doesn't own ${cost}.`;
 		}
 		let healingMod = isPhosani ? 1.5 : 1;
-		let foodRemoved: Bank = new Bank();
 		try {
-			foodRemoved = (
-				await removeFoodFromUser({
-					user,
-					totalHealingNeeded: Math.ceil(healAmountNeeded / users.length) * quantity * healingMod,
-					healPerAction: Math.ceil(healAmountNeeded / quantity) * healingMod,
-					activityName: NightmareMonster.name,
-					attackStylesUsed: ['melee']
-				})
-			).foodRemoved;
+			const { foodRemoved } = await removeFoodFromUser({
+				user,
+				totalHealingNeeded: Math.ceil(healAmountNeeded / users.length) * quantity * healingMod,
+				healPerAction: Math.ceil(healAmountNeeded / quantity) * healingMod,
+				activityName: NightmareMonster.name,
+				attackStylesUsed: ['melee']
+			});
+
+			const { realCost } = await user.specialRemoveItems(cost);
+			soloFoodUsage = realCost.clone().add(foodRemoved);
+
+			totalCost.add(foodRemoved).add(realCost);
 		} catch (_err: any) {
 			return typeof _err === 'string' ? _err : _err.message;
 		}
-		const { realCost } = await user.specialRemoveItems(cost);
-		soloFoodUsage = realCost.clone().add(foodRemoved);
-
-		totalCost.add(foodRemoved).add(realCost);
 	}
 
 	await updateBankSetting(globalClient, ClientSettings.EconomyStats.NightmareCost, totalCost);


### PR DESCRIPTION
### Description:

The only DeepScan bug I couldn't figure out was this one: https://deepscan.io/dashboard/#view=project&pid=12787&iid=91029884&tid=5852&subview=issues&bid=202715
(Did not expect type annotation here). It looks like it might just be a false positive, 
@gc can you please mark it as a false positive so it stops triggering?

I fixed all the other DeepScan issues, some were actual bugs. I followed the logic to ensure these were all accurate reports, as well.

### Changes:

- Fixes !price || isNaN() checks in rp.ts => Both of these are checked earlier, either in the current scope, or `evalMathExpression`
- Fixes a bug in farmingHelpers.ts where it should have returned null instead of just a `null` statement
- Removes null check on poh command, where it's already passed a null check
- In inferrnoCommand, simply adds to the already created bank instead of reassigning it before it's used.
- Nightmare: Removes the unused `_user` argument from `perUserCost` fn
- Nightmare: Rescopes the `foodRemoved` bank similarly to inferno, but since everything that references can benefit from this try/catch block, rescoping seemed appropriate.


### Other checks:

-   [x] I have tested all my changes thoroughly.
