### PR TITLE
adds "mysterious" alias to mysterious tree farming

### DIFF
--- a/src/lib/skilling/skills/farming/trees.ts
+++ b/src/lib/skilling/skills/farming/trees.ts
@@ -200,7 +200,7 @@ const trees: Plant[] = [
 		checkXp: 23_768.3,
 		harvestXp: 0,
 		name: 'Mysterious tree',
-		aliases: ['mysterious tree', 'mystery','mysterious'],
+		aliases: ['mysterious tree', 'mystery', 'mysterious'],
 		inputItems: new Bank({ 'Mysterious seed': 1 }),
 		outputLogs: itemID('Magic logs'),
 		outputRoots: itemID('Magic roots'),

--- a/src/lib/skilling/skills/farming/trees.ts
+++ b/src/lib/skilling/skills/farming/trees.ts
@@ -200,7 +200,7 @@ const trees: Plant[] = [
 		checkXp: 23_768.3,
 		harvestXp: 0,
 		name: 'Mysterious tree',
-		aliases: ['mysterious tree', 'mystery'],
+		aliases: ['mysterious tree', 'mystery','mysterious'],
 		inputItems: new Bank({ 'Mysterious seed': 1 }),
 		outputLogs: itemID('Magic logs'),
 		outputRoots: itemID('Magic roots'),


### PR DESCRIPTION
### Description:
What title says, it accepts aliases for "mysterious tree" and "mystery", but not mysterious.

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

-   [ ] I have tested all my changes thoroughly.
