### PR TITLE
Add Jar of smoke to notifications

### DIFF
--- a/src/lib/minions/data/killableMonsters/konarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/konarMonsters.ts
@@ -262,7 +262,7 @@ export const konarMonsters: KillableMonster[] = [
 		wildy: false,
 
 		difficultyRating: 4,
-		notifyDrops: resolveItems(['Dragon chainbody', 'Smoke Battlestaff', 'Pet smoke devil']),
+		notifyDrops: resolveItems(['Dragon chainbody', 'Smoke Battlestaff', 'Jar of smoke', 'Pet smoke devil']),
 		qpRequired: 0,
 		levelRequirements: {
 			slayer: 93


### PR DESCRIPTION
Other jars are in notifications so makes sense to add jar of smoke, its also rarer than the smoke battlestaff thats currently notified.
