### PR TITLE
Fixes Invention ongoing costs by duration

### DIFF
--- a/src/lib/customItems/invention/inventions.ts
+++ b/src/lib/customItems/invention/inventions.ts
@@ -28,4 +28,4 @@ addInvention(63_318, 'Drygore saw');
 addInvention(63_320, 'Dwarven toolkit');
 addInvention(63_322, 'Mecha rod');
 addInvention(63_324, 'Master hammer and chisel');
-addInvention(63_325, 'Abyssal amulet');
+addInvention(63_325, 'Abyssal amulet', 'Amulet of fury');

--- a/src/lib/invention/inventions.ts
+++ b/src/lib/invention/inventions.ts
@@ -359,7 +359,7 @@ export const Inventions: readonly Invention[] = [
 		extraDescription: () => {
 			let str = '';
 			for (const boost of inventionBoosts.abyssalAmulet.boosts) {
-				str += `**${boost.boost}%** faster Runecrafting for the following runes: ${boost.runes.join(',')}\n`;
+				str += `**${boost.boost}%** faster Runecrafting for the following runes: ${boost.runes.join(', ')}\n`;
 			}
 			return str;
 		}

--- a/src/lib/minions/functions/darkAltarCommand.ts
+++ b/src/lib/minions/functions/darkAltarCommand.ts
@@ -3,11 +3,13 @@ import { KlasaUser } from 'klasa';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import { KourendKebosDiary, userhasDiaryTier } from '../../diaries';
+import { inventionBoosts, InventionID, inventionItemBoost } from '../../invention/inventions';
 import { DarkAltarOptions } from '../../types/minions';
-import { formatDuration } from '../../util';
+import { formatDuration, stringMatches } from '../../util';
 import addSubTaskToActivityTask from '../../util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../util/calcMaxTripLength';
 import getOSItem from '../../util/getOSItem';
+import { hasItemsEquippedOrInBank } from '../../util/minionUtils';
 import { Favours, gotFavour } from '../data/kourendFavour';
 
 export const darkAltarRunes = {
@@ -84,6 +86,24 @@ export async function darkAltarCommand({
 	}
 
 	const maxTripLength = calcMaxTripLength(user, 'DarkAltar');
+
+	// Calculate Abyssal amulet boost:
+	if (hasItemsEquippedOrInBank(user, ['Abyssal amulet'])) {
+		const abyssalAmuletBoost = inventionBoosts.abyssalAmulet.boosts.find(b =>
+			b.runes.some(r => stringMatches(r, rune))
+		);
+		if (abyssalAmuletBoost) {
+			const res = await inventionItemBoost({
+				userID: BigInt(user.id),
+				inventionID: InventionID.MechaRod,
+				duration: maxTripLength
+			});
+			if (res.success) {
+				timePerRune = reduceNumByPercent(timePerRune, abyssalAmuletBoost.boost);
+				boosts.push(`${abyssalAmuletBoost.boost}% boost for Abyssal amulet (Removed ${res.materialCost})`);
+			}
+		}
+	}
 	const quantity = Math.floor(maxTripLength / timePerRune);
 	await addSubTaskToActivityTask<DarkAltarOptions>({
 		userID: user.id,

--- a/src/lib/minions/functions/darkAltarCommand.ts
+++ b/src/lib/minions/functions/darkAltarCommand.ts
@@ -90,12 +90,12 @@ export async function darkAltarCommand({
 	// Calculate Abyssal amulet boost:
 	if (hasItemsEquippedOrInBank(user, ['Abyssal amulet'])) {
 		const abyssalAmuletBoost = inventionBoosts.abyssalAmulet.boosts.find(b =>
-			b.runes.some(r => stringMatches(r, rune))
+			b.runes.some(r => stringMatches(r, `${rune} rune`))
 		);
 		if (abyssalAmuletBoost) {
 			const res = await inventionItemBoost({
 				userID: BigInt(user.id),
-				inventionID: InventionID.MechaRod,
+				inventionID: InventionID.AbyssalAmulet,
 				duration: maxTripLength
 			});
 			if (res.success) {

--- a/src/mahoji/commands/build.ts
+++ b/src/mahoji/commands/build.ts
@@ -109,20 +109,22 @@ export const buildCommand: OSBMahojiCommand = {
 
 		let boosts: string[] = [];
 
+		const boostedActionTime = reduceNumByPercent(
+			timeToBuildSingleObject,
+			inventionBoosts.drygoreSaw.buildBoostPercent
+		);
 		if (hasItemsEquippedOrInBank(user, ['Drygore saw'])) {
 			const boostRes = await inventionItemBoost({
 				userID: BigInt(user.id),
 				inventionID: InventionID.DrygoreSaw,
 				duration: Math.min(
 					maxTripLength,
-					options.quantity ? options.quantity * timeToBuildSingleObject : maxTripLength
+					Math.min(maxForMaterials, options.quantity ?? Math.floor(maxTripLength / boostedActionTime)) *
+						boostedActionTime
 				)
 			});
 			if (boostRes.success) {
-				timeToBuildSingleObject = reduceNumByPercent(
-					timeToBuildSingleObject,
-					inventionBoosts.drygoreSaw.buildBoostPercent
-				);
+				timeToBuildSingleObject = boostedActionTime;
 				boosts.push(
 					`${inventionBoosts.drygoreSaw.buildBoostPercent}% faster building from Drygore saw (${boostRes.messages})`
 				);

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -104,7 +104,7 @@ export const fishCommand: OSBMahojiCommand = {
 			inventionID: InventionID.MechaRod,
 			duration: Math.min(
 				maxTripLength,
-				options.quantity ?? Math.floor(maxTripLength / boostedTimePerFish) * boostedTimePerFish
+				(options.quantity ?? Math.floor(maxTripLength / boostedTimePerFish)) * boostedTimePerFish
 			)
 		});
 		if (res.success) {

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -98,13 +98,17 @@ export const fishCommand: OSBMahojiCommand = {
 		}
 		let maxTripLength = calcMaxTripLength(user, 'Fishing');
 
+		const boostedTimePerFish = reduceNumByPercent(scaledTimePerFish, inventionBoosts.mechaRod.speedBoostPercent);
 		const res = await inventionItemBoost({
 			userID: BigInt(user.id),
 			inventionID: InventionID.MechaRod,
-			duration: Math.min(maxTripLength, options.quantity ? options.quantity * scaledTimePerFish : maxTripLength)
+			duration: Math.min(
+				maxTripLength,
+				options.quantity ?? Math.floor(maxTripLength / boostedTimePerFish) * boostedTimePerFish
+			)
 		});
 		if (res.success) {
-			scaledTimePerFish = reduceNumByPercent(scaledTimePerFish, inventionBoosts.mechaRod.speedBoostPercent);
+			scaledTimePerFish = boostedTimePerFish;
 			boosts.push(`${inventionBoosts.mechaRod.speedBoostPercent}% faster for Mecha rod (${res.messages})`);
 		}
 

--- a/src/mahoji/commands/hunt.ts
+++ b/src/mahoji/commands/hunt.ts
@@ -178,16 +178,20 @@ export const huntCommand: OSBMahojiCommand = {
 
 		const maxTripLength = calcMaxTripLength(user, 'Hunter');
 		if (creature.huntTechnique === HunterTechniqueEnum.BoxTrapping) {
+			const boostedActionTime = reduceNumByPercent(timePerCatch, inventionBoosts.quickTrap.boxTrapBoostPercent);
 			const boostRes = await inventionItemBoost({
 				userID: user.id,
 				inventionID: InventionID.QuickTrap,
-				duration: Math.min(maxTripLength, options.quantity ? options.quantity * timePerCatch : maxTripLength)
+				duration: Math.min(
+					maxTripLength,
+					(options.quantity ?? Math.floor(maxTripLength / boostedActionTime)) * boostedActionTime
+				)
 			});
 			if (boostRes.success) {
 				boosts.push(
 					`${inventionBoosts.quickTrap.boxTrapBoostPercent}% boost for Quick-Trap invention (${boostRes.messages})`
 				);
-				timePerCatch = reduceNumByPercent(timePerCatch, inventionBoosts.quickTrap.boxTrapBoostPercent);
+				timePerCatch = boostedActionTime;
 			}
 		}
 

--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -155,13 +155,17 @@ export const lapsCommand: OSBMahojiCommand = {
 
 		let boosts: string[] = [];
 		if (userHasItemsEquippedAnywhere(user, 'Silverhawk boots')) {
+			const boostedTimePerLap = Math.floor(timePerLap / inventionBoosts.silverHawks.agilityBoostMultiplier);
 			const costRes = await inventionItemBoost({
 				userID: user.id,
 				inventionID: InventionID.SilverHawkBoots,
-				duration: Math.min(maxTripLength, options.quantity ? options.quantity * timePerLap : maxTripLength)
+				duration: Math.min(
+					maxTripLength,
+					(options.quantity ?? Math.floor(maxTripLength / boostedTimePerLap)) * boostedTimePerLap
+				)
 			});
 			if (costRes.success) {
-				timePerLap = Math.floor(timePerLap / inventionBoosts.silverHawks.agilityBoostMultiplier);
+				timePerLap = boostedTimePerLap;
 				boosts.push(
 					`${inventionBoosts.silverHawks.agilityBoostMultiplier}x faster for Silverhawk boots (${costRes.messages})`
 				);

--- a/src/mahoji/commands/mix.ts
+++ b/src/mahoji/commands/mix.ts
@@ -124,7 +124,10 @@ export const mineCommand: OSBMahojiCommand = {
 				inventionID: InventionID.MechaMortar,
 				duration: Math.min(
 					maxTripLength,
-					options.quantity ? options.quantity * timeToMixSingleItem : maxTripLength
+					reduceNumByPercent(
+						quantity * timeToMixSingleItem,
+						inventionBoosts.mechaMortar.herbloreSpeedBoostPercent
+					)
 				)
 			});
 			if (boostResult.success) {
@@ -135,6 +138,7 @@ export const mineCommand: OSBMahojiCommand = {
 				boosts.push(
 					`${inventionBoosts.mechaMortar.herbloreSpeedBoostPercent}% boost for Mecha-Mortar (${boostResult.messages})`
 				);
+				if (!options.quantity) quantity = Math.min(maxCanDo, Math.floor(maxTripLength / timeToMixSingleItem));
 			}
 		}
 		const duration = quantity * timeToMixSingleItem;

--- a/src/mahoji/commands/mix.ts
+++ b/src/mahoji/commands/mix.ts
@@ -119,22 +119,21 @@ export const mineCommand: OSBMahojiCommand = {
 		}
 
 		if (!options.wesley && !options.zahur) {
+			const boostedTimeToMixSingleItem = reduceNumByPercent(
+				timeToMixSingleItem,
+				inventionBoosts.mechaMortar.herbloreSpeedBoostPercent
+			);
 			const boostResult = await inventionItemBoost({
 				userID: BigInt(user.id),
 				inventionID: InventionID.MechaMortar,
 				duration: Math.min(
 					maxTripLength,
-					reduceNumByPercent(
-						quantity * timeToMixSingleItem,
-						inventionBoosts.mechaMortar.herbloreSpeedBoostPercent
-					)
+					Math.min(maxCanDo, options.quantity ?? Math.floor(maxTripLength / boostedTimeToMixSingleItem)) *
+						boostedTimeToMixSingleItem
 				)
 			});
 			if (boostResult.success) {
-				timeToMixSingleItem = reduceNumByPercent(
-					timeToMixSingleItem,
-					inventionBoosts.mechaMortar.herbloreSpeedBoostPercent
-				);
+				timeToMixSingleItem = boostedTimeToMixSingleItem;
 				boosts.push(
 					`${inventionBoosts.mechaMortar.herbloreSpeedBoostPercent}% boost for Mecha-Mortar (${boostResult.messages})`
 				);

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -160,18 +160,20 @@ export const runecraftCommand: OSBMahojiCommand = {
 				b.runes.some(r => stringMatches(r, runeObj.name))
 			);
 			if (abyssalAmuletBoost) {
+				const boostedActionTime = reduceNumByPercent(tripLength, abyssalAmuletBoost.boost);
 				const boostResult = await inventionItemBoost({
 					userID: BigInt(user.id),
 					inventionID: InventionID.AbyssalAmulet,
 					duration: Math.min(
 						maxTripLength,
-						quantity
-							? (quantity / inventorySize) * reduceNumByPercent(tripLength, abyssalAmuletBoost.boost)
-							: maxTripLength
+						Math.min(
+							Math.floor(maxTripLength / tripLength) * inventorySize,
+							quantity ? quantity / inventorySize : Math.floor(maxTripLength / boostedActionTime)
+						) * boostedActionTime
 					)
 				});
 				if (boostResult.success) {
-					tripLength = reduceNumByPercent(tripLength, abyssalAmuletBoost.boost);
+					tripLength = boostedActionTime;
 					boosts.push(
 						`${abyssalAmuletBoost.boost}% boost for Abyssal amulet (Removed ${boostResult.materialCost})`
 					);

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -4,7 +4,7 @@ import { Bank } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import { Emoji } from '../../lib/constants';
-import { inventionBoosts, InventionID, inventionItemBoost, Inventions } from '../../lib/invention/inventions';
+import { inventionBoosts, InventionID, inventionItemBoost } from '../../lib/invention/inventions';
 import { darkAltarCommand } from '../../lib/minions/functions/darkAltarCommand';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
@@ -154,8 +154,7 @@ export const runecraftCommand: OSBMahojiCommand = {
 		}
 		const maxTripLength = calcMaxTripLength(user, 'Runecraft');
 
-		const amuletId = Inventions.find(inv => inv.id === InventionID.AbyssalAmulet)!.item.id;
-		if (hasItemsEquippedOrInBank(user, [amuletId])) {
+		if (hasItemsEquippedOrInBank(user, ['Abyssal amulet'])) {
 			const abyssalAmuletBoost = inventionBoosts.abyssalAmulet.boosts.find(b =>
 				b.runes.some(r => stringMatches(r, runeObj.name))
 			);


### PR DESCRIPTION
### Description:

Currently, there's several problems with the invention costs by duration affecting: /fish, /hunt, /build, /mix, etc.
1. The Material Cost is different between trips when you use Repeat trip vs /mix
2. If you have less than the amount of supplies for a full trip, you're still charged for the entire trip unless you specify a quantity.
3. For example lets say you get a 50% boost, so instead of 1600 per trip you can do 3200... You get charged a full trip for doing 1600 even though it's only half a trip long now.

This fixes that, so that costs are consistent. You do X quantity, you pay Y cost. No matter how that quantity is determined, the cost will be consistent.

### Changes:

- Pre-calculates the boosted time so we can accurately determine the correct duration to pass to the boost cost calculator.
- Applies this new logic to 8 different activities where duration is the deciding factor for cost.

### Other checks:

-   [x] I have tested all my changes thoroughly.
-   [x] Many testers have confirmed this
