### PR TITLE
Only do the alch calculation if there is no override.

### DIFF
--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -31,7 +31,7 @@ export function sellPriceOfItem(item: Item, taxRate = 25): { price: number; base
 	let basePrice = customPrices[item.id] ?? item.price;
 	let price = basePrice;
 	price = reduceNumByPercent(price, taxRate);
-	if (price < (item.highalch ?? 0) * 3) {
+	if (!(item.id in customPrices) && price < (item.highalch ?? 0) * 3) {
 		price = calcPercentOfNum(30, item.highalch!);
 	}
 	price = clamp(price, 0, MAX_INT_JAVA);


### PR DESCRIPTION
### Description:

This is very important, the change was made on BSO production, but isn't merged yet.

This PR fixes the getSellPrice function so that moderator price overrides take priority over the 'alch-nerf' calculation.

In some cases, this alch-nerf calculation actually causes a money-dupe exploit.

### Changes:

- If the customPrices contains the items price, do not adjust for alch value.

### Other checks:

-   [x] I have tested all my changes thoroughly.
