### PR TITLE
Tidy plural in Smithing command error

### DIFF
--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -92,9 +92,9 @@ export const smithCommand: OSBMahojiCommand = {
 		if (duration > maxTripLength) {
 			return `${user.minionName} can't go on trips longer than ${formatDuration(
 				maxTripLength
-			)}, try a lower quantity. The highest amount of ${smithedItem.name}s you can smith is ${Math.floor(
-				maxTripLength / timeToSmithSingleBar
-			)}.`;
+			)}, try a lower quantity. The highest amount of ${smithedItem.name}${
+				smithedItem.name.charAt(smithedItem.name.length - 1).toLowerCase() === 's' ? '' : 's'
+			} you can smith is ${Math.floor(maxTripLength / timeToSmithSingleBar)}.`;
 		}
 
 		await user.removeItemsFromBank(cost);


### PR DESCRIPTION
Takes off the extra 's' from the error thrown when trying to smith too many nails for example.

Closes #4241

-   [x] I have tested all my changes thoroughly.
