### PR TITLE
Update Max Real QP to 290

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -354,7 +354,7 @@ export const badges: { [key: number]: string } = {
 	[BadgesEnum.SotWTrophy]: Emoji.SOTW
 };
 
-export const MAX_REAL_QP = 284;
+export const MAX_REAL_QP = 290;
 export const MAX_QP = 5000;
 export const MAX_XP = 5_000_000_000;
 


### PR DESCRIPTION
Updates the max real quest points to 290 in line with osrs. (Used for claiming lumbridge & draynor diary etc)

![unknown](https://user-images.githubusercontent.com/79149170/195062604-32e639a3-39f9-422a-8e60-3fc7e868e8f3.png)

