### PR TITLE
[BSO] Don't force equipping boost items for wildy (Revert recent change)

### DIFF
--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -568,7 +568,7 @@ export function resolveAvailableItemBoosts(user: MUser, monster: KillableMonster
 			// find the highest boost that the player has
 			for (const [itemID, boostAmount] of Object.entries(boostSet)) {
 				const parsedId = parseInt(itemID);
-				if (monster.wildy ? !user.hasEquipped(parsedId) : !user.hasEquippedOrInBank(parsedId)) {
+				if (!user.hasEquippedOrInBank(parsedId)) {
 					continue;
 				}
 				if (boostAmount > highestBoostAmount) {


### PR DESCRIPTION
### Description:

as discussed

### Other checks:

-   [ ] I have tested all my changes thoroughly.
