### PR TITLE
Fix multiplied loot from stars

### DIFF
--- a/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
@@ -235,7 +235,7 @@ export async function shootingStarsCommand(channelID: string, user: MUserClass, 
 		}
 		// Add clue scrolls , TODO: convert klasaUsers to user
 		if (star.clueScrollChance) {
-			loot.add(addSkillingClueToLoot(user, SkillsEnum.Mining, newQuantity, star.clueScrollChance, loot));
+			addSkillingClueToLoot(user, SkillsEnum.Mining, newQuantity, star.clueScrollChance, loot);
 		}
 
 		// Roll for pet


### PR DESCRIPTION
### Description:

Fix multiplied loot from stars

### Changes:

Removes loot.add() because the command already adds the clues to the loot.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
