### PR TITLE
Update max mage stats with void staff

### DIFF
--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -18,7 +18,7 @@ export const maxDefenceStats: { [key in DefenceGearStat]: number } = {
 
 export const maxOffenceStats: { [key in OffenceGearStat]: number } = {
 	[GearStat.AttackCrush]: 360,
-	[GearStat.AttackMagic]: 459,
+	[GearStat.AttackMagic]: 509,
 	[GearStat.AttackRanged]: 431,
 	[GearStat.AttackSlash]: 295,
 	[GearStat.AttackStab]: 361


### PR DESCRIPTION
Closes #4577 

Swaps the max mage stats to 509 which is achieved with the void staff rather than the virtus wand.

![195012568-768aa1cf-23d8-4653-aafd-ca333d131e7d](https://user-images.githubusercontent.com/79149170/195036076-a1346b71-429b-4adb-8748-cee4b3b5a6d9.jpg)