### PR TITLE
Fix Trips not returning

### DIFF
--- a/src/lib/DynamicButtons.ts
+++ b/src/lib/DynamicButtons.ts
@@ -1,5 +1,4 @@
 import {
-	ActionRowBuilder,
 	ButtonBuilder,
 	ButtonStyle,
 	DMChannel,
@@ -10,11 +9,11 @@ import {
 	TextChannel,
 	ThreadChannel
 } from 'discord.js';
-import { chunk, noOp, Time } from 'e';
+import { noOp, Time } from 'e';
 import murmurhash from 'murmurhash';
 
 import { BLACKLISTED_USERS } from './blacklists';
-import { awaitMessageComponentInteraction } from './util';
+import { awaitMessageComponentInteraction, makeComponents } from './util';
 import { minionIsBusy } from './util/minionIsBusy';
 
 type DynamicButtonFn = (opts: { message: Message; interaction: MessageComponentInteraction }) => unknown;
@@ -80,16 +79,10 @@ export class DynamicButtons {
 					})
 			)
 			.concat(extraButtons);
-		const chunkedButtons = chunk(buttons, 5);
-
-		let components: ActionRowBuilder<ButtonBuilder>[] = [];
-		for (const arr of chunkedButtons) {
-			components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(arr));
-		}
 
 		this.message = await this.channel.send({
 			...messageOptions,
-			components
+			components: makeComponents(buttons)
 		});
 		const collectedInteraction = await awaitMessageComponentInteraction({
 			message: this.message,

--- a/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
@@ -1,5 +1,5 @@
 import { activity_type_enum } from '@prisma/client';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
 import { percentChance, randInt, roll, Time } from 'e';
 import { Bank } from 'oldschooljs';
 import SimpleTable from 'oldschooljs/dist/structures/SimpleTable';
@@ -320,11 +320,7 @@ const activitiesCantGetStars: activity_type_enum[] = [
 
 export const starCache = new Map<string, Star & { expiry: number }>();
 
-export function handleTriggerShootingStar(
-	user: MUserClass,
-	data: ActivityTaskOptions,
-	components: ActionRowBuilder<ButtonBuilder>
-) {
+export function handleTriggerShootingStar(user: MUserClass, data: ActivityTaskOptions, components: ButtonBuilder[]) {
 	if (activitiesCantGetStars.includes(data.type)) return;
 	const miningLevel = user.skillLevel(SkillsEnum.Mining);
 	const elligibleStars = starSizes.filter(i => i.chance > 0 && i.level <= miningLevel);
@@ -341,6 +337,6 @@ export function handleTriggerShootingStar(
 		.setLabel(`Mine Size ${star.size} Crashed Star`)
 		.setEmoji('⭐')
 		.setStyle(ButtonStyle.Secondary);
-	components.addComponents(button);
+	components.push(button);
 	starCache.set(user.id, { ...star, expiry: Date.now() + Time.Minute * 5 + patronMaxTripBonus(user) / 2 });
 }


### PR DESCRIPTION
### Description:

Trips with lots of clue scrolls are not returning after the last update.

This is because it adds a button for each clue, and a row can only have 5 buttons.

### Changes:

- Updates handleTripFinish to use makeComponents()
- Updates dynamicButtons to use makeComponents()

### Other checks:

-   [x] I have tested all my changes thoroughly.
