### PR TITLE
Allow /simulate when minion is busy

### DIFF
--- a/src/mahoji/commands/simulate.ts
+++ b/src/mahoji/commands/simulate.ts
@@ -86,8 +86,7 @@ export const simulateCommand: OSBMahojiCommand = {
 	description: 'Simulate various OSRS related things.',
 	attributes: {
 		requiresMinion: true,
-		requiresMinionNotBusy: true,
-		examples: ['/smith name:Bronze platebody']
+		examples: ['/simulate cox quantity:1']
 	},
 	options: [
 		{


### PR DESCRIPTION
Can't see a reason you need your minion to be free to use this command. Allows you to simulate cox/pets while busy.

-   [ ] I have tested all my changes thoroughly.
