### PR TITLE
Dont re-fetch the user each addXP call

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -201,7 +201,7 @@ export class MUserClass {
 	}
 
 	addXP(params: AddXpParams) {
-		return addXP(this.id, params);
+		return addXP(this, params);
 	}
 
 	getKC(monsterID: number) {

--- a/src/lib/addXP.ts
+++ b/src/lib/addXP.ts
@@ -45,8 +45,7 @@ export async function onMax(user: MUser) {
 	kUser.send(MAXING_MESSAGE).catch(noOp);
 }
 
-export async function addXP(userID: string, params: AddXpParams): Promise<string> {
-	const user = await mUserFetch(userID);
+export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 	const currentXP = Number(user.user[`skills_${params.skillName}`]);
 	const currentLevel = user.skillLevel(params.skillName);
 	const currentTotalLevel = user.totalLevel;


### PR DESCRIPTION
### Description:

This is a very nice change as it saves multiple full user (MUser) fetches per task.

PVM tasks can add XP up to 6 different skills at a time, and most tasks add XP in at least 1 or 2+ skills.

Every time user.addXP() is called, it fetches a brand new MUser object, even though you're literally calling addXP from an MUser object.

### Changes:

- user.addXP() passes `this` instead of `this.id` to addXP()
- addXP() expects to receive `user: MUser` now

### Other checks:

-   [x] I have tested all my changes thoroughly.
