### PR TITLE
Resolve Achivement Diary claim spam

### DIFF
--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -43,7 +43,7 @@ export async function userhasDiaryTier(user: MUser, tier: DiaryTier): Promise<[t
 			if (skills[skill[0]] < skill[1]!) failSkills[skill[0]] = skill[1]!;
 			canDo = false;
 		}
-		reasons.push(`\n- You don't have these stats: ${formatSkillRequirements(failSkills)!}`);
+		reasons.push(`You don't have these stats: ${formatSkillRequirements(failSkills)!}`);
 	}
 
 	const { bank } = user;

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -43,7 +43,7 @@ export async function userhasDiaryTier(user: MUser, tier: DiaryTier): Promise<[t
 			if (skills[skill[0]] < skill[1]!) failSkills[skill[0]] = skill[1]!;
 			canDo = false;
 		}
-		reasons.push(`You don't have these stats: ${formatSkillRequirements(failSkills)!}`);
+		reasons.push(`\n- You don't have these stats: ${formatSkillRequirements(failSkills)!}`);
 	}
 
 	const { bank } = user;

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -42,8 +42,8 @@ export async function userhasDiaryTier(user: MUser, tier: DiaryTier): Promise<[t
 		for (const skill of objectEntries(tier.skillReqs)) {
 			if (skills[skill[0]] < skill[1]!) failSkills[skill[0]] = skill[1]!;
 			canDo = false;
-			reasons.push(`You don't have these stats: ${formatSkillRequirements(failSkills)!}`);
 		}
+		reasons.push(`You don't have these stats: ${formatSkillRequirements(failSkills)!}`);
 	}
 
 	const { bank } = user;

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -658,7 +658,7 @@ export const adminCommand: OSBMahojiCommand = {
 
 			return `${action === 'add' ? 'Added' : 'Removed'} ${badgeName} ${badges[badgeID]} badge to ${
 				options.badges.user.user.username
-			}}.`;
+			}.`;
 		}
 
 		if (options.bypass_age) {

--- a/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
@@ -132,7 +132,7 @@ export async function claimAchievementDiaryCommand(user: MUser, diaryName: strin
 			return `You successfully completed the ${name} and received ${loot}.`;
 		}
 
-		return `You can't claim the ${name} because ${reason}.`;
+		return `You can't claim the ${name} because: ${reason}.`;
 	}
 
 	return `You have already completed the entire ${diary.name} diary!`;

--- a/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
@@ -132,7 +132,7 @@ export async function claimAchievementDiaryCommand(user: MUser, diaryName: strin
 			return `You successfully completed the ${name} and received ${loot}.`;
 		}
 
-		return `You can't claim the ${name} because: ${reason}.`;
+		return `You can't claim the ${name} because: \n -${reason}.`;
 	}
 
 	return `You have already completed the entire ${diary.name} diary!`;


### PR DESCRIPTION
Closes #4474 

Moves the reason.push outside of the loop to stop it spamming when someone trys to claim an achievement diary without the required skill levels.

-   [x] I have tested all my changes thoroughly.
