### PR TITLE
BSO - Remove extra glough's experiment

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -554,12 +554,6 @@ export const allCollectionLogs: ICollection = {
 				kcActivity: Monsters.TzHaarKet.name,
 				allItems: Monsters.TzHaarKet.allItems,
 				items: tzHaarCL
-			},
-			"Glough's Experiments": {
-				alias: Monsters.DemonicGorilla.aliases,
-				allItems: Monsters.DemonicGorilla.allItems,
-				kcActivity: Monsters.DemonicGorilla.name,
-				items: demonicGorillaCL
 			}
 		}
 	},


### PR DESCRIPTION
Remove the extra glough's experiment cl from pvm and just have it in "other" to match osb.
Closes #4188

-   [ ] I have tested all my changes thoroughly.
