### PR TITLE
Make sell/trade/sacrifice ignore duplicate item names

### DIFF
--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -64,7 +64,8 @@ export const sacrificeCommand: OSBMahojiCommand = {
 			user,
 			search: options.search,
 			filters: [options.filter],
-			maxSize: 70
+			maxSize: 70,
+			noDuplicateItems: true
 		});
 
 		const sacVal = Number(user.user.sacrificedValue);

--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -86,7 +86,8 @@ export const sellCommand: OSBMahojiCommand = {
 			maxSize: 70,
 			filters: [options.filter],
 			search: options.search,
-			excludeItems: mUser.favoriteItems
+			excludeItems: mUser.favoriteItems,
+			noDuplicateItems: true
 		});
 		if (bankToSell.length === 0) return 'No items provided.';
 

--- a/src/mahoji/commands/trade.ts
+++ b/src/mahoji/commands/trade.ts
@@ -88,12 +88,14 @@ export const askCommand: OSBMahojiCommand = {
 						maxSize: 70,
 						flags: { tradeables: 'tradeables' },
 						filters: [options.filter],
-						search: options.search
+						search: options.search,
+						noDuplicateItems: true
 				  }).filter(i => itemIsTradeable(i.id, true));
 		const itemsReceived = parseBank({
 			inputStr: options.receive,
 			maxSize: 70,
-			flags: { tradeables: 'tradeables' }
+			flags: { tradeables: 'tradeables' },
+			noDuplicateItems: true
 		}).filter(i => itemIsTradeable(i.id, true));
 
 		if (options.price) {


### PR DESCRIPTION
### Description:

Currently, if you try to trade '1 blue partyhat' it will not only select item id 1042, but also 2422. 

This is true with all items with duplicate names.

While this is only really an issue for BSO, it also applies to OSB, so is being targeted to OSB.

(This is often abused by people sending 1 Blue Partyhat) and if they only have 2422's it only sends that, and it's indistinguishable from the 'real' one.)

### Changes:

- Adds `noDuplicateItems: true` to the parseBank() function in 4 places: sell, sacrifice, trade(sender), trade(recipient)

### Other checks:

-   [x] I have tested all my changes thoroughly.
