### PR TITLE
BSO - ODS Buy, make name required

### DIFF
--- a/src/mahoji/commands/bsominigames.ts
+++ b/src/mahoji/commands/bsominigames.ts
@@ -120,6 +120,7 @@ export const minigamesCommand: OSBMahojiCommand = {
 							type: ApplicationCommandOptionType.String,
 							name: 'name',
 							description: 'The thing you want to buy.',
+							required: true,
 							autocomplete: async (value: string) => {
 								return OuraniaBuyables.filter(i =>
 									!value ? true : i.item.name.toLowerCase().includes(value.toLowerCase())


### PR DESCRIPTION
Make the name element of the ods buy command required. This stops an error from throwing.

-   [ ] I have tested all my changes thoroughly.
