### PR TITLE
Add clue scrolls to granite/sandstone mining

### DIFF
--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -146,7 +146,8 @@ const ores: Ore[] = [
 		bankingTime: 10,
 		slope: 0.8,
 		intercept: 10.01,
-		petChance: 741_600
+		petChance: 741_600,
+		clueScrollChance: 741_600
 	},
 	{
 		level: 40,
@@ -182,7 +183,8 @@ const ores: Ore[] = [
 		bankingTime: 80,
 		slope: 0.85,
 		intercept: 10.91,
-		petChance: 741_600
+		petChance: 741_600,
+		clueScrollChance: 741_600
 	},
 	{
 		level: 55,


### PR DESCRIPTION
As per the wiki add the clue scroll chance to the ores of sandstone and granite. https://oldschool.runescape.wiki/w/Clue_geode

-   [x] I have tested all my changes thoroughly.
