### PR TITLE
Fix JMOD-Reddit posts

### DIFF
--- a/src/lib/crons.ts
+++ b/src/lib/crons.ts
@@ -5,7 +5,6 @@ import { schedule } from 'node-cron';
 import fetch from 'node-fetch';
 
 import { production } from '../config';
-import { untrustedGuildSettingsCache } from '../mahoji/mahojiSettings';
 import { analyticsTick } from './analytics';
 import { prisma } from './settings/prisma';
 import { cacheCleanup } from './util';
@@ -54,17 +53,16 @@ GROUP BY item_id;`);
 					}
 				},
 				select: {
-					id: true
+					id: true,
+					jmodComments: true
 				}
 			});
 
-			for (const { id } of guildsToSendToo) {
+			for (const { id, jmodComments } of guildsToSendToo) {
 				const guild = globalClient.guilds.cache.get(id);
 				if (!guild) continue;
-				const settings = untrustedGuildSettingsCache.get(guild.id);
-				if (!settings?.jmodComments) continue;
 
-				const channel = guild.channels.cache.get(settings.jmodComments);
+				const channel = guild.channels.cache.get(jmodComments!);
 
 				if (
 					channel &&


### PR DESCRIPTION
### Description:

OSRS Official discord came and reported their JMOD-Reddit hasn't worked in over a month.

After investigating, I have come to 2 possibilities:

1. The LRUCache of only 1,000 isn't enough to keep all active servers cached.
2. Ratelimiting from servers without `Manage webhooks` enabled is preventing non-webhook messages from going thru.
 (I suggested they enable Manage Webhooks on their jmod-reddit channel)

### Changes:

- Use the "jmodComments" variable directly from the DB since we're already querying it anyway. This way it's guaranteed to fire for all enabled servers. 

(If the number of enabled servers is a concern, then we should require a webhook/permission instead of just not sending it at all)

### Other checks:

-   [x] I have tested all my changes thoroughly.

I have tested all parts of the code, from fetching the reddit data, to sending the updates, using both webhooks + regular channels, and various combinations of removing the webhooks / permissions and retrying, and it works in all cases I have tested.