### PR TITLE
Fix create command for bingo

### DIFF
--- a/src/mahoji/commands/create.ts
+++ b/src/mahoji/commands/create.ts
@@ -207,16 +207,19 @@ export const createCommand: OSBMahojiCommand = {
 			if (onCreateResult.message) extraMessage += `\n\n${onCreateResult.message}`;
 		}
 
-		await user.removeItemsFromBank(inItems);
-		await transactItems({ userID: userID.toString(), itemsToAdd: outItems });
+		// Only allow +create to add items to CL
+		const addToCl = !createableItem.noCl && action === 'create';
+		await transactItems({
+			userID: userID.toString(),
+			collectionLog: addToCl,
+			itemsToAdd: outItems,
+			itemsToRemove: inItems
+		});
 
 		await updateBankSetting(globalClient, ClientSettings.EconomyStats.CreateCost, inItems);
 		await updateBankSetting(globalClient, ClientSettings.EconomyStats.CreateLoot, outItems);
 		await userStatsBankUpdate(user.id, 'create_cost_bank', inItems);
 		await userStatsBankUpdate(user.id, 'create_loot_bank', outItems);
-
-		// Only allow +create to add items to CL
-		if (!createableItem.noCl && action === 'create') await user.addItemsToCollectionLog({ items: outItems });
 
 		if (action === 'revert') {
 			return `You reverted ${inItems} into ${outItems}.${extraMessage}`;


### PR DESCRIPTION
### Description:

Because /create doesn't add CL during transactItems, bingo tiles aren't properly detected. This fixes that.

### Changes:

- Calculates whether or not to add to CL before calling transactItems()
- Passes that flag to transactItems
- Moves removeItemsFromBank to transactItems() call

### Other checks:

-   [x] I have tested all my changes thoroughly.
