### PR TITLE
DuelCommand GP deletion => Add new error type and log duelCommand to trace

### DIFF
--- a/src/lib/util/logError.ts
+++ b/src/lib/util/logError.ts
@@ -2,6 +2,15 @@ import { captureException } from '@sentry/node';
 
 import { production } from '../../config';
 
+export class BotError extends Error {
+	public code?: string;
+	constructor(message: string, name?: string, code?: string | null) {
+		super(message);
+		this.name = name ?? 'BotError';
+		if (code) this.code = code;
+	}
+}
+
 export function logError(err: Error | unknown, context?: Record<string, string>) {
 	if (production) {
 		captureException(err, {

--- a/src/lib/util/logError.ts
+++ b/src/lib/util/logError.ts
@@ -2,15 +2,6 @@ import { captureException } from '@sentry/node';
 
 import { production } from '../../config';
 
-export class BotError extends Error {
-	public code?: string;
-	constructor(message: string, name?: string, code?: string | null) {
-		super(message);
-		this.name = name ?? 'BotError';
-		if (code) this.code = code;
-	}
-}
-
 export function logError(err: Error | unknown, context?: Record<string, string>) {
 	if (production) {
 		captureException(err, {

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -80,7 +80,8 @@ export async function duelCommand(
 			user_id: String(duelSourceUser.id),
 			target_user_id: String(duelTargetUser.id),
 			wager: wagerAmount.toString(),
-			error_code: typeof err === 'object' && 'code' in err ? String(err.code) : 'NONE'
+			error_code: typeof err === 'object' && 'code' in err ? String(err.code) : 'NONE',
+			command: 'duel'
 		};
 		logError(err, extras);
 

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -7,7 +7,7 @@ import { Bank, Util } from 'oldschooljs';
 import { Emoji, Events } from '../../../lib/constants';
 import { UserSettings } from '../../../lib/settings/types/UserSettings';
 import { channelIsSendable, updateGPTrackSetting } from '../../../lib/util';
-import { BotError, logError } from '../../../lib/util/logError';
+import { logError } from '../../../lib/util/logError';
 import { mahojiParseNumber } from '../../mahojiSettings';
 
 async function checkBal(user: KlasaUser, amount: number) {
@@ -73,7 +73,7 @@ export async function duelCommand(
 		return "Duel cancelled, user didn't accept in time.";
 	}
 
-	function duelFail(err: BotError | Error) {
+	function duelFail(err: any) {
 		duelMessage.delete().catch(noOp);
 		const wagerAmount = amount ?? 0;
 		const extras = {
@@ -172,11 +172,14 @@ export async function duelCommand(
 		if (code === 'INTERACTION_COLLECTOR_ERROR') {
 			return cancel();
 		}
-		const failError =
-			err instanceof Error
-				? err
-				: new BotError(`Duel failed for unknown reason: ${String(err)}`, 'duelCommand Error');
+		let failError = err;
+		if (!(failError instanceof Error)) {
+			failError = new Error(`Duel failed for unknown reason: ${String(err)}`);
+			failError.name = 'duelCommand Error';
+		}
 		return duelFail(failError);
 	}
-	return duelFail(new BotError("duelCommand fell through try/catch this shouldn't happen", 'duelCommand Error'));
+	const failError = new Error("duelCommand fell through try/catch this shouldn't happen");
+	failError.name = 'duelCommand Error';
+	return duelFail(failError);
 }

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -169,7 +169,7 @@ export async function duelCommand(
 		}
 	} catch (err: any) {
 		const code = typeof err === 'object' && 'code' in err ? err.code : null;
-		if (code === 'INTERACTION_COLLECTOR_ERROR') {
+		if (code === 'INTERACTION_COLLECTOR_ERROR' && err.message.endsWith('time')) {
 			return cancel();
 		}
 		let failError = err;

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -73,7 +73,7 @@ export async function duelCommand(
 		return "Duel cancelled, user didn't accept in time.";
 	}
 
-	function duelFail(err: BotError) {
+	function duelFail(err: BotError | Error) {
 		duelMessage.delete().catch(noOp);
 		const wagerAmount = amount ?? 0;
 		const extras = {
@@ -171,9 +171,11 @@ export async function duelCommand(
 		if (code === 'INTERACTION_COLLECTOR_ERROR') {
 			return cancel();
 		}
-		return duelFail(
-			new BotError('Duel failed for unknown reason', `duelCommand Error${code ? `: [${code}]` : ''}`, code)
-		);
+		const failError =
+			err instanceof Error
+				? err
+				: new BotError(`Duel failed for unknown reason: ${String(err)}`, 'duelCommand Error');
+		return duelFail(failError);
 	}
 	return duelFail(new BotError("duelCommand fell through try/catch this shouldn't happen", 'duelCommand Error'));
 }


### PR DESCRIPTION
### Description:

The `/gamble duel` command ate some players money, and there's no obvious reason.

The duel was accepted, but before completion, another error was thrown (or the awaiter ended early, causing the try/catch the fall-through). This caused the duel to 'cancel' before completion, and both players lost their money.

### Changes:

- Added some logging to the duel failure so it logs errors that are NOT from timeout, as my testing strongly implies it was not a timeout error. [Process of elimination would tell us it's a timeout anyway if it happens again with no log]


### Other checks:

-   [x] I have tested all my changes thoroughly.
