### PR TITLE
Fix Hespori KC + Loot (again)

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -339,7 +339,9 @@ export const farmingTask: MinionTask = {
 			const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Farming, plantToHarvest.petChance);
 			if (plantToHarvest.seedType === 'hespori') {
 				await user.incrementKC(Monsters.Hespori.id, patchType.lastQuantity);
-				const hesporiLoot = Monsters.Hespori.kill(patchType.lastQuantity, { farmingLevel: currentFarmingLevel });
+				const hesporiLoot = Monsters.Hespori.kill(patchType.lastQuantity, {
+					farmingLevel: currentFarmingLevel
+				});
 				loot = hesporiLoot;
 				if (hesporiLoot.amount('Tangleroot')) tangleroot = true;
 			} else if (

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -338,8 +338,8 @@ export const farmingTask: MinionTask = {
 			let tangleroot = false;
 			const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Farming, plantToHarvest.petChance);
 			if (plantToHarvest.seedType === 'hespori') {
-				await user.incrementKC(Monsters.Hespori.id);
-				const hesporiLoot = Monsters.Hespori.kill(1, { farmingLevel: currentFarmingLevel });
+				await user.incrementKC(Monsters.Hespori.id, patchType.lastQuantity);
+				const hesporiLoot = Monsters.Hespori.kill(patchType.lastQuantity, { farmingLevel: currentFarmingLevel });
 				loot = hesporiLoot;
 				if (hesporiLoot.amount('Tangleroot')) tangleroot = true;
 			} else if (


### PR DESCRIPTION
### Description:

Adding it to master this time, so it doesn't get overwritten for the 4th time lol.

It has no negative impact on OSB/master, and really should function this way in case osrs ever adds a new patch, it only makes sense to use the farmed quantity.

### Changes:

Uses `patchType.lastQuantity` for KC increment and loot rolls

### Other checks:

-   [ ] I have tested all my changes thoroughly.
