### PR TITLE
Collect - Jewellery Box instead of duellings

### DIFF
--- a/src/mahoji/lib/abstracted_commands/collectCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/collectCommand.ts
@@ -11,6 +11,7 @@ import { CollectingOptions } from '../../../lib/types/minions';
 import { formatDuration, stringMatches, updateBankSetting } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import getOSItem from '../../../lib/util/getOSItem';
+import { getPOH } from './pohCommand';
 
 export interface Collectable {
 	item: Item;
@@ -168,8 +169,17 @@ export async function collectCommand(mahojiUser: User, user: KlasaUser, channelI
 		)}.`;
 	}
 
-	const cost = collectable.itemCost?.clone().multiply(quantity) ?? null;
-	if (cost) {
+	const poh = await getPOH(user.id);
+	const hasJewelleryBox = poh.jewellery_box !== null;
+
+	let cost: Bank = new Bank();
+
+	if (collectable.itemCost) {
+		{
+			cost = collectable.itemCost.clone().multiply(quantity);
+			if (cost.has('Ring of dueling(8)') && hasJewelleryBox)
+				cost.remove('Ring of dueling(8)', cost.amount('Ring of dueling(8)'));
+		}
 		if (!user.owns(cost)) {
 			return `You don't have the items needed for this trip, you need: ${cost}.`;
 		}


### PR DESCRIPTION
Allows the use of the player owned house jewellery boxes to send your minion to collect items instead of using up ring of duelings.

-   [x] I have tested all my changes thoroughly.
