### PR TITLE
Fix Black Demon XP / HP overwrite bug, and remove undead attrib from Malygos

### DIFF
--- a/src/lib/minions/data/killableMonsters/custom/customMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/custom/customMonsters.ts
@@ -1,4 +1,5 @@
 import { LootTable } from 'oldschooljs';
+import { MonsterData } from 'oldschooljs/dist/meta/monsterData';
 import Monster from 'oldschooljs/dist/structures/Monster';
 
 import setCustomMonster, { makeKillTable } from '../../../../util/setCustomMonster';
@@ -17,6 +18,7 @@ export interface CustomMonster extends Readonly<Omit<Readonly<KillableMonster>, 
 	readonly table: LootTable;
 	readonly baseMonster: Monster;
 	readonly hp?: number;
+	readonly customMonsterData?: Partial<MonsterData>;
 }
 
 export const customKillableMonsters: KillableMonster[] = [];
@@ -29,9 +31,16 @@ export const BSOMonsters = {
 
 for (const monster of Object.values(BSOMonsters)) {
 	const monsterData = { ...monster.baseMonster };
+	// This is necessary otherwise changes to HP, etc overwrite the base Monster:
+	monsterData.data = { ...monsterData.data };
 	if (monster.hp) {
 		monsterData.data.hitpoints = monster.hp;
 	}
-	setCustomMonster(monster.id, monster.name, monster.table, monsterData, { aliases: monster.aliases });
+	if (monster.customMonsterData) {
+		monsterData.data = { ...monsterData.data, ...monster.customMonsterData };
+	}
+	setCustomMonster(monster.id, monster.name, monster.table, monsterData, {
+		aliases: monster.aliases
+	});
 	customKillableMonsters.push({ ...monster, table: makeKillTable(monster.table) });
 }

--- a/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
+++ b/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
@@ -99,7 +99,7 @@ const Malygos: CustomMonster = {
 	uniques: resolveItems(['Abyssal thread', 'Abyssal cape', 'Ori', 'Dragon hunter lance']),
 	notifyDrops: resolveItems(['Abyssal cape', 'Ori']),
 	baseMonster: Monsters.Vorkath,
-	customMonsterData: { attributes: [MonsterAttribute.Dragon] }
+	customMonsterData: { attributes: [MonsterAttribute.Dragon, MonsterAttribute.Fiery] }
 };
 
 const Treebeard: CustomMonster = {

--- a/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
+++ b/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
@@ -1,5 +1,6 @@
 import { Time } from 'e';
 import { LootTable, Monsters } from 'oldschooljs';
+import { MonsterAttribute } from 'oldschooljs/dist/meta/monsterData';
 import RareDropTable from 'oldschooljs/dist/simulation/subtables/RareDropTable';
 import { itemID } from 'oldschooljs/dist/util';
 
@@ -97,7 +98,8 @@ const Malygos: CustomMonster = {
 	},
 	uniques: resolveItems(['Abyssal thread', 'Abyssal cape', 'Ori', 'Dragon hunter lance']),
 	notifyDrops: resolveItems(['Abyssal cape', 'Ori']),
-	baseMonster: Monsters.Vorkath
+	baseMonster: Monsters.Vorkath,
+	customMonsterData: { attributes: [MonsterAttribute.Dragon] }
 };
 
 const Treebeard: CustomMonster = {


### PR DESCRIPTION
### Description:

Black demons are giving like 4x more XP than intended because Tormented Demons are overwriting their hitpoints.

This PR fixes that, and also removes the `undead` attribute from Malygos as it was unintended for Malygos to get the Salve effect boost.

### Changes:

- Copies `Monster.data` data by value instead of by reference. (`...` expansion)
- Removes `undead` attributed from Malygos

### Other checks:

-   [x] I have tested all my changes thoroughly.
