### PR TITLE
Add deferReply to a few commands that common error out causing complaints.

### DIFF
--- a/src/mahoji/commands/casket.ts
+++ b/src/mahoji/commands/casket.ts
@@ -42,6 +42,7 @@ export const casketCommand: OSBMahojiCommand = {
 		}
 	],
 	run: async ({ options, userID, interaction }: CommandRunOptions<{ name: string; quantity: number }>) => {
+		await deferInteraction(interaction);
 		const user = await mUserFetch(userID.toString());
 		const limit = determineLimit(user);
 		if (options.quantity > limit) {

--- a/src/mahoji/commands/gamble.ts
+++ b/src/mahoji/commands/gamble.ts
@@ -184,7 +184,7 @@ export const gambleCommand: OSBMahojiCommand = {
 		}
 
 		if (options.dice) {
-			return diceCommand(user, options.dice.amount);
+			return diceCommand(user, interaction, options.dice.amount);
 		}
 
 		if (options.duel) {

--- a/src/mahoji/lib/abstracted_commands/diceCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/diceCommand.ts
@@ -1,9 +1,12 @@
+import { ChatInputCommandInteraction } from 'discord.js';
 import { Bank, Util } from 'oldschooljs';
 
 import { rand } from '../../../lib/util';
+import { deferInteraction } from '../../../lib/util/interactionReply';
 import { mahojiParseNumber, updateGPTrackSetting } from '../../mahojiSettings';
 
-export async function diceCommand(user: MUser, diceamount?: string) {
+export async function diceCommand(user: MUser, interaction: ChatInputCommandInteraction, diceamount?: string) {
+	await deferInteraction(interaction);
 	const roll = rand(1, 100);
 	const amount = mahojiParseNumber({ input: diceamount, min: 1, max: 500_000_000_000 });
 


### PR DESCRIPTION
### Description:

1. The dice command has been known to take too long to return, showing, 'application did not respond'.
When this happens, and they lose money, people assume the bot broke and stole their money, even though the code only removes the GP after they lost, I still get many complaints about it from people who don't know the code.
2. Also the casket command is likely to fail when Patron's use close to their max, especially for Grandmasters.

### Changes:

- Adds deferInteraction() to casket and diceCommand

### Other checks:

-   [ ] I have tested all my changes thoroughly.
