### PR TITLE
[BSO] Allows minion to do multiple CoX trips since they're fast

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -118,6 +118,7 @@ export const enum Emoji {
 	Purple = '🟪',
 	Green = '🟩',
 	Blue = '🟦',
+	Orange = '🟧',
 	Thieving = '<:thieving:630910829352452123>',
 	Hunter = '<:hunter:630911040166559784>',
 	Ely = '<:ely:784453586033049630>',

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -237,7 +237,7 @@ export const minimumCoxSuppliesNeeded = new Bank({
 	'Super restore(4)': 5
 });
 
-export async function checkCoxTeam(users: MUser[], cm: boolean): Promise<string | null> {
+export async function checkCoxTeam(users: MUser[], cm: boolean, quantity: number = 1): Promise<string | null> {
 	const hasHerbalist = users.some(u => u.skillLevel(SkillsEnum.Herblore) >= 78);
 	if (!hasHerbalist) {
 		return 'nobody with atleast level 78 Herblore';
@@ -246,9 +246,12 @@ export async function checkCoxTeam(users: MUser[], cm: boolean): Promise<string 
 	if (!hasFarmer) {
 		return 'nobody with atleast level 55 Farming';
 	}
-	const userWithoutSupplies = users.find(u => !u.bank.has(minimumCoxSuppliesNeeded));
+	const suppliesNeeded = minimumCoxSuppliesNeeded.clone().multiply(quantity);
+	const userWithoutSupplies = users.find(u => !u.bank.has(suppliesNeeded));
 	if (userWithoutSupplies) {
-		return `${userWithoutSupplies.usernameOrMention} doesn't have enough supplies`;
+		return `${userWithoutSupplies.usernameOrMention} doesn't have enough supplies for ${quantity} Raid${
+			quantity > 1 ? 's' : ''
+		}`;
 	}
 
 	for (const user of users) {
@@ -526,7 +529,6 @@ export async function calcCoxDuration(
 
 	duration -= duration * (teamSizeBoostPercent(size) / 100);
 
-	duration = randomVariation(duration, 5);
 	return { duration, reductions, totalReduction: totalSpeedReductions / size, degradeables: degradeableItems };
 }
 

--- a/src/lib/data/cox.ts
+++ b/src/lib/data/cox.ts
@@ -425,20 +425,20 @@ const itemBoosts: ItemBoost[][] = [
 	],
 	[
 		{
-			item: getOSItem('Sanguinesti staff'),
-			boost: 7,
-			mustBeEquipped: false,
-			setup: 'mage',
-			mustBeCharged: true,
-			requiredCharges: SANGUINESTI_CHARGES_PER_COX
-		},
-		{
 			item: getOSItem('Void staff'),
 			boost: 8,
 			mustBeEquipped: true,
 			setup: 'mage',
 			mustBeCharged: true,
 			requiredCharges: VOID_STAFF_CHARGES_PER_COX
+		},
+		{
+			item: getOSItem('Sanguinesti staff'),
+			boost: 7,
+			mustBeEquipped: false,
+			setup: 'mage',
+			mustBeCharged: true,
+			requiredCharges: SANGUINESTI_CHARGES_PER_COX
 		}
 	],
 	[

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -327,6 +327,7 @@ export interface RaidsOptions extends ActivityTaskOptions {
 	leader: string;
 	users: string[];
 	challengeMode: boolean;
+	quantity?: number;
 }
 
 export interface TheatreOfBloodTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -36,6 +36,7 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 		case 'AnimatedArmour':
 		case 'Sepulchre':
 		case 'Pickpocket':
+		case 'Raids':
 		case 'SoulWars':
 		case 'Cyclops': {
 			masterHPCapeBoost = 20;

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -432,7 +432,8 @@ export const tripHandlers = {
 			cox: {
 				start: {
 					challenge_mode: data.challengeMode,
-					type: data.users.length === 1 ? 'solo' : 'mass'
+					type: data.users.length === 1 ? 'solo' : 'mass',
+					quantity: data.quantity
 				}
 			}
 		})

--- a/src/mahoji/commands/raid.ts
+++ b/src/mahoji/commands/raid.ts
@@ -35,6 +35,14 @@ export const raidCommand: OSBMahojiCommand = {
 							name: 'challenge_mode',
 							description: 'Choose whether you want to do Challenge Mode.',
 							required: false
+						},
+						{
+							type: ApplicationCommandOptionType.Integer,
+							name: 'quantity',
+							description: 'The amount of raids you want to attempt.',
+							required: false,
+							min_value: 1,
+							max_value: 100
 						}
 					]
 				},
@@ -102,7 +110,7 @@ export const raidCommand: OSBMahojiCommand = {
 		userID,
 		channelID
 	}: CommandRunOptions<{
-		cox?: { start?: { type: 'solo' | 'mass'; challenge_mode?: boolean }; stats?: {} };
+		cox?: { start?: { type: 'solo' | 'mass'; challenge_mode?: boolean; quantity?: number }; stats?: {} };
 		tob?: {
 			start?: { solo?: boolean; hard_mode?: boolean; max_team_size?: number };
 			stats?: {};
@@ -118,8 +126,8 @@ export const raidCommand: OSBMahojiCommand = {
 
 		if (minionIsBusy(user.id)) return "Your minion is busy, you can't do this.";
 
-		if (cox) {
-			if (cox.start) return coxCommand(channelID, user, cox.start.type, Boolean(cox.start.challenge_mode));
+		if (cox && cox.start) {
+			return coxCommand(channelID, user, cox.start.type, Boolean(cox.start.challenge_mode), cox.start.quantity);
 		}
 		if (tob) {
 			if (tob.start) {

--- a/src/mahoji/lib/abstracted_commands/coxCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/coxCommand.ts
@@ -17,8 +17,9 @@ import { trackLoot } from '../../../lib/lootTrack';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import { MakePartyOptions } from '../../../lib/types';
 import { RaidsOptions } from '../../../lib/types/minions';
-import { channelIsSendable, formatDuration } from '../../../lib/util';
+import { channelIsSendable, formatDuration, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
+import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../mahojiSettings';
 
 const uniques = [
@@ -78,7 +79,13 @@ export async function coxStatsCommand(user: MUser) {
 **Total Gear Score:** ${Emoji.Gear} ${total.toFixed(1)}%`;
 }
 
-export async function coxCommand(channelID: string, user: MUser, type: 'solo' | 'mass', isChallengeMode: boolean) {
+export async function coxCommand(
+	channelID: string,
+	user: MUser,
+	type: 'solo' | 'mass',
+	isChallengeMode: boolean,
+	_quantity?: number
+) {
 	if (type !== 'mass' && type !== 'solo') {
 		return 'Specify your team setup for Chambers of Xeric, either solo or mass.';
 	}
@@ -152,13 +159,22 @@ export async function coxCommand(channelID: string, user: MUser, type: 'solo' | 
 		users = [user];
 	}
 
-	const teamCheckFailure = await checkCoxTeam(users, isChallengeMode);
+	const {
+		duration: raidDuration,
+		totalReduction,
+		reductions,
+		degradeables
+	} = await calcCoxDuration(users, isChallengeMode);
+	const maxTripLength = calcMaxTripLength(user, 'Raids');
+	const maxCanDo = Math.max(Math.floor(maxTripLength / raidDuration), 1);
+	const quantity = _quantity && _quantity * raidDuration <= maxTripLength ? _quantity : maxCanDo;
+	let duration = quantity * raidDuration;
+	const teamCheckFailure = await checkCoxTeam(users, isChallengeMode, quantity);
 	if (teamCheckFailure) {
 		return `Your mass failed to start because of this reason: ${teamCheckFailure}`;
 	}
 
-	const { duration, totalReduction, reductions, degradeables } = await calcCoxDuration(users, isChallengeMode);
-
+	duration = randomVariation(duration, 5);
 	let debugStr = '';
 	const isSolo = users.length === 1;
 
@@ -172,7 +188,7 @@ export async function coxCommand(channelID: string, user: MUser, type: 'solo' | 
 
 	const costResult = await Promise.all([
 		...users.map(async u => {
-			const supplies = await calcCoxInput(u, isSolo);
+			const supplies = (await calcCoxInput(u, isSolo)).multiply(quantity);
 			await u.removeItemsFromBank(supplies);
 			totalCost.add(supplies);
 			const { total } = calculateUserGearPercents(u);
@@ -206,18 +222,19 @@ export async function coxCommand(channelID: string, user: MUser, type: 'solo' | 
 		type: 'Raids',
 		leader: user.id,
 		users: users.map(u => u.id),
-		challengeMode: isChallengeMode
+		challengeMode: isChallengeMode,
+		quantity
 	});
 
 	let str = isSolo
-		? `${user.minionName} is now doing a Chambers of Xeric raid. The total trip will take ${formatDuration(
-				duration
-		  )}.`
+		? `${user.minionName} is now doing ${quantity > 1 ? quantity : 'a'} Chambers of Xeric raid${
+				quantity > 1 ? 's' : ''
+		  }. The total trip will take ${formatDuration(duration)}.`
 		: `${partyOptions.leader.usernameOrMention}'s party (${users
 				.map(u => u.usernameOrMention)
-				.join(', ')}) is now off to do a Chambers of Xeric raid - the total trip will take ${formatDuration(
-				duration
-		  )}.`;
+				.join(', ')}) is now off to do ${quantity > 1 ? quantity : 'a'} Chambers of Xeric raid${
+				quantity > 1 ? 's' : ''
+		  } - the total trip will take ${formatDuration(duration)}.`;
 
 	str += ` \n\n${debugStr}`;
 

--- a/src/mahoji/lib/abstracted_commands/coxCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/coxCommand.ts
@@ -1,4 +1,4 @@
-import { calcWhatPercent } from 'e';
+import { calcWhatPercent, sumArr } from 'e';
 import { Bank } from 'oldschooljs';
 
 import { setupParty } from '../../../extendables/Message/Party';
@@ -168,13 +168,19 @@ export async function coxCommand(
 	const maxTripLength = calcMaxTripLength(user, 'Raids');
 	const maxCanDo = Math.max(Math.floor(maxTripLength / raidDuration), 1);
 	const quantity = _quantity && _quantity * raidDuration <= maxTripLength ? _quantity : maxCanDo;
-	let duration = quantity * raidDuration;
+
 	const teamCheckFailure = await checkCoxTeam(users, isChallengeMode, quantity);
 	if (teamCheckFailure) {
 		return `Your mass failed to start because of this reason: ${teamCheckFailure}`;
 	}
 
-	duration = randomVariation(duration, 5);
+	// This gives a normal duration distribution. Better than (raidDuration * quantity) +/- 5%
+	let duration = sumArr(
+		Array(quantity)
+			.fill(raidDuration)
+			.map(d => randomVariation(d, 5))
+	);
+
 	let debugStr = '';
 	const isSolo = users.length === 1;
 

--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -1,4 +1,4 @@
-import { noOp, shuffleArr } from 'e';
+import { shuffleArr } from 'e';
 import { Bank } from 'oldschooljs';
 import { ChambersOfXeric } from 'oldschooljs/dist/simulation/misc/ChambersOfXeric';
 
@@ -14,9 +14,20 @@ import { RaidsOptions } from '../../../lib/types/minions';
 import { clAdjustedDroprate, roll } from '../../../lib/util';
 import { formatOrdinal } from '../../../lib/util/formatOrdinal';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
+import itemID from '../../../lib/util/itemID';
 import resolveItems from '../../../lib/util/resolveItems';
 import { updateBankSetting } from '../../../mahoji/mahojiSettings';
 
+interface RaidResultUser {
+	personalPoints: number;
+	loot: Bank;
+	mUser: MUser;
+	naturalDouble: boolean;
+	flappyMsg: string | null;
+	deaths: number;
+	deathChance: number;
+}
+const orangeItems = resolveItems(['Takon', 'Steve']);
 const notPurple = resolveItems(['Torn prayer scroll', 'Dark relic', 'Onyx']);
 const greenItems = resolveItems(['Twisted ancestral colour kit']);
 const blueItems = resolveItems(['Metamorphic dust']);
@@ -42,35 +53,91 @@ export function handleSpecialCoxLoot(user: MUser | null, loot: Bank) {
 export const raidsTask: MinionTask = {
 	type: 'Raids',
 	async run(data: RaidsOptions) {
-		const { channelID, users, challengeMode, duration, leader } = data;
+		const { channelID, users, challengeMode, duration, leader, quantity: _quantity } = data;
+		const quantity = _quantity ?? 1;
 		const allUsers = await Promise.all(users.map(async u => mUserFetch(u)));
-		const team = await createTeam(allUsers, challengeMode);
-
-		const loot = ChambersOfXeric.complete({
-			challengeMode,
-			timeToComplete: duration,
-			team
-		});
 
 		let totalPoints = 0;
-		for (const member of team) {
-			totalPoints += member.personalPoints;
+		const raidResults = new Map<string, RaidResultUser>();
+		const teamLoot = new TeamLoot([]);
+		for (let x = 0; x < quantity; x++) {
+			const team = await createTeam(allUsers, challengeMode);
+			const raidLoot = ChambersOfXeric.complete({
+				challengeMode,
+				timeToComplete: duration,
+				team
+			});
+			for (const [userID, userLoot] of Object.entries(raidLoot)) {
+				let userData = raidResults.get(userID);
+				// Do all the one-time / per-user stuff:
+				if (!userData) {
+					// User already fetched earlier, no need to make another DB call
+					const mUser = allUsers.find(u => u.id === userID)!;
+
+					// Set the double flags, so we don't charge for flappy repeatedly / give multiple boxes
+					let naturalDouble = false;
+					let flappyMsg: string | null = null;
+					if (roll(10)) {
+						naturalDouble = true;
+					} else {
+						const flappyRes = await userHasFlappy({ user: mUser, duration });
+						if (flappyRes.shouldGiveBoost) {
+							flappyMsg = flappyRes.userMsg;
+						}
+					}
+					userData = {
+						personalPoints: 0,
+						loot: new Bank(),
+						mUser,
+						naturalDouble,
+						flappyMsg,
+						deaths: 0,
+						deathChance: 0
+					};
+				}
+				// Handle the per-raid stuff
+				const member = team.find(m => m.id === userID)!;
+				userData.personalPoints += member.personalPoints;
+				userData.deaths += member.deaths;
+				userData.deathChance = member.deathChance;
+				totalPoints += member.personalPoints;
+				// Double loot now, so we don't double Steve / Takon / etc
+				if (userData.naturalDouble || userData.flappyMsg) userLoot.multiply(2);
+
+				if (challengeMode && roll(50) && userData.mUser.cl.has('Metamorphic dust')) {
+					const { bank } = userData.mUser.allItemsOwned();
+					const unownedPet = shuffleArr(chambersOfXericMetamorphPets).find(pet => !bank[pet]);
+					if (unownedPet) {
+						userLoot.add(unownedPet);
+						// Add pet to the mUser, this doesn't add to actual bank, just prevents duplicates
+						userData.mUser.bank.add(unownedPet);
+					}
+				}
+				if (userLoot.has('Ancient tablet')) {
+					userLoot.bank[itemID('Ancient tablet')] = 1;
+					// Add tablet to mUser, this doesn't add to user's bank, just prevents duplicates which would deny real loot rolls.
+					userData.mUser.bank.add('Ancient tablet');
+				}
+				handleSpecialCoxLoot(userData.mUser, userLoot);
+				userData.loot.add(userLoot);
+				teamLoot.add(userID, userLoot);
+				raidResults.set(userID, userData);
+			}
 		}
 
 		const minigameID = challengeMode ? 'raids_challenge_mode' : 'raids';
 
 		const totalLoot = new Bank();
-		const teamLoot = new TeamLoot([]);
 
-		let resultMessage = `<@${leader}> Your ${
-			challengeMode ? 'Challenge Mode Raid' : 'Raid'
-		} has finished. The total amount of points your team got is ${totalPoints.toLocaleString()}.\n`;
-		await Promise.all(allUsers.map(u => incrementMinigameScore(u.id, minigameID, 1)));
+		let resultMessage = `<@${leader}> Your ${challengeMode ? 'Challenge Mode Raid' : 'Raid'}${
+			quantity > 1 ? 's have' : ' has'
+		} finished. The total amount of points your team got is ${totalPoints.toLocaleString()}.\n`;
+		await Promise.all(allUsers.map(u => incrementMinigameScore(u.id, minigameID, quantity)));
 
-		for (let [userID, _userLoot] of Object.entries(loot)) {
-			const user = await mUserFetch(userID).catch(noOp);
+		for (let [userID, userData] of raidResults) {
+			const { personalPoints, deaths, deathChance, naturalDouble, flappyMsg, loot, mUser: user } = userData;
 			if (!user) continue;
-			const { personalPoints, deaths, deathChance } = team.find(u => u.id === user.id)!;
+			if (naturalDouble) loot.add(MysteryBoxes.roll());
 
 			await user.update({
 				total_cox_points: {
@@ -78,30 +145,11 @@ export const raidsTask: MinionTask = {
 				}
 			});
 
-			let flappyMsg: string | null = null;
-			const userLoot = new Bank(_userLoot);
-			if (roll(10)) {
-				userLoot.multiply(2);
-				userLoot.add(MysteryBoxes.roll());
-			} else {
-				const flappyRes = await userHasFlappy({ user, duration });
-				if (flappyRes.shouldGiveBoost) {
-					userLoot.multiply(2);
-					flappyMsg = flappyRes.userMsg;
-				}
-			}
-			if (challengeMode && roll(50) && user.cl.has('Metamorphic dust')) {
-				const { bank } = user.allItemsOwned();
-				const unownedPet = shuffleArr(chambersOfXericMetamorphPets).find(pet => !bank[pet]);
-				if (unownedPet) {
-					userLoot.add(unownedPet);
-				}
-			}
-			handleSpecialCoxLoot(user, userLoot);
-			teamLoot.add(user.id, userLoot);
-
-			const { itemsAdded } = await transactItems({ userID: user.id, itemsToAdd: userLoot, collectionLog: true });
-
+			const { itemsAdded } = await transactItems({
+				userID,
+				itemsToAdd: loot,
+				collectionLog: true
+			});
 			totalLoot.add(itemsAdded);
 
 			const items = itemsAdded.items();
@@ -109,7 +157,9 @@ export const raidsTask: MinionTask = {
 			const isPurple = items.some(([item]) => purpleItems.includes(item.id));
 			const isGreen = items.some(([item]) => greenItems.includes(item.id));
 			const isBlue = items.some(([item]) => blueItems.includes(item.id));
-			const emote = isBlue ? Emoji.Blue : isGreen ? Emoji.Green : Emoji.Purple;
+			const isOrange = items.some(([item]) => orangeItems.includes(item.id));
+			const specialLoot = isPurple || isGreen || isBlue || isOrange;
+			const emote = isOrange ? Emoji.Orange : isBlue ? Emoji.Blue : isGreen ? Emoji.Green : Emoji.Purple;
 			if (items.some(([item]) => purpleItems.includes(item.id) && !purpleButNotAnnounced.includes(item.id))) {
 				const itemsToAnnounce = itemsAdded.filter(item => purpleItems.includes(item.id), false);
 				globalClient.emit(
@@ -119,13 +169,13 @@ export const raidsTask: MinionTask = {
 					)} raid.`
 				);
 			}
-			const str = isPurple ? `${emote} ||${itemsAdded}||` : itemsAdded.toString();
+			const str = specialLoot ? `${emote} ||${itemsAdded}||` : itemsAdded.toString();
 			const deathStr = deaths === 0 ? '' : new Array(deaths).fill(Emoji.Skull).join(' ');
 
 			resultMessage += `\n${deathStr} **${user}** received: ${str} (${personalPoints?.toLocaleString()} pts, ${
 				Emoji.Skull
-			}${deathChance.toFixed(0)}%)`;
-			if (flappyMsg) resultMessage += flappyMsg;
+			}${deathChance.toFixed(0)}%) `;
+			if (flappyMsg) resultMessage += users.length === 1 ? `\n${flappyMsg}` : Emoji.Flappy;
 		}
 
 		updateBankSetting('cox_loot', totalLoot);

--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -158,7 +158,7 @@ export const raidsTask: MinionTask = {
 			const isGreen = items.some(([item]) => greenItems.includes(item.id));
 			const isBlue = items.some(([item]) => blueItems.includes(item.id));
 			const isOrange = items.some(([item]) => orangeItems.includes(item.id));
-			const specialLoot = isPurple || isGreen || isBlue || isOrange;
+			const specialLoot = isPurple || isOrange;
 			const emote = isOrange ? Emoji.Orange : isBlue ? Emoji.Blue : isGreen ? Emoji.Green : Emoji.Purple;
 			if (items.some(([item]) => purpleItems.includes(item.id) && !purpleButNotAnnounced.includes(item.id))) {
 				const itemsToAnnounce = itemsAdded.filter(item => purpleItems.includes(item.id), false);


### PR DESCRIPTION
### Description:

Finally, the hotly demanded feature is here! 

Multiple CoX trips! Now you can send your minion on for a trip as long as you've earned! You pay a lot for the privilege of extra time on your trips, now you can finally reap the rewards!

### Changes:

- Quantity value on the command (requires sync_command)
- Adds notification square 🟧 to Steve / Takon drops ( I can just make this purple or w/e if you want)
- Had to rearrange the activity quite a bit because it was **very** one-raid focused.
- Fixes Sang staff [smaller boost] taking priority over Void staff.


### Other checks:

-   [x] I have tested all my changes thoroughly.
