### PR TITLE
Fixes: Some leagues commands fail to reply about 50% of the time

### DIFF
--- a/src/mahoji/commands/leagues.ts
+++ b/src/mahoji/commands/leagues.ts
@@ -12,6 +12,7 @@ import {
 } from '../../lib/leagues/leagues';
 import { formatDuration } from '../../lib/util';
 import getUsersPerkTier from '../../lib/util/getUsersPerkTier';
+import { deferInteraction } from '../../lib/util/interactionReply';
 import { Cooldowns } from '../lib/Cooldowns';
 import { OSBMahojiCommand } from '../lib/util';
 
@@ -62,6 +63,7 @@ export const leaguesCommand: OSBMahojiCommand = {
 	],
 	run: async ({
 		options,
+		interaction,
 		userID
 	}: CommandRunOptions<{
 		check?: {};
@@ -69,6 +71,7 @@ export const leaguesCommand: OSBMahojiCommand = {
 		claim?: {};
 		view_all_tasks?: { exclude_finished?: boolean };
 	}>) => {
+		await deferInteraction(interaction);
 		const user = await mUserFetch(userID);
 		const cooldown = Cooldowns.get(
 			userID.toString(),


### PR DESCRIPTION
### Description:

Leagues check, leagues claim, etc, have to process a lot of data each call, and there's like a 50/50 chance the command will fail to reply on end-game progressed accounts before the timeout.

This is especially frustrating for /leagues claim, which can only be run every so often, and only shows the claimed tasks, once, and if it fails to reply on time, then you will never be able to see which tasks were completed since the last claim.

### Changes:

Adds deferInterction() to the leagues

### Other checks:

-   [ ] I have tested all my changes thoroughly.
