### PR TITLE
Fix "Abyssal tome gives negative score at CoX"  -  [BSO]

### DIFF
--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -2723,7 +2723,7 @@ setCustomItem(
 			melee_strength: 0,
 			ranged_strength: 0,
 			magic_damage: 2.5,
-			prayer: 0,
+			prayer: 5,
 			slot: EquipmentSlot.Shield,
 			requirements: { magic: 90 }
 		},


### PR DESCRIPTION
### Description:

Abyssal tome is a downgrade at cox because it's missing the prayer bonus

### Changes:

- Adds the +5 prayer bonus that the virtus book has

### Other checks:

-   [] I have tested all my changes thoroughly.
