### PR TITLE
Fix a few /giveaway bugs

### DIFF
--- a/src/lib/util/giveaway.ts
+++ b/src/lib/util/giveaway.ts
@@ -9,6 +9,11 @@ import { prisma } from '../settings/prisma';
 import { logError } from './logError';
 import { Giveaway } from '.prisma/client';
 
+async function refundGiveaway(creator: KlasaUser, loot: Bank) {
+	await creator.addItemsToBank({ items: loot });
+	creator.send(`Your giveaway failed to finish, you were refunded the items: ${loot}.`).catch(noOp);
+}
+
 export async function handleGiveawayCompletion(giveaway: Giveaway) {
 	if (giveaway.completed) {
 		throw new Error('Tried to complete an already completed giveaway.');
@@ -26,8 +31,12 @@ export async function handleGiveawayCompletion(giveaway: Giveaway) {
 			}
 		});
 
+		const creator = await globalClient.fetchUser(giveaway.user_id);
 		const channel = globalClient.channels.cache.get(giveaway.channel_id as Snowflake) as TextChannel | undefined;
-		if (!channel?.messages) return;
+		if (!channel?.messages) {
+			await refundGiveaway(creator, loot);
+			return;
+		}
 		const message = await channel?.messages.fetch(giveaway.message_id as Snowflake).catch(noOp);
 
 		const reactions = message ? message.reactions.cache.get(giveaway.reaction_id) : undefined;
@@ -38,12 +47,10 @@ export async function handleGiveawayCompletion(giveaway: Giveaway) {
 						.filter(u => !u.isIronman && !u.bot && u.id !== giveaway.user_id)
 						.values()
 			  );
-		const creator = await globalClient.fetchUser(giveaway.user_id);
 
 		if (users.length === 0 || !channel || !message) {
 			logError('Giveaway failed');
-			await creator.addItemsToBank({ items: loot });
-			creator.send(`Your giveaway failed to finish, you were refunded the items: ${loot}.`).catch(noOp);
+			await refundGiveaway(creator, loot);
 
 			if (message && channel) {
 				channel.send('Nobody entered the giveaway :(');

--- a/src/mahoji/commands/giveaway.ts
+++ b/src/mahoji/commands/giveaway.ts
@@ -175,7 +175,7 @@ React to this messsage with ${reaction} to enter.`,
 				logError(err, { user_id: user.id, emoji_id: reaction.id, guild_id: guildID.toString() });
 				return 'Unknown error. You will be refunded when the giveaway ends if the giveaway fails.';
 			}
-			return message;
+			return 'Giveaway started.';
 		}
 	}
 };


### PR DESCRIPTION
### Description:

Currently, whenever starting a new giveaway, this error is logged:
![image](https://user-images.githubusercontent.com/10122432/179870286-9cc532b4-5d7d-4cc4-a798-ac76c03088fa.png)

Also, if the bot is kicked, leaves the guild, or is otherwise removed from a guild before the giveaway is completed, the giveaway deletes all items on completion and does not refund them.

This fixes those issues.

### Changes:

- Makes the refund code into a function
- If the guild/messages check fails, refund items first instead of immediately withdrawing.
- Don't return the result of `await channel.send()` it's not the right return type for the mahoji commands.

### Other checks:

-   [x] I have tested all my changes thoroughly.
