### PR TITLE
Fixes problem where old item names map to custom items

### DIFF
--- a/src/lib/customItems/util.ts
+++ b/src/lib/customItems/util.ts
@@ -9,6 +9,7 @@ import getOSItem from '../util/getOSItem';
 export const customPrices: Record<number, number> = [];
 
 export const customItems: number[] = [];
+export const overwrittenItemNames: Map<string, Item> = new Map();
 
 export function isCustomItem(itemID: number) {
 	return customItems.includes(itemID);
@@ -30,12 +31,8 @@ export const hasSet: Item[] = [];
 // Prevent old item names from matching customItems
 export function ensureCustomItemName(nameToTest: string) {
 	const cleanNameToTest = cleanString(nameToTest);
-	const itemMapItemId = itemNameMap.get(cleanNameToTest);
-	if (itemMapItemId) {
-		const reverseMapItem = Items.get(itemMapItemId);
-		if (reverseMapItem && cleanNameToTest !== cleanString(reverseMapItem.name)) {
-			return false;
-		}
+	if (overwrittenItemNames.get(cleanNameToTest)) {
+		return false;
 	}
 	return true;
 }
@@ -50,6 +47,11 @@ export function setCustomItem(id: number, name: string, baseItem: string, newIte
 	const data = deepMerge({ ...getOSItem(baseItem) }, { ...newItemData, name, id });
 	data.price = price || 1;
 
+	// Track names of re-mapped items to break the link:
+	const oldItem = Items.get(id);
+	if (oldItem) {
+		overwrittenItemNames.set(cleanString(oldItem.name), oldItem);
+	}
 	Items.set(id, data);
 	const cleanName = cleanString(name);
 	itemNameMap.set(cleanName, id);

--- a/src/lib/customItems/util.ts
+++ b/src/lib/customItems/util.ts
@@ -33,10 +33,8 @@ export function ensureCustomItemName(nameToTest: string) {
 	const itemMapItemId = itemNameMap.get(cleanNameToTest);
 	if (itemMapItemId) {
 		const reverseMapItem = Items.get(itemMapItemId);
-		if (reverseMapItem) {
-			if (cleanNameToTest !== cleanString(reverseMapItem.name)) {
-				return false;
-			}
+		if (reverseMapItem && cleanNameToTest !== cleanString(reverseMapItem.name)) {
+			return false;
 		}
 	}
 	return true;

--- a/src/lib/customItems/util.ts
+++ b/src/lib/customItems/util.ts
@@ -4,6 +4,7 @@ import { Item } from 'oldschooljs/dist/meta/types';
 import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 import { cleanString } from 'oldschooljs/dist/util/cleanString';
 
+import { cleanString as deepCleanString } from '../util/cleanString';
 import getOSItem from '../util/getOSItem';
 
 export const customPrices: Record<number, number> = [];
@@ -30,7 +31,7 @@ export const hasSet: Item[] = [];
 
 // Prevent old item names from matching customItems
 export function ensureCustomItemName(nameToTest: string) {
-	const cleanNameToTest = cleanString(nameToTest);
+	const cleanNameToTest = deepCleanString(nameToTest);
 	if (overwrittenItemNames.get(cleanNameToTest)) {
 		return false;
 	}
@@ -50,7 +51,7 @@ export function setCustomItem(id: number, name: string, baseItem: string, newIte
 	// Track names of re-mapped items to break the link:
 	const oldItem = Items.get(id);
 	if (oldItem) {
-		overwrittenItemNames.set(cleanString(oldItem.name), oldItem);
+		overwrittenItemNames.set(deepCleanString(oldItem.name), oldItem);
 	}
 	Items.set(id, data);
 	const cleanName = cleanString(name);

--- a/src/lib/customItems/util.ts
+++ b/src/lib/customItems/util.ts
@@ -2,8 +2,8 @@ import deepMerge from 'deepmerge';
 import { Items } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 import { itemNameMap } from 'oldschooljs/dist/structures/Items';
-import { cleanString } from 'oldschooljs/dist/util/cleanString';
 
+import { cleanString } from '../util/cleanString';
 import getOSItem from '../util/getOSItem';
 
 export const customPrices: Record<number, number> = [];

--- a/src/lib/customItems/util.ts
+++ b/src/lib/customItems/util.ts
@@ -2,8 +2,8 @@ import deepMerge from 'deepmerge';
 import { Items } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 import { itemNameMap } from 'oldschooljs/dist/structures/Items';
+import { cleanString } from 'oldschooljs/dist/util/cleanString';
 
-import { cleanString } from '../util/cleanString';
 import getOSItem from '../util/getOSItem';
 
 export const customPrices: Record<number, number> = [];

--- a/src/lib/customItems/util.ts
+++ b/src/lib/customItems/util.ts
@@ -27,6 +27,21 @@ declare module 'oldschooljs/dist/meta/types' {
 
 export const hasSet: Item[] = [];
 
+// Prevent old item names from matching customItems
+export function ensureCustomItemName(nameToTest: string) {
+	const cleanNameToTest = cleanString(nameToTest);
+	const itemMapItemId = itemNameMap.get(cleanNameToTest);
+	if (itemMapItemId) {
+		const reverseMapItem = Items.get(itemMapItemId);
+		if (reverseMapItem) {
+			if (cleanNameToTest !== cleanString(reverseMapItem.name)) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
 export function setCustomItem(id: number, name: string, baseItem: string, newItemData?: Partial<Item>, price = 0) {
 	if (hasSet.some(i => i.id === id)) {
 		throw new Error(`Tried to add 2 custom items with same id ${id}, called ${name}`);

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -7,6 +7,7 @@ import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 import { filterableTypes } from '../data/filterables';
 import { evalMathExpression } from '../expressionParser';
 import { cleanString, stringMatches } from '../util';
+import {ensureCustomItemName} from "../customItems/util";
 
 const { floor, max, min } = Math;
 
@@ -24,6 +25,8 @@ export function parseQuantityAndItem(str = '', inputBank?: Bank): [Item[], numbe
 	}
 
 	let [potentialQty, ...potentialName] = split.length === 1 ? ['', [split[0]]] : split;
+
+	if (!ensureCustomItemName(potentialName.join(' ')) || !ensureCustomItemName(str)) return [];
 
 	let lazyItemGet = Items.get(potentialName.join(' ')) ?? Items.get(Number(potentialName.join(' ')));
 	if (str.includes('#') && lazyItemGet && inputBank) {

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -4,10 +4,10 @@ import { Bank, Items } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 
+import { ensureCustomItemName } from '../customItems/util';
 import { filterableTypes } from '../data/filterables';
 import { evalMathExpression } from '../expressionParser';
 import { cleanString, stringMatches } from '../util';
-import {ensureCustomItemName} from "../customItems/util";
 
 const { floor, max, min } = Math;
 

--- a/tests/parseStringBank.test.ts
+++ b/tests/parseStringBank.test.ts
@@ -527,4 +527,32 @@ describe('Bank Parsers', () => {
 		expect(result18.bank.amount('Ranarr seed')).toEqual(20);
 		expect(result18.price).toEqual(50_000_000);
 	});
+	test('ensureOldNamesDontWorkForCustomItems', () => {
+		const usersBank = new Bank()
+			.add('Smokey', 10)
+			.add('Doug', 3)
+			.add('Lil lamb', 10)
+			.add('Tradeable mystery box', 6);
+
+		expect(
+			parseBank({
+				inputBank: usersBank,
+				inputStr: 'snakeweed mixture, 1 an indigo pentagon, an indigo square, tmb'
+			}).toString()
+		).toEqual('6x Tradeable Mystery Box');
+
+		expect(
+			parseBank({
+				inputBank: usersBank,
+				inputStr: 'snakeweed mixture, 1 an indigo pentagon, an indigo square, mystery box'
+			}).toString()
+		).toEqual('No items');
+
+		expect(
+			parseBank({
+				inputBank: usersBank,
+				inputStr: 'snake@w-eed miXture, 0 doug, 1 lil lamb, 1 an indigo pentagon, an indigo square, mystery box'
+			}).toString()
+		).toEqual('3x Doug, 1x Lil Lamb');
+	});
 });


### PR DESCRIPTION
### Description:

Currently, with custom items, if they took the ID of a pre-existing item, the old item name still maps to the custom item.

**Examples:**
An indigo square => lil lamb
An indigo pentagon => doug
Abyssal demon => Ori
?? => Smokey

So when people are sacrificing osrs items that start with 'A' they inadvertantly sacrifice lil lamb + doug (actually happened)
Or someone evil could try to buy '???' for  100m [aka smokey] or trick someone into dropping/ sac'ing it since  they think it's a worthless UMB item.

### Changes:

- Ensures that the old name isn't being used by looking up the custom item name, and ensuring the new name is being used only.

### Other checks:

-   [x] I have tested all my changes thoroughly.

Tested: =b, =sellto, /sacrifice, /sell, /trade
(PS. There is a difference with the parseBankString between `0 Abyssal demon`, and `Abyssal Demon` that's why there's 2 checks.