### PR TITLE
Remove empty blowpipe boost

### DIFF
--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -343,9 +343,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		wildy: false,
 
 		difficultyRating: 6,
-		itemsRequired: deepResolveItems([
-			["Karil's crossbow", 'Rune crossbow', 'Armadyl crossbow', 'Toxic blowpipe', 'Toxic blowpipe (empty)']
-		]),
+		itemsRequired: deepResolveItems([["Karil's crossbow", 'Rune crossbow', 'Armadyl crossbow', 'Toxic blowpipe']]),
 		notifyDrops: resolveItems(['Dragon warhammer']),
 		qpRequired: 30,
 		itemInBankBoosts: [
@@ -355,7 +353,6 @@ export const chaeldarMonsters: KillableMonster[] = [
 			},
 			{
 				[itemID('Toxic blowpipe')]: 15,
-				[itemID('Toxic blowpipe (empty)')]: 10,
 				[itemID('Armadyl crossbow')]: 8
 			},
 			{


### PR DESCRIPTION
Remove the empty blowpipe boost from shamans, doesnt really make sense for an empty blowpipe to give a boost. We can now charge it and add darts to it, so makes sense to have it only give the boost for that version.

-   [ ] I have tested all my changes thoroughly.
