### PR TITLE
Remove pure essence check for daeyalt runecrafting

### DIFF
--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -204,11 +204,12 @@ export const runecraftCommand: OSBMahojiCommand = {
 			outputQuantity = Math.max(1, Math.floor((quantityPerEssence * quantity) / 3));
 		}
 		if (
-			numEssenceOwned === 0 ||
-			quantity === 0 ||
-			numEssenceOwned < quantity ||
-			!essenceRequired ||
-			numEssenceOwned < essenceRequired
+			!daeyalt_essence &&
+			(numEssenceOwned === 0 ||
+				quantity === 0 ||
+				numEssenceOwned < quantity ||
+				!essenceRequired ||
+				numEssenceOwned < essenceRequired)
 		) {
 			return "You don't have enough Pure Essence to craft these runes. You can acquire some through Mining, or purchasing from other players.";
 		}


### PR DESCRIPTION
### Description:

Fixed an issue where pure essence amount is checked when Daeyalt runecrafting

### Changes:

Added Daeyalt_essence = false as a requirement to check for pure essence quantity

### Other checks:

-   [ ] I have tested all my changes thoroughly.
