### PR TITLE
Hide unusable minion buttons when busy

### DIFF
--- a/src/commands/minion.ts
+++ b/src/commands/minion.ts
@@ -56,13 +56,15 @@ export default class MinionCommand extends BotCommand {
 			);
 		}
 
-		extraButtons.push(
-			new MessageButton()
-				.setLabel('Auto Slay')
-				.setEmoji(Emoji.Slayer)
-				.setCustomID('AUTO_SLAY')
-				.setStyle('SECONDARY')
-		);
+		if (!msg.author.minionIsBusy) {
+			extraButtons.push(
+				new MessageButton()
+					.setLabel('Auto Slay')
+					.setEmoji(Emoji.Slayer)
+					.setCustomID('AUTO_SLAY')
+					.setStyle('SECONDARY')
+			);
+		}
 
 		extraButtons.push(
 			new MessageButton()
@@ -71,7 +73,8 @@ export default class MinionCommand extends BotCommand {
 				.setCustomID('CHECK_PATCHES')
 				.setStyle('SECONDARY')
 		);
-		if (birdhouseDetails.isReady) {
+
+		if (!msg.author.minionIsBusy && birdhouseDetails.isReady) {
 			extraButtons.push(
 				new MessageButton()
 					.setLabel('Birdhouse Run')
@@ -81,7 +84,7 @@ export default class MinionCommand extends BotCommand {
 			);
 		}
 
-		if (await canRunAutoContract(msg.author.id)) {
+		if (!msg.author.minionIsBusy && (await canRunAutoContract(msg.author.id))) {
 			extraButtons.push(
 				new MessageButton()
 					.setLabel('Auto Farming Contract')
@@ -98,10 +101,12 @@ export default class MinionCommand extends BotCommand {
 
 		const bank = msg.author.bank();
 
-		for (const tier of ClueTiers.filter(t => bank.has(t.scrollID))
-			.reverse()
-			.slice(0, 3)) {
-			extraButtons.push(makeDoClueButton(tier));
+		if (!msg.author.minionIsBusy) {
+			for (const tier of ClueTiers.filter(t => bank.has(t.scrollID))
+				.reverse()
+				.slice(0, 3)) {
+				extraButtons.push(makeDoClueButton(tier));
+			}
 		}
 
 		return msg.channel.send({ content: msg.author.minionStatus, components: chunk(extraButtons, 5) });


### PR DESCRIPTION
### Description:

The following buttons should not be visible when minion is busy:
- Do X clue
- Birdhouse run
- Autoslay
- Farming contract



### Other checks:

-   [ ] I have tested all my changes thoroughly.

![image](https://user-images.githubusercontent.com/10122432/183073190-1599887b-aa86-49c8-9f7c-d8a51aca7646.png)
