### PR TITLE
fixed typo in command

### DIFF
--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -429,7 +429,7 @@ async function handleCombatOptions(user: KlasaUser, command: 'add' | 'remove' | 
 	if (!command || (command && command === 'list')) {
 		// List enabled combat options:
 		const cbOpts = settings.combat_options.map(o => CombatOptionsArray.find(coa => coa!.id === o)!.name);
-		return `Your current combat options are:\n${cbOpts.join('\n')}\n\nTry: \`/config user command_options help\``;
+		return `Your current combat options are:\n${cbOpts.join('\n')}\n\nTry: \`/config user combat_options help\``;
 	}
 
 	if (command === 'help' || !option || !['add', 'remove'].includes(command)) {


### PR DESCRIPTION
### Description:

fixed typo in the command `/config user combat_options`

### Changes:

the help line was wrong: `/config user command_options`. there isn't such a command.

### Other checks:

-   [✔] I have tested all my changes thoroughly.
