### PR TITLE
Fix continue alch trip

### DIFF
--- a/src/mahoji/lib/abstracted_commands/alchCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/alchCommand.ts
@@ -31,7 +31,7 @@ const unlimitedFireRuneProviders = resolveItems([
 export const timePerAlch = Time.Second * 3;
 
 export async function alchCommand(
-	interaction: SlashCommandInteraction,
+	interaction: SlashCommandInteraction | null,
 	channelID: bigint,
 	user: KlasaUser,
 	item: string,
@@ -83,14 +83,16 @@ export async function alchCommand(
 	if (!user.owns(consumedItems)) {
 		return `You don't have the required items, you need ${consumedItems}`;
 	}
-	await handleMahojiConfirmation(
-		interaction,
-		`${user}, please confirm you want to alch ${quantity} ${osItem.name} (${toKMB(
-			alchValue
-		)}). This will take approximately ${formatDuration(duration)}, and consume ${
-			fireRuneCost > 0 ? `${fireRuneCost}x Fire rune` : ''
-		} ${quantity}x Nature runes.`
-	);
+	if (interaction) {
+		await handleMahojiConfirmation(
+			interaction,
+			`${user}, please confirm you want to alch ${quantity} ${osItem.name} (${toKMB(
+				alchValue
+			)}). This will take approximately ${formatDuration(duration)}, and consume ${
+				fireRuneCost > 0 ? `${fireRuneCost}x Fire rune` : ''
+			} ${quantity}x Nature runes.`
+		);
+	}
 
 	await user.removeItemsFromBank(consumedItems);
 	await updateBankSetting(globalClient, ClientSettings.EconomyStats.MagicCostBank, consumedItems);

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -50,6 +50,14 @@ export default class extends Task {
 			`${user}, ${user.minionName} has finished alching ${quantity}x ${item.name}! ${loot} has been added to your bank. ${xpRes}. ${saved}`
 		].join('\n');
 
-		handleTripFinish(user, channelID, responses, ['alch', [quantity, [item]], true], undefined, data, loot);
+		handleTripFinish(
+			user,
+			channelID,
+			responses,
+			['activities', { alch: { quantity, item: item.name } }, true],
+			undefined,
+			data,
+			loot
+		);
 	}
 }


### PR DESCRIPTION
### Description:

The continue / repeat alch trip was still pointing to the old alch command.

When moving to the slash command, I noticed the `interaction` param could be null, so updated the `alchCommand()` function to skip the confirmation that required the interaction.

### Changes:

- Updates the onContinue param to use the mahoji command structure and arguments.
- Updates alchCommand to handle the null `interaction` possibility.

### Other checks:

-   [x] I have tested all my changes thoroughly.
