### PR TITLE
Fix trade command (incorrectly calling `filterLoot`)

### DIFF
--- a/src/mahoji/commands/trade.ts
+++ b/src/mahoji/commands/trade.ts
@@ -127,8 +127,8 @@ Both parties must click confirm to make the trade.`,
 
 		await senderUser.removeItemsFromBank(itemsSent);
 		await recipientUser.removeItemsFromBank(itemsReceived);
-		await senderUser.addItemsToBank({ items: itemsReceived, collectionLog: false });
-		await recipientUser.addItemsToBank({ items: itemsSent, collectionLog: false });
+		await senderUser.addItemsToBank({ items: itemsReceived, collectionLog: false, filterLoot: false });
+		await recipientUser.addItemsToBank({ items: itemsSent, collectionLog: false, filterLoot: false });
 
 		await prisma.economyTransaction.create({
 			data: {


### PR DESCRIPTION
### Description:

Adds `filterLoot: false` to the /trade command's `transactItems()` function calls to prevent items from changing while being  traded.


### Other checks:

-   [x] I have tested all my changes thoroughly.
