### PR TITLE
Castle Wars and LMS leagues task rebalance

### DIFF
--- a/src/lib/leagues/hardTasks.ts
+++ b/src/lib/leagues/hardTasks.ts
@@ -213,9 +213,9 @@ export const hardTasks: Task[] = [
 	},
 	{
 		id: 2024,
-		name: 'Complete 250 Castle Wars games',
+		name: 'Complete 50 Castle Wars games',
 		has: async ({ minigames }) => {
-			return minigames.castle_wars >= 250;
+			return minigames.castle_wars >= 50;
 		}
 	},
 	{
@@ -227,9 +227,9 @@ export const hardTasks: Task[] = [
 	},
 	{
 		id: 2026,
-		name: 'Complete 500 Last Man Standing games',
+		name: 'Complete 150 Last Man Standing games',
 		has: async ({ minigames }) => {
-			return minigames.lms >= 500;
+			return minigames.lms >= 150;
 		}
 	},
 	{


### PR DESCRIPTION
"Complete 250 Castle Wars games" and "Complete 500 Last Man Standing games" are hard tasks that take roughly 80 hours each to complete. Rebalancing these tasks to 50 CW and 150 LMS games make these tasks more inline with a hard task and will take roughly 15 hours each to complete.

Polls and community support:
![Discord_syxHXNtv6c](https://user-images.githubusercontent.com/69014816/201691065-7d01b371-94c5-4875-9656-6bd7653f42cf.png)

https://discord.com/channels/342983479501389826/1032668754561224734/1041519799529914418

![Discord_hXG60JEPdO](https://user-images.githubusercontent.com/69014816/201691196-dfe123e6-67a8-4b35-a99c-e99b1fca2874.png)

https://discord.com/channels/342983479501389826/991426782853070878/1010350082601799730
