### PR TITLE
Sets config.ts OWNER_IDS and SupportServer as source of truth

### DIFF
--- a/src/config.example.ts
+++ b/src/config.example.ts
@@ -30,5 +30,8 @@ export const DISCORD_SETTINGS: Partial<IDiscordSettings> = {
 	// Your bot unique ID goes here
 	BotID: '303730326692429825'
 };
-export const OWNER_ID = '157797566833098752';
+// Add or replace these with your Discord ID:
+export const OWNER_IDS = ['157797566833098752', 'your_discord_id'];
 export const MAXING_MESSAGE = 'Congratulations on maxing!';
+// Discord server where admin commands will be allowed:
+export const SupportServer = '940758552425955348';

--- a/src/config.example.ts
+++ b/src/config.example.ts
@@ -31,7 +31,7 @@ export const DISCORD_SETTINGS: Partial<IDiscordSettings> = {
 	BotID: '303730326692429825'
 };
 // Add or replace these with your Discord ID:
-export const OWNER_IDS = ['157797566833098752', 'your_discord_id'];
+export const OWNER_IDS = ['157797566833098752'];
 export const MAXING_MESSAGE = 'Congratulations on maxing!';
 // Discord server where admin commands will be allowed:
 export const SupportServer = '940758552425955348';

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -1,7 +1,8 @@
 import { GuildMember } from 'discord.js';
 import { Event, EventStore } from 'klasa';
 
-import { Roles, SupportServer } from '../lib/constants';
+import { SupportServer } from '../config';
+import { Roles } from '../lib/constants';
 
 export default class extends Event {
 	public constructor(store: EventStore, file: string[], directory: string) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,14 +1,14 @@
 import { Intents } from 'discord.js';
 import { KlasaClient, KlasaClientOptions } from 'klasa';
 
-import { customClientOptions, production, providerConfig } from '../config';
+import { customClientOptions, OWNER_IDS, production, providerConfig } from '../config';
 
 export const clientOptions: KlasaClientOptions = {
 	/* Discord.js Options */
 	messageCacheMaxSize: 200,
 	messageCacheLifetime: 120,
 	messageSweepInterval: 5000,
-	owners: ['157797566833098752'],
+	owners: [...OWNER_IDS],
 	shards: 'auto',
 	http: {
 		api: 'https://discord.com/api'

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,7 +11,6 @@ import { SkillsEnum } from './skilling/types';
 import { ActivityTaskOptions } from './types/minions';
 import resolveItems from './util/resolveItems';
 
-export const SupportServer = production ? '342983479501389826' : '940758552425955348';
 export const BotID = DISCORD_SETTINGS.BotID ?? '303730326692429825';
 
 export const Channel = {
@@ -522,7 +521,6 @@ export const DISABLED_COMMANDS = new Set<string>();
 export const PVM_METHODS = ['barrage', 'cannon', 'burst', 'none'] as const;
 export type PvMMethod = typeof PVM_METHODS[number];
 export const usernameCache = new Map<string, string>();
-export const OWNER_IDS = ['157797566833098752'];
 export const minionBuyButton: APIButtonComponentWithCustomId = {
 	type: ComponentType.Button,
 	custom_id: 'BUY_MINION',

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -2,9 +2,9 @@ import { Message, MessageActionRow, MessageButton } from 'discord.js';
 import { noOp } from 'e';
 import { KlasaUser } from 'klasa';
 
-import { CLIENT_ID, MAXING_MESSAGE } from '../config';
+import { CLIENT_ID, MAXING_MESSAGE, SupportServer } from '../config';
 import { minionStatusCommand } from '../mahoji/lib/abstracted_commands/minionStatusCommand';
-import { Events, LEVEL_99_XP, SupportServer } from './constants';
+import { Events, LEVEL_99_XP } from './constants';
 import { prisma } from './settings/prisma';
 import Skills from './skilling/skills';
 import { channelIsSendable } from './util';

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -31,8 +31,8 @@ import { ItemBank } from 'oldschooljs/dist/meta/types';
 import Items from 'oldschooljs/dist/structures/Items';
 import { bool, integer, MersenneTwister19937, nodeCrypto, real, shuffle } from 'random-js';
 
-import { CLIENT_ID, production } from '../config';
-import { skillEmoji, SupportServer, usernameCache } from './constants';
+import { CLIENT_ID, production, SupportServer } from '../config';
+import { skillEmoji, usernameCache } from './constants';
 import { DefenceGearStat, GearSetupType, GearSetupTypes, GearStat, OffenceGearStat } from './gear/types';
 import { Consumable } from './minions/types';
 import { POHBoosts } from './poh';

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -492,7 +492,7 @@ export const adminCommand: OSBMahojiCommand = {
 		await interaction.deferReply();
 
 		const adminUser = await mahojiUsersSettingsFetch(userID);
-		const isOwner = OWNER_IDS.includes(userID.toString()) || OWNER_IDS.includes(interaction.userID.toString());
+		const isOwner = OWNER_IDS.includes(userID.toString());
 		const isMod = isOwner || adminUser.bitfield.includes(BitField.isModerator);
 		if (!guildID || !isMod || (production && guildID.toString() !== SupportServer)) return randArrItem(gifs);
 

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -492,7 +492,7 @@ export const adminCommand: OSBMahojiCommand = {
 		await interaction.deferReply();
 
 		const adminUser = await mahojiUsersSettingsFetch(userID);
-		const isOwner = OWNER_IDS.includes(String(userID)) || OWNER_IDS.includes(interaction.userID.toString());
+		const isOwner = OWNER_IDS.includes(userID.toString()) || OWNER_IDS.includes(interaction.userID.toString());
 		const isMod = isOwner || adminUser.bitfield.includes(BitField.isModerator);
 		if (!guildID || !isMod || (production && guildID.toString() !== SupportServer)) return randArrItem(gifs);
 

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -15,9 +15,9 @@ import { inspect } from 'node:util';
 import { Bank } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
 
-import { CLIENT_ID, production } from '../../config';
+import { CLIENT_ID, OWNER_IDS, production, SupportServer } from '../../config';
 import { BLACKLISTED_GUILDS, BLACKLISTED_USERS, syncBlacklists } from '../../lib/blacklists';
-import { badges, BadgesEnum, BitField, BitFieldData, DISABLED_COMMANDS, OWNER_IDS } from '../../lib/constants';
+import { badges, BadgesEnum, BitField, BitFieldData, DISABLED_COMMANDS } from '../../lib/constants';
 import { countUsersWithItemInCl, prisma } from '../../lib/settings/prisma';
 import { cancelTask, minionActivityCacheDelete } from '../../lib/settings/settings';
 import {
@@ -144,7 +144,7 @@ const viewableThings: {
 export const adminCommand: OSBMahojiCommand = {
 	name: 'admin',
 	description: 'Allows you to trade items with other players.',
-	guildID: production ? '342983479501389826' : '940758552425955348',
+	guildID: SupportServer,
 	options: [
 		{
 			type: ApplicationCommandOptionType.Subcommand,
@@ -492,7 +492,10 @@ export const adminCommand: OSBMahojiCommand = {
 		await interaction.deferReply();
 
 		const adminUser = await mahojiUsersSettingsFetch(userID);
-		const isMod = adminUser.bitfield.includes(BitField.isModerator);
+		const isOwner = OWNER_IDS.includes(String(userID)) || OWNER_IDS.includes(interaction.userID.toString());
+		const isMod = isOwner || adminUser.bitfield.includes(BitField.isModerator);
+		if (!guildID || !isMod || (production && guildID.toString() !== SupportServer)) return randArrItem(gifs);
+
 		if (options.wipe_bingo_temp_cls) {
 			if (userID.toString() !== '319396464402890753' && !isMod) return randArrItem(gifs);
 			const usersToReset = await prisma.user.findMany({
@@ -773,7 +776,7 @@ LIMIT 10;
 		 * Owner Only Commands
 		 *
 		 */
-		if (userID.toString() !== '157797566833098752' || interaction.userID.toString() !== '157797566833098752') {
+		if (!isOwner) {
 			return randArrItem(gifs);
 		}
 		if (options.viewbank) {

--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -59,6 +59,7 @@ const randomPatMessage = (minionName: string) => randArrItem(patMessages).replac
 
 export async function getUserInfo(user: User) {
 	const klasaUser = await globalClient.fetchUser(user.id);
+	await klasaUser.settings.sync(true);
 	const roboChimpUser = await roboChimpUserFetch(BigInt(user.id));
 
 	const bitfields = `${(user.bitfield as BitField[])

--- a/src/mahoji/lib/abstracted_commands/dailyCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/dailyCommand.ts
@@ -5,7 +5,8 @@ import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import { SlashCommandInteraction } from 'mahoji/dist/lib/structures/SlashCommandInteraction';
 import { Bank } from 'oldschooljs';
 
-import { COINS_ID, Emoji, SupportServer } from '../../../lib/constants';
+import { SupportServer } from '../../../config';
+import { COINS_ID, Emoji } from '../../../lib/constants';
 import pets from '../../../lib/data/pets';
 import { DynamicButtons } from '../../../lib/DynamicButtons';
 import { getRandomTriviaQuestions } from '../../../lib/roboChimp';

--- a/src/mahoji/lib/inhibitors.ts
+++ b/src/mahoji/lib/inhibitors.ts
@@ -4,7 +4,7 @@ import { KlasaUser } from 'klasa';
 import { ComponentType } from 'mahoji';
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 
-import { OWNER_ID, production } from '../../config';
+import { OWNER_IDS, production, SupportServer } from '../../config';
 import { BLACKLISTED_GUILDS, BLACKLISTED_USERS } from '../../lib/blacklists';
 import {
 	BadgesEnum,
@@ -13,8 +13,7 @@ import {
 	Channel,
 	DISABLED_COMMANDS,
 	minionBuyButton,
-	PerkTier,
-	SupportServer
+	PerkTier
 } from '../../lib/constants';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { CategoryFlag } from '../../lib/types';
@@ -281,7 +280,7 @@ const inhibitors: Inhibitor[] = [
 		name: 'cooldown',
 		run: async ({ user, command }) => {
 			if (!command.attributes?.cooldown) return false;
-			if (OWNER_ID === user.id || user.bitfield.includes(BitField.isModerator)) return false;
+			if (OWNER_IDS.includes(user.id) || user.bitfield.includes(BitField.isModerator)) return false;
 			const cooldownForThis = Cooldowns.get(user.id, command.name, command.attributes.cooldown);
 			if (cooldownForThis) {
 				return `This command is on cooldown, you can use it again in ${formatDuration(cooldownForThis)}`;

--- a/src/monitors/rareRoles.ts
+++ b/src/monitors/rareRoles.ts
@@ -2,7 +2,8 @@ import { TextChannel } from 'discord.js';
 import { Time } from 'e';
 import { KlasaMessage, Monitor, MonitorStore } from 'klasa';
 
-import { Channel, Emoji, SupportServer } from '../lib/constants';
+import { SupportServer } from '../config';
+import { Channel, Emoji } from '../lib/constants';
 import { roll } from '../lib/util';
 
 const rareRoles: [string, number, string][] = [

--- a/src/tasks/roles.ts
+++ b/src/tasks/roles.ts
@@ -2,9 +2,9 @@ import { Guild } from 'discord.js';
 import { noOp, notEmpty } from 'e';
 import { Task } from 'klasa';
 
-import { production } from '../config';
+import { production, SupportServer } from '../config';
 import { ClueTiers } from '../lib/clues/clueTiers';
-import { BOT_TYPE, Roles, SupportServer, usernameCache } from '../lib/constants';
+import { BOT_TYPE, Roles, usernameCache } from '../lib/constants';
 import { getCollectionItems } from '../lib/data/Collections';
 import { Minigames } from '../lib/settings/minigames';
 import { prisma } from '../lib/settings/prisma';


### PR DESCRIPTION
### Description:

As discussed

### Changes:

- Uses config.ts OWNER_IDS and SupportServer as source of truth for these options.
- Updates config.example.ts accordingly
- Adds klasaUser sync to admin.view_user

### Other checks:

-   [x] I have tested all my changes thoroughly.
