### PR TITLE
Allow lb cl "overall" as an option

### DIFF
--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -664,10 +664,10 @@ export const leaderboardCommand: OSBMahojiCommand = {
 					name: 'cl',
 					description: 'The cl you want to select.',
 					required: true,
-					autocomplete: async (value: string) => {
-						return allClNames
-							.filter(i => (!value ? true : i.toLowerCase().includes(value.toLowerCase())))
-							.map(i => ({ name: i, value: i }));
+					autocomplete: async value => {
+						return ['overall', ...allClNames.map(i => i)]
+							.filter(name => (!value ? true : name.toLowerCase().includes(value.toLowerCase())))
+							.map(i => ({ name: toTitleCase(i), value: i }));
 					}
 				},
 				ironmanOnlyOption


### PR DESCRIPTION
Allows mobile users to view the lb cl overall, and makes it appear as an option.

Closes #4173

-   [x] I have tested all my changes thoroughly.
