### PR TITLE
Remove Amethyst items from fletchables

### DIFF
--- a/src/lib/skilling/skills/fletching/fletchables/tips.ts
+++ b/src/lib/skilling/skills/fletching/fletchables/tips.ts
@@ -93,33 +93,6 @@ const Tips: Fletchable[] = [
 		inputItems: new Bank({ Onyx: 1 }),
 		tickRate: 5,
 		outputMultiple: 12
-	},
-	{
-		name: 'Amethyst arrowtips',
-		id: itemID('Amethyst arrowtips'),
-		level: 82,
-		xp: 60,
-		inputItems: new Bank({ Amethyst: 1 }),
-		tickRate: 5,
-		outputMultiple: 15
-	},
-	{
-		name: 'Amethyst bolt tips',
-		id: itemID('Amethyst bolt tips'),
-		level: 83,
-		xp: 60,
-		inputItems: new Bank({ Amethyst: 1 }),
-		tickRate: 5,
-		outputMultiple: 15
-	},
-	{
-		name: 'Amethyst javelin heads',
-		id: itemID('Amethyst javelin heads'),
-		level: 87,
-		xp: 60,
-		inputItems: new Bank({ Amethyst: 1 }),
-		tickRate: 2,
-		outputMultiple: 5
 	}
 ];
 


### PR DESCRIPTION
Removes some amethyst options that are under fletchables incorrectly. 
Checked the relevant ones are under crafting as they should be. 
Closes #4368

-   [x] I have tested all my changes thoroughly.
