### PR TITLE
Fix "Second-guess" logic for Spawnlamp / Spawnbox

### DIFF
--- a/src/mahoji/lib/buttonUserPicker.ts
+++ b/src/mahoji/lib/buttonUserPicker.ts
@@ -60,8 +60,9 @@ export async function buttonUserPicker({
 			if (guessed.includes(id)) {
 				const amountTimesGuessed = guessed.filter(g => g.toString() === i.user.id).length;
 				if (
+					!creatorGetsTwoGuesses ||
 					i.user.id !== creator.toString() ||
-					(amountTimesGuessed < 2 && isCreator && creatorGetsTwoGuesses)
+					(amountTimesGuessed >= 2 && isCreator && creatorGetsTwoGuesses)
 				) {
 					return i.reply({ ephemeral: true, content: 'You already guessed wrong.' });
 				}


### PR DESCRIPTION
### Description:

Currently, spawnbox + lamp are bugged in the following ways:
1. The 'second guess' feature doesn't work. (Still only allows 1 guess)
2. If 'second-guess' is not enabled [ie. spawnbox], then it gives infinite guesses.

### Changes:

- Fixes the logic to correct both of the above problems

### Other checks:

-   [ ] I have tested all my changes thoroughly.
