### PR TITLE
Add Toggle for Birdhouse Run Button

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -208,7 +208,8 @@ export enum BitField {
 	HasTornPrayerScroll = 18,
 	IsWikiContributor = 19,
 	HasSlepeyTablet = 20,
-	IsPatronTier6 = 21
+	IsPatronTier6 = 21,
+	DisableBirdhouseRunButton = 22
 }
 
 interface BitFieldData {
@@ -248,7 +249,12 @@ export const BitFieldData: Record<BitField, BitFieldData> = {
 	[BitField.PermanentIronman]: { name: 'Permanent Ironman', protected: false, userConfigurable: false },
 
 	[BitField.AlwaysSmallBank]: { name: 'Always Use Small Banks', protected: false, userConfigurable: true },
-	[BitField.DisabledRandomEvents]: { name: 'Disabled Random Events', protected: false, userConfigurable: true }
+	[BitField.DisabledRandomEvents]: { name: 'Disabled Random Events', protected: false, userConfigurable: true },
+	[BitField.DisableBirdhouseRunButton]: {
+		name: 'Disable Birdhouse Run Button',
+		protected: false,
+		userConfigurable: true
+	}
 } as const;
 
 export const enum PatronTierID {

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -6,7 +6,7 @@ import { calculateBirdhouseDetails } from '../../mahoji/lib/abstracted_commands/
 import { handleTriggerShootingStar } from '../../mahoji/lib/abstracted_commands/shootingStarsCommand';
 import { updateGPTrackSetting, userStatsBankUpdate } from '../../mahoji/mahojiSettings';
 import { ClueTiers } from '../clues/clueTiers';
-import { COINS_ID, Emoji, PerkTier } from '../constants';
+import { BitField, COINS_ID, Emoji, PerkTier } from '../constants';
 import { handleGrowablePetGrowth } from '../growablePets';
 import { handlePassiveImplings } from '../implings';
 import { triggerRandomEvent } from '../randomEvents';
@@ -114,7 +114,8 @@ export async function handleTripFinish(
 	if (perkTier > PerkTier.One) {
 		if (clueReceived) components.addComponents(makeDoClueButton(clueReceived));
 		const birdHousedetails = await calculateBirdhouseDetails(user.id);
-		if (birdHousedetails.isReady) components.addComponents(makeBirdHouseTripButton());
+		if (birdHousedetails.isReady && !user.bitfield.includes(BitField.DisableBirdhouseRunButton))
+			components.addComponents(makeBirdHouseTripButton());
 		const { currentTask } = await getUsersCurrentSlayerInfo(user.id);
 		if ((currentTask === null || currentTask.quantity_remaining <= 0) && data.type === 'MonsterKilling') {
 			components.addComponents(makeNewSlayerTaskButton());

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -34,6 +34,10 @@ const toggles = [
 	{
 		name: 'Small Bank Images',
 		bit: BitField.AlwaysSmallBank
+	},
+	{
+		name: 'Disable Birdhouse Run Button',
+		bit: BitField.DisableBirdhouseRunButton
 	}
 ];
 

--- a/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
@@ -1,7 +1,7 @@
 import { ButtonBuilder, ButtonStyle, ComponentType } from 'discord.js';
 
 import { ClueTiers } from '../../../lib/clues/clueTiers';
-import { Emoji, minionBuyButton } from '../../../lib/constants';
+import { BitField, Emoji, minionBuyButton } from '../../../lib/constants';
 import { roboChimpUserFetch } from '../../../lib/roboChimp';
 import { makeComponents } from '../../../lib/util';
 import { minionStatus } from '../../../lib/util/minionStatus';
@@ -69,7 +69,7 @@ export async function minionStatusCommand(user: MUser) {
 			.setStyle(ButtonStyle.Secondary)
 	);
 
-	if (!user.minionIsBusy && birdhouseDetails.isReady) {
+	if (!user.minionIsBusy && birdhouseDetails.isReady && !user.bitfield.includes(BitField.DisableBirdhouseRunButton)) {
 		buttons.push(
 			new ButtonBuilder()
 				.setCustomId('DO_BIRDHOUSE_RUN')


### PR DESCRIPTION
### Description:

Feature #4350.

Users often miss-click on the birdhouse run button when returning from a trip. This adds a toggle that removes the birdhouse run button from appearing in return trips or minion status. 

![image](https://user-images.githubusercontent.com/57806957/195209775-59026503-9014-4f51-95c3-a8e0b80a92de.png)

### Changes:

- Adds a toggle under user config for the birdhouse run button (disable button is default OFF).
- Check toggle on return trip and add button is user has disabled button OFF.
- Check toggle on minion status and add button is user has disabled button OFF.

### Other checks:

-   [X] I have tested all my changes thoroughly.
