### PR TITLE
Allow cancellation of ba + sw

### DIFF
--- a/src/mahoji/lib/abstracted_commands/cancelTaskCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/cancelTaskCommand.ts
@@ -30,14 +30,6 @@ export async function cancelTaskCommand(user: User, interaction?: SlashCommandIn
 		}
 	}
 
-	if (currentTask.type === 'BarbarianAssault') {
-		return `${mName} is currently doing Barbarian Assault, and cant leave their team!`;
-	}
-
-	if (currentTask.type === 'SoulWars') {
-		return `${mName} is currently doing Soul Wars, and cant leave their team!`;
-	}
-
 	if (currentTask.type === 'Raids' || currentTask.type === 'TheatreOfBlood') {
 		const data = currentTask as RaidsOptions;
 		if (data.users.length > 1) {


### PR DESCRIPTION
Since we can no longer mass barbarian assault or soul wars, this adds the ability to cancel these trips.
Closes #4184

-   [x] I have tested all my changes thoroughly.
