### PR TITLE
Update manta ray and sea turtle xp for cooking

### DIFF
--- a/src/lib/skilling/skills/cooking.ts
+++ b/src/lib/skilling/skills/cooking.ts
@@ -203,7 +203,7 @@ export const Cookables: Cookable[] = [
 	},
 	{
 		level: 82,
-		xp: 211,
+		xp: 211.3,
 		id: itemID('Sea turtle'),
 		name: 'Sea turtle',
 		alias: ['sea', 'turtle'],
@@ -234,7 +234,7 @@ export const Cookables: Cookable[] = [
 	},
 	{
 		level: 91,
-		xp: 216.2,
+		xp: 216.3,
 		id: itemID('Manta ray'),
 		name: 'Manta ray',
 		alias: ['manta'],


### PR DESCRIPTION
Manta ray's and sea turtles are currently marginally out for the xp when cooked, any little xp helps ;)
https://oldschool.runescape.wiki/w/Sea_turtle
https://oldschool.runescape.wiki/w/Manta_ray

-   [ ] I have tested all my changes thoroughly.
