### PR TITLE
Fix wipe issue on ToB

### DIFF
--- a/src/mahoji/lib/abstracted_commands/tobCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/tobCommand.ts
@@ -97,7 +97,14 @@ export async function tobStartCommand(user: KlasaUser, channelID: bigint, isHard
 		return `Your mass failed to start because of this reason: ${teamCheckFailure} ${users}`;
 	}
 
-	const { duration, totalReduction, reductions, wipedRoom, deathDuration, parsedTeam } = createTOBTeam({
+	const {
+		duration,
+		totalReduction,
+		reductions,
+		wipedRoom: _wipedRoom,
+		deathDuration,
+		parsedTeam
+	} = createTOBTeam({
 		team: await Promise.all(
 			users.map(async u => ({
 				user: u,
@@ -111,7 +118,7 @@ export async function tobStartCommand(user: KlasaUser, channelID: bigint, isHard
 		),
 		hardMode: isHardMode
 	});
-
+	const wipedRoom = _wipedRoom ? TOBRooms.find(room => _wipedRoom.name === room.name)! : null;
 	let debugStr = '';
 
 	const totalCost = new Bank();


### PR DESCRIPTION
### Description:

If team wipes on BSO, the return trip message fails.

### Changes:

Gets room via find() first so that indexOf() can correctly identify the value, because it's based off the Address, not object equality.

### Other checks:

-   [x] I have tested all my changes thoroughly.
