### PR TITLE
Removes KBD as an alternative for Konar tasks

### DIFF
--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -82,7 +82,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		monster: Monsters.BlackDragon,
 		amount: [10, 15],
 		weight: 6,
-		monsters: [Monsters.BlackDragon.id,Monsters.BabyBlackDragon.id,Monsters.BrutalBlackDragon.id],
+		monsters: [Monsters.BlackDragon.id, Monsters.BabyBlackDragon.id, Monsters.BrutalBlackDragon.id],
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,
 		slayerLevel: 77,

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -85,8 +85,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		monsters: [
 			Monsters.BlackDragon.id,
 			Monsters.BabyBlackDragon.id,
-			Monsters.BrutalBlackDragon.id,
-			Monsters.KingBlackDragon.id
+			Monsters.BrutalBlackDragon.id
 		],
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -82,11 +82,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		monster: Monsters.BlackDragon,
 		amount: [10, 15],
 		weight: 6,
-		monsters: [
-			Monsters.BlackDragon.id,
-			Monsters.BabyBlackDragon.id,
-			Monsters.BrutalBlackDragon.id
-		],
+		monsters: [Monsters.BlackDragon.id,Monsters.BabyBlackDragon.id,Monsters.BrutalBlackDragon.id],
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,
 		slayerLevel: 77,


### PR DESCRIPTION
### Description:

In-game, Konar cannot assign KBD as part of Black dragon assignments. This update makes it Konar consistent to in-game

### Changes:

- Removed KBD as a possible alternative for Black dragon tasks

### Other checks:

-   [ ] I have tested all my changes thoroughly.
