### PR TITLE
Nerf Nihiliz

### DIFF
--- a/src/lib/minions/data/killableMonsters/custom/Nihiliz.ts
+++ b/src/lib/minions/data/killableMonsters/custom/Nihiliz.ts
@@ -37,7 +37,6 @@ const regularTable = new LootTable({ limit: 41 })
 	.add('Coins', [50_000, 200_000])
 	.add('Pure essence', [1500, 2500], 2)
 	.oneIn(1000, 'Ancient staff')
-	.tertiary(500, 'Uncut zenyte', [1, 3])
 
 	/* Sub Tables */
 	.add(RareSeedTable, 2, 3, { multiply: true });
@@ -49,7 +48,7 @@ export const NihilizLootTable = new LootTable()
 	.tertiary(4, rawFoodTable)
 	.tertiary(8, clueTable)
 	.tertiary(10, 'Nihil shard', [5, 20])
-	.tertiary(1200, 'Nihil horn')
-	.tertiary(900, 'Zaryte vambraces')
+	.tertiary(2000, 'Nihil horn')
+	.tertiary(1200, 'Zaryte vambraces')
 	.tertiary(150, 'Clue scroll (grandmaster)')
 	.tertiary(5000, 'Nexling');


### PR DESCRIPTION
Description:

As discussed, this nerfs the Profit per hour of Nihiliz by around 40.3m/hr

However, more significantly, it nerfs the `Raw GP coming into the game` by nearly 50% (81m => 40.7m)

This is because Uncut zenytes are removed, which are essentially pure cash, and the unique drops are also significantly rarer, any they also hold a high bot-sell value.

### Changes:

- Removes Uncut zenytes from the drop table
- Increases [makes rarer] the drop rate for Nihil horn from 1200 => 2000
- Increases [rarer] the drop rate for Zaryte vambraces from 1 in 900 => 1200

### Other checks:

-   [x] I have tested all my changes thoroughly.
