### PR TITLE
Put 'fixed Nex armours' like /create Pernix cowl, above 'Revert Pernix cowl'

### DIFF
--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -24,6 +24,23 @@ for (const { baseItem, dyedVersions } of dyedItems) {
 	}
 }
 
+const nexArmourCreatables: Createable[] = [];
+for (const [component, brokenOutfit, repairedOutfit] of nexBrokenArmorDetails) {
+	for (let i = 0; i < brokenOutfit.length; i++) {
+		nexArmourCreatables.push({
+			name: getOSItem(repairedOutfit[i]).name,
+			inputItems: {
+				[component.id]: 1,
+				[brokenOutfit[i]]: 1
+			},
+			outputItems: {
+				[repairedOutfit[i]]: 1
+			},
+			requiredSkills: { smithing: 80, crafting: 80 }
+		});
+	}
+}
+
 const nexCreatables: Createable[] = [
 	{
 		name: 'Virtus wand',
@@ -47,6 +64,7 @@ const nexCreatables: Createable[] = [
 		},
 		requiredSkills: { smithing: 80, crafting: 80 }
 	},
+	...nexArmourCreatables,
 	...brokenPernixOutfit.map(piece => ({
 		name: `Revert ${getOSItem(piece).name}`,
 		inputItems: new Bank().add(piece),
@@ -69,22 +87,6 @@ const nexCreatables: Createable[] = [
 		}
 	}))
 ];
-
-for (const [component, brokenOutfit, repairedOutfit] of nexBrokenArmorDetails) {
-	for (let i = 0; i < brokenOutfit.length; i++) {
-		nexCreatables.push({
-			name: getOSItem(repairedOutfit[i]).name,
-			inputItems: {
-				[component.id]: 1,
-				[brokenOutfit[i]]: 1
-			},
-			outputItems: {
-				[repairedOutfit[i]]: 1
-			},
-			requiredSkills: { smithing: 80, crafting: 80 }
-		});
-	}
-}
 
 const componentRevertables: Createable[] = [
 	{


### PR DESCRIPTION
### Description:

When trying to fix/repair Nex armours, the first auto-complete option is the Revert option. This is undesirable as when trying to repair the armours, the 'default' behavior is to destroy them.

### Changes:

- Places the Nex armours creatables above the Revert nex armour creatables

### Other checks:

-   [x] I have tested all my changes thoroughly.

### Before:
![image](https://user-images.githubusercontent.com/10122432/188391580-e58a0e4e-34e2-4357-be35-120d332095b7.png)

### After:
![image](https://user-images.githubusercontent.com/10122432/188391675-29c3a145-696d-4bcf-a924-ae384d4c49f7.png)
