### PR TITLE
Minor Nihiliz nerf (Remove sharks, anglerfish, etc)

### DIFF
--- a/src/lib/minions/data/killableMonsters/custom/Nihiliz.ts
+++ b/src/lib/minions/data/killableMonsters/custom/Nihiliz.ts
@@ -9,15 +9,13 @@ const clueTable = new LootTable()
 	.add('Clue scroll (medium)', [1, 5], 4)
 	.add('Clue scroll (medium)', 1, 8);
 
-const foodTable = new LootTable()
-	.add('Shark', [1, 50], 3)
-	.add('Manta ray', [1, 50], 2)
+const rawFoodTable = new LootTable()
 	.add('Raw tuna', [50, 150], 3)
 	.add('Raw swordfish', [40, 120], 2)
-	.add('Raw anglerfish', [5, 10], 2)
-	.add('Raw rocktail', [2, 5], 2);
+	.add('Raw trout', [30, 100], 4)
+	.add('Raw lobster', [40, 100], 5);
 
-const regularTable = new LootTable()
+const regularTable = new LootTable({ limit: 41 })
 	/* Supplies */
 	.add('Dragon bolts (unf)', [20, 30], 2)
 	.add('Cadantine seed', [1, 3], 2)
@@ -37,7 +35,7 @@ const regularTable = new LootTable()
 	.add('Runite ore', [10, 50])
 
 	/* Food */
-	.add(foodTable, 1, 14)
+	.add(rawFoodTable, 1, 10)
 
 	/* Other */
 	.add('Coins', [50_000, 200_000])
@@ -52,7 +50,7 @@ export const NihilizLootTable = new LootTable()
 	.every(regularTable, 3)
 
 	/* Tertiary */
-	.tertiary(4, foodTable)
+	.tertiary(4, rawFoodTable)
 	.tertiary(8, clueTable)
 	.tertiary(10, 'Nihil shard', [5, 20])
 	.tertiary(1200, 'Nihil horn')

--- a/src/lib/minions/data/killableMonsters/custom/Nihiliz.ts
+++ b/src/lib/minions/data/killableMonsters/custom/Nihiliz.ts
@@ -9,11 +9,7 @@ const clueTable = new LootTable()
 	.add('Clue scroll (medium)', [1, 5], 4)
 	.add('Clue scroll (medium)', 1, 8);
 
-const rawFoodTable = new LootTable()
-	.add('Raw tuna', [50, 150], 3)
-	.add('Raw swordfish', [40, 120], 2)
-	.add('Raw trout', [30, 100], 4)
-	.add('Raw lobster', [40, 100], 5);
+const rawFoodTable = new LootTable().add('Raw tuna', [25, 75], 3).add('Raw swordfish', [20, 60], 2);
 
 const regularTable = new LootTable({ limit: 41 })
 	/* Supplies */


### PR DESCRIPTION
### Description:

Nerfing Nihiliz so that there is a net-negative on the Food supply in BSO.

This basically does 2 things:
1. Removes all cooked food, and the raw angler fish + rocktail, **without** increasing any other drop rates
2. Also lowers the chance to even hit the rawFoodTable to bring in less raw food also.

### Changes:

- Removed Sharks, Manta rays, raw rocktail, raw anglerfish
- Lowered quantities of raw food to compensate for fewer items on the table.
- Lowered chance to hit the `rawFoodTable`
- Added empty slots on the drop table so the other drops won't be more common. (Total weight = 37, limit = 41)
-    ^ (4 slots are now blank, to compensate for the 14 => 10 change from the rawFoodTable)

### Other checks:

-   [x] I have tested all my changes thoroughly.

Example 10k loot:
![image](https://user-images.githubusercontent.com/10122432/184368787-d078111b-9aff-4a76-8fa3-01fdcac1ef74.png)
