### PR TITLE
Fix Arcane Harvester when harvesting it uses the wrong plant

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -520,7 +520,7 @@ export default class extends Task {
 			}
 
 			if (hasPlopper) loot.multiply(4);
-			const res = await arcaneHarvesterEffect(user, plant, loot);
+			const res = await arcaneHarvesterEffect(user, plantToHarvest, loot);
 			if (res) infoStr.push(res);
 
 			if (loot.has('Plopper')) {


### PR DESCRIPTION
### Description:

Currently, Arcane Harvester uses the wrong plant for calculating price + whether or not it should apply.

When harvesting, it uses the plant you are **planting** instead of what's being harvested.

### Changes:

- Changes arcaneHarvesterEffect() call to use the harvesting plant.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
