### PR TITLE
Naxxus 0-day bug fix (Crystal shards => Crystal dust)

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -2037,6 +2037,15 @@ const Createables: Createable[] = [
 			[itemID('Death tiara')]: 1
 		}
 	},
+	{
+		name: 'Crystal dust',
+		inputItems: new Bank({
+			'Crystal dust': 1
+		}),
+		outputItems: {
+			[itemID('Crystal dust')]: 10
+		}
+	},
 	...Reverteables,
 	...crystalTools,
 	...ornamentKits,

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -2038,7 +2038,7 @@ const Createables: Createable[] = [
 		}
 	},
 	{
-		name: 'Crystal dust',
+		name: 'Crystal shard',
 		inputItems: new Bank({
 			'Crystal dust': 1
 		}),

--- a/src/lib/skilling/skills/herblore/mixables/crush.ts
+++ b/src/lib/skilling/skills/herblore/mixables/crush.ts
@@ -119,18 +119,6 @@ const Crush: Mixable[] = [
 		tickRate: 2,
 		bankTimePerPotion: 0,
 		wesley: true
-	},
-	{
-		name: 'Crystal dust',
-		aliases: ['crystal', 'crystal shard', 'crystal dust'],
-		id: itemID('Crystal dust'),
-		level: 70,
-		xp: 0,
-		inputItems: resolveNameBank({ 'Crystal shard': 1 }),
-		tickRate: 2,
-		bankTimePerPotion: 0.17,
-		wesley: false,
-		outputMultiple: 10
 	}
 ];
 


### PR DESCRIPTION
### Description:

Crystal shards => Crystal dust creation should be instant, hence it was moved to be a Creatable.

This should really be merged before Naxxus launch

### Changes:

Moved Crystal dust to Creatables. 

### Other checks:

-   [ ] I have tested all my changes thoroughly.
