### PR TITLE
Adjusted Ensouled head kill speeds

### DIFF
--- a/src/lib/minions/data/killableMonsters/reanimated.ts
+++ b/src/lib/minions/data/killableMonsters/reanimated.ts
@@ -178,7 +178,7 @@ for (const { mon, magicLvl, cost, prayerXP, magicXP } of renanimatedMonstersRaw)
 		id: mon.id,
 		name: mon.name,
 		aliases: mon.aliases,
-		timeToFinish: (Time.Second * magicLvl) / 10,
+		timeToFinish: magicLvl > 28 ? 13.2 * Time.Second : 8.1 * Time.Second,
 		table: mon,
 		wildy: false,
 		difficultyRating: 1,


### PR DESCRIPTION
### Description:

Adjusted Ensouled head kill speeds to better reflect in game rates. All reanimated monsters over lvl 16 magic have flat 35 hp giving them very similar kill speeds. 

https://www.youtube.com/watch?v=yl-iPiPVO-M&ab_channel=KillzoneOSRS

### Changes:

See above, balanced rates.

### Other checks:

-   [X] I have tested all my changes thoroughly.
