### PR TITLE
Fix /k show_info not working when minion is busy.

### DIFF
--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -57,7 +57,6 @@ export const killCommand: OSBMahojiCommand = {
 	description: 'Send your minion to kill things.',
 	attributes: {
 		requiresMinion: true,
-		requiresMinionNotBusy: true,
 		examples: ['/k name:zulrah']
 	},
 	options: [

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -122,6 +122,9 @@ export async function minionKillCommand(
 	quantity: number | undefined,
 	method: PvMMethod | undefined
 ) {
+	if (user.minionIsBusy) {
+		return 'Your minion is busy.';
+	}
 	const { minionName } = user;
 
 	const boosts = [];


### PR DESCRIPTION
### Description:

Removes minion busy check from the /k command and adds it to the minionkillcommand

### Changes:


### Other checks:

-   [ ] I have tested all my changes thoroughly.
