### PR TITLE
[BSO] Fix small issue with my parseBank update  (Matching lamps is finnicky)

### DIFF
--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -26,7 +26,8 @@ export function parseQuantityAndItem(str = '', inputBank?: Bank): [Item[], numbe
 
 	let [potentialQty, ...potentialName] = split.length === 1 ? ['', [split[0]]] : split;
 
-	if (!ensureCustomItemName(potentialName.join(' ')) || !ensureCustomItemName(str)) return [];
+	if (!ensureCustomItemName(str)) return [];
+	if (!isNaN(Number(potentialQty)) && !ensureCustomItemName(potentialName.join(' '))) return [];
 
 	let lazyItemGet = Items.get(potentialName.join(' ')) ?? Items.get(Number(potentialName.join(' ')));
 	if (str.includes('#') && lazyItemGet && inputBank) {

--- a/tests/parseStringBank.test.ts
+++ b/tests/parseStringBank.test.ts
@@ -532,7 +532,9 @@ describe('Bank Parsers', () => {
 			.add('Smokey', 10)
 			.add('Doug', 3)
 			.add('Lil lamb', 10)
-			.add('Tradeable mystery box', 6);
+			.add('Tradeable mystery box', 6)
+			.add('Huge lamp', 33)
+			.add('Average lamp');
 
 		expect(
 			parseBank({
@@ -554,5 +556,13 @@ describe('Bank Parsers', () => {
 				inputStr: 'snake@w-eed miXture, 0 doug, 1 lil lamb, 1 an indigo pentagon, an indigo square, mystery box'
 			}).toString()
 		).toEqual('3x Doug, 1x Lil Lamb');
+
+		// Test when part of the name matches an overwritten item (ie. "lamp")
+		expect(
+			parseBank({
+				inputBank: usersBank,
+				inputStr: 'Huge lamp, Lil lamb, Smokey, average lamp'
+			}).toString()
+		).toEqual('33x Huge lamp, 10x Smokey, 10x Lil Lamb, 1x Average lamp');
 	});
 });


### PR DESCRIPTION
### Description:

After the latest update, there was a bug in my code that was recently found. Because parseItemAndQuantity splits up the string, (looking for a quantity), an item like, "Huge lamp" searches for both, "lamp," and, "Huge lamp". But it only takes 1 match to an old item for this to fail.

The problem is "Lamp" is the name of an item that's been overwritten, so the solution here is simple: only check the `split()` version if the first segment is a number.

### Changes:

- Adds a new test looking for this issue.
- Fixes the bank parsing bug

### Other checks:

-   [x] I have tested all my changes thoroughly.
