### PR TITLE
Fix bug with Bank filters (Make filter orders of magnitude more efficient)

### DIFF
--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -1,5 +1,3 @@
-import { Bank } from 'oldschooljs';
-
 import { gracefulItems } from '../skilling/skills/agility';
 import { Craftables } from '../skilling/skills/crafting/craftables';
 import { Fletchables } from '../skilling/skills/fletching/fletchables';
@@ -1118,11 +1116,10 @@ export const baseFilters: Filterable[] = [
 		aliases: ['not sacrificed', 'not sac'],
 		items: user => {
 			if (!user) return [];
-			const sacBank = new Bank(user.user.sacrificedBank as ItemBank);
-			return user.bank
-				.items()
-				.filter(i => !sacBank.has(i[0].id))
-				.map(i => i[0].id);
+			const sacBank = user.user.sacrificedBank as ItemBank;
+			return Object.entries(user.bank.bank)
+				.filter(i => !sacBank[i[0]])
+				.map(i => Number(i[0]));
 		}
 	}
 ];

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -99,6 +99,7 @@ export function parseBankFromFlags({
 		type.aliases.some(alias => flagsKeys.some(i => stringMatches(i, alias)))
 	);
 
+	const itemFilter = filter ? filter.items(user) : undefined;
 	for (const [item, quantity] of bank.items()) {
 		if (maxSize && newBank.length >= maxSize) break;
 		if (flagsKeys.includes('tradeables') && !itemIsTradeable(item.id)) continue;
@@ -113,7 +114,7 @@ export function parseBankFromFlags({
 		}
 
 		const qty = Math.min(maxQuantity, quantity === 0 ? Math.max(1, bank.amount(item.id)) : quantity);
-		if (filter && !filter.items(user).includes(item.id)) continue;
+		if (itemFilter && !itemFilter.includes(item.id)) continue;
 		if (excludeItems.includes(item.id)) continue;
 
 		newBank.add(item.id, qty);


### PR DESCRIPTION
### Description:

- Bank filters are extremely inefficient
- Not sacrificed filter can freeze the bot for several minutes in extreme cases.
- This essentially changes some code from O(n) => O(1) which is a huge improvement. It now takes 1 second where as before it took 5 minutes.

### Changes:
- Compute the filter only once, instead of per bank-item
- Optimize the Not Sacrificed filter:
- Avoid creating unnecessary Bank and copying large amounts of memory
- Avoid creating thousands of `Item` objects when you only need the ID.


### Other checks:

-   [x] I have tested all my changes thoroughly.
