### PR TITLE
Fixes Slayer Task Bugs for Inferno and Fight Caves

### DIFF
--- a/src/tasks/minions/minigames/fightCavesActivity.ts
+++ b/src/tasks/minions/minigames/fightCavesActivity.ts
@@ -95,7 +95,7 @@ export const fightCavesTask: MinionTask = {
 			let msg = `${rangeXP}. ${hpXP}.`;
 			if (isOnTask) {
 				const slayXP = await user.addXP({ skillName: SkillsEnum.Slayer, amount: 11_760, duration });
-				msg = `**Task cancelled.** \n${msg} ${slayXP}.`;
+				msg = `**Slayer task cancelled.** \n${msg} ${slayXP}.`;
 
 				await prisma.slayerTask.update({
 					where: {
@@ -153,17 +153,20 @@ export const fightCavesTask: MinionTask = {
 
 		let msg = `${rangeXP}. ${hpXP}.`;
 		if (isOnTask) {
-			// 25,250 for Jad + 11,760 for waves.
-			const slayerXP = 37_010;
-			const currentStreak = user.user.slayer_task_streak;
-			const points = await calculateSlayerPoints(currentStreak, usersTask.slayerMaster!, user);
-
 			const { newUser } = await user.update({
-				slayer_points: {
-					increment: points
-				},
 				slayer_task_streak: {
 					increment: 1
+				}
+			});
+
+			// 25,250 for Jad + 11,760 for waves.
+			const slayerXP = 37_010;
+			const currentStreak = newUser.slayer_task_streak;
+			const points = await calculateSlayerPoints(currentStreak, usersTask.slayerMaster!, user);
+
+			const secondNewUser = await user.update({
+				slayer_points: {
+					increment: points
 				}
 			});
 
@@ -179,7 +182,7 @@ export const fightCavesTask: MinionTask = {
 			const slayXP = await user.addXP({ skillName: SkillsEnum.Slayer, amount: slayerXP, duration });
 			const xpMessage = `${msg} ${slayXP}`;
 
-			msg = `Jad task completed. ${xpMessage}. \n**You've completed ${currentStreak} tasks and received ${points} points; giving you a total of ${newUser.slayer_points}; return to a Slayer master.**`;
+			msg = `Jad task completed. ${xpMessage}. \n**You've completed ${currentStreak} tasks and received ${points} points; giving you a total of ${secondNewUser.newUser.slayer_points}; return to a Slayer master.**`;
 			// End slayer code
 		}
 

--- a/src/tasks/minions/minigames/infernoActivity.ts
+++ b/src/tasks/minions/minigames/infernoActivity.ts
@@ -93,6 +93,8 @@ export const infernoTask: MinionTask = {
 				}
 			}
 			if (isOnTask) {
+				text += '**Slayer task cancelled.**\n';
+
 				await prisma.slayerTask.update({
 					where: {
 						id: usersTask.currentTask!.id
@@ -105,14 +107,18 @@ export const infernoTask: MinionTask = {
 			}
 		}
 
-		if (isOnTask) {
-			const points = await calculateSlayerPoints(user.user.slayer_last_task, usersTask.slayerMaster!, user);
+		if (isOnTask && !deathTime) {
 			const { newUser } = await user.update({
-				slayer_points: {
-					increment: points
-				},
 				slayer_task_streak: {
 					increment: 1
+				}
+			});
+
+			const currentStreak = newUser.slayer_task_streak;
+			const points = await calculateSlayerPoints(currentStreak, usersTask.slayerMaster!, user);
+			const secondNewUser = await user.update({
+				slayer_points: {
+					increment: points
 				}
 			});
 
@@ -126,7 +132,7 @@ export const infernoTask: MinionTask = {
 				}
 			});
 
-			text += `\n\n**You've completed ${newUser.slayer_task_streak} tasks and received ${points} points; giving you a total of ${newUser.slayer_points}; return to a Slayer master.**`;
+			text += `\n\n**You've completed ${currentStreak} tasks and received ${points} points; giving you a total of ${secondNewUser.newUser.slayer_points}; return to a Slayer master.**`;
 		}
 
 		if (unusedItems.length > 0) {
@@ -141,12 +147,12 @@ export const infernoTask: MinionTask = {
 		}
 
 		if (diedPreZuk) {
-			text = `You died ${formatDuration(deathTime!)} into your attempt, before you reached Zuk.`;
+			text += `You died ${formatDuration(deathTime!)} into your attempt, before you reached Zuk.`;
 			chatText = `You die before you even reach TzKal-Zuk...atleast you tried, I give you ${baseBank.amount(
 				'Tokkul'
 			)}x Tokkul.`;
 		} else if (diedZuk) {
-			text = `You died ${formatDuration(deathTime!)} into your attempt, during the Zuk fight.`;
+			text += `You died ${formatDuration(deathTime!)} into your attempt, during the Zuk fight.`;
 			chatText = `You died to Zuk. Nice try JalYt, for your effort I give you ${baseBank.amount(
 				'Tokkul'
 			)}x Tokkul.`;

--- a/src/tasks/minions/minigames/infernoActivity.ts
+++ b/src/tasks/minions/minigames/infernoActivity.ts
@@ -128,7 +128,7 @@ export const infernoTask: MinionTask = {
 				},
 				data: {
 					quantity_remaining: 0,
-					skipped: deathTime ? true : false
+					skipped: false
 				}
 			});
 


### PR DESCRIPTION
### Description:

- Resolves Issue #4553.
- Resolves a bug where failing an Inferno run silently completes the slayer task and awards slayer points.

### Changes:

- Calculate current slayer task streak before calculating points to award (like monsterActivity does it).
- Only complete an Inferno task is the user does not die.
- Add a Slayer Task Cancelled message when the user dies in Inferno and is on task.
- Fix message in Fight Caves to be more specific (Task Cancelled -> Slayer Task Cancelled). 

### Other checks:

-   [X] I have tested all my changes thoroughly.