### PR TITLE
[Naxxus] Prevent duplicates until log is full

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -429,7 +429,10 @@ export const allCollectionLogs: ICollection = {
 			},
 			Naxxus: {
 				alias: Naxxus.aliases,
-				allItems: NaxxusLootTable.allItems,
+				allItems: [
+					...resolveItems(['Dark crystal', 'Abyssal gem', 'Tattered tome', 'Spellbound ring']),
+					...NaxxusLootTable.allItems
+				],
 				items: naxxusCL
 			},
 			Nex: {

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -19,7 +19,7 @@ import {
 } from '../minions/data/killableMonsters/custom/bosses/KalphiteKing';
 import KingGoldemar from '../minions/data/killableMonsters/custom/bosses/KingGoldemar';
 import { MoktangLootTable } from '../minions/data/killableMonsters/custom/bosses/Moktang';
-import { Naxxus, NaxxusLootTable } from '../minions/data/killableMonsters/custom/bosses/Naxxus';
+import { Naxxus, NaxxusLootTableFinishable } from '../minions/data/killableMonsters/custom/bosses/Naxxus';
 import { VasaMagus } from '../minions/data/killableMonsters/custom/bosses/VasaMagus';
 import { BSOMonsters } from '../minions/data/killableMonsters/custom/customMonsters';
 import { sepulchreFloors } from '../minions/data/sepulchre';
@@ -429,10 +429,7 @@ export const allCollectionLogs: ICollection = {
 			},
 			Naxxus: {
 				alias: Naxxus.aliases,
-				allItems: [
-					...resolveItems(['Dark crystal', 'Abyssal gem', 'Tattered tome', 'Spellbound ring']),
-					...NaxxusLootTable.allItems
-				],
+				allItems: NaxxusLootTableFinishable.allItems,
 				items: naxxusCL
 			},
 			Nex: {

--- a/src/lib/minions/data/killableMonsters/custom/bosses/Naxxus.ts
+++ b/src/lib/minions/data/killableMonsters/custom/bosses/Naxxus.ts
@@ -72,6 +72,12 @@ export const NaxxusLootTable = new LootTable()
 	.tertiary(10, 'Korulsi seed')
 	.tertiary(25, 'Grand crystal acorn');
 
+export const NaxxusLootTableFinishable = NaxxusLootTable.clone()
+	.tertiary(500, 'Spellbound ring')
+	.tertiary(500, 'Abyssal gem')
+	.tertiary(750, 'Tattered tome')
+	.tertiary(750, 'Dark crystal');
+
 export const NAXXUS_HP = 3900;
 
 export const Naxxus: KillableMonster = {
@@ -80,7 +86,7 @@ export const Naxxus: KillableMonster = {
 	aliases: ['nax'],
 	timeToFinish: Time.Minute * 30,
 	notifyDrops: resolveItems(['Dark crystal', 'Abyssal gem', 'Tattered tome', 'Spellbound ring']),
-	table: makeKillTable(NaxxusLootTable),
+	table: makeKillTable(NaxxusLootTableFinishable),
 	emoji: '',
 	wildy: false,
 	difficultyRating: 10,
@@ -108,7 +114,7 @@ export const Naxxus: KillableMonster = {
 	}
 };
 
-setCustomMonster(Naxxus.id, 'Naxxus', NaxxusLootTable, Monsters.GeneralGraardor, {
+setCustomMonster(Naxxus.id, 'Naxxus', NaxxusLootTableFinishable, Monsters.GeneralGraardor, {
 	id: Naxxus.id,
 	name: 'Naxxus',
 	aliases: ['naxxus', 'naxx']

--- a/src/lib/minions/data/killableMonsters/custom/bosses/Naxxus.ts
+++ b/src/lib/minions/data/killableMonsters/custom/bosses/Naxxus.ts
@@ -69,10 +69,6 @@ const naxxusLoot = new LootTable().add(runes, 3).add(talismans, 3).add(herbs, 3)
 export const NaxxusLootTable = new LootTable()
 	.add(naxxusLoot, 2)
 	.tertiary(9, 'Clue scroll (grandmaster)')
-	.tertiary(750, 'Dark crystal')
-	.tertiary(500, 'Abyssal gem')
-	.tertiary(750, 'Tattered tome')
-	.tertiary(500, 'Spellbound ring')
 	.tertiary(10, 'Korulsi seed')
 	.tertiary(25, 'Grand crystal acorn');
 

--- a/src/tasks/minions/bso/naxxusActivity.ts
+++ b/src/tasks/minions/bso/naxxusActivity.ts
@@ -22,7 +22,7 @@ export default class extends Task {
 		loot.add(Naxxus.table.kill(quantity, {}));
 
 		// Handle uniques => Don't give duplicates until log full
-		const uniqueChance = 157;
+		const uniqueChance = 150;
 		if (roll(uniqueChance)) {
 			const uniques = [
 				{ name: 'Dark crystal', weight: 3 },

--- a/src/tasks/minions/bso/naxxusActivity.ts
+++ b/src/tasks/minions/bso/naxxusActivity.ts
@@ -25,10 +25,10 @@ export default class extends Task {
 		const uniqueChance = 150;
 		if (roll(uniqueChance)) {
 			const uniques = [
-				{ name: 'Dark crystal', weight: 3 },
-				{ name: 'Abyssal gem', weight: 2 },
-				{ name: 'Tattered tome', weight: 3 },
-				{ name: 'Spellbound ring', weight: 2 }
+				{ name: 'Dark crystal', weight: 2 },
+				{ name: 'Abyssal gem', weight: 3 },
+				{ name: 'Tattered tome', weight: 2 },
+				{ name: 'Spellbound ring', weight: 3 }
 			];
 			const cl = user.cl();
 			const filteredUniques = uniques.filter(u => !cl.has(u.name));

--- a/src/tasks/minions/bso/naxxusActivity.ts
+++ b/src/tasks/minions/bso/naxxusActivity.ts
@@ -2,7 +2,7 @@ import { roll } from 'e';
 import { Task } from 'klasa';
 import { Bank, LootTable } from 'oldschooljs';
 
-import { Naxxus } from '../../../lib/minions/data/killableMonsters/custom/bosses/Naxxus';
+import { Naxxus, NaxxusLootTable } from '../../../lib/minions/data/killableMonsters/custom/bosses/Naxxus';
 import { addMonsterXP } from '../../../lib/minions/functions';
 import announceLoot from '../../../lib/minions/functions/announceLoot';
 import { trackLoot } from '../../../lib/settings/prisma';
@@ -19,7 +19,7 @@ export default class extends Task {
 		const user = await this.client.fetchUser(userID);
 
 		const loot = new Bank();
-		loot.add(Naxxus.table.kill(quantity, {}));
+		loot.add(NaxxusLootTable.roll(quantity));
 
 		// Handle uniques => Don't give duplicates until log full
 		const uniqueChance = 150;

--- a/src/tasks/minions/bso/naxxusActivity.ts
+++ b/src/tasks/minions/bso/naxxusActivity.ts
@@ -1,5 +1,6 @@
+import { roll } from 'e';
 import { Task } from 'klasa';
-import { Bank } from 'oldschooljs';
+import { Bank, LootTable } from 'oldschooljs';
 
 import { Naxxus } from '../../../lib/minions/data/killableMonsters/custom/bosses/Naxxus';
 import { addMonsterXP } from '../../../lib/minions/functions';
@@ -19,6 +20,24 @@ export default class extends Task {
 
 		const loot = new Bank();
 		loot.add(Naxxus.table.kill(quantity, {}));
+
+		// Handle uniques => Don't give duplicates until log full
+		const uniqueChance = 157;
+		if (roll(uniqueChance)) {
+			const uniques = [
+				{ name: 'Dark crystal', weight: 3 },
+				{ name: 'Abyssal gem', weight: 2 },
+				{ name: 'Tattered tome', weight: 3 },
+				{ name: 'Spellbound ring', weight: 2 }
+			];
+			const cl = user.cl();
+			const filteredUniques = uniques.filter(u => !cl.has(u.name));
+			const uniqueTable = filteredUniques.length === 0 ? uniques : filteredUniques;
+			const lootTable = new LootTable();
+			uniqueTable.map(u => lootTable.add(u.name, 1, u.weight));
+
+			loot.add(lootTable.roll());
+		}
 
 		const xpStr = await addMonsterXP(user, {
 			monsterID: Naxxus.id,


### PR DESCRIPTION
### Description:

Kept the same base-drop rates for the items, but if you roll a duplicate, it will give you a different unique on the drop table.

### Changes:

- Removes the uniques from Naxxus primary loot table
- Adds the logic to skip duplicates to naxxusActivity
- Updates the collection log data so that it works exactly like it did before this change.

### Other checks:

-   [x] I have tested all my changes thoroughly.

### Math:

The odds of receiving any Unique were 1/500 + 1/500 + 1/750 + 1/750, which reduces to 1/150 for any unique.

So now, the drop rate to get any unique is now 1 in 150, with the Abyssal tome / Void staff unique bases weighted 2, and the spellbound ring and abyssal gem weighted 3.

The total weight is 10, meaning the drop rates are as follows:
150 x 10/3 = 1 in 500  for the Abyssal gem / Spellbound ring
150 x 10/2 = 1 in 750  for the Dark crystal / Tattered tome

These are the same as they were before :)

Of course, skipping duplicates means you will complete the CL significantly faster on average, we basically remove bad luck :)
