### PR TITLE
Add demonic offering spells to castables

### DIFF
--- a/src/lib/skilling/skills/magic/castables.ts
+++ b/src/lib/skilling/skills/magic/castables.ts
@@ -13,6 +13,7 @@ export interface Castable {
 	gpCost?: number;
 	craftLevel?: number;
 	craftXp?: number;
+	prayerXp?: number;
 }
 
 export const Castables: Castable[] = [
@@ -329,5 +330,55 @@ export const Castables: Castable[] = [
 		qpRequired: 50,
 		craftXp: 130,
 		craftLevel: 61
+	},
+	{
+		id: itemID('Fiendish ashes'),
+		name: 'Demonic offering fiendish',
+		level: 84,
+		xp: 175,
+		input: new Bank().add('Fiendish ashes', 3).add('Soul rune', 1).add('Wrath rune', 1),
+		output: null,
+		ticks: 8,
+		prayerXp: 90
+	},
+	{
+		id: itemID('Vile ashes'),
+		name: 'Demonic offering vile',
+		level: 84,
+		xp: 175,
+		input: new Bank().add('Vile ashes', 3).add('Soul rune', 1).add('Wrath rune', 1),
+		output: null,
+		ticks: 8,
+		prayerXp: 225
+	},
+	{
+		id: itemID('Malicious ashes'),
+		name: 'Demonic offering malicious',
+		level: 84,
+		xp: 175,
+		input: new Bank().add('Malicious ashes', 3).add('Soul rune', 1).add('Wrath rune', 1),
+		output: null,
+		ticks: 8,
+		prayerXp: 585
+	},
+	{
+		id: itemID('Abyssal ashes'),
+		name: 'Demonic offering abyssal',
+		level: 84,
+		xp: 175,
+		input: new Bank().add('Abyssal ashes', 3).add('Soul rune', 1).add('Wrath rune', 1),
+		output: null,
+		ticks: 8,
+		prayerXp: 765
+	},
+	{
+		id: itemID('Infernal ashes'),
+		name: 'Demonic offering infernal',
+		level: 84,
+		xp: 175,
+		input: new Bank().add('Infernal ashes', 3).add('Soul rune', 1).add('Wrath rune', 1),
+		output: null,
+		ticks: 8,
+		prayerXp: 990
 	}
 ];

--- a/src/mahoji/lib/abstracted_commands/castCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/castCommand.ts
@@ -96,9 +96,16 @@ export async function castCommand(channelID: bigint, user: KlasaUser, name: stri
 		).toLocaleString()} Crafting XP/Hr**`;
 	}
 
+	let prayerXpHr = '';
+	if (spell.prayerXp) {
+		prayerXpHr = `and** ${Math.round(
+			((spell.prayerXp * quantity) / (duration / Time.Minute)) * 60
+		).toLocaleString()} Prayer XP/Hr**`;
+	}
+
 	return `${user.minionName} is now casting ${quantity}x ${spell.name}, it'll take around ${formatDuration(
 		duration
 	)} to finish. Removed ${cost}${
 		spell.gpCost ? ` and ${gpCost} Coins` : ''
-	} from your bank. **${magicXpHr}** ${craftXpHr}`;
+	} from your bank. **${magicXpHr}** ${craftXpHr}${prayerXpHr}`;
 }

--- a/src/tasks/minions/castingActivity.ts
+++ b/src/tasks/minions/castingActivity.ts
@@ -31,8 +31,17 @@ export default class extends Task {
 			});
 		}
 
-		// let craftXpRes = ``;
-		// const craftXpReceived = await user.addXP(SkillsEnum.Crafting, craftXpReceived, duration);
+		let prayerXpReceived = 0;
+		let prayerXpRes = '';
+		if (spell.prayerXp) {
+			prayerXpReceived = spell.prayerXp * quantity;
+
+			prayerXpRes = await user.addXP({
+				skillName: SkillsEnum.Prayer,
+				amount: prayerXpReceived,
+				duration
+			});
+		}
 
 		const loot = spell.output?.clone().multiply(quantity);
 		if (loot) {
@@ -41,7 +50,7 @@ export default class extends Task {
 
 		let str = `${user}, ${user.minionName} finished casting ${quantity}x ${spell.name}, you received ${
 			loot ?? 'no items'
-		}. ${xpRes} ${craftXpRes}`;
+		}. ${xpRes} ${craftXpRes}${prayerXpRes}`;
 
 		handleTripFinish(
 			user,


### PR DESCRIPTION
Enables you to gain prayer xp from the demonic ashes that currently have no use in the bot.

XP/hr seems slightly higher than what the wiki suggests, but the ticks are accurate to what the wiki says.

-   [x] I have tested all my changes thoroughly.
