### PR TITLE
[BSO] Fixes some Tame bugs (most importantly: Aliases now work again!)

### DIFF
--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -76,8 +76,8 @@ export const igneArmors = [
 export type TameKillableMonster = {
 	loot: (opts: { quantity: number; tame: Tame }) => Bank;
 	deathChance?: (opts: { tame: Tame }) => number;
-	oriWorks?: false;
-	mustBeAdult?: true;
+	oriWorks?: boolean;
+	mustBeAdult?: boolean;
 	minArmorTier?: Item;
 } & Omit<KillableMonster, 'table'>;
 
@@ -550,7 +550,7 @@ export async function tameLastFinishedActivity(user: MUser) {
 			tame_id: tameID
 		},
 		orderBy: {
-			finish_date: 'desc'
+			start_date: 'desc'
 		}
 	});
 }

--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -784,7 +784,9 @@ async function killCommand(user: MUser, channelID: string, str: string) {
 		return `${tameName(tame)} is busy.`;
 	}
 	//
-	const monster = tameKillableMonsters.find(i => stringMatches(i.name, str));
+	const monster = tameKillableMonsters.find(
+		i => stringMatches(i.name, str) || i.aliases.some(alias => stringMatches(alias, str))
+	);
 	if (!monster) return "That's not a valid monster.";
 	if (monster.mustBeAdult && tame.growth_stage !== tame_growth.adult) {
 		return 'Only fully grown tames can kill this monster.';

--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -1239,7 +1239,12 @@ export const tamesCommand: OSBMahojiCommand = {
 					required: true,
 					autocomplete: async (value: string) => {
 						return tameKillableMonsters
-							.filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())))
+							.filter(i =>
+								!value
+									? true
+									: i.name.toLowerCase().includes(value.toLowerCase()) ||
+									  i.aliases.some(alias => stringMatches(alias, value))
+							)
 							.map(i => ({ name: i.name, value: i.name }));
 					}
 				}


### PR DESCRIPTION
### Description:

Fixes the following bugs:
1. Aliases now work again for /tames kill
2. Type issue where false/true was used instead of `boolean`
3. Fixes bug in test mode where sometimes the last /tame activity is not the one that's repeated

### Changes:

- Adds alias checking to the string provided to the /tames kill command.
- Adds alias checking the autocomplete for /tames kill
- Changes the oriWorks and mustBeAdult types to `boolean`
- Sorts last task by start_date instead of finish_date.
  ^    This bug only affects test mode (production = false), but it's still good to fix to prevent reports every time someone stumbles on it. To reproduce: in test mode, do  /tames kill men, then /tames kill cox, and when you try to repeat the trip, it will be men, not cox.

### Other checks:

-   [x] I have tested all my changes thoroughly.
