### PR TITLE
Don't check pure essence quantity if using daeyalt

### DIFF
--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -203,14 +203,16 @@ export const runecraftCommand: OSBMahojiCommand = {
 		if (runeObj.name === 'Elder rune') {
 			outputQuantity = Math.max(1, Math.floor((quantityPerEssence * quantity) / 3));
 		}
-		if (
-			numEssenceOwned === 0 ||
-			quantity === 0 ||
-			numEssenceOwned < quantity ||
-			!essenceRequired ||
-			numEssenceOwned < essenceRequired
-		) {
-			return "You don't have enough Pure Essence to craft these runes. You can acquire some through Mining, or purchasing from other players.";
+		if (!daeyalt_essence) {
+			if (
+				numEssenceOwned === 0 ||
+				quantity === 0 ||
+				numEssenceOwned < quantity ||
+				!essenceRequired ||
+				numEssenceOwned < essenceRequired
+			) {
+				return "You don't have enough Pure Essence to craft these runes. You can acquire some through Mining, or purchasing from other players.";
+			}
 		}
 
 		const numberOfInventories = Math.max(Math.ceil(quantity / inventorySize), 1);


### PR DESCRIPTION
### Description:

Fixed issue where pure essence quantity was checked when Daeyalt runecrafting

### Changes:

Added a check if Daeyalt = true, don't run pure essence quantity check

### Other checks:

-   [x] I have tested all my changes thoroughly.
