### PR TITLE
adjusted offer speed

### DIFF
--- a/src/mahoji/commands/offer.ts
+++ b/src/mahoji/commands/offer.ts
@@ -203,7 +203,7 @@ export const mineCommand: OSBMahojiCommand = {
 			} to Barlak and received ${xp} Construction XP.`;
 		}
 
-		const speedMod = 4.8;
+		const speedMod = 1.5;
 
 		const bone = Prayer.Bones.find(
 			bone => stringMatches(bone.name, options.name) || stringMatches(bone.name.split(' ')[0], options.name)


### PR DESCRIPTION
### Description:

Adjusted the offering speed to better reflect in game rates and also keep it moderate lower since we got more skilled and active PKers in the bot. Used the offical skilling discord as backup for rates.

### Changes:

Balanced rates based on recorded ingame rates. 
https://www.youtube.com/watch?v=GmQLLWFRlj0&ab_channel=dids

### Other checks:

-   [X] I have tested all my changes thoroughly.
