### PR TITLE
Fix (Nerf) Abyssal amulet Runecraft boosts

### DIFF
--- a/src/lib/invention/inventions.ts
+++ b/src/lib/invention/inventions.ts
@@ -64,10 +64,11 @@ export const inventionBoosts = {
 	abyssalAmulet: {
 		boosts: [
 			{ runes: ['Fire rune', 'Water rune', 'Air rune', 'Earth rune', 'Body rune', 'Mind rune'], boost: 65 },
-			{ runes: ['Mist rune', 'Mud rune', 'Lava rune', 'Steam rune', 'Dust rune', 'Smoke rune'], boost: 20 },
-			{ runes: ['Cosmic rune', 'Astral rune', 'Soul rune', 'Law rune', 'Nature rune'], boost: 70 },
-			{ runes: ['Chaos rune', 'Death rune'], boost: 75 },
-			{ runes: ['Blood rune', 'Wrath rune'], boost: 85 },
+			{ runes: ['Mist rune', 'Mud rune', 'Dust rune'], boost: 35 },
+			{ runes: ['Lava rune', 'Steam rune', 'Smoke rune'], boost: 20 },
+			{ runes: ['Death rune', 'Astral rune', 'Wrath rune', 'Law rune', 'Nature rune'], boost: 50 },
+			{ runes: ['Chaos rune', 'Cosmic rune'], boost: 60 },
+			{ runes: ['Blood rune', 'Soul rune'], boost: 95 },
 			{ runes: ['Elder rune'], boost: 65 }
 		]
 	},


### PR DESCRIPTION
### Description:

Some of the Abyssal amulet boosts are way out of whack.

Sometimes the entire group was overpowered, and other times, runes were in the wrong category, leading to overpowered results.

Everything gets nerfed, EXCEPT Bloods + Souls are now grouped together, and get a 95% boost, because they get no boost from **Pouches,** so Blood  + Soul are still by far the slowest method of runecrafting.

Also, the weaker 'combo' runes get a slight buff, because they were classed wrong.

### Buffs:
- Blood + Soul: Buffed to 95%, and they're still the slowest by far.
- Mist, Mud, and Dust buffed from 20 => 35% ( still slower than most other runes )

### Nerfs:
- Death nerfed from 75 => 50%
- Wrath nerfed from 85 => 50%
- Cosmic nerfed from 70 => 60%
- Law nerfed from 70 => 50%
- Nature nerfed from 70 => 50%
- Chaos nerfed from 75 => 60%
- Astral nerfed from  70 => 50%

### Other checks:

-   [x] I have tested all my changes thoroughly.
