### PR TITLE
Fix Skipper sac value boost

### DIFF
--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -127,7 +127,7 @@ export const sacrificeCommand: OSBMahojiCommand = {
 		let str = '';
 		const hasSkipper = user.usingPet('Skipper') || user.owns('Skipper');
 		if (hasSkipper) {
-			totalPrice = Math.floor(totalPrice * 1.15);
+			totalPrice = Math.floor(totalPrice * 1.4);
 		}
 
 		let gotHammy = false;


### PR DESCRIPTION
### Description:

Skipper is supposed to add 40% boost to sacrificed items, but it's only adding 15% since it was moved to slash command.

### Changes:

Adjusted the boost back to 40%

### Other checks:

-   [x] I have tested all my changes thoroughly.
