### PR TITLE
Fix inferno stats /data command

### DIFF
--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -331,8 +331,8 @@ GROUP BY data->>'monsterID';`);
 				await prisma.$queryRaw`SELECT mins, COUNT(mins) FROM (SELECT ((data->>'deathTime')::int / 1000 / 60) as mins
 FROM activity
 WHERE type = 'Inferno'
-AND data->>'deathTime' IS NOT NULL) death_mins
 AND completed = true
+AND data->>'deathTime' IS NOT NULL) death_mins
 GROUP BY mins;`;
 			const buffer = await lineChart(
 				'Global Inferno Death Times',
@@ -351,8 +351,8 @@ GROUP BY mins;`;
 FROM activity
 WHERE type = 'Inferno'
 AND user_id = ${BigInt(user.id)}
-AND data->>'deathTime' IS NOT NULL) death_mins
 AND completed = true
+AND data->>'deathTime' IS NOT NULL) death_mins
 GROUP BY mins;`);
 			const buffer = await lineChart(
 				'Personal Inferno Death Times',


### PR DESCRIPTION
### Description:

Fixes 2 of the inferno stats commands

### Changes:

Moves `AND completed = true` inside the enclosed query  where it belongs, otherwise it's a syntax error.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
