### PR TITLE
reorder gauntlets and remy

### DIFF
--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -65,11 +65,11 @@ export const cookCommand: OSBMahojiCommand = {
 			if (hasRemy) timeToCookSingleCookable /= 1.5;
 		} else if (user.hasEquipped('Cooking master cape')) {
 			timeToCookSingleCookable /= 5;
-		} else if (hasRemy) {
-			timeToCookSingleCookable /= 2;
 		} else if (user.hasEquipped('Dwarven gauntlets')) {
 			timeToCookSingleCookable /= 3;
-		}
+		} else if (hasRemy) {
+			timeToCookSingleCookable /= 2;
+		
 
 		const userBank = user.bank;
 		const inputCost = new Bank(cookable.inputCookables);

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -69,7 +69,7 @@ export const cookCommand: OSBMahojiCommand = {
 			timeToCookSingleCookable /= 3;
 		} else if (hasRemy) {
 			timeToCookSingleCookable /= 2;
-		
+		}
 
 		const userBank = user.bank;
 		const inputCost = new Bank(cookable.inputCookables);


### PR DESCRIPTION
### Description:

Made gauntlets prio over remy as they have a bigger boost

### Changes:

Reordered if else statement so dwarven gauntlets (/3 boost), takes prio over remy (/2 boost)

### Other checks:

-   [ ] I have tested all my changes thoroughly.
