### PR TITLE
Add ability to dismantle rev weapons for ether.

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -126,6 +126,15 @@ for (const [uWep, cWep] of [
 			[itemID(uWep)]: 1
 		}
 	});
+	revWeapons.push({
+		name: `Revert ${uWep.toLowerCase()}`,
+		inputItems: {
+			[itemID(uWep)]: 1
+		},
+		outputItems: {
+			[itemID('Revenant ether')]: 7500
+		}
+	});
 }
 
 const metamorphPetCreatables: Createable[] = chambersOfXericMetamorphPets.map(pet => ({


### PR DESCRIPTION
### Description:

Adds ability to dismantle rev weapons, like `Craw's bow (u)` for 7,500 ether as you can in OSRS.

### Changes:

- Adds additional Createable per rev-weapon, but this time for the uncharged variant => 7500 Ether.

### Other checks:

-   [x] I have tested all my changes thoroughly.
