### PR TITLE
Add pink skirt to buyables

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -901,6 +901,11 @@ const Buyables: Buyable[] = [
 		ironmanPrice: 100
 	},
 	{
+		name: 'Pink skirt',
+		gpCost: 1000,
+		ironmanPrice: 2
+	},
+	{
 		name: 'Bull roarer',
 		gpCost: 1000,
 		ironmanPrice: 100


### PR DESCRIPTION
Pink skirt is used in a stash unit and the only current way to obtain is 1/64 from skeleton mages.

Would be good to have it as a buyable. 

https://oldschool.runescape.wiki/w/Pink_skirt

-   [ ] I have tested all my changes thoroughly.
