### PR TITLE
Fix 'Already in this mass' Join message + Ironman message

### DIFF
--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -95,7 +95,9 @@ export async function setupParty(channel: TextChannel, leaderUser: MUser, option
 						!user.user.minion_hasBought
 					) {
 						interaction.reply({
-							content: 'You cannot mass if you are busy, an ironman, or have no minion.',
+							content: `You cannot mass if you are busy${
+								!options.ironmanAllowed ? ', an ironman' : ''
+							}, or have no minion.`,
 							ephemeral: true
 						});
 						return false;

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -151,14 +151,14 @@ export async function setupParty(channel: TextChannel, leaderUser: MUser, option
 
 				switch (btn.id) {
 					case 'PARTY_JOIN': {
+						if (usersWhoConfirmed.includes(mUser.id)) {
+							return reply('You are already in this mass.');
+						}
 						if (
 							partyLockCache.has(mUser.id) ||
 							(options.usersAllowed && !options.usersAllowed.includes(mUser.id))
 						) {
 							return reply('You cannot join this mass.');
-						}
-						if (usersWhoConfirmed.includes(mUser.id)) {
-							return reply('You are already in this mass.');
 						}
 
 						// Add the user


### PR DESCRIPTION
### Description:

Currently, the 'you cannot join this mass' takes priority over the 'You are already in this mass' message, causing people to spam join, or think they aren't in the mass if the initial response is lost/not seen.

Also, it says, "you cannot join ... if you're an ironman ..." when you're busy. 

### Changes:

- Swaps the order/priority of the 'join' error messages
- Only show the 'is an ironman' failure message if ironmen actually aren't allowed.

### Other checks:

-   [x] I have tested all my changes thoroughly.
