### PR TITLE
Typo fix - Admin badges add

### DIFF
--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -658,7 +658,7 @@ export const adminCommand: OSBMahojiCommand = {
 
 			return `${action === 'add' ? 'Added' : 'Removed'} ${badgeName} ${badges[badgeID]} badge to ${
 				options.badges.user.user.username
-			}}.`;
+			}.`;
 		}
 
 		if (options.bypass_age) {


### PR DESCRIPTION
Removes an extra bracket so it isn't included in the return text