### PR TITLE
Fix GitHub subs sync'ing from RoboChimp

### DIFF
--- a/src/lib/http/routes/webhooks/githubSponsors.ts
+++ b/src/lib/http/routes/webhooks/githubSponsors.ts
@@ -26,7 +26,7 @@ const githubSponsors = (server: FastifyServer) =>
 						content: `${data.sender.login}[${data.sender.id}] became a Tier ${tier - 1} sponsor.`
 					});
 					if (user) {
-						await patreonTask.givePerks(user.id, tier);
+						await patreonTask.givePerks(user, tier);
 					}
 					break;
 				}
@@ -41,7 +41,7 @@ const githubSponsors = (server: FastifyServer) =>
 						} to Tier ${to - 1}.`
 					});
 					if (user) {
-						await patreonTask.changeTier(user.id, from, to);
+						await patreonTask.changeTier(user, from, to);
 					}
 					break;
 				}
@@ -49,7 +49,7 @@ const githubSponsors = (server: FastifyServer) =>
 					const tier = parseStrToTier(data.sponsorship.tier.name);
 					if (!tier) return;
 					if (user) {
-						await patreonTask.removePerks(user.id);
+						await patreonTask.removePerks(user);
 					}
 
 					sendToChannelID(Channel.NewSponsors, {

--- a/src/lib/http/routes/webhooks/githubSponsors.ts
+++ b/src/lib/http/routes/webhooks/githubSponsors.ts
@@ -4,7 +4,7 @@ import { patreonTask } from '../../../patreon';
 import { sendToChannelID } from '../../../util/webhook';
 import { GithubSponsorsWebhookData } from '../../githubApiTypes';
 import { FastifyServer } from '../../types';
-import { getUserFromGithubID, parseStrToTier, verifyGithubSecret } from '../../util';
+import { getUserIdFromGithubID, parseStrToTier, verifyGithubSecret } from '../../util';
 
 const githubSponsors = (server: FastifyServer) =>
 	server.route({
@@ -16,7 +16,7 @@ const githubSponsors = (server: FastifyServer) =>
 				throw reply.badRequest();
 			}
 			const data = request.body as GithubSponsorsWebhookData;
-			const user = await getUserFromGithubID(data.sender.id.toString());
+			const userID = await getUserIdFromGithubID(data.sender.id.toString());
 			// eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
 			switch (data.action) {
 				case 'created': {
@@ -25,8 +25,8 @@ const githubSponsors = (server: FastifyServer) =>
 					sendToChannelID(Channel.NewSponsors, {
 						content: `${data.sender.login}[${data.sender.id}] became a Tier ${tier - 1} sponsor.`
 					});
-					if (user) {
-						await patreonTask.givePerks(user, tier);
+					if (userID) {
+						await patreonTask.givePerks(userID, tier);
 					}
 					break;
 				}
@@ -40,21 +40,21 @@ const githubSponsors = (server: FastifyServer) =>
 							from - 1
 						} to Tier ${to - 1}.`
 					});
-					if (user) {
-						await patreonTask.changeTier(user, from, to);
+					if (userID) {
+						await patreonTask.changeTier(userID, from, to);
 					}
 					break;
 				}
 				case 'cancelled': {
 					const tier = parseStrToTier(data.sponsorship.tier.name);
 					if (!tier) return;
-					if (user) {
-						await patreonTask.removePerks(user);
+					if (userID) {
+						await patreonTask.removePerks(userID);
 					}
 
 					sendToChannelID(Channel.NewSponsors, {
 						content: `${data.sender.login}[${data.sender.id}] cancelled being a Tier ${tier - 1} sponsor. ${
-							user ? 'Removing perks.' : "Cant remove perks because couldn't find discord user."
+							userID ? 'Removing perks.' : "Cant remove perks because couldn't find discord user."
 						}`
 					});
 

--- a/src/lib/http/util.ts
+++ b/src/lib/http/util.ts
@@ -116,7 +116,7 @@ export async function fetchSponsors() {
 	return data;
 }
 
-export async function getUserFromGithubID(githubID: string) {
+export async function getUserIdFromGithubID(githubID: string) {
 	const result = await roboChimpClient.user.findFirst({
 		select: { id: true },
 		where: { github_id: Number(githubID) }

--- a/src/lib/http/util.ts
+++ b/src/lib/http/util.ts
@@ -122,7 +122,7 @@ export async function getUserFromGithubID(githubID: string) {
 		where: { github_id: Number(githubID) }
 	});
 	if (!result) return null;
-	return globalClient.fetchUser(result.id);
+	return result.id.toString();
 }
 
 export function encryptJWT(payload: unknown, secret = CLIENT_SECRET) {

--- a/src/lib/http/util.ts
+++ b/src/lib/http/util.ts
@@ -5,7 +5,6 @@ import * as jwt from 'jwt-simple';
 
 import { CLIENT_SECRET, GITHUB_TOKEN, patreonConfig } from '../../config';
 import { PerkTier } from '../constants';
-import { prisma } from '../settings/prisma';
 
 export function rateLimit(max: number, timeWindow: string) {
 	return {
@@ -118,11 +117,12 @@ export async function fetchSponsors() {
 }
 
 export async function getUserFromGithubID(githubID: string) {
-	const result = await prisma.$queryRawUnsafe<{ id: string }[]>(
-		`SELECT id FROM users WHERE github_id = '${githubID}';`
-	);
-	if (result.length === 0) return null;
-	return globalClient.fetchUser(result[0].id);
+	const result = await roboChimpClient.user.findFirst({
+		select: { id: true },
+		where: { github_id: Number(githubID) }
+	});
+	if (!result) return null;
+	return globalClient.fetchUser(result.id);
 }
 
 export function encryptJWT(payload: unknown, secret = CLIENT_SECRET) {

--- a/src/lib/patreon.ts
+++ b/src/lib/patreon.ts
@@ -6,7 +6,7 @@ import { patreonConfig, production } from '../config';
 import { mahojiUserSettingsUpdate } from '../mahoji/settingsUpdate';
 import { cacheBadges } from './badges';
 import { BadgesEnum, BitField, Channel, PatronTierID, PerkTier } from './constants';
-import { fetchSponsors, getUserFromGithubID } from './http/util';
+import { fetchSponsors, getUserIdFromGithubID } from './http/util';
 import backgroundImages from './minions/data/bankBackgrounds';
 import { roboChimpUserFetch } from './roboChimp';
 import { Patron } from './types';
@@ -191,9 +191,9 @@ class PatreonTask {
 		const sponsors = await fetchSponsors();
 		for (const sponsor of sponsors) {
 			if (!sponsor.tier) continue;
-			const user = await getUserFromGithubID(sponsor.githubID);
-			if (!user) continue;
-			let res = await this.validatePerks(user, sponsor.tier);
+			const userID = await getUserIdFromGithubID(sponsor.githubID);
+			if (!userID) continue;
+			let res = await this.validatePerks(userID, sponsor.tier);
 			if (res) {
 				messages.push(res);
 			}

--- a/src/lib/patreon.ts
+++ b/src/lib/patreon.ts
@@ -193,7 +193,7 @@ class PatreonTask {
 			if (!sponsor.tier) continue;
 			const user = await getUserFromGithubID(sponsor.githubID);
 			if (!user) continue;
-			let res = await this.validatePerks(user.id, sponsor.tier);
+			let res = await this.validatePerks(user, sponsor.tier);
 			if (res) {
 				messages.push(res);
 			}


### PR DESCRIPTION
### Description:

Converts missed githubID lookup to robochimp.

### Changes:

- Updates getUserFromGithubID function to use robochimp instead of the primary prisma client.
- Changes function to return the user_id instead of fetching the Discord User (from the API or cache if lucky) for each Github sponsor, new and old. 
- Change function + variable names to reflect new return type

### Other checks:

-   [ ] I have tested all my changes thoroughly.
