### PR TITLE
Nex, Gora, Dwarven stat rebalance

### DIFF
--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -275,7 +275,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 43,
-			attack_slash: 23,
+			attack_slash: 19,
 			attack_crush: 23,
 			attack_magic: -5,
 			attack_ranged: 0,
@@ -303,7 +303,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 37,
-			attack_slash: 19,
+			attack_slash: 16,
 			attack_crush: 19,
 			attack_magic: -5,
 			attack_ranged: 0,
@@ -332,7 +332,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 19,
-			attack_slash: 10,
+			attack_slash: 17,
 			attack_crush: 10,
 			attack_magic: -5,
 			attack_ranged: 0,
@@ -361,7 +361,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 19,
-			attack_slash: 10,
+			attack_slash: 9,
 			attack_crush: 10,
 			attack_magic: -5,
 			attack_ranged: 0,

--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -274,7 +274,7 @@ setCustomItem(
 	'Torva platebody',
 	{
 		equipment: {
-			attack_stab: 44,
+			attack_stab: 43,
 			attack_slash: 23,
 			attack_crush: 23,
 			attack_magic: -5,

--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -245,11 +245,10 @@ setCustomItem(
 	'Gorajan warrior helmet',
 	'Torva full helm',
 	{
-		/** 
 		equipment: {
-			attack_stab: 36,
-			attack_slash: 19,
-			attack_crush: 19,
+			attack_stab: 30,
+			attack_slash: 15,
+			attack_crush: 15,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -265,29 +264,417 @@ setCustomItem(
 			prayer: 1,
 			slot: EquipmentSlot.Head,
 			requirements: null
-		}*/
+		}
 	},
 	55_000_000
 );
-setCustomItem(40_034, 'Gorajan warrior top', 'Torva platebody', {}, 55_000_000);
-setCustomItem(40_035, 'Gorajan warrior legs', 'Torva platelegs', {}, 55_000_000);
-setCustomItem(40_036, 'Gorajan warrior gloves', 'Torva gloves', {}, 55_000_000);
-setCustomItem(40_037, 'Gorajan warrior boots', 'Torva boots', {}, 55_000_000);
+setCustomItem(
+	40_034,
+	'Gorajan warrior top',
+	'Torva platebody',
+	{
+		equipment: {
+			attack_stab: 44,
+			attack_slash: 23,
+			attack_crush: 23,
+			attack_magic: -5,
+			attack_ranged: 0,
+
+			defence_stab: 160,
+			defence_slash: 150,
+			defence_crush: 150,
+			defence_magic: 0,
+			defence_ranged: 165,
+
+			melee_strength: 5,
+			ranged_strength: 0,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Body,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+setCustomItem(
+	40_035,
+	'Gorajan warrior legs',
+	'Torva platelegs',
+	{
+		equipment: {
+			attack_stab: 37,
+			attack_slash: 19,
+			attack_crush: 19,
+			attack_magic: -5,
+			attack_ranged: 0,
+
+			defence_stab: 130,
+			defence_slash: 130,
+			defence_crush: 130,
+			defence_magic: 0,
+			defence_ranged: 130,
+
+			melee_strength: 5,
+			ranged_strength: 0,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Legs,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_036,
+	'Gorajan warrior gloves',
+	'Torva gloves',
+	{
+		equipment: {
+			attack_stab: 19,
+			attack_slash: 10,
+			attack_crush: 10,
+			attack_magic: -5,
+			attack_ranged: 0,
+
+			defence_stab: 18,
+			defence_slash: 18,
+			defence_crush: 18,
+			defence_magic: 0,
+			defence_ranged: 35,
+
+			melee_strength: 5,
+			ranged_strength: 0,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Hands,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_037,
+	'Gorajan warrior boots',
+	'Torva boots',
+	{
+		equipment: {
+			attack_stab: 19,
+			attack_slash: 10,
+			attack_crush: 10,
+			attack_magic: -5,
+			attack_ranged: 0,
+
+			defence_stab: 24,
+			defence_slash: 24,
+			defence_crush: 24,
+			defence_magic: 0,
+			defence_ranged: 35,
+
+			melee_strength: 5,
+			ranged_strength: 0,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Feet,
+			requirements: null
+		}
+	},
+	55_000_000
+);
 
 setCustomItem(40_038, 'Scroll of proficiency', 'Coal', {}, 1_000_000);
 setCustomItem(40_040, 'Chaotic remnant', 'Coal', {}, 10_000_000);
 
-setCustomItem(40_042, 'Gorajan occult helmet', 'Virtus mask', {}, 55_000_000);
-setCustomItem(40_043, 'Gorajan occult top', 'Virtus robe top', {}, 55_000_000);
-setCustomItem(40_044, 'Gorajan occult legs', 'Virtus robe legs', {}, 55_000_000);
-setCustomItem(40_045, 'Gorajan occult gloves', 'Virtus gloves', {}, 55_000_000);
-setCustomItem(40_046, 'Gorajan occult boots', 'Virtus boots', {}, 55_000_000);
+setCustomItem(
+	40_042,
+	'Gorajan occult helmet',
+	'Virtus mask',
+	{
+		equipment: {
+			attack_stab: 0,
+			attack_slash: 0,
+			attack_crush: 0,
+			attack_magic: 21,
+			attack_ranged: -3,
 
-setCustomItem(40_047, 'Gorajan archer helmet', 'Pernix cowl', {}, 55_000_000);
-setCustomItem(40_048, 'Gorajan archer top', 'Pernix body', {}, 55_000_000);
-setCustomItem(40_049, 'Gorajan archer legs', 'Pernix chaps', {}, 55_000_000);
-setCustomItem(40_050, 'Gorajan archer gloves', 'Pernix gloves', {}, 55_000_000);
-setCustomItem(40_051, 'Gorajan archer boots', 'Pernix boots', {}, 55_000_000);
+			defence_stab: 35,
+			defence_slash: 35,
+			defence_crush: 35,
+			defence_magic: 85,
+			defence_ranged: 75,
+
+			melee_strength: 0,
+			ranged_strength: 0,
+			magic_damage: 5,
+			prayer: 1,
+			slot: EquipmentSlot.Head,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_043,
+	'Gorajan occult top',
+	'Virtus robe top',
+	{
+		equipment: {
+			attack_stab: 0,
+			attack_slash: 0,
+			attack_crush: 0,
+			attack_magic: 46,
+			attack_ranged: -5,
+
+			defence_stab: 44,
+			defence_slash: 44,
+			defence_crush: 55,
+			defence_magic: 65,
+			defence_ranged: 5,
+
+			melee_strength: 0,
+			ranged_strength: 0,
+			magic_damage: 5,
+			prayer: 1,
+			slot: EquipmentSlot.Body,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_044,
+	'Gorajan occult legs',
+	'Virtus robe legs',
+	{
+		equipment: {
+			attack_stab: 0,
+			attack_slash: 0,
+			attack_crush: 0,
+			attack_magic: 41,
+			attack_ranged: -5,
+
+			defence_stab: 22,
+			defence_slash: 20,
+			defence_crush: 15,
+			defence_magic: 65,
+			defence_ranged: 15,
+
+			melee_strength: 0,
+			ranged_strength: 0,
+			magic_damage: 5,
+			prayer: 1,
+			slot: EquipmentSlot.Legs,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_045,
+	'Gorajan occult gloves',
+	'Virtus gloves',
+	{
+		equipment: {
+			attack_stab: 0,
+			attack_slash: 0,
+			attack_crush: 0,
+			attack_magic: 23,
+			attack_ranged: -5,
+
+			defence_stab: 9,
+			defence_slash: 9,
+			defence_crush: 9,
+			defence_magic: 12,
+			defence_ranged: 9,
+
+			melee_strength: 0,
+			ranged_strength: 0,
+			magic_damage: 5,
+			prayer: 1,
+			slot: EquipmentSlot.Hands,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_046,
+	'Gorajan occult boots',
+	'Virtus boots',
+	{
+		equipment: {
+			attack_stab: 0,
+			attack_slash: 0,
+			attack_crush: 0,
+			attack_magic: 23,
+			attack_ranged: -5,
+
+			defence_stab: 9,
+			defence_slash: 9,
+			defence_crush: 9,
+			defence_magic: 12,
+			defence_ranged: 9,
+
+			melee_strength: 0,
+			ranged_strength: 0,
+			magic_damage: 5,
+			prayer: 1,
+			slot: EquipmentSlot.Feet,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_047,
+	'Gorajan archer helmet',
+	'Pernix cowl',
+	{
+		equipment: {
+			attack_stab: -5,
+			attack_slash: -5,
+			attack_crush: -5,
+			attack_magic: -12,
+			attack_ranged: 21,
+
+			defence_stab: 25,
+			defence_slash: 25,
+			defence_crush: 17,
+			defence_magic: 25,
+			defence_ranged: 58,
+
+			melee_strength: 0,
+			ranged_strength: 5,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Head,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_048,
+	'Gorajan archer top',
+	'Pernix body',
+	{
+		equipment: {
+			attack_stab: -5,
+			attack_slash: -5,
+			attack_crush: -5,
+			attack_magic: -12,
+			attack_ranged: 42,
+
+			defence_stab: 25,
+			defence_slash: 25,
+			defence_crush: 25,
+			defence_magic: 73,
+			defence_ranged: 62,
+
+			melee_strength: 0,
+			ranged_strength: 5,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Body,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_049,
+	'Gorajan archer legs',
+	'Pernix chaps',
+	{
+		equipment: {
+			attack_stab: -5,
+			attack_slash: -5,
+			attack_crush: -5,
+			attack_magic: -12,
+			attack_ranged: 26,
+
+			defence_stab: 25,
+			defence_slash: 15,
+			defence_crush: 5,
+			defence_magic: 45,
+			defence_ranged: 38,
+
+			melee_strength: 0,
+			ranged_strength: 5,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Legs,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_050,
+	'Gorajan archer gloves',
+	'Pernix gloves',
+	{
+		equipment: {
+			attack_stab: 0,
+			attack_slash: 0,
+			attack_crush: -5,
+			attack_magic: -5,
+			attack_ranged: 20,
+
+			defence_stab: 4,
+			defence_slash: 4,
+			defence_crush: 1,
+			defence_magic: 27,
+			defence_ranged: 15,
+
+			melee_strength: 0,
+			ranged_strength: 5,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Hands,
+			requirements: null
+		}
+	},
+	55_000_000
+);
+
+setCustomItem(
+	40_051,
+	'Gorajan archer boots',
+	'Pernix boots',
+	{
+		equipment: {
+			attack_stab: 0,
+			attack_slash: 0,
+			attack_crush: 0,
+			attack_magic: -12,
+			attack_ranged: 20,
+
+			defence_stab: 4,
+			defence_slash: 4,
+			defence_crush: 3,
+			defence_magic: 6,
+			defence_ranged: 6,
+
+			melee_strength: 0,
+			ranged_strength: 5,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Feet,
+			requirements: null
+		}
+	},
+	55_000_000
+);
 
 setCustomItem(40_052, 'Scroll of mystery', 'Coal', {}, 1_000_000);
 

--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -1076,7 +1076,7 @@ setCustomItem(
 			defence_ranged: 36,
 			melee_strength: 0,
 			ranged_strength: 0,
-			magic_damage: 0,
+			magic_damage: 2,
 			prayer: 10,
 			slot: EquipmentSlot.Cape,
 			requirements: null

--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -240,7 +240,35 @@ setCustomItem(40_030, 'Amulet of zealots', 'Amulet of fury', {}, 1_000_000);
 setCustomItem(40_031, 'Scroll of dexterity', 'Coal', {}, 1_000_000);
 setCustomItem(40_032, 'Scroll of teleportation', 'Coal', {}, 1_000_000);
 
-setCustomItem(40_033, 'Gorajan warrior helmet', 'Torva full helm', {}, 55_000_000);
+setCustomItem(
+	40_033,
+	'Gorajan warrior helmet',
+	'Torva full helm',
+	{
+		/** 
+		equipment: {
+			attack_stab: 36,
+			attack_slash: 19,
+			attack_crush: 19,
+			attack_magic: -5,
+			attack_ranged: 0,
+
+			defence_stab: 70,
+			defence_slash: 75,
+			defence_crush: 75,
+			defence_magic: -5,
+			defence_ranged: 55,
+
+			melee_strength: 5,
+			ranged_strength: 0,
+			magic_damage: 0,
+			prayer: 1,
+			slot: EquipmentSlot.Head,
+			requirements: null
+		}*/
+	},
+	55_000_000
+);
 setCustomItem(40_034, 'Gorajan warrior top', 'Torva platebody', {}, 55_000_000);
 setCustomItem(40_035, 'Gorajan warrior legs', 'Torva platelegs', {}, 55_000_000);
 setCustomItem(40_036, 'Gorajan warrior gloves', 'Torva gloves', {}, 55_000_000);

--- a/src/lib/customItems/dwarven.ts
+++ b/src/lib/customItems/dwarven.ts
@@ -41,8 +41,8 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 7,
-			attack_slash: 7,
-			attack_crush: 28,
+			attack_slash: 8,
+			attack_crush: 26,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -70,7 +70,7 @@ setCustomItem(
 		equipment: {
 			attack_stab: 12,
 			attack_slash: 12,
-			attack_crush: 43,
+			attack_crush: 39,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -80,7 +80,7 @@ setCustomItem(
 			defence_magic: 0,
 			defence_ranged: 105,
 
-			melee_strength: 2,
+			melee_strength: 3,
 			ranged_strength: 0,
 			magic_damage: 0,
 			prayer: 1,
@@ -98,7 +98,7 @@ setCustomItem(
 		equipment: {
 			attack_stab: 8,
 			attack_slash: 8,
-			attack_crush: 34,
+			attack_crush: 33,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -125,8 +125,8 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 5,
-			attack_slash: 2,
-			attack_crush: 10,
+			attack_slash: 5,
+			attack_crush: 16,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -152,9 +152,9 @@ setCustomItem(
 	'Torva gloves',
 	{
 		equipment: {
-			attack_stab: 4,
-			attack_slash: 9,
-			attack_crush: 15,
+			attack_stab: 5,
+			attack_slash: 5,
+			attack_crush: 16,
 			attack_magic: -5,
 			attack_ranged: 0,
 

--- a/src/lib/customItems/nex.ts
+++ b/src/lib/customItems/nex.ts
@@ -221,9 +221,9 @@ setCustomItem(
 	'Rune full helm',
 	{
 		equipment: {
-			attack_stab: 35,
-			attack_slash: 18,
-			attack_crush: 18,
+			attack_stab: 29,
+			attack_slash: 14,
+			attack_crush: 14,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -253,9 +253,9 @@ setCustomItem(
 	'Rune platebody',
 	{
 		equipment: {
-			attack_stab: 35,
-			attack_slash: 18,
-			attack_crush: 18,
+			attack_stab: 43,
+			attack_slash: 22,
+			attack_crush: 22,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -285,9 +285,9 @@ setCustomItem(
 	'Rune platelegs',
 	{
 		equipment: {
-			attack_stab: 35,
-			attack_slash: 18,
-			attack_crush: 18,
+			attack_stab: 36,
+			attack_slash: 20,
+			attack_crush: 20,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -317,9 +317,9 @@ setCustomItem(
 	'Rune boots',
 	{
 		equipment: {
-			attack_stab: 22,
-			attack_slash: 2,
-			attack_crush: 2,
+			attack_stab: 18,
+			attack_slash: 9,
+			attack_crush: 9,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -349,9 +349,9 @@ setCustomItem(
 	'Rune gloves',
 	{
 		equipment: {
-			attack_stab: 26,
-			attack_slash: 16,
-			attack_crush: 16,
+			attack_stab: 18,
+			attack_slash: 9,
+			attack_crush: 9,
 			attack_magic: -5,
 			attack_ranged: 0,
 
@@ -425,12 +425,14 @@ setCustomItem(
 			attack_slash: -5,
 			attack_crush: -5,
 			attack_magic: -12,
-			attack_ranged: 45,
+			attack_ranged: 41,
+
 			defence_stab: 25,
 			defence_slash: 25,
 			defence_crush: 25,
 			defence_magic: 73,
 			defence_ranged: 62,
+
 			melee_strength: 0,
 			ranged_strength: 5,
 			magic_damage: 0,
@@ -456,6 +458,7 @@ setCustomItem(
 			attack_crush: -5,
 			attack_magic: -12,
 			attack_ranged: 25,
+
 			defence_stab: 25,
 			defence_slash: 15,
 			defence_crush: 5,
@@ -518,12 +521,14 @@ setCustomItem(
 			attack_slash: 0,
 			attack_crush: -5,
 			attack_magic: -5,
-			attack_ranged: 15,
+			attack_ranged: 19,
+
 			defence_stab: 4,
 			defence_slash: 4,
 			defence_crush: 1,
 			defence_magic: 27,
 			defence_ranged: 15,
+
 			melee_strength: 0,
 			ranged_strength: 5,
 			magic_damage: 0,
@@ -694,7 +699,7 @@ setCustomItem(
 
 			melee_strength: 0,
 			ranged_strength: 0,
-			magic_damage: 1,
+			magic_damage: 5,
 			prayer: 1,
 			slot: EquipmentSlot.Hands,
 			requirements: null

--- a/src/lib/customItems/nex.ts
+++ b/src/lib/customItems/nex.ts
@@ -253,7 +253,7 @@ setCustomItem(
 	'Rune platebody',
 	{
 		equipment: {
-			attack_stab: 43,
+			attack_stab: 42,
 			attack_slash: 22,
 			attack_crush: 22,
 			attack_magic: -5,

--- a/src/lib/customItems/nex.ts
+++ b/src/lib/customItems/nex.ts
@@ -254,7 +254,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 42,
-			attack_slash: 22,
+			attack_slash: 18,
 			attack_crush: 22,
 			attack_magic: -5,
 			attack_ranged: 0,
@@ -286,7 +286,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 36,
-			attack_slash: 20,
+			attack_slash: 16,
 			attack_crush: 20,
 			attack_magic: -5,
 			attack_ranged: 0,
@@ -318,7 +318,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 18,
-			attack_slash: 9,
+			attack_slash: 8,
 			attack_crush: 9,
 			attack_magic: -5,
 			attack_ranged: 0,
@@ -350,7 +350,7 @@ setCustomItem(
 	{
 		equipment: {
 			attack_stab: 18,
-			attack_slash: 9,
+			attack_slash: 16,
 			attack_crush: 9,
 			attack_magic: -5,
 			attack_ranged: 0,

--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -17,17 +17,17 @@ export const maxDefenceStats: { [key in DefenceGearStat]: number } = {
 };
 
 export const maxOffenceStats: { [key in OffenceGearStat]: number } = {
-	[GearStat.AttackCrush]: 360,
-	[GearStat.AttackMagic]: 509,
-	[GearStat.AttackRanged]: 431,
-	[GearStat.AttackSlash]: 295,
-	[GearStat.AttackStab]: 361
+	[GearStat.AttackCrush]: 359,
+	[GearStat.AttackMagic]: 537,
+	[GearStat.AttackRanged]: 436,
+	[GearStat.AttackSlash]: 300,
+	[GearStat.AttackStab]: 364
 };
 
 export const maxOtherStats: { [key in OtherGearStat]: number } = {
 	[GearStat.MeleeStrength]: 243,
 	[GearStat.RangedStrength]: 172,
-	[GearStat.MagicDamage]: 51,
+	[GearStat.MagicDamage]: 60,
 	[GearStat.Prayer]: 66
 };
 

--- a/src/lib/gear/index.ts
+++ b/src/lib/gear/index.ts
@@ -27,7 +27,7 @@ export const maxOffenceStats: { [key in OffenceGearStat]: number } = {
 export const maxOtherStats: { [key in OtherGearStat]: number } = {
 	[GearStat.MeleeStrength]: 243,
 	[GearStat.RangedStrength]: 172,
-	[GearStat.MagicDamage]: 60,
+	[GearStat.MagicDamage]: 62,
 	[GearStat.Prayer]: 66
 };
 


### PR DESCRIPTION
### Description:

Rebalanced stats on Nex/gora and Dwarven gear. Added +1 in some stats for Gora to help autoequip


### Changes:

Did Dwarven/Nex gear by redistributing offensive weighting across the items, outcome is they have the same stats when full set is equipped. Numbers in comment.

Updated Gorajan gear to have +1 offensive stats in slash/stab/crush for warrior, +1 magic attack for occult, and +1 range attack for archer.

Pernix change stops Zaryte vambraces equipping.
Dwarven + Torva Crush change stops 4/5 dwarven, 1/5 torva/gora equip on auto equip crush.

Fixes: #4561
### Other checks:

-   [ ] I have tested all my changes thoroughly.
