### PR TITLE
Update Phosani Nightmare rune cost

### DIFF
--- a/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
@@ -115,8 +115,8 @@ function perUserCost(isPhosani: boolean, quantity: number) {
 		cost.add('Super combat potion(4)', Math.max(1, Math.floor(quantity / 2)))
 			.add('Sanfew serum(4)', quantity)
 			.add('Super restore(4)', quantity)
-			.add('Fire rune', 11 * 100 * quantity)
-			.add('Air rune', 7 * 100 * quantity)
+			.add('Fire rune', 10 * 70 * quantity)
+			.add('Air rune', 7 * 70 * quantity)
 			.add('Wrath rune', 70 * quantity);
 	}
 	return cost;


### PR DESCRIPTION
Makes the air and fire rune costs match that of the wrath runes for fire surge.
Closes #3542

-   [x] I have tested all my changes thoroughly.
