### PR TITLE
Replace JMOD scythe with a clearer name

### DIFF
--- a/src/lib/bsoOpenables.ts
+++ b/src/lib/bsoOpenables.ts
@@ -297,7 +297,6 @@ const cantBeDropped = resolveItems([
 	'Bank lottery ticket',
 	'Tester gift box',
 	'Coins',
-	22_664, // JMOD Scythe of Vitur,
 	'Red Partyhat',
 	'Yellow partyhat',
 	'Blue partyhat',

--- a/src/lib/data/itemAliases.ts
+++ b/src/lib/data/itemAliases.ts
@@ -321,3 +321,6 @@ setItemAlias(7126, 'Pirate leggings (red)');
 
 setItemAlias(6107, 'Ghostly robe top');
 setItemAlias(6108, 'Ghostly robe bottom');
+
+// JMOD Scythe:
+setItemAlias(22_664, 'JMOD Scythe of vitur');

--- a/src/lib/data/itemAliases.ts
+++ b/src/lib/data/itemAliases.ts
@@ -323,4 +323,4 @@ setItemAlias(6107, 'Ghostly robe top');
 setItemAlias(6108, 'Ghostly robe bottom');
 
 // JMOD Scythe:
-setItemAlias(22_664, 'JMOD Scythe of vitur');
+setItemAlias(22_664, 'Scythe of vitur (JMod)');


### PR DESCRIPTION
### Description:

Re-adds JMOD scythe to umbs

There are so many Scythes's out there now, that there shouldn't be the same issue where people complain about getting a 'fake scythe.' Scythes are easy to obtain now for their GE value instead of 4-5b, and collectors would probably even swap real scythes for the JMOD variant.

### Changes:

- Removes JMOD scythe from the 'cantBeDropped' list
- Renames it to 'JMOD Scythe of vitur' to avoid confuision

### Other checks:

-   [ ] I have tested all my changes thoroughly.
