### PR TITLE
[BSO] Add Flappy to GotR

### DIFF
--- a/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
+++ b/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
@@ -3,6 +3,7 @@ import { Bank } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import { Events } from '../../../lib/constants';
+import { userHasFlappy } from '../../../lib/invention/inventions';
 import { trackLoot } from '../../../lib/lootTrack';
 import { getMinigameEntity, incrementMinigameScore } from '../../../lib/settings/minigames';
 import Runecraft from '../../../lib/skilling/skills/runecraft';
@@ -120,9 +121,13 @@ export const guardiansOfTheRiftTask: MinionTask = {
 		}
 
 		let rewardsGuardianLoot = new Bank();
-		for (let i = 0; i < quantity * rolls; i++) {
-			rewardsGuardianLoot.add(rewardsGuardianTable.roll());
+		let rewardsQty = 0;
+		for (let i = 0; i < quantity; i++) {
+			rewardsQty += randInt(rolls - 1, rolls);
 		}
+		const flappyRes = await userHasFlappy({ user, duration });
+		if (flappyRes.shouldGiveBoost) rewardsQty *= 2;
+		rewardsGuardianLoot.add(rewardsGuardianTable.roll(rewardsQty));
 
 		const totalLoot = new Bank();
 		totalLoot.add(rewardsGuardianLoot);
@@ -150,6 +155,7 @@ export const guardiansOfTheRiftTask: MinionTask = {
 				? ` ${Math.floor((setBonus - 1) * 100)}% Quantity bonus for Raiments Of The Eye Set Items`
 				: ''
 		}. ${xpResRunecraft} ${xpResCrafting} ${xpResMining}`;
+		if (flappyRes) str += `\n${flappyRes.userMsg}`;
 
 		if (rewardsGuardianLoot.amount('Abyssal Protector') > 0) {
 			str += "\n\n**You have a funny feeling you're being followed...**";

--- a/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
+++ b/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
@@ -126,7 +126,7 @@ export const guardiansOfTheRiftTask: MinionTask = {
 			rewardsQty += randInt(rolls - 1, rolls);
 		}
 		const flappyRes = await userHasFlappy({ user, duration });
-		if (flappyRes.shouldGiveBoost) rewardsQty *= 2;
+		if (flappyRes?.shouldGiveBoost) rewardsQty *= 2;
 		rewardsGuardianLoot.add(rewardsGuardianTable.roll(rewardsQty));
 
 		const totalLoot = new Bank();

--- a/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
+++ b/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
@@ -126,7 +126,7 @@ export const guardiansOfTheRiftTask: MinionTask = {
 			rewardsQty += randInt(rolls - 1, rolls);
 		}
 		const flappyRes = await userHasFlappy({ user, duration });
-		if (flappyRes?.shouldGiveBoost) rewardsQty *= 2;
+		if (flappyRes.shouldGiveBoost) rewardsQty *= 2;
 		rewardsGuardianLoot.add(rewardsGuardianTable.roll(rewardsQty));
 
 		const totalLoot = new Bank();
@@ -155,7 +155,7 @@ export const guardiansOfTheRiftTask: MinionTask = {
 				? ` ${Math.floor((setBonus - 1) * 100)}% Quantity bonus for Raiments Of The Eye Set Items`
 				: ''
 		}. ${xpResRunecraft} ${xpResCrafting} ${xpResMining}`;
-		if (flappyRes) str += `\n${flappyRes.userMsg}`;
+		if (flappyRes.userMsg) str += `\n${flappyRes.userMsg}`;
 
 		if (rewardsGuardianLoot.amount('Abyssal Protector') > 0) {
 			str += "\n\n**You have a funny feeling you're being followed...**";


### PR DESCRIPTION
### Description:

Adds Flappy to Guardians of the Rift. 

### Changes:

- Adds 2x rewards if Flappy boost is active.

### Other checks:

-   [x] I have tested all my changes thoroughly.
