### PR TITLE
KG repeat trip on solo death

### DIFF
--- a/src/tasks/minions/bso/kingGoldemarActivity.ts
+++ b/src/tasks/minions/bso/kingGoldemarActivity.ts
@@ -53,7 +53,7 @@ export default class extends Task {
 				`${tagAll}\n\n${solo ? 'You were' : 'Your team was'} crushed by King Goldemar, you never stood a chance.`
 				[
 					'k',
-					{ name: solo ? 'King Goldemar (Solo)' : 'King Goldemar (Mass) },
+					{ name: solo ? 'King Goldemar (Solo)' : 'King Goldemar (Mass)' },
 					true
 				],
 				undefined,

--- a/src/tasks/minions/bso/kingGoldemarActivity.ts
+++ b/src/tasks/minions/bso/kingGoldemarActivity.ts
@@ -51,7 +51,7 @@ export default class extends Task {
 				return handleTripFinish(
 					users[0],
 					channelID,
-					`${tagAll}\n\n${'You were'} crushed by King Goldemar, you never stood a chance.`,
+					`${tagAll}\n\nYou were crushed by King Goldemar, you never stood a chance.`,
 					['k', { name: 'King Goldemar (Solo)' }, true],
 					undefined,
 					data,

--- a/src/tasks/minions/bso/kingGoldemarActivity.ts
+++ b/src/tasks/minions/bso/kingGoldemarActivity.ts
@@ -47,11 +47,19 @@ export default class extends Task {
 
 		const tagAll = users.map(u => u.toString()).join(', ');
 		if (deaths.length === idArr.length) {
-			return sendToChannelID(channelID, {
-				content: `${tagAll}\n\n${
-					solo ? 'You were' : 'Your team was'
-				} crushed by King Goldemar, you never stood a chance.`
-			});
+			return handleTripFinish(
+				user,				
+				channelID,
+				`${tagAll}\n\n${solo ? 'You were' : 'Your team was'} crushed by King Goldemar, you never stood a chance.`
+				[
+					'k',
+					{ name: solo ? 'King Goldemar (Solo)' : 'King Goldemar (Mass) },
+					true
+				],
+				undefined,
+				data,
+				null
+			);
 		}
 
 		await Promise.all(users.map(u => u.incrementMonsterScore(KingGoldemar.id, 1)));

--- a/src/tasks/minions/bso/kingGoldemarActivity.ts
+++ b/src/tasks/minions/bso/kingGoldemarActivity.ts
@@ -47,19 +47,20 @@ export default class extends Task {
 
 		const tagAll = users.map(u => u.toString()).join(', ');
 		if (deaths.length === idArr.length) {
-			return handleTripFinish(
-				user,				
-				channelID,
-				`${tagAll}\n\n${solo ? 'You were' : 'Your team was'} crushed by King Goldemar, you never stood a chance.`
-				[
-					'k',
-					{ name: solo ? 'King Goldemar (Solo)' : 'King Goldemar (Mass)' },
-					true
-				],
-				undefined,
-				data,
-				null
-			);
+			if (solo) {
+				return handleTripFinish(
+					users[0],
+					channelID,
+					`${tagAll}\n\n${'You were'} crushed by King Goldemar, you never stood a chance.`,
+					['k', { name: 'King Goldemar (Solo)' }, true],
+					undefined,
+					data,
+					null
+				);
+			}
+			return sendToChannelID(channelID, {
+				content: `${tagAll}\n\n${'Your team was'} crushed by King Goldemar, you never stood a chance.`
+			});
 		}
 
 		await Promise.all(users.map(u => u.incrementMonsterScore(KingGoldemar.id, 1)));


### PR DESCRIPTION
Adds the repeat trip to when your minion dies at KG.

Closes #4297 

-   [x] I have tested all my changes thoroughly.
