### PR TITLE
[BSO] - Fix bug crashing Kalphite King trips

### DIFF
--- a/src/tasks/minions/bso/kalphiteKingActivity.ts
+++ b/src/tasks/minions/bso/kalphiteKingActivity.ts
@@ -89,7 +89,7 @@ export const kalphiteKingTask: MinionTask = {
 		let soloItemsAdded = null;
 
 		const totalLoot = new Bank();
-		for (let [userID, loot] of Object.entries(teamsLoot)) {
+		for (let [userID, loot] of teamsLoot.entries()) {
 			const user = await mUserFetch(userID).catch(noOp);
 			if (!user) continue;
 			totalLoot.add(loot);


### PR DESCRIPTION
### Description:

KK Trips are crashing instead of returning. No loot is being given.

This is from a recent change that converted the teamsLoot into a TeamLoot class but still trying to treat it like a Map later.

### Changes:

- Changes the `for...of` to use TeamLoot.prototype.entries() instead of Object.entries().

### Other checks:

-   [x] I have tested all my changes thoroughly.
