### PR TITLE
Remove twisted slayer helm, duplicated creatables

### DIFF
--- a/src/lib/data/creatables/leagueCreatables.ts
+++ b/src/lib/data/creatables/leagueCreatables.ts
@@ -1,6 +1,5 @@
 import { Bank } from 'oldschooljs';
 
-import { SlayerTaskUnlocksEnum } from '../../slayer/slayerUnlocks';
 import { Createable } from '../createables';
 
 const toolCreatables: Createable[] = [
@@ -557,45 +556,6 @@ const cannonOrnaments: Createable[] = [
 	}
 ];
 
-const other: Createable[] = [
-	{
-		name: 'Twisted slayer helmet',
-		inputItems: new Bank({
-			'Twisted horns': 1,
-			'Slayer helmet': 1
-		}),
-		outputItems: new Bank().add('Twisted slayer helmet'),
-		requiredSlayerUnlocks: [SlayerTaskUnlocksEnum.TwistedVision]
-	},
-	{
-		name: 'Revert Twisted slayer helmet',
-		inputItems: new Bank({
-			'Twisted slayer helmet': 1
-		}),
-		outputItems: new Bank().add('Slayer helmet').add('Twisted horns'),
-		noCl: true,
-		requiredSlayerUnlocks: [SlayerTaskUnlocksEnum.TwistedVision]
-	},
-	{
-		name: 'Twisted slayer helmet (i)',
-		inputItems: new Bank({
-			'Twisted horns': 1,
-			'Slayer helmet (i)': 1
-		}),
-		outputItems: new Bank().add('Twisted slayer helmet (i)'),
-		requiredSlayerUnlocks: [SlayerTaskUnlocksEnum.TwistedVision]
-	},
-	{
-		name: 'Revert Twisted slayer helmet (i)',
-		inputItems: new Bank({
-			'Twisted slayer helmet (i)': 1
-		}),
-		outputItems: new Bank().add('Slayer helmet (i)').add('Twisted horns'),
-		noCl: true,
-		requiredSlayerUnlocks: [SlayerTaskUnlocksEnum.TwistedVision]
-	}
-];
-
 const clothes: Createable[] = [
 	{
 		name: 'Unpack Twisted relic hunter (t1) armour set',
@@ -820,6 +780,5 @@ export const leaguesCreatables = [
 	...cannonOrnaments,
 	...mysticOrnaments,
 	...clothes,
-	...graceful,
-	...other
+	...graceful
 ];


### PR DESCRIPTION
There is already the twisted slayer helm create commands in - https://github.com/oldschoolgg/oldschoolbot/blob/master/src/lib/data/creatables/slayer.ts

As it has been duplicated here it appears twice in the /create list, also this batch of them doesn't have the malevolent masquerade unlock requirement.

-   [x] I have tested all my changes thoroughly.
