### PR TITLE
Allow cooking karambwans to repeat

### DIFF
--- a/src/lib/skilling/skills/cooking.ts
+++ b/src/lib/skilling/skills/cooking.ts
@@ -125,6 +125,7 @@ export const Cookables: Cookable[] = [
 		xp: 190,
 		id: itemID('Cooked karambwan'),
 		name: 'Karambwan',
+		alias: ['Cooked karambwan'],
 		inputCookables: { [itemID('Raw karambwan')]: 1 },
 		stopBurnAt: 99,
 		burntCookable: itemID('Burnt karambwan')

--- a/src/lib/skilling/skills/cooking.ts
+++ b/src/lib/skilling/skills/cooking.ts
@@ -124,8 +124,8 @@ export const Cookables: Cookable[] = [
 		level: 30,
 		xp: 190,
 		id: itemID('Cooked karambwan'),
-		name: 'Karambwan',
-		alias: ['cooked karambwan'],
+		name: 'Cooked karambwan',
+		alias: ['karambwan'],
 		inputCookables: { [itemID('Raw karambwan')]: 1 },
 		stopBurnAt: 99,
 		burntCookable: itemID('Burnt karambwan')

--- a/src/lib/skilling/skills/cooking.ts
+++ b/src/lib/skilling/skills/cooking.ts
@@ -125,7 +125,7 @@ export const Cookables: Cookable[] = [
 		xp: 190,
 		id: itemID('Cooked karambwan'),
 		name: 'Karambwan',
-		alias: ['Cooked karambwan'],
+		alias: ['cooked karambwan'],
 		inputCookables: { [itemID('Raw karambwan')]: 1 },
 		stopBurnAt: 99,
 		burntCookable: itemID('Burnt karambwan')


### PR DESCRIPTION
Adds an alias of "cooked karambwan" to karambwans. As it gets the name from itemID and is currently unable to repeat the trips.

-   [x] I have tested all my changes thoroughly.
