### PR TITLE
Replace /minion stats command

### DIFF
--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -135,6 +135,11 @@ export const minionCommand: OSBMahojiCommand = {
 		},
 		{
 			type: ApplicationCommandOptionType.Subcommand,
+			name: 'stats',
+			description: 'Check the stats of your minion.'
+		},
+		{
+			type: ApplicationCommandOptionType.Subcommand,
 			name: 'achievementdiary',
 			description: 'Manage your achievement diary.',
 			options: [

--- a/src/mahoji/commands/use.ts
+++ b/src/mahoji/commands/use.ts
@@ -9,7 +9,6 @@ export const mahojiUseCommand: OSBMahojiCommand = {
 	description: 'Use items/things.',
 	attributes: {
 		requiresMinion: true,
-		requiresMinionNotBusy: true,
 		examples: ['/use name:Mithril seeds']
 	},
 	options: [


### PR DESCRIPTION
### Description:

Replaces /minion stats command, with the data points removed as they are in /data now.
And don't require minion to be free to use `use`.


### Other checks:

-   [x] I have tested all my changes thoroughly.
