### PR TITLE
Revert Cl Adjusted rate for Hammy pet

### DIFF
--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -6,6 +6,7 @@ import { ItemBank } from 'oldschooljs/dist/meta/types';
 import { Events } from '../../lib/constants';
 import { cats } from '../../lib/growablePets';
 import minionIcons from '../../lib/minions/data/minionIcons';
+import { toKMB } from '../../lib/util';
 import { deferInteraction } from '../../lib/util/interactionReply';
 import { parseBank } from '../../lib/util/parseStringBank';
 import { filterOption } from '../lib/mahojiCommandOptions';

--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -2,11 +2,9 @@ import { roll } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
-
 import { Events } from '../../lib/constants';
 import { cats } from '../../lib/growablePets';
 import minionIcons from '../../lib/minions/data/minionIcons';
-import { clAdjustedDroprate, toKMB } from '../../lib/util';
 import { deferInteraction } from '../../lib/util/interactionReply';
 import { parseBank } from '../../lib/util/parseStringBank';
 import { filterOption } from '../lib/mahojiCommandOptions';
@@ -134,9 +132,8 @@ export const sacrificeCommand: OSBMahojiCommand = {
 		}
 
 		let hammyCount = 0;
-		const hammyDroprate = clAdjustedDroprate(user, 'Hammy', 140, 1.175);
 		for (let i = 0; i < Math.floor(totalPrice / 51_530_000); i++) {
-			if (roll(hammyDroprate)) {
+			if (roll(140)) {
 				hammyCount++;
 				break;
 			}

--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -2,6 +2,7 @@ import { roll } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
+
 import { Events } from '../../lib/constants';
 import { cats } from '../../lib/growablePets';
 import minionIcons from '../../lib/minions/data/minionIcons';


### PR DESCRIPTION
### Description:

Removed the clAdjustedRate changes that made Hammy rarer as you had more in CL. This is because such an update doesn't make sense for a sacrifice meme pet with no perk - which is intended to entice players to sacrifice items to get more. Making it increasingly rarer as you sacrifice more and more only removes incentive to Sacrifice items. 

### Changes:

- Reverted sacrifice.ts to the same state as it was when Cyr added the code for Multiple hammy drops. 

### Other checks:

-   [ ] I have tested all my changes thoroughly.
