### PR TITLE
Fix some BSO Boss instance issues.

### DIFF
--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -118,6 +118,7 @@ export interface BossOptions {
 	gearSetup: GearSetupType;
 	itemCost?: (options: { user: MUser; kills: number; baseFood: Bank; solo: boolean }) => Promise<Bank>;
 	mostImportantStat: keyof GearStats;
+	ignoreStats?: (keyof GearStats)[];
 	food: Bank | ((user: MUser) => Bank);
 	settingsKeys?: [ClientBankKey, ClientBankKey];
 	channel: TextChannel;
@@ -159,6 +160,7 @@ export class BossInstance {
 	gearSetup: GearSetupType;
 	itemCost?: (options: { user: MUser; kills: number; baseFood: Bank; solo: boolean }) => Promise<Bank>;
 	mostImportantStat: keyof GearStats;
+	ignoreStats: (keyof GearStats)[] = [];
 	food: Bank | ((user: MUser) => Bank);
 	bossUsers: BossUser[] = [];
 	duration: number = -1;
@@ -194,6 +196,7 @@ export class BossInstance {
 		this.gearSetup = options.gearSetup;
 		this.itemCost = options.itemCost;
 		this.mostImportantStat = options.mostImportantStat;
+		this.ignoreStats = options.ignoreStats ?? [];
 		this.id = options.id;
 		this.food = options.food;
 		this.settingsKeys = options.settingsKeys;
@@ -307,7 +310,12 @@ export class BossInstance {
 			}
 		}
 
-		const gearPercent = calcSetupPercent(this.bisGear, user.gear[this.gearSetup], this.mostImportantStat, []);
+		const gearPercent = calcSetupPercent(
+			this.bisGear,
+			user.gear[this.gearSetup],
+			this.mostImportantStat,
+			this.ignoreStats
+		);
 		if (gearPercent < 20) {
 			return [true, 'has terrible gear'];
 		}
@@ -346,7 +354,7 @@ export class BossInstance {
 			let userPercentChange = 0;
 
 			// Gear
-			const gearPercent = calcSetupPercent(this.bisGear, gear, this.mostImportantStat, []);
+			const gearPercent = calcSetupPercent(this.bisGear, gear, this.mostImportantStat, this.ignoreStats);
 			const gearBoostPercent = calcPercentOfNum(gearPercent, speedReductionForGear);
 			userPercentChange += gearBoostPercent;
 			debugStr.push(`**Gear**[${gearPercent.toFixed(1)}%]`);

--- a/src/mahoji/lib/abstracted_commands/igneCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/igneCommand.ts
@@ -72,6 +72,7 @@ export async function igneCommand(
 			return userBank.has(heatResBank.bank) ? heatResBank : normalBank;
 		},
 		mostImportantStat: 'attack_crush',
+		ignoreStats: ['attack_ranged', 'attack_magic'],
 		food: () => new Bank(),
 		settingsKeys: ['ignecarus_cost', 'ignecarus_loot'],
 		channel,

--- a/src/mahoji/lib/abstracted_commands/kgCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/kgCommand.ts
@@ -58,6 +58,7 @@ export async function kgCommand(
 		gearSetup: 'melee',
 		itemCost: async data => data.baseFood.multiply(data.kills).add('Coins', gpCostPerKill(data.user) * data.kills),
 		mostImportantStat: 'attack_slash',
+		ignoreStats: ['attack_ranged', 'attack_magic'],
 		food: () => new Bank(),
 		settingsKeys: ['kg_cost', 'kg_loot'],
 		channel,

--- a/src/mahoji/lib/abstracted_commands/vasaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/vasaCommand.ts
@@ -53,6 +53,7 @@ export async function vasaCommand(user: MUser, channelID: string, quantity?: num
 				)
 			),
 		mostImportantStat: 'attack_magic',
+		ignoreStats: ['attack_ranged', 'attack_crush', 'attack_slash', 'attack_stab'],
 		food: () => new Bank(),
 		settingsKeys: ['vasa_cost', 'vasa_loot'],
 		channel: globalClient.channels.cache.get(channelID.toString())! as TextChannel,

--- a/src/mahoji/lib/abstracted_commands/vasaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/vasaCommand.ts
@@ -1,5 +1,5 @@
 import { EmbedBuilder, TextChannel } from 'discord.js';
-import { randInt, Time } from 'e';
+import { randInt, sumArr, Time } from 'e';
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import { Bank } from 'oldschooljs';
 
@@ -44,7 +44,14 @@ export async function vasaCommand(user: MUser, channelID: string, quantity?: num
 		}),
 		gearSetup: 'mage',
 		itemCost: async data =>
-			data.baseFood.multiply(data.kills).add('Elder rune', randInt(55 * data.kills, 100 * data.kills)),
+			data.baseFood.multiply(data.kills).add(
+				'Elder rune',
+				sumArr(
+					Array(data.kills)
+						.fill(0)
+						.map(() => randInt(55, 100))
+				)
+			),
 		mostImportantStat: 'attack_magic',
 		food: () => new Bank(),
 		settingsKeys: ['vasa_cost', 'vasa_loot'],

--- a/src/tasks/minions/bso/ignecarusActivity.ts
+++ b/src/tasks/minions/bso/ignecarusActivity.ts
@@ -157,7 +157,7 @@ export const ignecarusTask: MinionTask = {
 			bossUsers[0].user,
 			channelID,
 			resultStr,
-			['k', { name: bossUsers.length === 1 ? 'Ignecarus (Solo)' : 'Ignecarus (Mass)' }, true],
+			['k', { name: bossUsers.length === 1 ? 'Ignecarus (Solo)' : 'Ignecarus (Mass)', quantity }, true],
 			undefined,
 			data,
 			null

--- a/src/tasks/minions/bso/vasaMagusActivity.ts
+++ b/src/tasks/minions/bso/vasaMagusActivity.ts
@@ -113,7 +113,7 @@ export const vasaTask: MinionTask = {
 			user,
 			channelID,
 			resultStr,
-			['k', { name: 'vasa' }, true],
+			['k', { name: 'vasa', quantity }, true],
 			image.file.attachment,
 			data,
 			itemsAdded


### PR DESCRIPTION
### Description:

This PR fixes the following issues:
1. Repeat trip not saving the manually specified quantity of the trip.
2. BossInstance fights defaulting to 1 quantity
3. Vasa calculating Elder rune cost incorrectly for multiple kills.
4. Adds support for `ignoredStats` to bosses, so having a low Range or Magic stat won't prevent you from killing a Melee boss.

### Changes:

- Adds `quantity` attribute to the onContinue parameter of handleTripFinish for Igne and Vasa
- Converts the NaN logic in Boss.ts / BossInstance class to null logic.
- Instead of choosing a random number between (qty * 55) and (qty * 100) runes, it calculates randInt(55, 100) for each kill, and sums it up. 
- The gearCalc code already supports ignoreStats, so I just added support to the class to set the option.

The result of above makes Elder rune costs much more likely to be in the middle of the range, instead of an equal cost for any rune amount, which is how it should be if you're doing multiple kills.

### Other checks:

-   [x] I have tested all my changes thoroughly.
