### PR TITLE
Give Moktang Hitpoints Master Cape boost

### DIFF
--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -43,6 +43,7 @@ export function calcMaxTripLength(user: User | KlasaUser, activity?: activity_ty
 		case 'VasaMagus':
 		case 'Ignecarus':
 		case 'KingGoldemar':
+		case 'Moktang':
 		case 'Dungeoneering': {
 			masterHPCapeBoost = 10;
 			regularHPBoost = true;


### PR DESCRIPTION
### Description:

Give Moktang the 10% boost from HP Cape like other combat-relatved custom activities.

### Changes:

- Adds Moktang to the list of activities that receive the 10% Hitpoints master cape boost

### Other checks:

-   [x] I have tested all my changes thoroughly.
