### PR TITLE
Allow similar items to work for tame feeds

### DIFF
--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -7,6 +7,7 @@ import { Item, ItemBank } from 'oldschooljs/dist/meta/types';
 
 import { collectables } from '../mahoji/lib/abstracted_commands/collectCommand';
 import { mahojiUsersSettingsFetch } from '../mahoji/mahojiSettings';
+import { getSimilarItems } from './data/similarItems';
 import killableMonsters, { effectiveMonsters } from './minions/data/killableMonsters';
 import { prisma, trackLoot } from './settings/prisma';
 import { runCommand } from './settings/settings';
@@ -110,7 +111,8 @@ export const tameSpecies: Species[] = [
 
 export function tameHasBeenFed(tame: Tame, item: string | number) {
 	const { id } = Items.get(item)!;
-	return Boolean((tame.fed_items as ItemBank)[id]);
+	const items = [id, ...getSimilarItems(id)];
+	return items.some(i => Boolean((tame.fed_items as ItemBank)[i]));
 }
 
 export function tameGrowthLevel(tame: Tame) {

--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -912,7 +912,7 @@ async function viewCommand(user: KlasaUser, tameID: number): CommandResponse {
 **Hatch Date:** ${time(tame.date)} / ${time(tame.date, 'R')}
 **${toTitleCase(species.relevantLevelCategory)} Level:** ${tame[`max_${species.relevantLevelCategory}_level`]}
 **Boosts:** ${feedableItems
-			.filter(i => fedItems.has(i.item.id))
+			.filter(i => [i.item.id, ...getSimilarItems(i.item.id)].some(si => fedItems.has(si)))
 			.map(i => `${i.item.name} (${i.description})`)
 			.join(', ')}`,
 		attachments: [image.file, fedImage.file]

--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -646,14 +646,7 @@ async function feedCommand(interaction: SlashCommandInteraction, user: KlasaUser
 					`Feeding a '${item.name}' to your tame won't give it a perk, are you sure you want to?`
 				);
 			}
-			if (tameHasBeenFed(tame, item.id)) {
-				await handleMahojiConfirmation(
-					interaction,
-					`You already have the perk, '${description}.' Feeding another **${item.name}** won't increase the boost.`
-				);
-			} else {
-				specialStrArr.push(`**${item.name}**: ${description}`);
-			}
+			specialStrArr.push(`**${item.name}**: ${description}`);
 		}
 	}
 	let specialStr = specialStrArr.length === 0 ? '' : `\n\n${specialStrArr.join(', ')}`;

--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -646,7 +646,14 @@ async function feedCommand(interaction: SlashCommandInteraction, user: KlasaUser
 					`Feeding a '${item.name}' to your tame won't give it a perk, are you sure you want to?`
 				);
 			}
-			specialStrArr.push(`**${item.name}**: ${description}`);
+			if (tameHasBeenFed(tame, item.id)) {
+				await handleMahojiConfirmation(
+					interaction,
+					`You already have the perk, '${description}.' Feeding another **${item.name}** won't increase the boost.`
+				);
+			} else {
+				specialStrArr.push(`**${item.name}**: ${description}`);
+			}
 		}
 	}
 	let specialStr = specialStrArr.length === 0 ? '' : `\n\n${specialStrArr.join(', ')}`;
@@ -912,7 +919,7 @@ async function viewCommand(user: KlasaUser, tameID: number): CommandResponse {
 **Hatch Date:** ${time(tame.date)} / ${time(tame.date, 'R')}
 **${toTitleCase(species.relevantLevelCategory)} Level:** ${tame[`max_${species.relevantLevelCategory}_level`]}
 **Boosts:** ${feedableItems
-			.filter(i => [i.item.id, ...getSimilarItems(i.item.id)].some(si => fedItems.has(si)))
+			.filter(i => tameHasBeenFed(tame, i.item.id))
 			.map(i => `${i.item.name} (${i.description})`)
 			.join(', ')}`,
 		attachments: [image.file, fedImage.file]

--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -12,6 +12,7 @@ import { Canvas, CanvasRenderingContext2D, Image, loadImage } from 'skia-canvas/
 
 import { badges } from '../../lib/constants';
 import { Eatables } from '../../lib/data/eatables';
+import { getSimilarItems } from '../../lib/data/similarItems';
 import killableMonsters from '../../lib/minions/data/killableMonsters';
 import getUserFoodFromBank from '../../lib/minions/functions/getUserFoodFromBank';
 import { KillableMonster } from '../../lib/minions/types';
@@ -637,7 +638,8 @@ async function feedCommand(interaction: SlashCommandInteraction, user: KlasaUser
 
 	let specialStrArr = [];
 	for (const { item, description, tameSpeciesCanBeFedThis } of thisTameSpecialFeedableItems) {
-		if (bankToAdd.has(item.id)) {
+		const similarItems = [item.id, ...getSimilarItems(item.id)];
+		if (similarItems.some(si => bankToAdd.has(si))) {
 			if (!tameSpeciesCanBeFedThis.includes(species!.type)) {
 				await handleMahojiConfirmation(
 					interaction,


### PR DESCRIPTION
### Description:

This PR will allow similar items, like Dwarven warhammer (ice) to work as Tame fed options.

This helps players in a few ways:
1. [Especially] Players who already fed dyed variants to their Tames expecting it to work (like they do everywhere else).
2. Also encourages more players to feed items to their tame, removing them from the economy, because giving the Tame an untradeable version **feels** easier, however it still removes a DWWH from the economy that will have to be replaced at some point. (Either way it's still removing a DWWH from the game).

This also adds some useful warnings if you're trying to feed a Boost item you've already fed.


### Changes:

- Adds similar items check when checking for boosts, as well as during the initial feed.
- Warns if trying to feed an item you already get the boost for.

### Other checks:

-   [x] I have tested all my changes thoroughly.
