### PR TITLE
Dont run tickers during shutdown

### DIFF
--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -372,6 +372,7 @@ export function initTickers() {
 		if (ticker.timer !== null) clearTimeout(ticker.timer);
 		const fn = async () => {
 			try {
+				if (globalClient.isShuttingDown) return;
 				await ticker.cb();
 			} catch (err) {
 				logError(err);

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -22,7 +22,6 @@ import { patreonTask } from '../../lib/patreon';
 import { runRolesTask } from '../../lib/rolesTask';
 import { countUsersWithItemInCl, prisma } from '../../lib/settings/prisma';
 import { cancelTask, minionActivityCacheDelete } from '../../lib/settings/settings';
-import { tickers } from '../../lib/tickers';
 import {
 	calcPerHour,
 	convertBankToPerHourStats,
@@ -797,9 +796,6 @@ LIMIT 10;
 		}
 		if (options.reboot) {
 			globalClient.isShuttingDown = true;
-			for (const ticker of tickers) {
-				if (ticker.timer) clearTimeout(ticker.timer);
-			}
 			await sleep(Time.Second * 20);
 			await interactionReply(interaction, {
 				content: 'https://media.discordapp.net/attachments/357422607982919680/1004657720722464880/freeze.gif'


### PR DESCRIPTION
### Description:

Currently, if trips return in the middle of a shutdown, they are killed mid-process.

This means sometimes the trips half-complete, fully complete but don't send a message, or just get marked completed and don't execute at all.

### Changes:

-- If client is shutting down then skip tickers.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
