### PR TITLE
Daeyalt Essence - Runecrafting/Mining

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -2022,6 +2022,15 @@ const Createables: Createable[] = [
 			[itemID('Death tiara')]: 1
 		}
 	},
+	{
+		name: 'Daeyalt essence',
+		inputItems: new Bank({
+			'Daeyalt shard': 1
+		}),
+		outputItems: new Bank({
+			'Daeyalt essence': 1
+		})
+	},
 	...Reverteables,
 	...crystalTools,
 	...ornamentKits,

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -198,6 +198,16 @@ const ores: Ore[] = [
 		clueScrollChance: 148_320
 	},
 	{
+		level: 60,
+		xp: 5,
+		id: 24_706,
+		name: 'Daeyalt shard',
+		respawnTime: 0.5,
+		bankingTime: 0,
+		slope: 0,
+		intercept: 100
+	},
+	{
 		level: 70,
 		xp: 95,
 		id: 449,

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -201,8 +201,8 @@ const ores: Ore[] = [
 		level: 60,
 		xp: 5,
 		id: 24_706,
-		name: 'Daeyalt shard',
-		respawnTime: 0.5,
+		name: 'Daeyalt essence rock',
+		respawnTime: 3,
 		bankingTime: 0,
 		slope: 0,
 		intercept: 100

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -24,6 +24,7 @@ export interface RunecraftActivityTaskOptions extends ActivityTaskOptions {
 	essenceQuantity: number;
 	imbueCasts: number;
 	useStaminas?: boolean;
+	daeyaltEssence?: boolean;
 }
 
 export interface DarkAltarOptions extends ActivityTaskOptions {

--- a/src/mahoji/commands/mine.ts
+++ b/src/mahoji/commands/mine.ts
@@ -267,7 +267,7 @@ export const mineCommand: OSBMahojiCommand = {
 
 		// Check for daeyalt shard requirements.
 		const [hasDaeyaltReqs, daeyaltReason] = klasaUser.hasSkillReqs(daeyaltEssenceSkillRequirements);
-		if (ore.name === 'Daeyalt shard') {
+		if (ore.name === 'Daeyalt essence rock') {
 			if (!hasDaeyaltReqs) {
 				return `To mine ${ore.name}, you need ${daeyaltReason}.`;
 			}

--- a/src/mahoji/commands/mine.ts
+++ b/src/mahoji/commands/mine.ts
@@ -4,6 +4,7 @@ import { Bank } from 'oldschooljs';
 
 import { determineMiningTime } from '../../lib/skilling/functions/determineMiningTime';
 import Mining from '../../lib/skilling/skills/mining';
+import { Skills } from '../../lib/types';
 import { MiningActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, getSkillsOfMahojiUser, itemNameFromID, randomVariation } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
@@ -196,6 +197,20 @@ export const miningCapeOreEffect: Bank = new Bank({
 	Amethyst: 0
 });
 
+const daeyaltEssenceSkillRequirements: Skills = {
+	woodcutting: 62,
+	fletching: 60,
+	crafting: 56,
+	agility: 52,
+	attack: 50,
+	slayer: 50,
+	magic: 49,
+	herblore: 40,
+	construction: 5,
+	thieving: 22,
+	strength: 40
+};
+
 export const mineCommand: OSBMahojiCommand = {
 	name: 'mine',
 	description: 'Send your minion to mine things.',
@@ -243,10 +258,22 @@ export const mineCommand: OSBMahojiCommand = {
 		}
 
 		let { quantity, powermine } = options;
+		const klasaUser = await globalClient.fetchUser(userID);
 		const user = await mahojiUsersSettingsFetch(userID);
 		const skills = getSkillsOfMahojiUser(user, true);
 		if (skills.mining < ore.level) {
 			return `${minionName(user)} needs ${ore.level} Mining to mine ${ore.name}.`;
+		}
+
+		// Check for daeyalt shard requirements.
+		const [hasDaeyaltReqs, daeyaltReason] = klasaUser.hasSkillReqs(daeyaltEssenceSkillRequirements);
+		if (ore.name === 'Daeyalt shard') {
+			if (!hasDaeyaltReqs) {
+				return `To mine ${ore.name}, you need ${daeyaltReason}.`;
+			}
+			if (user.QP < 125) {
+				return `To mine ${ore.name}, you need atleast 125 Quest Points.`;
+			}
 		}
 
 		const boosts = [];

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -156,7 +156,7 @@ export const runecraftCommand: OSBMahojiCommand = {
 		if (daeyalt_essence) {
 			if (!quantity) quantity = Math.min(daeyaltEssenceOwned, maxCanDo);
 			if (daeyaltEssenceOwned === 0 || quantity === 0 || daeyaltEssenceOwned < quantity) {
-				return "You don't have enough Daeyalt Essence to craft these runes. You can acquire Daeyalt Shards through Mining, and then exchange for essence with the `/buy` command.";
+				return "You don't have enough Daeyalt Essence to craft these runes. You can acquire Daeyalt Shards through Mining, and then exchange for essence with the `/create` command.";
 			}
 		} else {
 			if (!quantity) quantity = Math.min(numEssenceOwned, maxCanDo);

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -51,15 +51,21 @@ export const runecraftCommand: OSBMahojiCommand = {
 			name: 'usestams',
 			description: 'Set this to false to not use stamina potions (default true)',
 			required: false
+		},
+		{
+			type: ApplicationCommandOptionType.Boolean,
+			name: 'daeyalt_essence',
+			description: 'Set this to true to use daeyalt essence (default false)',
+			required: false
 		}
 	],
 	run: async ({
 		userID,
 		options,
 		channelID
-	}: CommandRunOptions<{ rune: string; quantity?: number; usestams?: boolean }>) => {
+	}: CommandRunOptions<{ rune: string; quantity?: number; usestams?: boolean; daeyalt_essence?: boolean }>) => {
 		const user = await globalClient.fetchUser(userID.toString());
-		let { rune, quantity, usestams } = options;
+		let { rune, quantity, usestams, daeyalt_essence } = options;
 
 		rune = rune.toLowerCase().replace('rune', '').trim();
 
@@ -98,6 +104,7 @@ export const runecraftCommand: OSBMahojiCommand = {
 
 		const bank = user.bank();
 		const numEssenceOwned = bank.amount('Pure essence');
+		const daeyaltEssenceOwned = bank.amount('Daeyalt essence');
 
 		let { tripLength } = runeObj;
 		const boosts = [];
@@ -146,10 +153,17 @@ export const runecraftCommand: OSBMahojiCommand = {
 		const maxCanDo = Math.floor(maxTripLength / tripLength) * inventorySize;
 
 		// If no quantity provided, set it to the max.
-		if (!quantity) quantity = Math.min(numEssenceOwned, maxCanDo);
+		if (daeyalt_essence) {
+			if (!quantity) quantity = Math.min(daeyaltEssenceOwned, maxCanDo);
+			if (daeyaltEssenceOwned === 0 || quantity === 0 || daeyaltEssenceOwned < quantity) {
+				return "You don't have enough Daeyalt Essence to craft these runes. You can acquire Daeyalt Shards through Mining, and then exchange for essence with the `/buy` command.";
+			}
+		} else {
+			if (!quantity) quantity = Math.min(numEssenceOwned, maxCanDo);
 
-		if (numEssenceOwned === 0 || quantity === 0 || numEssenceOwned < quantity) {
-			return "You don't have enough Pure Essence to craft these runes. You can acquire some through Mining, or purchasing from other players.";
+			if (numEssenceOwned === 0 || quantity === 0 || numEssenceOwned < quantity) {
+				return "You don't have enough Pure Essence to craft these runes. You can acquire some through Mining, or purchasing from other players.";
+			}
 		}
 
 		const numberOfInventories = Math.max(Math.ceil(quantity / inventorySize), 1);
@@ -224,7 +238,12 @@ export const runecraftCommand: OSBMahojiCommand = {
 			totalCost.add(removeTalismanAndOrRunes);
 		}
 
-		totalCost.add('Pure essence', quantity);
+		if (daeyalt_essence) {
+			totalCost.add('Daeyalt essence', quantity);
+			if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
+		} else {
+			totalCost.add('Pure essence', quantity);
+		}
 		if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
 
 		await user.removeItemsFromBank(totalCost);
@@ -236,14 +255,21 @@ export const runecraftCommand: OSBMahojiCommand = {
 			channelID: channelID.toString(),
 			essenceQuantity: quantity,
 			useStaminas: usestams,
+			daeyaltEssence: daeyalt_essence,
 			duration,
 			imbueCasts,
 			type: 'Runecraft'
 		});
 
-		let response = `${user.minionName} is now turning ${quantity}x Essence into ${
-			runeObj.name
-		}, it'll take around ${formatDuration(
+		let response = `${user.minionName} is now turning ${quantity}x`;
+
+		if (daeyalt_essence) {
+			response += ' Daeyalt ';
+		} else {
+			response += ' Pure ';
+		}
+
+		response += `Essence into ${runeObj.name}, it'll take around ${formatDuration(
 			duration
 		)} to finish, this will take ${numberOfInventories}x trips to the altar. You'll get ${
 			quantityPerEssence * quantity

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -119,7 +119,7 @@ export default class extends Task {
 				for (let i = 0; i < quantity; i++) {
 					loot.add(Mining.GraniteRockTable.roll());
 				}
-			} else if (ore.name === 'Daeyalt shard') {
+			} else if (ore.name === 'Daeyalt essence rock') {
 				for (let i = 0; i < quantity; i++) {
 					daeyaltQty += rand(2, 3);
 				}

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -84,6 +84,8 @@ export default class extends Task {
 			}
 		}
 
+		let daeyaltQty = 0;
+
 		if (!powermine) {
 			// Gem rocks roll off the GemRockTable
 			if (ore.name === 'Gem rock') {
@@ -117,6 +119,11 @@ export default class extends Task {
 				for (let i = 0; i < quantity; i++) {
 					loot.add(Mining.GraniteRockTable.roll());
 				}
+			} else if (ore.name === 'Daeyalt shard') {
+				for (let i = 0; i < quantity; i++) {
+					daeyaltQty += rand(2, 3);
+				}
+				loot.add(ore.id, daeyaltQty);
 			} else {
 				loot.add(ore.id, quantity);
 			}

--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -10,7 +10,7 @@ import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
 export default class extends Task {
 	async run(data: RunecraftActivityTaskOptions) {
-		const { runeID, essenceQuantity, userID, channelID, imbueCasts, duration, useStaminas } = data;
+		const { runeID, essenceQuantity, userID, channelID, imbueCasts, duration, useStaminas, daeyaltEssence } = data;
 		const user = await this.client.fetchUser(userID);
 
 		const rune = Runecraft.Runes.find(_rune => _rune.id === runeID)!;
@@ -18,7 +18,13 @@ export default class extends Task {
 		const quantityPerEssence = calcMaxRCQuantity(rune, user);
 		const runeQuantity = essenceQuantity * quantityPerEssence;
 
-		const xpReceived = essenceQuantity * rune.xp;
+		let runeXP = rune.xp;
+
+		if (daeyaltEssence) {
+			runeXP = rune.xp * 1.5;
+		}
+
+		const xpReceived = essenceQuantity * runeXP;
 
 		const magicXpReceived = imbueCasts * 86;
 
@@ -50,6 +56,10 @@ export default class extends Task {
 			);
 		}
 
+		if (daeyaltEssence) {
+			str += '\nYou are gaining 50% more Runecrafting XP due to using Daeyalt Essence.';
+		}
+
 		str += `\n\nYou received: ${loot}.`;
 
 		await transactItems({
@@ -62,7 +72,11 @@ export default class extends Task {
 			user,
 			channelID,
 			str,
-			['runecraft', { quantity: essenceQuantity, rune: rune.name, usestams: useStaminas }, true],
+			[
+				'runecraft',
+				{ quantity: essenceQuantity, rune: rune.name, usestams: useStaminas, daeyalt_essence: daeyaltEssence },
+				true
+			],
 			undefined,
 			data,
 			loot


### PR DESCRIPTION
Checks for the relevant skill levels and quest points before allowing you to mine Daeyalt Shards.
Adds the mining of daeyalt shards to exchange for daeyalt essence (using the /create command)
Adds a boolean optional command on the runecrafting command to use daeyalt essence at a 50% increased xp rate. (doesn't work on blood/soul runes)
If the boolean is not selected it defaults to false.

Closes #1017

-   [x] I have tested all my changes thoroughly.
