### PR TITLE
Remove duplicate entries in /finish

### DIFF
--- a/src/lib/finishables.ts
+++ b/src/lib/finishables.ts
@@ -245,6 +245,7 @@ const monsterPairedCLs = Monsters.map(mon => {
 	const cl = allCollectionLogsFlat.find(c => stringMatches(c.name, mon.name));
 	if (!cl) return null;
 	if (!cl.items.every(id => mon.allItems.includes(id))) return null;
+	if (finishables.find(f => stringMatches(f.name, mon.name))) return null;
 	return {
 		name: mon.name,
 		aliases: mon.aliases,

--- a/src/lib/finishables.ts
+++ b/src/lib/finishables.ts
@@ -245,7 +245,7 @@ const monsterPairedCLs = Monsters.map(mon => {
 	const cl = allCollectionLogsFlat.find(c => stringMatches(c.name, mon.name));
 	if (!cl) return null;
 	if (!cl.items.every(id => mon.allItems.includes(id))) return null;
-	if (finishables.find(f => stringMatches(f.name, mon.name))) return null;
+	if (finishables.some(f => stringMatches(f.name, mon.name))) return null;
 	return {
 		name: mon.name,
 		aliases: mon.aliases,


### PR DESCRIPTION
### Description:

- Remove duplicate entries in /finish when a custom entry overrides a default one.

### Changes:

- Add check to see if monster exists already in finishables before adding the standard monster pair.

### Other checks:

-   [x] I have tested all my changes thoroughly.
