### PR TITLE
PoH Items command on master

### DIFF
--- a/src/mahoji/commands/poh.ts
+++ b/src/mahoji/commands/poh.ts
@@ -8,6 +8,7 @@ import {
 	makePOHImage,
 	pohBuildCommand,
 	pohDestroyCommand,
+	pohListItemsCommand,
 	pohMountItemCommand,
 	pohWallkitCommand,
 	pohWallkits
@@ -103,6 +104,11 @@ export const pohCommand: OSBMahojiCommand = {
 					required: true
 				}
 			]
+		},
+		{
+			type: ApplicationCommandOptionType.Subcommand,
+			name: 'items',
+			description: 'List the buildable items in your POH.'
 		}
 	],
 	run: async ({
@@ -115,6 +121,7 @@ export const pohCommand: OSBMahojiCommand = {
 		build?: { name: string };
 		destroy?: { name: string };
 		mount_item?: { name: string };
+		items?: { name: string };
 	}>) => {
 		const user = await mUserFetch(userID);
 		const mahojiUser = await mahojiUsersSettingsFetch(userID);
@@ -134,6 +141,9 @@ export const pohCommand: OSBMahojiCommand = {
 		}
 		if (options.mount_item) {
 			return pohMountItemCommand(user, options.mount_item.name);
+		}
+		if (options.items) {
+			return pohListItemsCommand();
 		}
 		return 'Invalid command.';
 	}

--- a/src/mahoji/lib/abstracted_commands/pohCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/pohCommand.ts
@@ -3,7 +3,7 @@ import { Bank } from 'oldschooljs';
 
 import { BitField } from '../../../lib/constants';
 import { Favours, gotFavour } from '../../../lib/minions/data/kourendFavour';
-import { getPOHObject, itemsNotRefundable, PoHObjects } from '../../../lib/poh';
+import { getPOHObject, GroupedPohObjects, itemsNotRefundable, PoHObjects } from '../../../lib/poh';
 import { pohImageGenerator } from '../../../lib/pohImage';
 import { prisma } from '../../../lib/settings/prisma';
 import { SkillsEnum } from '../../../lib/skilling/types';
@@ -249,4 +249,20 @@ export async function pohDestroyCommand(user: MUser, name: string) {
 	});
 
 	return { ...(await makePOHImage(user)), content: str };
+}
+
+export async function pohListItemsCommand() {
+	const textStr = [];
+
+	for (const [key, arr] of Object.entries(GroupedPohObjects)) {
+		textStr.push(`${key}: ${arr.map(i => i.name).join(', ')}`);
+	}
+
+	const attachment = Buffer.from(textStr.join('\n'));
+
+	return {
+		content: 'Here are all the items you can build in your PoH.',
+
+		files: [{ attachment, name: 'Buildables.txt' }]
+	};
 }


### PR DESCRIPTION
### Description:

Added command that was there previously to list the buildable items in PoH

### Changes:

Added subcommand on PoH, it lists out in the same format as before, but in text output format due to character limit in discord.

### Other checks:

-   [x] I have tested all my changes thoroughly.

Closes https://github.com/oldschoolgg/oldschoolbot/issues/4382