### PR TITLE
Heblore repeat trip fix

### DIFF
--- a/src/tasks/minions/herbloreActivity.ts
+++ b/src/tasks/minions/herbloreActivity.ts
@@ -15,8 +15,10 @@ export default class extends Task {
 
 		const xpReceived = zahur && mixableItem.zahur === true ? 0 : quantity * mixableItem.xp;
 
+		let outputQuantity = quantity;
+
 		if (mixableItem.outputMultiple) {
-			quantity *= mixableItem.outputMultiple;
+			outputQuantity *= mixableItem.outputMultiple;
 		}
 
 		const xpRes = await user.addXP({
@@ -25,9 +27,9 @@ export default class extends Task {
 			duration
 		});
 
-		let str = `${user}, ${user.minionName} finished making ${quantity}x ${mixableItem.name}. ${xpRes}`;
+		let str = `${user}, ${user.minionName} finished making ${outputQuantity}x ${mixableItem.name}. ${xpRes}`;
 
-		const loot = new Bank().add(mixableItem.id, quantity);
+		const loot = new Bank().add(mixableItem.id, outputQuantity);
 
 		await user.addItemsToBank({ items: loot, collectionLog: true });
 


### PR DESCRIPTION
There's currently a bug with /mix, when an item has an output multiplier, the repeat trip is currently looking to repeat with the multiplier, and throws an error saying to try a lower quantity.
This fixes that error by adding an outputQuantity and using the old quantity to repeat.

Closes #4069

-   [x] I have tested all my changes thoroughly.
