### PR TITLE
Fix Ironman self cracker

### DIFF
--- a/src/mahoji/lib/abstracted_commands/crackerCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/crackerCommand.ts
@@ -30,7 +30,7 @@ export async function crackerCommand({
 }) {
 	const otherPerson = await mUserFetch(otherPersonID);
 	const owner = await mUserFetch(ownerID);
-	if (owner.isIronman && owner === otherPerson) {
+	if (owner.isIronman && owner.id === otherPerson.id) {
 		await owner.removeItemsFromBank(new Bank().add('Christmas cracker', 1));
 		const loot = PartyhatTable.roll();
 		await owner.addItemsToBank({ items: loot, collectionLog: true });


### PR DESCRIPTION
### Description:

Fixed iron accounts not being able to pull a cracker with themselves

### Changes:

Modified the self check on iron to use minion.id instead of minion. This is the same as for non-irons.

### Other checks:

-   [x] I have tested all my changes thoroughly.
