### PR TITLE
Fix 2 Bingo bugs. (1 - Boss tile, 2 - Admin command)

### DIFF
--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -501,7 +501,7 @@ export const adminCommand: OSBMahojiCommand = {
 			const usersToReset = await prisma.user.findMany({
 				where: {
 					bingo_tickets_bought: {
-						gt: 1
+						gt: 0
 					}
 				},
 				select: {

--- a/src/mahoji/lib/bingo.ts
+++ b/src/mahoji/lib/bingo.ts
@@ -69,7 +69,8 @@ export const bingoTiles: BingoTile[] = [
 			'Olmlet',
 			"Lil' zik",
 			'Sraracha',
-			'Nexling'
+			'Nexling',
+			'Little nightmare'
 		])
 	},
 	{


### PR DESCRIPTION
### Description:

Fixes two bugs, 
1. Little nightmare doesn't count as a boss pet
2. Admin clear temp cl for bingo users only works for users with 2+ bingo tickets

### Changes:

- Fixes above bugs.

### Other checks:

-   [x] I have tested all my changes thoroughly.
