### PR TITLE
Fix "Repeat trip" button in `/m` and `/minion status`

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -57,7 +57,7 @@ export async function onMessage(msg: Message) {
 					new MessageButton()
 						.setCustomID(a.custom_id)
 						.setLabel(a.label!)
-						.setEmoji(a.emoji!.id!)
+						.setEmoji(a.emoji!.id ?? a.emoji!.name!)
 						.setStyle('SECONDARY')
 				);
 			}

--- a/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
@@ -100,7 +100,7 @@ export async function minionStatusCommand(
 			type: ComponentType.Button,
 			custom_id: 'REPEAT_TRIP',
 			label: 'Repeat Trip',
-			emoji: { id: '🔁' },
+			emoji: { name: '🔁' },
 			style: ButtonStyle.Secondary
 		});
 	}


### PR DESCRIPTION
### Description:

Steps to reprodouce:
1. Send minion on any repeatable trip
2. While minion is free, try to run `/m` or `/minion status`

At this point you will see this error: 
![image](https://user-images.githubusercontent.com/10122432/187008868-4cd638a9-7c0a-44fa-9f84-cff194788129.png)
`DiscordAPIError[50035]: Invalid Form Body
data.components[0].components[4].emoji.id[NUMBER_TYPE_COERCE]: Value "�" is not a snowflake.`

This is because using a symbol is not valid as emoji.id for the components objects, while it does work for MessageButton.addEmoji().

This also fixes the Stopwatch emoji on Check patches when you \@mention the bot

### Changes:

- Changes Repeat trip button to use `name:` instead of `id:`
- Changes the Bot \@mention events.ts code so use emoji.id ?? emoji.name 

### Other checks:

-   [x] I have tested all my changes thoroughly.
