### PR TITLE
Myth Cape Rack (construction)

### DIFF
--- a/src/lib/skilling/skills/construction/constructables.ts
+++ b/src/lib/skilling/skills/construction/constructables.ts
@@ -145,6 +145,14 @@ const Constructables: Constructable[] = [
 		ticks: 5
 	},
 	{
+		id: 21_913,
+		name: 'Mythical cape (mounted)',
+		input: [Plank.TeakPlank, 3],
+		xp: 370,
+		level: 47,
+		ticks: 5
+	},
+	{
 		id: itemID('Mahogany armchair'),
 		name: 'Mahogany armchair',
 		input: [Plank.MahoganyPlank, 2],

--- a/src/mahoji/commands/build.ts
+++ b/src/mahoji/commands/build.ts
@@ -87,7 +87,7 @@ export const buildCommand: OSBMahojiCommand = {
 				return `${user.minionName} needs 205 Quest Points to build a ${object.name}.`;
 			}
 			if (!hasDs2Requirements) {
-				return `${user.minionName} to build a ${object.name}, you need: ${ds2Reason}.`;
+				return `In order to build a ${object.name}, you need: ${ds2Reason}.`;
 			}
 			if (!user.hasItemEquippedOrInBank('Mythical cape')) {
 				return `${user.minionName} needs to own a Mythical cape to build a ${object.name}.`;

--- a/src/mahoji/commands/build.ts
+++ b/src/mahoji/commands/build.ts
@@ -3,14 +3,38 @@ import { APIUser, ApplicationCommandOptionType, CommandRunOptions } from 'mahoji
 import { Bank } from 'oldschooljs';
 
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
 import Constructables from '../../lib/skilling/skills/construction/constructables';
 import { SkillsEnum } from '../../lib/skilling/types';
+import { Skills } from '../../lib/types';
 import { ConstructionActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, updateBankSetting } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { stringMatches } from '../../lib/util/cleanString';
 import { OSBMahojiCommand } from '../lib/util';
 import { getSkillsOfMahojiUser, mahojiUsersSettingsFetch } from '../mahojiSettings';
+
+const ds2Requirements: Skills = {
+	magic: 75,
+	smithing: 70,
+	mining: 68,
+	crafting: 62,
+	agility: 60,
+	thieving: 60,
+	construction: 50,
+	hitpoints: 50,
+	herblore: 45,
+	prayer: 42,
+	strength: 50,
+	woodcutting: 55,
+	fishing: 53,
+	cooking: 53,
+	ranged: 30,
+	defence: 40,
+	firemaking: 49,
+	fletching: 25,
+	slayer: 18
+};
 
 export const buildCommand: OSBMahojiCommand = {
 	name: 'build',
@@ -50,11 +74,24 @@ export const buildCommand: OSBMahojiCommand = {
 		const object = Constructables.find(
 			object => stringMatches(object.name, options.name) || stringMatches(object.name.split(' ')[0], options.name)
 		);
+		const [hasDs2Requirements, ds2Reason] = user.hasSkillReqs(ds2Requirements);
 
 		if (!object) return 'Thats not a valid object to build.';
 
 		if (user.skillLevel(SkillsEnum.Construction) < object.level) {
 			return `${user.minionName} needs ${object.level} Construction to create a ${object.name}.`;
+		}
+
+		if (object.name === 'Mythical cape (mounted)') {
+			if (user.settings.get(UserSettings.QP) < 205) {
+				return `${user.minionName} needs 205 Quest Points to build a ${object.name}.`;
+			}
+			if (!hasDs2Requirements) {
+				return `${user.minionName} to build a ${object.name}, you need: ${ds2Reason}.`;
+			}
+			if (!user.hasItemEquippedOrInBank('Mythical cape')) {
+				return `${user.minionName} needs to own a Mythical cape to build a ${object.name}.`;
+			}
 		}
 
 		let timeToBuildSingleObject = object.ticks * 300;


### PR DESCRIPTION
Adds the mythical cape (mounted) to the list of constructables. Ensures the user needs the relevant skills for ds2 along with the quest points. It then finally checks they have a myth cape in their bank or on them as they would need one. Closes #4181

-   [x] I have tested all my changes thoroughly.
