### PR TITLE
Fix 2 Sepulchre pet (Giant squirrel) bugs

### DIFF
--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -6,7 +6,7 @@ import { trackLoot } from '../../../lib/settings/prisma';
 import { incrementMinigameScore } from '../../../lib/settings/settings';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import { SepulchreActivityTaskOptions } from '../../../lib/types/minions';
-import { roll, skillingPetDropRate } from '../../../lib/util';
+import { roll } from '../../../lib/util';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 
@@ -23,24 +23,23 @@ export const sepulchreTask: MinionTask = {
 		let thievingXP = 0;
 		let numCoffinsOpened = 0;
 
+		const highestCompletedFloor = completedFloors.reduce((prev, next) => (prev.number > next.number ? prev : next));
 		for (let i = 0; i < quantity; i++) {
 			for (const floor of completedFloors) {
 				if (floor.number === 5) {
 					loot.add(GrandHallowedCoffin.roll());
 				}
 
-				const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Agility, floor.petChance);
-
 				const numCoffinsToOpen = 1;
 				numCoffinsOpened += numCoffinsToOpen;
 				for (let i = 0; i < numCoffinsToOpen; i++) {
 					loot.add(openCoffin(floor.number, user));
 				}
-				if (roll(petDropRate)) {
-					loot.add('Giant squirrel');
-				}
 				agilityXP += floor.xp;
 				thievingXP = 200 * numCoffinsOpened;
+			}
+			if (roll(highestCompletedFloor.petChance)) {
+				loot.add('Giant squirrel');
 			}
 		}
 


### PR DESCRIPTION
### Description:

There are 2 bugs, 1 is new with the skillingPetDropRate. This should not apply to 'static' rates like the sepulchre.

The second  is older, and already affects OSB. Sepulchre only checks the pet rate ONCE at the end of a run, you do not get the pet chance at the end of every floor, only on your final floor when you leave the sepulchre.

### Changes:

- Removes XP adjusted droprate `skillingPetDropRate` for Giant squirrel
- Only calculates once per sepulchre, not once per floor.

### Other checks:

-   [x] I have tested all my changes thoroughly.
