### PR TITLE
Volcanic dye doesn't work for re-dying

### DIFF
--- a/src/mahoji/lib/abstracted_commands/useCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/useCommand.ts
@@ -154,9 +154,15 @@ const genericUsables: {
 	}
 ];
 
-const allDyes = ['Dungeoneering dye', 'Blood dye', 'Ice dye', 'Shadow dye', 'Third age dye', 'Monkey dye'].map(
-	getOSItem
-);
+const allDyes = [
+	'Dungeoneering dye',
+	'Blood dye',
+	'Ice dye',
+	'Shadow dye',
+	'Third age dye',
+	'Monkey dye',
+	'Volcanic dye'
+].map(getOSItem);
 for (const group of dyedItems) {
 	for (const dyedVersion of group.dyedVersions) {
 		for (const dye of allDyes.filter(i => i !== dyedVersion.dye)) {


### PR DESCRIPTION
### Description:

Volcanic dye doesn't work for re-dying

### Changes:

- Add Volcanic dye to the list of re-dyable dyes

### Other checks:

-   [ ] I have tested all my changes thoroughly.
