### PR TITLE
[BSO] - Nex / Boss improvements

### DIFF
--- a/src/lib/bso/calcBossFood.ts
+++ b/src/lib/bso/calcBossFood.ts
@@ -1,0 +1,23 @@
+import { Bank } from 'oldschooljs';
+
+import calculateMonsterFood from '../minions/functions/calculateMonsterFood';
+import { KillableMonster } from '../minions/types';
+
+export function calcBossFood(user: MUser, monster: KillableMonster, teamSize: number, quantity: number) {
+	let [healAmountNeeded] = calculateMonsterFood(monster, user);
+	const kc = user.getKC(monster.id);
+	if (kc > 50) healAmountNeeded *= 0.5;
+	else if (kc > 30) healAmountNeeded *= 0.6;
+	else if (kc > 15) healAmountNeeded *= 0.7;
+	else if (kc > 10) healAmountNeeded *= 0.8;
+	else if (kc > 5) healAmountNeeded *= 0.9;
+	healAmountNeeded /= (teamSize + 1) / 1.5;
+	let brewsNeeded = Math.ceil((healAmountNeeded * quantity) / 16);
+	if (teamSize === 1) brewsNeeded += 2;
+	const restoresNeeded = Math.ceil(brewsNeeded / 3);
+	const items = new Bank({
+		'Saradomin brew(4)': brewsNeeded,
+		'Super restore(4)': restoresNeeded
+	});
+	return items;
+}

--- a/src/lib/minions/functions/calculateMonsterFood.ts
+++ b/src/lib/minions/functions/calculateMonsterFood.ts
@@ -3,7 +3,6 @@ import { calcWhatPercent, reduceNumByPercent } from 'e';
 import { GearSetupType, GearStat } from '../../gear';
 import { inverseOfOffenceStat } from '../../gear/functions/inverseOfStat';
 import { maxDefenceStats, maxOffenceStats, readableStatName } from '../../structures/Gear';
-import killableMonsters from '../data/killableMonsters';
 import { KillableMonster } from '../types';
 
 const { floor, max } = Math;
@@ -16,7 +15,7 @@ export default function calculateMonsterFood(monster: Readonly<KillableMonster>,
 	}
 
 	if (monster.name === 'Koschei the deathless') {
-		return [killableMonsters.find(m => m.id === monster.id)!.healAmountNeeded!, ''];
+		return [monster.healAmountNeeded!, ''];
 	}
 
 	let gearToCheck: GearSetupType = 'melee';

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -48,8 +48,7 @@ import { bool, integer, MersenneTwister19937, nodeCrypto, real, shuffle } from '
 import { CLIENT_ID, production, SupportServer } from '../config';
 import { BitField, ProjectileType, skillEmoji, usernameCache } from './constants';
 import { DefenceGearStat, GearSetupType, GearSetupTypes, GearStat, OffenceGearStat } from './gear/types';
-import calculateMonsterFood from './minions/functions/calculateMonsterFood';
-import { Consumable, KillableMonster } from './minions/types';
+import { Consumable } from './minions/types';
 import { MUserClass } from './MUser';
 import { PaginatedMessage } from './PaginatedMessage';
 import { POHBoosts } from './poh';
@@ -932,23 +931,4 @@ export function getAllIDsOfUser(user: MUser) {
 
 export function isFunction(input: unknown): input is Function {
 	return typeof input === 'function';
-}
-
-export function calcBossFood(user: MUser, monster: KillableMonster, teamSize: number, quantity: number) {
-	let [healAmountNeeded] = calculateMonsterFood(monster, user);
-	const kc = user.getKC(monster.id);
-	if (kc > 50) healAmountNeeded *= 0.5;
-	else if (kc > 30) healAmountNeeded *= 0.6;
-	else if (kc > 15) healAmountNeeded *= 0.7;
-	else if (kc > 10) healAmountNeeded *= 0.8;
-	else if (kc > 5) healAmountNeeded *= 0.9;
-	healAmountNeeded /= (teamSize + 1) / 1.5;
-	let brewsNeeded = Math.ceil((healAmountNeeded * quantity) / 16);
-	if (teamSize === 1) brewsNeeded += 2;
-	const restoresNeeded = Math.ceil(brewsNeeded / 3);
-	const items = new Bank({
-		'Saradomin brew(4)': brewsNeeded,
-		'Super restore(4)': restoresNeeded
-	});
-	return items;
 }

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -369,8 +369,8 @@ export const tripHandlers = {
 		commandName: 'k',
 		args: (data: NexTaskOptions) => {
 			return {
-				name: 'nex',
-				quantity: data.quantity
+				name: `nex ${data.users.length === 1 ? 'solo' : 'mass'}`,
+				quantity: data.users.length === 1 ? data.quantity : undefined
 			};
 		}
 	},
@@ -570,7 +570,8 @@ export const tripHandlers = {
 	[activity_type_enum.KalphiteKing]: {
 		commandName: 'k',
 		args: (data: NewBossOptions) => ({
-			name: `Kalphite King ${data.users.length === 1 ? 'solo' : 'mass'}`
+			name: `Kalphite King ${data.users.length === 1 ? 'solo' : 'mass'}`,
+			quantity: data.users.length === 1 ? data.quantity : undefined
 		})
 	},
 	[activity_type_enum.Ignecarus]: {

--- a/src/mahoji/lib/abstracted_commands/kkCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/kkCommand.ts
@@ -3,6 +3,7 @@ import { increaseNumByPercent, reduceNumByPercent, round, Time } from 'e';
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import { Bank } from 'oldschooljs';
 
+import { calcBossFood } from '../../../lib/bso/calcBossFood';
 import { gorajanWarriorOutfit, torvaOutfit } from '../../../lib/data/CollectionsExport';
 import { trackLoot } from '../../../lib/lootTrack';
 import { KalphiteKingMonster } from '../../../lib/minions/data/killableMonsters/custom/bosses/KalphiteKing';
@@ -12,7 +13,7 @@ import { setupParty } from '../../../lib/party';
 import { Gear } from '../../../lib/structures/Gear';
 import { MakePartyOptions } from '../../../lib/types';
 import { BossActivityTaskOptions } from '../../../lib/types/minions';
-import { calcBossFood, channelIsSendable, formatDuration, isWeekend } from '../../../lib/util';
+import { channelIsSendable, formatDuration, isWeekend } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import calcDurQty from '../../../lib/util/calcMassDurationQuantity';
 import { getKalphiteKingGearStats } from '../../../lib/util/getKalphiteKingGearStats';

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -189,9 +189,12 @@ export async function minionKillCommand(
 	if (['vasa', 'vasa magus'].some(i => stringMatches(i, name))) return vasaCommand(user, channelID, quantity);
 	if (name.toLowerCase().includes('nightmare')) return nightmareCommand(user, channelID, name);
 	if (name.toLowerCase().includes('wintertodt')) return wintertodtCommand(user, channelID);
-	if (name.toLowerCase().includes('ignecarus')) return igneCommand(interaction, user, channelID, name, quantity);
-	if (name.toLowerCase().includes('goldemar')) return kgCommand(interaction, user, channelID, name, quantity);
-	if (name.toLowerCase().includes('kalphite king')) return kkCommand(interaction, user, channelID, name, quantity);
+	if (['igne ', 'ignecarus'].some(i => name.toLowerCase().includes(i)))
+		return igneCommand(interaction, user, channelID, name, quantity);
+	if (['kg', 'goldemar'].some(i => name.toLowerCase().includes(i)))
+		return kgCommand(interaction, user, channelID, name, quantity);
+	if (['kk', 'kalphite king'].some(i => name.toLowerCase().includes(i)))
+		return kkCommand(interaction, user, channelID, name, quantity);
 	if (name.toLowerCase().includes('nex')) return nexCommand(interaction, user, channelID, name, quantity);
 	if (name.toLowerCase().includes('moktang')) return moktangCommand(user, channelID, quantity);
 	if (name.toLowerCase().includes('naxxus')) return naxxusCommand(user, channelID, quantity);

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -2,6 +2,7 @@ import { ChatInputCommandInteraction } from 'discord.js';
 import { increaseNumByPercent, reduceNumByPercent, round, Time } from 'e';
 import { Bank } from 'oldschooljs';
 
+import { calcBossFood } from '../../../lib/bso/calcBossFood';
 import { gorajanArcherOutfit, pernixOutfit } from '../../../lib/data/CollectionsExport';
 import { trackLoot } from '../../../lib/lootTrack';
 import { calculateMonsterFood } from '../../../lib/minions/functions';
@@ -10,7 +11,7 @@ import { NexMonster } from '../../../lib/nex';
 import { setupParty } from '../../../lib/party';
 import { MakePartyOptions } from '../../../lib/types';
 import { BossActivityTaskOptions } from '../../../lib/types/minions';
-import { calcBossFood, channelIsSendable, formatDuration, isWeekend } from '../../../lib/util';
+import { channelIsSendable, formatDuration, isWeekend } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import calcDurQty from '../../../lib/util/calcMassDurationQuantity';
 import { getNexGearStats } from '../../../lib/util/getNexGearStats';

--- a/src/tasks/minions/bso/kalphiteKingActivity.ts
+++ b/src/tasks/minions/bso/kalphiteKingActivity.ts
@@ -16,7 +16,6 @@ import { BossActivityTaskOptions } from '../../../lib/types/minions';
 import { getKalphiteKingGearStats } from '../../../lib/util/getKalphiteKingGearStats';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
-import { sendToChannelID } from '../../../lib/util/webhook';
 import { updateBankSetting } from '../../../mahoji/mahojiSettings';
 
 interface KalphiteKingUser {
@@ -175,14 +174,11 @@ export const kalphiteKingTask: MinionTask = {
 
 		if (users.length > 1) {
 			if (Object.values(kcAmounts).length === 0) {
-				sendToChannelID(channelID, {
-					content: `${users
-						.map(id => `<@${id}>`)
-						.join(' ')} Your team all died, and failed to defeat the Kalphite King.`
-				});
-			} else {
-				sendToChannelID(channelID, { content: resultStr });
+				resultStr = `${users
+					.map(id => `<@${id}>`)
+					.join(' ')} Your team all died, and failed to defeat the Kalphite King.`;
 			}
+			handleTripFinish(leaderUser, channelID, resultStr, undefined, data, null);
 		} else {
 			const image = !kcAmounts[userID]
 				? undefined

--- a/src/tasks/minions/bso/kalphiteKingActivity.ts
+++ b/src/tasks/minions/bso/kalphiteKingActivity.ts
@@ -97,7 +97,7 @@ export const kalphiteKingTask: MinionTask = {
 			const { previousCL, itemsAdded } = await user.addItemsToBank({ items: loot, collectionLog: true });
 			const kcToAdd = kcAmounts[user.id];
 			if (kcToAdd) await user.incrementKC(KalphiteKingMonster.id, kcToAdd);
-			const purple = Object.keys(loot).some(id => kalphiteKingCL.includes(parseInt(id)));
+			const purple = Object.keys(loot.bank).some(id => kalphiteKingCL.includes(parseInt(id)));
 
 			const usersTask = await getUsersCurrentSlayerInfo(user.id);
 			const isOnTask =

--- a/src/tasks/minions/bso/nexActivity.ts
+++ b/src/tasks/minions/bso/nexActivity.ts
@@ -9,7 +9,7 @@ import { trackLoot } from '../../../lib/lootTrack';
 import { addMonsterXP } from '../../../lib/minions/functions';
 import announceLoot from '../../../lib/minions/functions/announceLoot';
 import { NexMonster } from '../../../lib/nex';
-import { ItemBank } from '../../../lib/types';
+import { TeamLoot } from '../../../lib/simulation/TeamLoot';
 import { BossActivityTaskOptions } from '../../../lib/types/minions';
 import { roll } from '../../../lib/util';
 import { getNexGearStats } from '../../../lib/util/getNexGearStats';
@@ -29,7 +29,7 @@ export const nexTask: MinionTask = {
 	type: 'Nex',
 	async run(data: BossActivityTaskOptions) {
 		const { channelID, userID, users, quantity, duration } = data;
-		const teamsLoot: { [key: string]: ItemBank } = {};
+		const teamsLoot = new TeamLoot([]);
 		const kcAmounts: { [key: string]: number } = {};
 
 		const parsedUsers: NexUser[] = [];
@@ -79,9 +79,7 @@ export const nexTask: MinionTask = {
 			}
 			const winner = teamTable.roll()?.item;
 			if (!winner) continue;
-			const currentLoot = teamsLoot[winner];
-			if (!currentLoot) teamsLoot[winner] = loot.bank;
-			else teamsLoot[winner] = new Bank().add(currentLoot).add(loot).bank;
+			teamsLoot.add(winner, loot);
 
 			kcAmounts[winner] = Boolean(kcAmounts[winner]) ? ++kcAmounts[winner] : 1;
 		}
@@ -94,7 +92,7 @@ export const nexTask: MinionTask = {
 		let soloPrevCl = new Bank();
 		let soloItemsAdded: Bank = new Bank();
 
-		for (let [userID, loot] of Object.entries(teamsLoot)) {
+		for (let [userID, loot] of teamsLoot.entries()) {
 			const { user } = parsedUsers.find(p => p.id === userID)!;
 			if (!user) continue;
 			let xpStr = '';
@@ -118,7 +116,7 @@ export const nexTask: MinionTask = {
 
 			const kcToAdd = kcAmounts[user.id];
 			if (kcToAdd) await user.incrementKC(NexMonster.id, kcToAdd);
-			const purple = Object.keys(loot).some(id => nexCL.includes(parseInt(id)));
+			const purple = Object.keys(loot.bank).some(id => nexCL.includes(parseInt(id)));
 
 			resultStr += `${purple ? Emoji.Purple : ''} **${user} received:** ||${new Bank(loot)}||\n`;
 
@@ -145,7 +143,7 @@ export const nexTask: MinionTask = {
 			kc: quantity,
 			users: users.map(i => ({
 				id: i,
-				loot: teamsLoot[i] ? new Bank(teamsLoot[i]) : new Bank(),
+				loot: teamsLoot.get(i),
 				duration
 			}))
 		});

--- a/src/tasks/minions/bso/nexActivity.ts
+++ b/src/tasks/minions/bso/nexActivity.ts
@@ -15,7 +15,6 @@ import { roll } from '../../../lib/util';
 import { getNexGearStats } from '../../../lib/util/getNexGearStats';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
-import { sendToChannelID } from '../../../lib/util/webhook';
 import { updateBankSetting } from '../../../mahoji/mahojiSettings';
 
 interface NexUser {
@@ -161,12 +160,9 @@ export const nexTask: MinionTask = {
 
 		if (users.length > 1) {
 			if (Object.values(kcAmounts).length === 0) {
-				sendToChannelID(channelID, {
-					content: `${users.map(id => `<@${id}>`).join(' ')} Your team all died, and failed to defeat Nex.`
-				});
-			} else {
-				sendToChannelID(channelID, { content: resultStr });
+				resultStr = `${users.map(id => `<@${id}>`).join(' ')} Your team all died, and failed to defeat Nex.`;
 			}
+			handleTripFinish(leaderUser, channelID, resultStr, undefined, data, null);
 		} else {
 			const image = !kcAmounts[userID]
 				? undefined


### PR DESCRIPTION
### Description:

This improves Nex the same way KK was a while ago. 

The max kills/trip is 40 with 3 players and with 6+, so its always better to use 3 players, often leaving 1 or 2 people on their own. This fixes that by scaling to up to 6 players, so there are no additional kills per player per hour.

Also fixes repeating nex+kk masses, and makes the kk alias work

### Changes:

- Scales Nex up to 6 players instead of 3.
- Converts Nex to the TeamLoot class
- Adds aliases for KK/KG
- Fixes KK Purples
- Centralizes the bosses' calcFood function
- Removes useless import of KillableMonsters into calcMonsterFood.ts

### Other checks:

-   [x] I have tested all my changes thoroughly.
