### PR TITLE
Allow hunter trips to remember staminas preference

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -157,6 +157,7 @@ export interface HunterActivityTaskOptions extends ActivityTaskOptions {
 	quantity: number;
 	usingHuntPotion: boolean;
 	wildyPeak: Peak | null;
+	usingStaminaPotion: boolean;
 }
 
 export interface AlchingActivityTaskOptions extends ActivityTaskOptions {

--- a/src/mahoji/commands/hunt.ts
+++ b/src/mahoji/commands/hunt.ts
@@ -73,6 +73,12 @@ export const huntCommand: OSBMahojiCommand = {
 		let usingHuntPotion = Boolean(options.hunter_potion);
 		let wildyScore = 0;
 
+		if (options.stamina_potions === undefined) {
+			options.stamina_potions = true;
+		}
+
+		let usingStaminaPotion = Boolean(options.stamina_potions);
+
 		const creature = Hunter.Creatures.find(creature =>
 			creature.aliases.some(
 				alias => stringMatches(alias, options.name) || stringMatches(alias.split(' ')[0], options.name)
@@ -181,7 +187,7 @@ export const huntCommand: OSBMahojiCommand = {
 					? Math.round(duration / (9 * Time.Minute))
 					: Math.round(duration / (18 * Time.Minute));
 
-			if (options.stamina_potions !== false && userBank.amount('Stamina potion(4)') >= staminaPotionQuantity) {
+			if (usingStaminaPotion && userBank.amount('Stamina potion(4)') >= staminaPotionQuantity) {
 				removeBank.add('Stamina potion(4)', staminaPotionQuantity);
 				boosts.push(`20% boost for using ${staminaPotionQuantity}x Stamina potion(4)`);
 				duration *= 0.8;
@@ -231,6 +237,7 @@ export const huntCommand: OSBMahojiCommand = {
 			quantity,
 			duration,
 			usingHuntPotion,
+			usingStaminaPotion,
 			wildyPeak,
 			type: 'Hunter'
 		});

--- a/src/tasks/minions/HunterActivity/hunterActivity.ts
+++ b/src/tasks/minions/HunterActivity/hunterActivity.ts
@@ -39,7 +39,8 @@ const riskDeathNumbers = [
 
 export default class extends Task {
 	async run(data: HunterActivityTaskOptions) {
-		const { creatureName, quantity, userID, channelID, usingHuntPotion, wildyPeak, duration } = data;
+		const { creatureName, quantity, userID, channelID, usingHuntPotion, wildyPeak, duration, usingStaminaPotion } =
+			data;
 		const user = await this.client.fetchUser(userID);
 		const userBank = user.bank();
 		const currentLevel = user.skillLevel(SkillsEnum.Hunter);
@@ -195,7 +196,16 @@ export default class extends Task {
 			user,
 			channelID,
 			str,
-			['hunt', { name: creatureName, quantity, hunter_potion: data.usingHuntPotion }, true],
+			[
+				'hunt',
+				{
+					name: creatureName,
+					quantity,
+					hunter_potion: data.usingHuntPotion,
+					stamina_potions: usingStaminaPotion
+				},
+				true
+			],
 			undefined,
 			data,
 			loot


### PR DESCRIPTION
Currently if you do stamina_potions and false on a hunter command, the repeat trip tries using staminas next trip.

-   [x] I have tested all my changes thoroughly.
