### PR TITLE
Sarachnis food usage

### DIFF
--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -238,7 +238,7 @@ const killableMonsters: KillableMonster[] = [
 		},
 		uniques: resolveItems(['Sraracha', 'Jar of eyes', 'Giant egg sac(full)', 'Sarachnis cudgel']),
 		healAmountNeeded: 9 * 20,
-		attackStyleToUse: GearStat.AttackSlash,
+		attackStyleToUse: GearStat.AttackCrush,
 		attackStylesUsed: [GearStat.AttackStab, GearStat.AttackRanged],
 		minimumGearRequirements: {
 			melee: {


### PR DESCRIPTION
Change sarachnis to check attack crush for food usage. Closes #4242

-   [x] I have tested all my changes thoroughly.
