### PR TITLE
Bandosian Components add to CL

### DIFF
--- a/src/lib/data/creatables/nex.ts
+++ b/src/lib/data/creatables/nex.ts
@@ -8,14 +8,16 @@ export const nexCreatables: Createable[] = [
 		inputItems: new Bank({
 			'Bandos chestplate': 1
 		}),
-		outputItems: new Bank({ 'Bandosian components': 3 })
+		outputItems: new Bank({ 'Bandosian components': 3 }),
+		forceAddToCl: true
 	},
 	{
 		name: 'Revert bandos tassets',
 		inputItems: new Bank({
 			'Bandos tassets': 1
 		}),
-		outputItems: new Bank({ 'Bandosian components': 2 })
+		outputItems: new Bank({ 'Bandosian components': 2 }),
+		forceAddToCl: true
 	},
 	{
 		name: 'Torva full helm',

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -28,6 +28,7 @@ export interface Createable {
 	requiredSkills?: Skills;
 	QPRequired?: number;
 	noCl?: boolean;
+	forceAddToCl?: boolean;
 	GPCost?: number;
 	cantBeInCL?: boolean;
 	requiredSlayerUnlocks?: SlayerTaskUnlocksEnum[];

--- a/src/mahoji/commands/create.ts
+++ b/src/mahoji/commands/create.ts
@@ -205,7 +205,12 @@ export const createCommand: OSBMahojiCommand = {
 		}
 
 		// Only allow +create to add items to CL
-		const addToCl = !createableItem.noCl && action === 'create';
+		let addToCl = !createableItem.noCl && action === 'create';
+
+		if (createableItem.forceAddToCl) {
+			addToCl = true;
+		}
+
 		await transactItems({
 			userID: userID.toString(),
 			collectionLog: addToCl,


### PR DESCRIPTION
As bandosian components are on the creatables cl, this PR adds an optional boolean that can be added onto creatables like reverts to force add them on to the cl.

-   [x] I have tested all my changes thoroughly.
