### PR TITLE
Fix Trips not returning (Adds AutoComponentGrid)

### DIFF
--- a/src/lib/DynamicButtons.ts
+++ b/src/lib/DynamicButtons.ts
@@ -1,5 +1,4 @@
 import {
-	ActionRowBuilder,
 	ButtonBuilder,
 	ButtonStyle,
 	DMChannel,
@@ -10,10 +9,11 @@ import {
 	TextChannel,
 	ThreadChannel
 } from 'discord.js';
-import { chunk, noOp, Time } from 'e';
+import { noOp, Time } from 'e';
 import murmurhash from 'murmurhash';
 
 import { BLACKLISTED_USERS } from './blacklists';
+import { AutoComponentGrid } from './structures/AutoComponentGrid';
 import { awaitMessageComponentInteraction } from './util';
 import { minionIsBusy } from './util/minionIsBusy';
 
@@ -80,16 +80,10 @@ export class DynamicButtons {
 					})
 			)
 			.concat(extraButtons);
-		const chunkedButtons = chunk(buttons, 5);
-
-		let components: ActionRowBuilder<ButtonBuilder>[] = [];
-		for (const arr of chunkedButtons) {
-			components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(arr));
-		}
-
+		const buttonGrid = new AutoComponentGrid<ButtonBuilder>(buttons);
 		this.message = await this.channel.send({
 			...messageOptions,
-			components
+			components: buttonGrid.outputComponents()
 		});
 		const collectedInteraction = await awaitMessageComponentInteraction({
 			message: this.message,

--- a/src/lib/structures/AutoComponentGrid.ts
+++ b/src/lib/structures/AutoComponentGrid.ts
@@ -1,0 +1,21 @@
+import { ActionRowBuilder, AnyComponentBuilder, normalizeArray, RestOrArray } from 'discord.js';
+import { chunk } from 'e';
+
+export class AutoComponentGrid<T extends AnyComponentBuilder> {
+	public readonly components: T[];
+	constructor(...components: RestOrArray<T>) {
+		this.components = [];
+		if (components) this.components.push(...normalizeArray(components));
+	}
+
+	addComponents(...components: RestOrArray<T>) {
+		this.components.push(...normalizeArray(components));
+		return this;
+	}
+
+	outputComponents() {
+		const buttonGroups = chunk(this.components, 5);
+		const result = buttonGroups.map(g => new ActionRowBuilder<T>({ components: g }));
+		return result;
+	}
+}

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -1,5 +1,5 @@
 import { activity_type_enum } from '@prisma/client';
-import { ActionRowBuilder, AttachmentBuilder, ButtonBuilder, MessageCollector } from 'discord.js';
+import { AttachmentBuilder, ButtonBuilder, MessageCollector } from 'discord.js';
 import { Bank } from 'oldschooljs';
 
 import { calculateBirdhouseDetails } from '../../mahoji/lib/abstracted_commands/birdhousesCommand';
@@ -11,6 +11,7 @@ import { handleGrowablePetGrowth } from '../growablePets';
 import { handlePassiveImplings } from '../implings';
 import { triggerRandomEvent } from '../randomEvents';
 import { getUsersCurrentSlayerInfo } from '../slayer/slayerUtil';
+import { AutoComponentGrid } from '../structures/AutoComponentGrid';
 import { ActivityTaskOptions } from '../types/minions';
 import { channelIsSendable } from '../util';
 import {
@@ -106,7 +107,7 @@ export async function handleTripFinish(
 	const channel = globalClient.channels.cache.get(channelID);
 	if (!channelIsSendable(channel)) return;
 
-	const components = new ActionRowBuilder<ButtonBuilder>();
+	const components = new AutoComponentGrid<ButtonBuilder>();
 	components.addComponents(makeRepeatTripButton());
 	const casketReceived = loot ? ClueTiers.find(i => loot?.has(i.id)) : undefined;
 	if (casketReceived) components.addComponents(makeOpenCasketButton(casketReceived));
@@ -125,6 +126,6 @@ export async function handleTripFinish(
 	sendToChannelID(channelID, {
 		content: message,
 		image: attachment,
-		components: components.components.length > 0 ? [components] : undefined
+		components: components.components.length > 0 ? components.outputComponents() : undefined
 	});
 }

--- a/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
@@ -1,5 +1,5 @@
 import { activity_type_enum } from '@prisma/client';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
 import { percentChance, randInt, roll, Time } from 'e';
 import { Bank } from 'oldschooljs';
 import SimpleTable from 'oldschooljs/dist/structures/SimpleTable';
@@ -8,6 +8,7 @@ import { Emoji, Events } from '../../../lib/constants';
 import addSkillingClueToLoot from '../../../lib/minions/functions/addSkillingClueToLoot';
 import { determineMiningTime } from '../../../lib/skilling/functions/determineMiningTime';
 import { Ore, SkillsEnum } from '../../../lib/skilling/types';
+import { AutoComponentGrid } from '../../../lib/structures/AutoComponentGrid';
 import { ItemBank } from '../../../lib/types';
 import { ActivityTaskOptions } from '../../../lib/types/minions';
 import { formatDuration, itemNameFromID } from '../../../lib/util';
@@ -323,7 +324,7 @@ export const starCache = new Map<string, Star & { expiry: number }>();
 export function handleTriggerShootingStar(
 	user: MUserClass,
 	data: ActivityTaskOptions,
-	components: ActionRowBuilder<ButtonBuilder>
+	components: AutoComponentGrid<ButtonBuilder>
 ) {
 	if (activitiesCantGetStars.includes(data.type)) return;
 	const miningLevel = user.skillLevel(SkillsEnum.Mining);


### PR DESCRIPTION
### Description:

Trips with lots of clue scrolls are not returning after the last update.

This is because it adds a button for each clue, and a row can only have 5 buttons.

This PR adds an AutoComponentGrid, which allows you to just add buttons without thinking about how many there are, and then automatically outputs them in the right format.

Uses the same format as ActionRowBuilder

### Changes:

- Adds AutoComponentGrid
- Updates handleTripFinish to use the new class
- Updates dynamicButtons to use the new class

### Other checks:

-   [x] I have tested all my changes thoroughly.
