### PR TITLE
Don't run tickers before client ready

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import { modalInteractionHook } from './lib/modals';
 import { runStartupScripts } from './lib/startupScripts';
 import { OldSchoolBotClient } from './lib/structures/OldSchoolBotClient';
 import { syncActivityCache } from './lib/Task';
-import { initTickers } from './lib/tickers';
 import { UserError } from './lib/UserError';
 import { runTimedLoggedFn } from './lib/util';
 import { syncActiveUserIDs } from './lib/util/cachedUserIDs';
@@ -157,7 +156,6 @@ client.on('guildCreate', guild => {
 		guild.leave();
 	}
 });
-initTickers();
 
 client.on('ready', () => runTimedLoggedFn('OnStartup', async () => onStartup()));
 

--- a/src/mahoji/lib/events.ts
+++ b/src/mahoji/lib/events.ts
@@ -6,6 +6,7 @@ import { cacheBadges } from '../../lib/badges';
 import { syncBlacklists } from '../../lib/blacklists';
 import { DISABLED_COMMANDS } from '../../lib/constants';
 import { prisma } from '../../lib/settings/prisma';
+import { initTickers } from '../../lib/tickers';
 import { cacheCleanup } from '../../lib/util';
 import { syncLinkedAccounts } from '../../lib/util/linkedAccountsUtil';
 import { CUSTOM_PRICE_CACHE } from '../commands/sell';
@@ -53,4 +54,6 @@ export async function onStartup() {
 
 	await syncLinkedAccounts();
 	await cacheCleanup();
+
+	initTickers();
 }


### PR DESCRIPTION
### Description:

This is the only other cause I can think of for minion return trip messages to fail to be sent/received.

If the task is processed before the client is ready, then messages won't be sent.

### Changes:

- Moves the initTickers() command to onStartup() which runs after the client is ready.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
