### PR TITLE
Update Pharaoh's sceptre drop rate

### DIFF
--- a/src/lib/minions/data/plunder.ts
+++ b/src/lib/minions/data/plunder.ts
@@ -60,42 +60,48 @@ export const plunderRooms = [
 		thievingLevel: 21,
 		xp: 720,
 		rockyChance: 41_355,
-		roomTable: Room1Table
+		roomTable: Room1Table,
+		sceptreChance: 3500
 	},
 	{
 		number: 2,
 		thievingLevel: 31,
 		xp: 1165,
 		rockyChance: 29_540,
-		roomTable: Room2Table
+		roomTable: Room2Table,
+		sceptreChance: 2250
 	},
 	{
 		number: 3,
 		thievingLevel: 41,
 		xp: 2005,
 		rockyChance: 25_847,
-		roomTable: Room3Table
+		roomTable: Room3Table,
+		sceptreChance: 1250
 	},
 	{
 		number: 4,
 		thievingLevel: 51,
 		xp: 2958,
 		rockyChance: 20_678,
-		roomTable: Room4Table
+		roomTable: Room4Table,
+		sceptreChance: 750
 	},
 	{
 		number: 5,
 		thievingLevel: 61,
 		xp: 4280,
 		rockyChance: 20_678,
-		roomTable: Room5Table
+		roomTable: Room5Table,
+		sceptreChance: 650
 	},
 	{
 		number: 6,
 		thievingLevel: 71,
 		xp: 6465,
 		rockyChance: 20_678,
-		roomTable: Room6Table
+		roomTable: Room6Table,
+		sceptreChance: 650
 	},
 	{
 		number: 7,
@@ -103,7 +109,8 @@ export const plunderRooms = [
 		thievingLevel: 81,
 		xp: 9738,
 		rockyChance: 10_339,
-		roomTable: Room7Table
+		roomTable: Room7Table,
+		sceptreChance: 650
 	},
 	{
 		number: 8,
@@ -111,7 +118,8 @@ export const plunderRooms = [
 		thievingLevel: 91,
 		xp: 12_665,
 		rockyChance: 6893,
-		roomTable: Room8Table
+		roomTable: Room8Table,
+		sceptreChance: 650
 	}
 ];
 
@@ -121,18 +129,14 @@ export const plunderBoosts = resolveNameBank({
 
 export function lootRoom(room: number): [ItemBank, number] {
 	const loot = new Bank();
-	const sceptreChance = 1000;
 	const roomObj = plunderRooms[room - 1];
 
 	if (roll(roomObj.rockyChance)) {
 		loot.add('Rocky');
 	}
 
-	for (let i = 0; i < 2; i++) {
-		if (roll(sceptreChance)) {
-			loot.add("Pharaoh's sceptre");
-			break;
-		}
+	if (roll(roomObj.sceptreChance)) {
+		loot.add("Pharaoh's sceptre");
 	}
 
 	const amountUrns = rand(9, 14);

--- a/src/lib/minions/data/plunder.ts
+++ b/src/lib/minions/data/plunder.ts
@@ -135,8 +135,11 @@ export function lootRoom(room: number): [ItemBank, number] {
 		loot.add('Rocky');
 	}
 
-	if (roll(roomObj.sceptreChance)) {
-		loot.add("Pharaoh's sceptre");
+	for (let i = 0; i < 2; i++) {
+		if (roll(roomObj.sceptreChance)) {
+			loot.add("Pharaoh's sceptre");
+			break;
+		}
 	}
 
 	const amountUrns = rand(9, 14);


### PR DESCRIPTION
The Pharaoh's sceptre drop rates were updated in May, this PR updates them to the new rate, which effectively makes it harder to obtain at early levels, but easier at the higher levels.

https://oldschool.runescape.wiki/w/Update:Poll_76_Improvements
https://oldschool.runescape.wiki/w/Pharaoh%27s_sceptre#Obtaining

-   [x] I have tested all my changes thoroughly.
