### PR TITLE
Allow fish barrel to extend trips

### DIFF
--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -19,6 +19,11 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 	max += patronMaxTripBonus(user);
 
 	switch (activity) {
+		case 'Fishing':
+			if (user.allItemsOwned().has('Fish sack barrel') || user.allItemsOwned().has('Fish barrel')) {
+				max += Time.Minute * 9;
+			}
+			break;
 		case 'Nightmare':
 		case 'GroupMonsterKilling':
 		case 'MonsterKilling':

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -124,6 +124,14 @@ export const fishCommand: OSBMahojiCommand = {
 			);
 		}
 
+		if (user.allItemsOwned().has('Fish sack barrel') || user.allItemsOwned().has('Fish barrel')) {
+			boosts.push(
+				`+9 trip minutes for having a ${
+					user.allItemsOwned().has('Fish sack barrel') ? 'Fish sack barrel' : 'Fish barrel'
+				}`
+			);
+		}
+
 		const maxTripLength = calcMaxTripLength(user, 'Fishing');
 
 		let { quantity } = options;


### PR DESCRIPTION
This is a redo of PR #2659

- Allows the fish barrel/fish sack barrel to extend any trips under the fish command by 9 minutes. 
- Adds a boost message showing that the boost is working.

Can't see any reason why this can't be on the osb branch. I believe the current fish barrel extend will have to be deleted off the bso branch if this gets merged to prevent duplication.

Closes #3352

-   [x] I have tested all my changes thoroughly.
