### PR TITLE
[BSO] Boss Class (Pumpkinhead) improvements - more than 2x faster processing.

### DIFF
--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -44,6 +44,7 @@ export async function setupParty(channel: TextChannel, leaderUser: MUser, option
 	const usersWhoConfirmed: string[] = [options.leader.id];
 	let deleted = false;
 	const massTimeout = options.massTimeout ?? Time.Minute * 2;
+	let massStarted = false;
 
 	function getMessageContent(): MessageOptions & MessageEditOptions {
 		const userText =
@@ -133,6 +134,8 @@ export async function setupParty(channel: TextChannel, leaderUser: MUser, option
 			});
 
 			async function startTrip() {
+				if (massStarted) return;
+				massStarted = true;
 				await confirmMessage.delete().catch(noOp);
 				if (!partyCancelled && usersWhoConfirmed.length < options.minSize) {
 					channel.send(`${leaderUser} Not enough people joined your mass!`);

--- a/src/extendables/Message/Party.ts
+++ b/src/extendables/Message/Party.ts
@@ -44,7 +44,6 @@ export async function setupParty(channel: TextChannel, leaderUser: MUser, option
 	const usersWhoConfirmed: string[] = [options.leader.id];
 	let deleted = false;
 	const massTimeout = options.massTimeout ?? Time.Minute * 2;
-	let massStarted = false;
 
 	function getMessageContent(): MessageOptions & MessageEditOptions {
 		const userText =
@@ -134,8 +133,6 @@ export async function setupParty(channel: TextChannel, leaderUser: MUser, option
 			});
 
 			async function startTrip() {
-				if (massStarted) return;
-				massStarted = true;
 				await confirmMessage.delete().catch(noOp);
 				if (!partyCancelled && usersWhoConfirmed.length < options.minSize) {
 					channel.send(`${leaderUser} Not enough people joined your mass!`);

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -440,7 +440,7 @@ export class BossInstance {
 			// Handle big masses - Asynchronously process food removal to speed it up dramatically
 			await Promise.allSettled(
 				this.bossUsers.map(bu =>
-					bu.user.removeItemsFromBank(bu.itemsToRemove).catch(_res => (bu.invalid = true))
+					bu.user.removeItemsFromBank(bu.itemsToRemove).catch(() => (bu.invalid = true))
 				)
 			);
 			this.bossUsers = this.bossUsers.filter(bu => !bu.invalid);

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -448,12 +448,8 @@ export class BossInstance {
 		} else {
 			// Small masses that fail if a user has no food anymore.
 			for (const bossUser of this.bossUsers) {
-				try {
-					await bossUser.user.removeItemsFromBank(bossUser.itemsToRemove);
-					totalCost.add(bossUser.itemsToRemove);
-				} catch (e) {
-					throw e;
-				}
+				await bossUser.user.removeItemsFromBank(bossUser.itemsToRemove);
+				totalCost.add(bossUser.itemsToRemove);
 			}
 		}
 		if (this.settingsKeys) {

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -284,7 +284,6 @@ export class BossInstance {
 		this.tempQty = this.quantity;
 		// Force qty to 1 for init calculations
 		this.quantity = this.calculateQty(this.baseDuration);
-		await this.validateTeam();
 		const { bossUsers, duration, totalPercent } = await this.calculateBossUsers();
 		this.quantity = this.calculateQty(duration);
 		this.duration = duration * this.quantity;
@@ -436,17 +435,26 @@ export class BossInstance {
 		await this.validateTeam();
 
 		const totalCost = new Bank();
-		for (const bossUser of this.bossUsers) {
-			try {
-				await bossUser.user.removeItemsFromBank(bossUser.itemsToRemove);
-				totalCost.add(bossUser.itemsToRemove);
-			} catch (e) {
-				if (!this.skipInvalidUsers) throw e;
-				bossUser.invalid = true;
-			}
-		}
+
 		if (this.skipInvalidUsers) {
+			// Handle big masses - Asynchronously process food removal to speed it up dramatically
+			await Promise.allSettled(
+				this.bossUsers.map(bu =>
+					bu.user.removeItemsFromBank(bu.itemsToRemove).catch(_res => (bu.invalid = true))
+				)
+			);
 			this.bossUsers = this.bossUsers.filter(bu => !bu.invalid);
+			this.bossUsers.map(bu => totalCost.add(bu.itemsToRemove));
+		} else {
+			// Small masses that fail if a user has no food anymore.
+			for (const bossUser of this.bossUsers) {
+				try {
+					await bossUser.user.removeItemsFromBank(bossUser.itemsToRemove);
+					totalCost.add(bossUser.itemsToRemove);
+				} catch (e) {
+					throw e;
+				}
+			}
 		}
 		if (this.settingsKeys) {
 			updateBankSetting(this.settingsKeys[0], totalCost);

--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -439,9 +439,7 @@ export class BossInstance {
 		if (this.skipInvalidUsers) {
 			// Handle big masses - Asynchronously process food removal to speed it up dramatically
 			await Promise.allSettled(
-				this.bossUsers.map(bu =>
-					bu.user.removeItemsFromBank(bu.itemsToRemove).catch(() => (bu.invalid = true))
-				)
+				this.bossUsers.map(bu => bu.user.removeItemsFromBank(bu.itemsToRemove).catch(() => (bu.invalid = true)))
 			);
 			this.bossUsers = this.bossUsers.filter(bu => !bu.invalid);
 			this.bossUsers.map(bu => totalCost.add(bu.itemsToRemove));


### PR DESCRIPTION
### Description:

The delay between the mass 'starting' and the the 'trip send' message appearing can be 30+ seconds. This causes people to freak out and spam the bot, which is just not good. Plus it uses a lot more time than necessary.

In simulated trials of 300 Boss users, the processing time went from 23 seconds down to **9 seconds**.

### Changes:

- Removes duplicate call to validateUsers()  (Saves 3 seconds)
- Asynchronously removes food from users - (Saves 11 seconds)

### Other checks:

-   [x] I have tested all my changes thoroughly.
