### PR TITLE
Fix thieving pet calculation

### DIFF
--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -77,8 +77,15 @@ export const pickpocketTask: MinionTask = {
 				}
 			}
 		} else if (obj.type === 'stall') {
-			for (let i = 0; i < (successfulQuantity * obj.lootPercent!) / 100; i++) {
-				loot.add(obj.table.roll());
+			for (let i = 0; i < successfulQuantity; i++) {
+				if (percentChance(obj.lootPercent!)) {
+					loot.add(obj.table.roll());
+				}
+
+				// Roll for pet
+				if (roll(petDropRate)) {
+					loot.add('Rocky');
+				}
 			}
 		}
 

--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -70,16 +70,16 @@ export const pickpocketTask: MinionTask = {
 				} else {
 					loot.add(lootItems);
 				}
+
+				// Roll for pet
+				if (roll(petDropRate)) {
+					loot.add('Rocky');
+				}
 			}
 		} else if (obj.type === 'stall') {
 			for (let i = 0; i < (successfulQuantity * obj.lootPercent!) / 100; i++) {
 				loot.add(obj.table.roll());
 			}
-		}
-
-		// Roll for pet
-		if (roll(petDropRate / successfulQuantity)) {
-			loot.add('Rocky');
 		}
 
 		if (loot.has('Coins')) {


### PR DESCRIPTION
### Description:

This can lead to guaranteed pet drop [on bso]  or more likely than it should be on OSB

### Changes:

- Roll pet chance per success instead rolling (petChance/successCount)

### Other checks:

-   [ ] I have tested all my changes thoroughly.
