### PR TITLE
Fix lucky pick GP deletion bug

### DIFF
--- a/src/mahoji/lib/abstracted_commands/luckyPickCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/luckyPickCommand.ts
@@ -122,7 +122,7 @@ export async function luckyPickCommand(
 		button: ButtonInstance;
 		interaction: MessageComponentInteraction;
 	}) => {
-		let amountReceived = button.mod(amount);
+		let amountReceived = Math.floor(button.mod(amount));
 		await klasaUser.addItemsToBank({ items: new Bank().add('Coins', amountReceived) });
 		await updateGPTrackSetting('gp_luckypick', amountReceived - amount);
 		await updateGPTrackSetting('gp_luckypick', amountReceived - amount, klasaUser);


### PR DESCRIPTION
### Description:

If users win a 1.5x when gambling an odd amount of GP, the fraction causes the DB update to fail, and the GP lost.

### Changes:

- Adds Math.floor() to floor the winnings 

### Other checks:

-   [ ] I have tested all my changes thoroughly.
