### PR TITLE
Fix PVM Degradeable boosts

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -468,6 +468,17 @@ export function convertAttackStyleToGearSetup(style: OffenceGearStat | DefenceGe
 	return setup;
 }
 
+export function convertPvmStylesToGearSetup(attackStyles: SkillsEnum[]) {
+	const usedSetups: GearSetupType[] = [];
+	if (attackStyles.includes(SkillsEnum.Ranged)) usedSetups.push('range');
+	if (attackStyles.includes(SkillsEnum.Magic)) usedSetups.push('mage');
+	if (![SkillsEnum.Magic, SkillsEnum.Ranged].some(s => attackStyles.includes(s))) {
+		usedSetups.push('melee');
+	}
+	if (usedSetups.length === 0) usedSetups.push('melee');
+	return usedSetups;
+}
+
 export function sanitizeBank(bank: Bank) {
 	for (const [key, value] of Object.entries(bank.bank)) {
 		if (value < 1) {


### PR DESCRIPTION
### Description:

Currently, the degradeable item boosts only work if the preferred attack style of the monster matches the weapon you're using.
This lets it work where it shouldn't, and NOT where it should.

This changes it so that if you are able to use that attack style on the monster, then the boost will be applied.

### Changes:

- Uses the current training style to determine if a degradeable item will boost.
- Splits the boost application from the charge degradation so the boost can influence the kills/trip.

### Other checks:

-   [x] I have tested all my changes thoroughly.
