### PR TITLE
Allow stalls/tzhaar to check cl for fire cape.

### DIFF
--- a/src/lib/skilling/skills/thieving/stealables.ts
+++ b/src/lib/skilling/skills/thieving/stealables.ts
@@ -33,7 +33,7 @@ export interface Stealable {
 	level: number;
 	xp: number;
 	qpRequired?: number;
-	itemsRequired?: ItemBank;
+	fireCapeRequired?: ItemBank;
 	table: LootTable;
 	id: number;
 	// Stall properties
@@ -208,7 +208,7 @@ const stalls: Stealable[] = [
 		// World hopping rate
 		respawnTime: Time.Second * 15,
 		lootPercent: 100,
-		itemsRequired: resolveNameBank({
+		fireCapeRequired: resolveNameBank({
 			'Fire cape': 1
 		})
 	}
@@ -511,7 +511,7 @@ const pickpocketables: Stealable[] = [
 		stunDamage: 4,
 		slope: 1.611_25,
 		intercept: -80.993_75,
-		itemsRequired: resolveNameBank({
+		fireCapeRequired: resolveNameBank({
 			'Fire cape': 1
 		})
 	}

--- a/src/lib/skilling/skills/thieving/stealables.ts
+++ b/src/lib/skilling/skills/thieving/stealables.ts
@@ -22,9 +22,6 @@ import Vyre from 'oldschooljs/dist/simulation/monsters/low/t-z/Vyre';
 import WarriorWoman from 'oldschooljs/dist/simulation/monsters/low/t-z/WarriorWoman';
 import YanilleWatchman from 'oldschooljs/dist/simulation/monsters/low/t-z/YanilleWatchman';
 import LootTable from 'oldschooljs/dist/structures/LootTable';
-import { resolveNameBank } from 'oldschooljs/dist/util';
-
-import { ItemBank } from '../../../types';
 
 export interface Stealable {
 	name: string;
@@ -33,7 +30,7 @@ export interface Stealable {
 	level: number;
 	xp: number;
 	qpRequired?: number;
-	fireCapeRequired?: ItemBank;
+	fireCapeRequired?: boolean;
 	table: LootTable;
 	id: number;
 	// Stall properties
@@ -208,9 +205,7 @@ const stalls: Stealable[] = [
 		// World hopping rate
 		respawnTime: Time.Second * 15,
 		lootPercent: 100,
-		fireCapeRequired: resolveNameBank({
-			'Fire cape': 1
-		})
+		fireCapeRequired: true
 	}
 ];
 
@@ -511,9 +506,7 @@ const pickpocketables: Stealable[] = [
 		stunDamage: 4,
 		slope: 1.611_25,
 		intercept: -80.993_75,
-		fireCapeRequired: resolveNameBank({
-			'Fire cape': 1
-		})
+		fireCapeRequired: true
 	}
 ];
 

--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -1,5 +1,4 @@
 import { APIUser, ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
-import { Bank } from 'oldschooljs';
 
 import { ArdougneDiary, userhasDiaryTier } from '../../lib/diaries';
 import { Favours, gotFavour } from '../../lib/minions/data/kourendFavour';
@@ -72,10 +71,12 @@ export const stealCommand: OSBMahojiCommand = {
 			} a ${stealable.name}.`;
 		}
 
-		if (stealable.fireCapeRequired && !user.cl().has(stealable.fireCapeRequired)) {
-			return `You need these items to ${
-				stealable.type === 'pickpockable' ? 'pickpocket this NPC' : 'steal from this stall'
-			}: ${new Bank(stealable.fireCapeRequired)}.`;
+		if ((stealable.fireCapeRequired = true)) {
+			if (user.cl().amount('Fire cape') === 0) {
+				return `In order to ${
+					stealable.type === 'pickpockable' ? 'pickpocket this NPC' : 'steal from this stall'
+				}, you need a fire cape in your collection log.`;
+			}
 		}
 
 		if (user.skillLevel(SkillsEnum.Thieving) < stealable.level) {

--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -71,7 +71,7 @@ export const stealCommand: OSBMahojiCommand = {
 			} a ${stealable.name}.`;
 		}
 
-		if ((stealable.fireCapeRequired = true)) {
+		if (stealable.fireCapeRequired) {
 			if (user.cl().amount('Fire cape') === 0) {
 				return `In order to ${
 					stealable.type === 'pickpockable' ? 'pickpocket this NPC' : 'steal from this stall'

--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -72,10 +72,10 @@ export const stealCommand: OSBMahojiCommand = {
 			} a ${stealable.name}.`;
 		}
 
-		if (stealable.itemsRequired && !user.allItemsOwned().has(stealable.itemsRequired)) {
+		if (stealable.fireCapeRequired && !user.cl().has(stealable.fireCapeRequired)) {
 			return `You need these items to ${
 				stealable.type === 'pickpockable' ? 'pickpocket this NPC' : 'steal from this stall'
-			}: ${new Bank(stealable.itemsRequired)}.`;
+			}: ${new Bank(stealable.fireCapeRequired)}.`;
 		}
 
 		if (user.skillLevel(SkillsEnum.Thieving) < stealable.level) {


### PR DESCRIPTION
If pet hunting, users might have gambled all their capes, or sacrificed it in order to attempt the inferno. We can assume the minions showed the fire cape before sacrificing it to allow access to the city.

-   [x] I have tested all my changes thoroughly.
