### PR TITLE
Prevent 2x dwwh again

### DIFF
--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -146,7 +146,8 @@ export const smithCommand: OSBMahojiCommand = {
 			channelID: channelID.toString(),
 			quantity,
 			duration,
-			type: 'Smithing'
+			type: 'Smithing',
+			cantBeDoubled: smithedItem.cantBeDoubled
 		});
 		let str = `${user.minionName} is now smithing ${quantity * smithedItem.outputMultiple}x ${
 			smithedItem.name


### PR DESCRIPTION
### Description:

Slash commands broke the fix preventing 2x dwwh. This replaces it.

### Changes:

- Adds cantBeDoubled param when smithing applicable stuff

### Other checks:

-   [x] I have tested all my changes thoroughly.
