### PR TITLE
Add New Monsters / Activities and Aliases to the Finish Command

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -324,7 +324,7 @@ export const kingBlackDragonCL = resolveItems([
 	'Draconic visage'
 ]);
 export const krakenCL = resolveItems(['Pet kraken', 'Kraken tentacle', 'Trident of the seas (full)', 'Jar of dirt']);
-export const theNightmareCL = resolveItems([
+export const theNightmareNormalCL = resolveItems([
 	'Little nightmare',
 	"Inquisitor's mace",
 	"Inquisitor's great helm",
@@ -334,10 +334,9 @@ export const theNightmareCL = resolveItems([
 	'Volatile orb',
 	'Harmonised orb',
 	'Eldritch orb',
-	'Jar of dreams',
-	'Slepey tablet',
-	'Parasitic egg'
+	'Jar of dreams'
 ]);
+export const theNightmareCL = resolveItems([...theNightmareNormalCL, 'Slepey tablet', 'Parasitic egg']);
 export const oborCL = resolveItems(['Hill giant club']);
 export const sarachnisCL = resolveItems(['Sraracha', 'Jar of eyes', 'Giant egg sac(full)', 'Sarachnis cudgel']);
 export const scorpiaCL = resolveItems(["Scorpia's offspring", 'Odium shard 3', 'Malediction shard 3']);
@@ -450,7 +449,7 @@ export const chambersOfXericCL = resolveItems([
 	"Xeric's general",
 	"Xeric's champion"
 ]);
-export const theatreOfBLoodCL = resolveItems([
+export const theatreOfBLoodNormalCL = resolveItems([
 	"Lil' zik",
 	'Scythe of vitur (uncharged)',
 	'Ghrazi rapier',
@@ -464,7 +463,11 @@ export const theatreOfBLoodCL = resolveItems([
 	'Sinhaza shroud tier 2',
 	'Sinhaza shroud tier 3',
 	'Sinhaza shroud tier 4',
-	'Sinhaza shroud tier 5',
+	'Sinhaza shroud tier 5'
+]);
+
+export const theatreOfBLoodCL = resolveItems([
+	...theatreOfBLoodNormalCL,
 	'Sanguine dust',
 	'Holy ornament kit',
 	'Sanguine ornament kit'

--- a/src/lib/finishables.ts
+++ b/src/lib/finishables.ts
@@ -35,37 +35,59 @@ interface Finishable {
 	kill: (args: KillArgs) => Bank;
 	customResponse?: (kc: number) => string;
 	maxAttempts?: number;
+	tertiaryDrops?: { itemId: number; kcNeeded: number }[];
 }
 
 export const finishables: Finishable[] = [
 	{
 		name: 'Chambers of Xeric (Solo, Non-CM)',
-		aliases: ['raids', 'cox'],
+		aliases: ['cox', 'raid1', 'raids1', 'chambers', 'xeric'],
 		cl: chambersOfXericNormalCL,
 		kill: () => ChambersOfXeric.complete({ team: [{ id: '1', personalPoints: 25_000 }] })['1']
 	},
 	{
 		name: 'Chambers of Xeric (Solo, CM)',
-		aliases: ['raids cm', 'cox cm'],
+		aliases: ['coxcm', 'raid1cm', 'raids1cm', 'chamberscm', 'xericcm'],
 		cl: chambersOfXericCL,
 		kill: () =>
 			ChambersOfXeric.complete({
 				challengeMode: true,
 				team: [{ id: '1', personalPoints: 25_000, canReceiveAncientTablet: true, canReceiveDust: true }],
 				timeToComplete: 1
-			})['1']
+			})['1'],
+		tertiaryDrops: [
+			{ itemId: itemID("Xeric's guard"), kcNeeded: 100 },
+			{ itemId: itemID("Xeric's warrior"), kcNeeded: 500 },
+			{ itemId: itemID("Xeric's sentinel"), kcNeeded: 1000 },
+			{ itemId: itemID("Xeric's general"), kcNeeded: 1500 },
+			{ itemId: itemID("Xeric's champion"), kcNeeded: 2000 }
+		]
 	},
 	{
 		name: 'Theatre of Blood (Solo, Non-HM)',
 		aliases: ['tob', 'theatre of blood'],
 		cl: theatreOfBLoodNormalCL,
-		kill: () => new Bank(TheatreOfBlood.complete({ hardMode: false, team: [{ id: '1', deaths: [] }] }).loot['1'])
+		kill: () => new Bank(TheatreOfBlood.complete({ hardMode: false, team: [{ id: '1', deaths: [] }] }).loot['1']),
+		tertiaryDrops: [
+			{ itemId: itemID('Sinhaza shroud tier 1'), kcNeeded: 100 },
+			{ itemId: itemID('Sinhaza shroud tier 2'), kcNeeded: 500 },
+			{ itemId: itemID('Sinhaza shroud tier 3'), kcNeeded: 1000 },
+			{ itemId: itemID('Sinhaza shroud tier 4'), kcNeeded: 1500 },
+			{ itemId: itemID('Sinhaza shroud tier 5'), kcNeeded: 2000 }
+		]
 	},
 	{
 		name: 'Theatre of Blood (Solo, HM)',
-		aliases: ['tob hm', 'theatre of blood hm'],
+		aliases: ['tob hard', 'tob hard mode', 'tobhm'],
 		cl: theatreOfBLoodCL,
-		kill: () => new Bank(TheatreOfBlood.complete({ hardMode: true, team: [{ id: '1', deaths: [] }] }).loot['1'])
+		kill: () => new Bank(TheatreOfBlood.complete({ hardMode: true, team: [{ id: '1', deaths: [] }] }).loot['1']),
+		tertiaryDrops: [
+			{ itemId: itemID('Sinhaza shroud tier 1'), kcNeeded: 100 },
+			{ itemId: itemID('Sinhaza shroud tier 2'), kcNeeded: 500 },
+			{ itemId: itemID('Sinhaza shroud tier 3'), kcNeeded: 1000 },
+			{ itemId: itemID('Sinhaza shroud tier 4'), kcNeeded: 1500 },
+			{ itemId: itemID('Sinhaza shroud tier 5'), kcNeeded: 2000 }
+		]
 	},
 	{
 		name: 'The Nightmare',
@@ -81,15 +103,16 @@ export const finishables: Finishable[] = [
 	},
 	{
 		name: 'Gauntlet',
-		aliases: [],
+		aliases: ['gauntlet', 'gaunt', 'ng'],
 		cl: theGauntletCL.filter(i => i !== itemID('Gauntlet cape')),
 		kill: () => gauntlet({ died: false, type: 'normal' })
 	},
 	{
 		name: 'Corrupted Gauntlet',
-		aliases: ['cg'],
+		aliases: ['cgauntlet', 'corruptedg', 'corruptg', 'cg'],
 		cl: theGauntletCL,
-		kill: () => gauntlet({ died: false, type: 'corrupted' })
+		kill: () => gauntlet({ died: false, type: 'corrupted' }),
+		tertiaryDrops: [{ itemId: itemID('Gauntlet cape'), kcNeeded: 1 }]
 	},
 	{
 		name: 'Nex',
@@ -121,8 +144,14 @@ export const finishables: Finishable[] = [
 	{
 		name: 'Tempoross',
 		cl: temporossCL,
-		aliases: ['temp'],
-		kill: () => getTemporossLoot(1, 99, new Bank())
+		aliases: ['temp', 'ross', 'tempo', 'watertodt'],
+		kill: () => getTemporossLoot(1, 99, new Bank()),
+		tertiaryDrops: [
+			{ itemId: itemID('Spirit angler top'), kcNeeded: 65 },
+			{ itemId: itemID('Spirit angler waders'), kcNeeded: 65 },
+			{ itemId: itemID('Spirit angler headband'), kcNeeded: 65 },
+			{ itemId: itemID('Spirit angler boots'), kcNeeded: 65 }
+		]
 	}
 ];
 

--- a/src/mahoji/commands/finish.ts
+++ b/src/mahoji/commands/finish.ts
@@ -32,6 +32,7 @@ export const finishCommand: OSBMahojiCommand = {
 		const kcBank = new Bank();
 		let kc = 0;
 		const maxAttempts = val.maxAttempts ?? 100_000;
+		let unlockedSpiritOutfit = false;
 		for (let i = 0; i < maxAttempts; i++) {
 			if (val.cl.every(id => loot.has(id))) break;
 			kc++;
@@ -52,14 +53,13 @@ export const finishCommand: OSBMahojiCommand = {
 				if (kc === 1500) thisLoot.add('Sinhaza shroud tier 4', 1);
 				if (kc === 2000) thisLoot.add('Sinhaza shroud tier 5', 1);
 			}
-			if (val.name === 'Corrupted Gauntlet') thisLoot.add('Gauntlet cape', 1);
-			if (val.name === 'Tempoross') {
-				if (loot.amount('Spirit flakes') >= 4800) {
-					thisLoot.add('Spirit angler top', 1);
-					thisLoot.add('Spirit angler waders', 1);
-					thisLoot.add('Spirit angler boots', 1);
-					thisLoot.add('Spirit angler headband', 1);
-				}
+			if (val.name === 'Corrupted Gauntlet' && kc === 1) thisLoot.add('Gauntlet cape', 1);
+			if (val.name === 'Tempoross' && !unlockedSpiritOutfit && loot.amount('Spirit flakes') >= 4800) {
+				thisLoot.add('Spirit angler top', 1);
+				thisLoot.add('Spirit angler waders', 1);
+				thisLoot.add('Spirit angler boots', 1);
+				thisLoot.add('Spirit angler headband', 1);
+				unlockedSpiritOutfit = true;
 			}
 
 			const purpleItems = thisLoot.items().filter(i => val.cl.includes(i[0].id) && !loot.has(i[0].id));

--- a/src/mahoji/commands/finish.ts
+++ b/src/mahoji/commands/finish.ts
@@ -26,40 +26,25 @@ export const finishCommand: OSBMahojiCommand = {
 	],
 	run: async ({ interaction, options }: CommandRunOptions<{ input: string }>) => {
 		await deferInteraction(interaction);
-		const val = finishables.find(i => stringMatches(i.name, options.input) || i.aliases?.includes(options.input));
+		const val = finishables.find(
+			i => stringMatches(i.name, options.input) || i.aliases?.some(alias => stringMatches(alias, options.input))
+		);
 		if (!val) return "That's not a valid thing you can simulate finishing.";
 		let loot = new Bank();
 		const kcBank = new Bank();
 		let kc = 0;
 		const maxAttempts = val.maxAttempts ?? 100_000;
-		let unlockedSpiritOutfit = false;
 		for (let i = 0; i < maxAttempts; i++) {
 			if (val.cl.every(id => loot.has(id))) break;
 			kc++;
 			const thisLoot = val.kill({ accumulatedLoot: loot });
 
-			// This section adds loot that is normally not rolled from the loot table
-			if (val.name === 'Chambers of Xeric (Solo, CM)') {
-				if (kc === 100) thisLoot.add("Xeric's guard", 1);
-				if (kc === 500) thisLoot.add("Xeric's warrior", 1);
-				if (kc === 1000) thisLoot.add("Xeric's sentinel", 1);
-				if (kc === 1500) thisLoot.add("Xeric's general", 1);
-				if (kc === 2000) thisLoot.add("Xeric's champion", 1);
-			}
-			if (val.name.includes('Theatre of Blood')) {
-				if (kc === 100) thisLoot.add('Sinhaza shroud tier 1', 1);
-				if (kc === 500) thisLoot.add('Sinhaza shroud tier 2', 1);
-				if (kc === 1000) thisLoot.add('Sinhaza shroud tier 3', 1);
-				if (kc === 1500) thisLoot.add('Sinhaza shroud tier 4', 1);
-				if (kc === 2000) thisLoot.add('Sinhaza shroud tier 5', 1);
-			}
-			if (val.name === 'Corrupted Gauntlet' && kc === 1) thisLoot.add('Gauntlet cape', 1);
-			if (val.name === 'Tempoross' && !unlockedSpiritOutfit && loot.amount('Spirit flakes') >= 4800) {
-				thisLoot.add('Spirit angler top', 1);
-				thisLoot.add('Spirit angler waders', 1);
-				thisLoot.add('Spirit angler boots', 1);
-				thisLoot.add('Spirit angler headband', 1);
-				unlockedSpiritOutfit = true;
+			if (val.tertiaryDrops) {
+				for (const drop of val.tertiaryDrops) {
+					if (kc === drop.kcNeeded) {
+						thisLoot.add(drop.itemId);
+					}
+				}
 			}
 
 			const purpleItems = thisLoot.items().filter(i => val.cl.includes(i[0].id) && !loot.has(i[0].id));

--- a/src/mahoji/commands/finish.ts
+++ b/src/mahoji/commands/finish.ts
@@ -26,7 +26,7 @@ export const finishCommand: OSBMahojiCommand = {
 	],
 	run: async ({ interaction, options }: CommandRunOptions<{ input: string }>) => {
 		await deferInteraction(interaction);
-		const val = finishables.find(i => stringMatches(i.name, options.input));
+		const val = finishables.find(i => stringMatches(i.name, options.input) || i.aliases?.includes(options.input));
 		if (!val) return "That's not a valid thing you can simulate finishing.";
 		let loot = new Bank();
 		const kcBank = new Bank();
@@ -36,6 +36,32 @@ export const finishCommand: OSBMahojiCommand = {
 			if (val.cl.every(id => loot.has(id))) break;
 			kc++;
 			const thisLoot = val.kill({ accumulatedLoot: loot });
+
+			// This section adds loot that is normally not rolled from the loot table
+			if (val.name === 'Chambers of Xeric (Solo, CM)') {
+				if (kc === 100) thisLoot.add("Xeric's guard", 1);
+				if (kc === 500) thisLoot.add("Xeric's warrior", 1);
+				if (kc === 1000) thisLoot.add("Xeric's sentinel", 1);
+				if (kc === 1500) thisLoot.add("Xeric's general", 1);
+				if (kc === 2000) thisLoot.add("Xeric's champion", 1);
+			}
+			if (val.name.includes('Theatre of Blood')) {
+				if (kc === 100) thisLoot.add('Sinhaza shroud tier 1', 1);
+				if (kc === 500) thisLoot.add('Sinhaza shroud tier 2', 1);
+				if (kc === 1000) thisLoot.add('Sinhaza shroud tier 3', 1);
+				if (kc === 1500) thisLoot.add('Sinhaza shroud tier 4', 1);
+				if (kc === 2000) thisLoot.add('Sinhaza shroud tier 5', 1);
+			}
+			if (val.name === 'Corrupted Gauntlet') thisLoot.add('Gauntlet cape', 1);
+			if (val.name === 'Tempoross') {
+				if (loot.amount('Spirit flakes') >= 4800) {
+					thisLoot.add('Spirit angler top', 1);
+					thisLoot.add('Spirit angler waders', 1);
+					thisLoot.add('Spirit angler boots', 1);
+					thisLoot.add('Spirit angler headband', 1);
+				}
+			}
+
 			const purpleItems = thisLoot.items().filter(i => val.cl.includes(i[0].id) && !loot.has(i[0].id));
 			for (const p of purpleItems) kcBank.add(p[0].id, kc);
 			loot.add(thisLoot);


### PR DESCRIPTION
### Description:

Adds the ability to use aliases in the finish command. Also adds more options for simulation using this command (COX CM, TOB, TOB HM, Nightmare, Phosani, Gauntlet, Corrupted Gauntlet, Nex)

Closes issues: #3383, partially #3142, #2033

### Changes:

- Pass monster and activity aliases through to command options
- Allow the above following monsters / activities to be simulated

### Other checks:

-   [X] I have tested all my changes thoroughly.
