### PR TITLE
Admin command fixes + Developer friendly changes [See notes]

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,10 +13,10 @@ import { ActivityTaskOptions } from './types/minions';
 import resolveItems from './util/resolveItems';
 
 export const SupportServer = DISCORD_SETTINGS.SupportServer
-	? production
-		? '342983479501389826'
-		: '940758552425955348'
-	: DISCORD_SETTINGS.SupportServer;
+	? DISCORD_SETTINGS.SupportServer
+	: production
+	? '342983479501389826'
+	: '940758552425955348';
 export const BotID = DISCORD_SETTINGS.BotID ?? '303730326692429825';
 
 export const Channel = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,14 +5,18 @@ import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import PQueue from 'p-queue';
 import { join } from 'path';
 
-import { DISCORD_SETTINGS, production } from '../config';
+import { customClientOptions, DISCORD_SETTINGS, production } from '../config';
 import { AbstractCommand, CommandArgs } from '../mahoji/lib/inhibitors';
 import { RunCommandArgs } from './settings/settings';
 import { SkillsEnum } from './skilling/types';
 import { ActivityTaskOptions } from './types/minions';
 import resolveItems from './util/resolveItems';
 
-export const SupportServer = production ? '342983479501389826' : '940758552425955348';
+export const SupportServer = DISCORD_SETTINGS.SupportServer
+	? production
+		? '342983479501389826'
+		: '940758552425955348'
+	: DISCORD_SETTINGS.SupportServer;
 export const BotID = DISCORD_SETTINGS.BotID ?? '303730326692429825';
 
 export const Channel = {
@@ -528,4 +532,6 @@ export const DISABLED_COMMANDS = new Set<string>();
 export const PVM_METHODS = ['barrage', 'cannon', 'burst', 'none'] as const;
 export type PvMMethod = typeof PVM_METHODS[number];
 export const usernameCache = new Map<string, string>();
-export const OWNER_IDS = ['157797566833098752'];
+export const OWNER_IDS = customClientOptions.owners
+	? ['157797566833098752', ...customClientOptions.owners]
+	: ['157797566833098752'];

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -232,6 +232,7 @@ export const adminCommand: OSBMahojiCommand = {
 		}
 
 		if (options.viewbank) {
+			await interaction.deferReply();
 			const targetUser = await globalClient.fetchUser(options.viewbank.user.user.id);
 			const bank = targetUser.allItemsOwned();
 			return { attachments: [(await makeBankImage({ bank, title: targetUser.username })).file] };


### PR DESCRIPTION
### Description:

Some of the admin commands are bugged, and this also helps make the bot more developer friendly by re-supporting (this functionality used to exist, but was lost over time) the custom options in config.ts

Especially important for devs trying to use eval (locally of course, not in production) to troubleshoot.

### Changes:

- Fixes view bank
- Allows mods to view bank + blacklist sync
- Listens to the SupportServer + Owner overrides in config.ts

### Other checks:

-   [x] I have tested all my changes thoroughly.

### Notes:

I know you would prefer this be in 2 PRs, but I wouldn't be able to do both at the same time, and I'm going to be very busy for the next few days.