### PR TITLE
Fix fightcaves repeat trip

### DIFF
--- a/src/tasks/minions/minigames/fightCavesActivity.ts
+++ b/src/tasks/minions/minigames/fightCavesActivity.ts
@@ -111,7 +111,7 @@ export default class extends Task {
 				user,
 				channelID,
 				`${user} ${msg}`,
-				['fightcaves', [], true],
+				['activities', { fight_caves: {} }, true],
 				await chatHeadImage({
 					content: `TzTok-Jad stomp you to death...nice try though JalYt, for your effort I give you ${tokkulReward}x Tokkul. ${attemptsStr}.`,
 					head: 'mejJal'


### PR DESCRIPTION
Currently if you die during the waves you can repeat the trip, however if you die to Jad you cannot. This fixes that bug.

-   [x] I have tested all my changes thoroughly.
