### PR TITLE
Don't force equipping boost items for wildy (Revert recent change)

### DIFF
--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -549,7 +549,7 @@ export function resolveAvailableItemBoosts(user: MUser, monster: KillableMonster
 			// find the highest boost that the player has
 			for (const [itemID, boostAmount] of Object.entries(boostSet)) {
 				const parsedId = parseInt(itemID);
-				if (monster.wildy ? !user.hasEquipped(parsedId) : !user.hasEquippedOrInBank(parsedId)) {
+				if (!user.hasEquippedOrInBank(parsedId)) {
 					continue;
 				}
 				if (boostAmount > highestBoostAmount) {


### PR DESCRIPTION
### Description:

Beyond the fact that you can just keep spec weapons in your inventory, this doesn't do anything except make it a pain in the nikta to kill things in the wilderness, needing to change equipment all the time.

### Examples
1. Vetion - Requires Viggora's chainmace (25%) and Dragon warhammer (5%) equipped
2. Malygos - Requires 3 different special attack weapons, so you would need to equip gear in FOUR (because of hellfire bow in wildy slot) different slots.

### Changes:

- Removes wildy ternary forcing items to be equipped.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
