### PR TITLE
Update poh build to show whole list

### DIFF
--- a/src/mahoji/commands/poh.ts
+++ b/src/mahoji/commands/poh.ts
@@ -13,7 +13,7 @@ import {
 } from '../lib/abstracted_commands/pohCommand';
 import { ownedItemOption } from '../lib/mahojiCommandOptions';
 import { OSBMahojiCommand } from '../lib/util';
-import { getSkillsOfMahojiUser, mahojiUsersSettingsFetch } from '../mahojiSettings';
+import { mahojiUsersSettingsFetch } from '../mahojiSettings';
 
 export const pohCommand: OSBMahojiCommand = {
 	name: 'poh',
@@ -60,11 +60,13 @@ export const pohCommand: OSBMahojiCommand = {
 					name: 'name',
 					description: 'The object you want to build.',
 					required: true,
-					autocomplete: async (value: string, user: APIUser) => {
-						const skills = getSkillsOfMahojiUser(await mahojiUsersSettingsFetch(user.id), true);
-						return PoHObjects.filter(i => i.level <= skills.construction)
-							.filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())))
-							.map(i => ({ name: i.name, value: i.name }));
+					autocomplete: async (value: string) => {
+						return PoHObjects.filter(i =>
+							!value ? true : i.name.toLowerCase().includes(value.toLowerCase())
+						).map(i => ({
+							name: i.name,
+							value: i.name
+						}));
 					}
 				}
 			]


### PR DESCRIPTION
Update the poh build command to show the whole list of buildables, this is useful when you want to build something but are unsure what level it is as it then throws the construction level error.

Closes #4193 

-   [x] I have tested all my changes thoroughly.
