### PR TITLE
Fix ba high gambles increment

### DIFF
--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -183,11 +183,15 @@ export async function barbAssaultGambleCommand(
 	const { newUser } = await user.update({
 		honour_points: {
 			decrement: cost * quantity
-		},
-		high_gambles: {
-			increment: quantity
 		}
 	});
+	if (name === 'High') {
+		await user.update({
+			high_gambles: {
+				increment: quantity
+			}
+		});
+	}
 	const loot = new Bank().add(table.roll(quantity));
 	if (loot.has('Pet penance queen')) {
 		const amount = await countUsersWithItemInCl(itemID('Pet penance queen'), false);

--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -183,15 +183,14 @@ export async function barbAssaultGambleCommand(
 	const { newUser } = await user.update({
 		honour_points: {
 			decrement: cost * quantity
-		}
+		},
+		high_gambles:
+			name === 'High'
+				? {
+						increment: quantity
+				  }
+				: undefined
 	});
-	if (name === 'High') {
-		await user.update({
-			high_gambles: {
-				increment: quantity
-			}
-		});
-	}
 	const loot = new Bank().add(table.roll(quantity));
 	if (loot.has('Pet penance queen')) {
 		const amount = await countUsersWithItemInCl(itemID('Pet penance queen'), false);


### PR DESCRIPTION
Fix Barbarian Assault gambles to only increase the high gambles counter when a high gamble is used.

Currently low and medium gambles are causing it to increment.

Closes #4582 

-   [x] I have tested all my changes thoroughly.
