### PR TITLE
Fix invention bonecrusher XP tracking

### DIFF
--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -62,7 +62,7 @@ async function bonecrusherEffect(user: KlasaUser, loot: Bank, duration: number, 
 	totalXP *= 5;
 	userStatsUpdate(user.id, () => ({
 		bonecrusher_prayer_xp: {
-			increment: totalXP
+			increment: Math.floor(totalXP)
 		}
 	}));
 	const xpStr = await user.addXP({


### PR DESCRIPTION
### Description:

Decimals are causing this to break

### Changes:

- Math.floor() the amount of xp gained, just like addXP does

### Other checks:

-   [ ] I have tested all my changes thoroughly.
![image](https://user-images.githubusercontent.com/10122432/184071796-a25ca7e3-942d-48ff-a1f7-66948c69a90d.png)

 