### PR TITLE
Change BSO skilling pet multiplier to 5b

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -771,7 +771,7 @@ export function skillingPetDropRate(
 	skill: SkillsEnum,
 	baseDropRate: number
 ): { petDropRate: number } {
-	const twoHundredMillXP = user.skillsAsXP[skill] >= 200_000_000;
+	const twoHundredMillXP = user.skillsAsXP[skill] >= 5_000_000_000;
 	const skillLevel = user.skillsAsLevels[skill];
 	const petRateDivisor = twoHundredMillXP ? 15 : 1;
 	const dropRate = Math.floor((baseDropRate - skillLevel * 25) / petRateDivisor);

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -152,12 +152,12 @@ describe('util', () => {
 		});
 		const dropRateLvl99 = Math.floor((baseDropRate - 99 * 25) / 1);
 		expect(skillingPetDropRate(testUser, SkillsEnum.Agility, baseDropRate).petDropRate).toEqual(dropRateLvl99);
-		// Lvl 120 (BSO) and 200M xp
+		// Lvl 120 (BSO) and 5B xp
 		testUser = mockMUser({
-			skills_agility: 200_000_000
+			skills_agility: 5_000_000_000
 		});
-		const dropRate200M = Math.floor((baseDropRate - 120 * 25) / 15);
-		expect(skillingPetDropRate(testUser, SkillsEnum.Agility, baseDropRate).petDropRate).toEqual(dropRate200M);
+		const dropRate5b = Math.floor((baseDropRate - 120 * 25) / 15);
+		expect(skillingPetDropRate(testUser, SkillsEnum.Agility, baseDropRate).petDropRate).toEqual(dropRate5b);
 	});
 
 	test('userBusyCache', () => {


### PR DESCRIPTION
### Description:

As we discussed, this changes the 15x increase of pet rate requirement to 5b XP for BSO
