### PR TITLE
Add Gear output image support to /eval

### DIFF
--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -17,11 +17,13 @@ import { ItemBank } from 'oldschooljs/dist/meta/types';
 import { CLIENT_ID, OWNER_IDS, production, SupportServer } from '../../config';
 import { BLACKLISTED_GUILDS, BLACKLISTED_USERS, syncBlacklists } from '../../lib/blacklists';
 import { badges, BadgesEnum, BitField, BitFieldData, DISABLED_COMMANDS } from '../../lib/constants';
+import { generateGearImage } from '../../lib/gear/functions/generateGearImage';
 import { getUsersPerkTier } from '../../lib/MUser';
 import { patreonTask } from '../../lib/patreon';
 import { runRolesTask } from '../../lib/rolesTask';
 import { countUsersWithItemInCl, prisma } from '../../lib/settings/prisma';
 import { cancelTask, minionActivityCacheDelete } from '../../lib/settings/settings';
+import { Gear } from '../../lib/structures/Gear';
 import {
 	calcPerHour,
 	cleanString,
@@ -66,6 +68,7 @@ async function unsafeEval({ userID, code }: { userID: string; code: string }) {
 	let thenable = false;
 	// eslint-disable-next-line @typescript-eslint/init-declarations
 	try {
+		code = `\nconst {Gear} = require('../../lib/structures/Gear')\n${code};`;
 		code = `\nconst {Bank} = require('oldschooljs');\n${code}`;
 		// eslint-disable-next-line no-eval
 		result = eval(code);
@@ -86,6 +89,10 @@ async function unsafeEval({ userID, code }: { userID: string; code: string }) {
 	stopwatch.stop();
 	if (result instanceof Bank) {
 		return { files: [(await makeBankImage({ bank: result })).file] };
+	}
+	if (result instanceof Gear) {
+		const image = await generateGearImage(await mUserFetch(userID), result, null, null);
+		return { files: [image] };
 	}
 
 	if (Buffer.isBuffer(result)) {


### PR DESCRIPTION
### Description:

Adds support for Gear image output to eval.

(Showing BSO Example, but you get the idea)
`/admin eval code: new Gear({"2h":{"item":48220,"quantity":1},"ammo":{"item":22228,"quantity":1},"body":{"item":40048,"quantity":1},"cape":{"item":40056,"quantity":1},"feet":{"item":40051,"quantity":1},"hands":{"item":40050,"quantity":1},"head":{"item":40047,"quantity":1},"legs":{"item":40049,"quantity":1},"neck":{"item":48010,"quantity":1},"ring":{"item":11771,"quantity":1},"shield":null,"weapon":null})`
![image](https://user-images.githubusercontent.com/10122432/200449430-9e17cf55-ce61-4471-970b-a9b41bb2e220.png)


### Changes:

- Adds support to return gear to admin.ts (/admin)

### Other checks:

-   [x] I have tested all my changes thoroughly.
