### PR TITLE
Fix abyssal tentacle wasting whips on create with onCreate() charges

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -367,7 +367,7 @@ model User {
   temp_cl            Json      @default("{}") @db.Json
   last_temp_cl_reset DateTime? @db.Timestamp(6)
 
-  tentacle_charges Int @default(10000)
+  tentacle_charges Int @default(0)
   sang_charges     Int @default(0)
 
   gp_luckypick BigInt @default(0)

--- a/src/lib/data/creatables/slayer.ts
+++ b/src/lib/data/creatables/slayer.ts
@@ -1,5 +1,7 @@
 import { Bank } from 'oldschooljs';
+import { toKMB } from 'oldschooljs/dist/util/util';
 
+import { mahojiUserSettingsUpdate } from '../../../mahoji/mahojiSettings';
 import { SlayerTaskUnlocksEnum } from '../../slayer/slayerUnlocks';
 import { Createable } from '../createables';
 
@@ -130,7 +132,16 @@ export const slayerCreatables: Createable[] = [
 		}),
 		outputItems: new Bank({ 'Abyssal tentacle': 1 }),
 		GPCost: 0,
-		maxCanOwn: 1
+		maxCanOwn: 1,
+		onCreate: async (qty, user) => {
+			await mahojiUserSettingsUpdate(user.id, { tentacle_charges: { increment: 10_000 * qty } });
+			return {
+				result: true,
+				message: `Your Abyssal tentacle was given ${toKMB(
+					10_000 * qty
+				)} charges.\nUse \`/minion charge\` to add more.`
+			};
+		}
 	},
 	{
 		name: 'Brimstone ring',

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -33,6 +33,7 @@ export interface Createable {
 	requiredSlayerUnlocks?: SlayerTaskUnlocksEnum[];
 	requiredFavour?: Favours;
 	maxCanOwn?: number;
+	onCreate?:
 }
 
 const goldenProspectorCreatables: Createable[] = [

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1,3 +1,4 @@
+import { KlasaUser } from 'klasa';
 import { Bank } from 'oldschooljs';
 
 import { Favours } from '../minions/data/kourendFavour';
@@ -33,7 +34,7 @@ export interface Createable {
 	requiredSlayerUnlocks?: SlayerTaskUnlocksEnum[];
 	requiredFavour?: Favours;
 	maxCanOwn?: number;
-	onCreate?:
+	onCreate?: (qty: number, user: KlasaUser) => Promise<{ result: boolean; message: string }>;
 }
 
 const goldenProspectorCreatables: Createable[] = [

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -93,6 +93,7 @@ const source: [string, (string | number)[]][] = [
 	['Malediction ward', [12_806]],
 	['Dark bow', [12_765, 12_766, 12_767, 12_768]],
 	['Abyssal whip', ['Volcanic abyssal whip', 'Frozen abyssal whip', 'Abyssal tentacle']],
+	['Abyssal tentacle', ['Abyssal tentacle (or)']],
 	['Granite maul', [12_848]],
 	['Rune scimitar', [23_330, 23_332, 23_334]],
 	[

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -25,7 +25,7 @@ export const degradeableItems: DegradeableItem[] = [
 	{
 		item: getOSItem('Abyssal tentacle'),
 		settingsKey: 'tentacle_charges',
-		itemsToRefundOnBreak: new Bank().add('Kraken tentacle'),
+		itemsToRefundOnBreak: new Bank().add('Abyssal tentacle'),
 		setup: 'melee',
 		aliases: ['tentacle', 'tent'],
 		chargeInput: {

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -25,7 +25,7 @@ export const degradeableItems: DegradeableItem[] = [
 	{
 		item: getOSItem('Abyssal tentacle'),
 		settingsKey: 'tentacle_charges',
-		itemsToRefundOnBreak: new Bank().add('Abyssal tentacle'),
+		itemsToRefundOnBreak: new Bank().add('Kraken tentacle'),
 		setup: 'melee',
 		aliases: ['tentacle', 'tent'],
 		chargeInput: {

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -52,7 +52,7 @@ Client.defaultUserSchema
 	.add('main_account', 'string', { default: null })
 	.add('premium_balance_tier', 'integer', { default: null })
 	.add('premium_balance_expiry_date', 'integer', { default: null, maximum: Number.MAX_SAFE_INTEGER })
-	.add('tentacle_charges', 'integer', { default: 10_000 })
+	.add('tentacle_charges', 'integer', { default: 0 })
 	.add('sang_charges', 'integer', { default: 0 })
 	.add('volcanic_mine_points', 'integer', { default: 0 })
 	.add('slayer', folder =>

--- a/src/mahoji/commands/create.ts
+++ b/src/mahoji/commands/create.ts
@@ -197,6 +197,16 @@ export const createCommand: OSBMahojiCommand = {
 			return `You don't have the required items to ${action} this item. You need: ${inItems}.`;
 		}
 
+		let extraMessage = '';
+		// Handle onCreate() features, and last chance to abort:
+		if (createableItem.onCreate) {
+			const onCreateResult = await createableItem.onCreate(quantity, user);
+			if (!onCreateResult.result) {
+				return onCreateResult.message;
+			}
+			extraMessage += `\n\n${onCreateResult.message}`;
+		}
+
 		await user.removeItemsFromBank(inItems);
 		await transactItems({ userID: userID.toString(), itemsToAdd: outItems });
 
@@ -209,8 +219,8 @@ export const createCommand: OSBMahojiCommand = {
 		if (!createableItem.noCl && action === 'create') await user.addItemsToCollectionLog({ items: outItems });
 
 		if (action === 'revert') {
-			return `You reverted ${inItems} into ${outItems}.`;
+			return `You reverted ${inItems} into ${outItems}.${extraMessage}`;
 		}
-		return `You received ${outItems}.`;
+		return `You received ${outItems}.${extraMessage}`;
 	}
 };

--- a/src/mahoji/commands/create.ts
+++ b/src/mahoji/commands/create.ts
@@ -204,7 +204,7 @@ export const createCommand: OSBMahojiCommand = {
 			if (!onCreateResult.result) {
 				return onCreateResult.message;
 			}
-			extraMessage += `\n\n${onCreateResult.message}`;
+			if (onCreateResult.message) extraMessage += `\n\n${onCreateResult.message}`;
 		}
 
 		await user.removeItemsFromBank(inItems);


### PR DESCRIPTION
### Description:

When Abyssal tentacle was launched as a degradeable, because the 10k charges were the default, and there was no way to add charges with the \/create method, we limited the user's ability to create multiple tentacles, and we DONT revert it to a Kraken tentacle. 

This was changed and has caused several people to lose their whips when attempting to re-create their abyssal tentacle.


### Changes:

- Adds onCreate() optional function to Creatable interface
- Inserts code into create.ts command to call and process the results of onCreate()
- Adds the onCreate() hook to the Abyssal tentacle creatable

### Other checks:

-   [x] I have tested all my changes thoroughly.
