### PR TITLE
Prevent 4x Moktang drops

### DIFF
--- a/src/mahoji/lib/abstracted_commands/moktangCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/moktangCommand.ts
@@ -106,6 +106,7 @@ export async function moktangActivity(data: MoktangTaskOptions) {
 	}
 	if (isDoubleLootActive(data.duration)) {
 		loot.multiply(2);
+		data.cantBeDoubled = true;
 	}
 
 	const res = await klasaUser.addItemsToBank({ items: loot, collectionLog: true });


### PR DESCRIPTION
### Description:

Double loot + Global 2x loot stack with Moktang, giving up to 4x Igne frames, this seeks to limit that to 2x.

### Changes:

- Adds `cantBeDoubled = true` to the ActivityData when double loot is in effect so handleTripFinish() knows not to double (again)

### Other checks:

-   [ ] I have tested all my changes thoroughly.
