### PR TITLE
Don't always show badges - (2k message limit)

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -190,20 +190,16 @@ export class MUserClass {
 		return usernameCache.get(this.id) ?? this.mention;
 	}
 
-	get badgedUsername() {
-		const rawBadges = this.user.badges.map(num => badges[num]);
-		if (this.isIronman) {
-			rawBadges.push(Emoji.Ironman);
-		}
-		return `${rawBadges.length > 0 ? `${rawBadges.join(' ')} ` : ''}${this.usernameOrMention}`;
-	}
-
-	badgeString() {
+	get badgeString() {
 		const rawBadges = this.user.badges.map(num => badges[num]);
 		if (this.isIronman) {
 			rawBadges.push(Emoji.Ironman);
 		}
 		return rawBadges.join(' ');
+	}
+
+	get badgedUsername() {
+		return `${this.badgeString.length > 0 ? `${this.badgeString} ` : ''}${this.usernameOrMention}`;
 	}
 
 	toString() {

--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -11,7 +11,7 @@ import { mahojiUserSettingsUpdate } from '../mahoji/settingsUpdate';
 import { addXP } from './addXP';
 import { userIsBusy } from './busyCounterCache';
 import { ClueTiers } from './clues/clueTiers';
-import { BitField, PerkTier, projectiles, Roles, usernameCache } from './constants';
+import { badges, BitField, Emoji, PerkTier, projectiles, Roles, usernameCache } from './constants';
 import { allPetIDs } from './data/CollectionsExport';
 import { getSimilarItems } from './data/similarItems';
 import { GearSetup, UserFullGearSetup } from './gear/types';
@@ -188,6 +188,22 @@ export class MUserClass {
 
 	get usernameOrMention() {
 		return usernameCache.get(this.id) ?? this.mention;
+	}
+
+	get badgedUsername() {
+		const rawBadges = this.user.badges.map(num => badges[num]);
+		if (this.isIronman) {
+			rawBadges.push(Emoji.Ironman);
+		}
+		return `${rawBadges.length > 0 ? `${rawBadges.join(' ')} ` : ''}${this.usernameOrMention}`;
+	}
+
+	badgeString() {
+		const rawBadges = this.user.badges.map(num => badges[num]);
+		if (this.isIronman) {
+			rawBadges.push(Emoji.Ironman);
+		}
+		return rawBadges.join(' ');
 	}
 
 	toString() {

--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -199,7 +199,7 @@ export class MUserClass {
 	}
 
 	get badgedUsername() {
-		return `${this.badgeString.length > 0 ? `${this.badgeString} ` : ''}${this.usernameOrMention}`;
+		return `${this.badgeString} ${this.usernameOrMention}`;
 	}
 
 	toString() {

--- a/src/lib/addXP.ts
+++ b/src/lib/addXP.ts
@@ -34,7 +34,7 @@ export async function onMax(user: MUser) {
 	const { normies, irons } = await howManyMaxed();
 
 	const str = `🎉 ${
-		user.usernameOrMention
+		user.badgedUsername
 	}'s minion just achieved level 99 in every skill, they are the **${formatOrdinal(normies)}** minion to be maxed${
 		user.isIronman ? `, and the **${formatOrdinal(irons)}** ironman to max.` : '.'
 	} 🎉`;
@@ -93,7 +93,7 @@ export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 			if (currentXP < XPMilestone && newXP >= XPMilestone) {
 				globalClient.emit(
 					Events.ServerNotification,
-					`${skill.emoji} **${user.usernameOrMention}'s** minion, ${
+					`${skill.emoji} **${user.badgedUsername}'s** minion, ${
 						user.minionName
 					}, just achieved ${newXP.toLocaleString()} XP in ${toTitleCase(params.skillName)}!`
 				);
@@ -111,7 +111,7 @@ export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 			}[]
 		>(`SELECT COUNT(*) FROM users WHERE "skills.${params.skillName}" >= ${LEVEL_99_XP};`);
 
-		let str = `${skill.emoji} **${user.usernameOrMention}'s** minion, ${
+		let str = `${skill.emoji} **${user.badgedUsername}'s** minion, ${
 			user.minionName
 		}, just achieved level 99 in ${skillNameCased}! They are the ${formatOrdinal(
 			parseInt(usersWith.count) + 1

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -425,6 +425,7 @@ export const DISABLED_COMMANDS = new Set<string>();
 export const PVM_METHODS = ['barrage', 'cannon', 'burst', 'none'] as const;
 export type PvMMethod = typeof PVM_METHODS[number];
 export const usernameCache = new Map<string, string>();
+export const badgesCache = new Map<string, string>();
 export const minionBuyButton = new ButtonBuilder()
 	.setCustomId('BUY_MINION')
 	.setLabel('Buy Minion')

--- a/src/lib/minions/functions/announceLoot.ts
+++ b/src/lib/minions/functions/announceLoot.ts
@@ -1,7 +1,6 @@
-import { userMention } from '@discordjs/builders';
 import { Bank } from 'oldschooljs';
 
-import { Events, usernameCache } from '../../constants';
+import { Events } from '../../constants';
 import { ArrayItemsResolved } from '../../types';
 import { minionName } from '../../util/minionUtils';
 import { effectiveMonsters } from '../data/killableMonsters';
@@ -27,13 +26,11 @@ export default async function announceLoot({
 		let notif = '';
 
 		if (team && team.size > 1) {
-			notif = `In ${team.leader.usernameOrMention}'s party of ${team.size} minions killing ${
+			notif = `In ${team.leader.badgedUsername}'s party of ${team.size} minions killing ${
 				effectiveMonsters.find(m => m.id === monsterID)!.name
-			}, **${team.lootRecipient.usernameOrMention}** just received **${itemsToAnnounce}**!`;
+			}, **${team.lootRecipient.badgedUsername}** just received **${itemsToAnnounce}**!`;
 		} else {
-			const username = usernameCache.get(user.id);
-
-			notif = `**${username ?? userMention(user.id)}'s** minion, ${minionName(
+			notif = `**${user.badgedUsername}'s** minion, ${minionName(
 				user
 			)}, just received **${itemsToAnnounce}**, their ${
 				effectiveMonsters.find(m => m.id === monsterID)!.name

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -91,7 +91,7 @@ for (const clueTier of ClueTiers) {
 			if (announcedLoot.length > 0) {
 				globalClient.emit(
 					Events.ServerNotification,
-					`**${user.usernameOrMention}'s** minion, ${user.minionName}, just opened their ${formatOrdinal(
+					`**${user.badgedUsername}'s** minion, ${user.minionName}, just opened their ${formatOrdinal(
 						nthCasket
 					)} ${clueTier.name} casket and received **${announcedLoot}**!`
 				);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -595,7 +595,7 @@ export function getBadges(user: MUser | string | bigint) {
 	if (typeof user === 'string' || typeof user === 'bigint') {
 		return badgesCache.get(user.toString()) ?? '';
 	}
-	return user.badgeString();
+	return user.badgeString;
 }
 
 export function getUsername(id: string | bigint, withBadges: boolean = true) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -32,7 +32,7 @@ import Items from 'oldschooljs/dist/structures/Items';
 import { bool, integer, MersenneTwister19937, nodeCrypto, real, shuffle } from 'random-js';
 
 import { production, SupportServer } from '../config';
-import { skillEmoji, usernameCache } from './constants';
+import { badgesCache, skillEmoji, usernameCache } from './constants';
 import { DefenceGearStat, GearSetupType, GearSetupTypes, GearStat, OffenceGearStat } from './gear/types';
 import { Consumable } from './minions/types';
 import { MUserClass } from './MUser';
@@ -591,8 +591,17 @@ export function skillingPetDropRate(
 	return { petDropRate: dropRate };
 }
 
-export function getUsername(id: string | bigint) {
-	return usernameCache.get(id.toString()) ?? 'Unknown';
+export function getBadges(user: MUser | string | bigint) {
+	if (typeof user === 'string' || typeof user === 'bigint') {
+		return badgesCache.get(user.toString()) ?? '';
+	}
+	return user.badgeString();
+}
+
+export function getUsername(id: string | bigint, withBadges: boolean = true) {
+	let username = usernameCache.get(id.toString()) ?? 'Unknown';
+	if (withBadges) username = `${getBadges(id)} ${username}`;
+	return username;
 }
 
 export function shuffleRandom<T>(input: number, arr: readonly T[]): T[] {

--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -2,7 +2,7 @@ import { Embed } from '@discordjs/builders';
 import { chunk } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
-import { badges, Emoji, usernameCache } from '../../lib/constants';
+import { badges, badgesCache, Emoji, usernameCache } from '../../lib/constants';
 import { allClNames, getCollectionItems } from '../../lib/data/Collections';
 import { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
 import { allOpenables } from '../../lib/openables';
@@ -453,15 +453,15 @@ export async function cacheUsernames() {
 
 	for (const user of allNewUsers) {
 		const badgeUser = arrayOfIronmenAndBadges.find(i => i.id === user.id);
-		let name = stripEmojis(user.username!);
+		const name = stripEmojis(user.username!);
+		usernameCache.set(user.id, name);
 		if (badgeUser) {
 			const rawBadges = badgeUser.badges.map(num => badges[num]);
 			if (badgeUser.ironman) {
 				rawBadges.push(Emoji.Ironman);
 			}
-			name = `${rawBadges.join(' ')} ${name}`;
+			badgesCache.set(user.id, rawBadges.join(' '));
 		}
-		usernameCache.set(user.id, name);
 	}
 }
 

--- a/src/mahoji/commands/mass.ts
+++ b/src/mahoji/commands/mass.ts
@@ -89,7 +89,7 @@ export const massCommand: OSBMahojiCommand = {
 				minSize: 2,
 				maxSize: 10,
 				ironmanAllowed: false,
-				message: `${user.usernameOrMention} is doing a ${monster.name} mass! Use the buttons below to join/leave.`,
+				message: `${user.badgedUsername} is doing a ${monster.name} mass! Use the buttons below to join/leave.`,
 				customDenier: async user => {
 					if (!user.user.minion_hasBought) {
 						return [true, "you don't have a minion."];

--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -84,7 +84,7 @@ export async function getUserInfo(user: MUser) {
 	};
 	return {
 		...result,
-		everythingString: `${user.usernameOrMention}[${user.id}]
+		everythingString: `${user.badgedUsername}[${user.id}]
 **Perk Tier:** ${result.perkTier}
 **Blacklisted:** ${result.isBlacklisted}
 **Badges:** ${result.badges.join(' ')}

--- a/src/mahoji/commands/offer.ts
+++ b/src/mahoji/commands/offer.ts
@@ -37,7 +37,7 @@ function notifyUniques(user: MUser, activity: string, uniques: number[], loot: B
 	if (itemsToAnnounce.length > 0) {
 		globalClient.emit(
 			Events.ServerNotification,
-			`**${user.usernameOrMention}'s** minion, ${
+			`**${user.badgedUsername}'s** minion, ${
 				user.minionName
 			}, while offering ${qty}x ${activity}, found **${itemsToAnnounce}**${
 				randQty ? ` on their ${formatOrdinal(randQty)} offering!` : '!'

--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -89,7 +89,7 @@ export const sacrificeCommand: OSBMahojiCommand = {
 
 			await handleMahojiConfirmation(
 				interaction,
-				`${user.usernameOrMention}.. are you sure you want to sacrifice your ${item.name}${
+				`${user.badgedUsername}.. are you sure you want to sacrifice your ${item.name}${
 					bankToSac.length > 1 ? 's' : ''
 				} for ${deathRunes} death runes? *Note: These are cute, fluffy little cats.*`
 			);
@@ -103,7 +103,7 @@ export const sacrificeCommand: OSBMahojiCommand = {
 				totalCatsSacrificed += sacBank.amount(cat);
 			}
 
-			return `${user.usernameOrMention}, you sacrificed ${bankToSac} and received ${loot}. You've sacrificed ${totalCatsSacrificed} cats.`;
+			return `${user.badgedUsername}, you sacrificed ${bankToSac} and received ${loot}. You've sacrificed ${totalCatsSacrificed} cats.`;
 		}
 
 		let totalPrice = 0;
@@ -120,7 +120,7 @@ export const sacrificeCommand: OSBMahojiCommand = {
 		await user.removeItemsFromBank(bankToSac);
 
 		if (totalPrice > 200_000_000) {
-			globalClient.emit(Events.ServerNotification, `${user.usernameOrMention} just sacrificed ${bankToSac}!`);
+			globalClient.emit(Events.ServerNotification, `${user.badgedUsername} just sacrificed ${bankToSac}!`);
 		}
 
 		const { newUser } = await user.update({
@@ -144,7 +144,7 @@ export const sacrificeCommand: OSBMahojiCommand = {
 					str += `\n\nYou have now unlocked the **${icon.name}** minion icon!`;
 					globalClient.emit(
 						Events.ServerNotification,
-						`**${user.usernameOrMention}** just unlocked the ${icon.emoji} icon for their minion.`
+						`**${user.badgedUsername}** just unlocked the ${icon.emoji} icon for their minion.`
 					);
 					break;
 				}

--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -197,7 +197,7 @@ export async function barbAssaultGambleCommand(
 
 		globalClient.emit(
 			Events.ServerNotification,
-			`<:Pet_penance_queen:324127377649303553> **${user.usernameOrMention}'s** minion, ${
+			`<:Pet_penance_queen:324127377649303553> **${user.badgedUsername}'s** minion, ${
 				user.minionName
 			}, just received a Pet penance queen from their ${formatOrdinal(
 				newUser.high_gambles

--- a/src/mahoji/lib/abstracted_commands/capegamble.ts
+++ b/src/mahoji/lib/abstracted_commands/capegamble.ts
@@ -43,7 +43,7 @@ export async function capeGambleCommand(user: MUser, type: string, interaction: 
 		await user.addItemsToBank({ items: new Bank().add(pet.id), collectionLog: true });
 		globalClient.emit(
 			Events.ServerNotification,
-			`**${user.usernameOrMention}'s** just received their ${formatOrdinal(
+			`**${user.badgedUsername}'s** just received their ${formatOrdinal(
 				(await mUserFetch(user.id)).cl.amount(pet.id)
 			)} ${pet.name} pet by sacrificing a ${item.name} for the ${formatOrdinal(newSacrificedCount)} time!`
 		);

--- a/src/mahoji/lib/abstracted_commands/dailyCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/dailyCommand.ts
@@ -158,7 +158,7 @@ export async function dailyCommand(
 
 	await buttons.render({
 		messageOptions: {
-			content: `**${Emoji.Diango} Diango asks ${user.usernameOrMention}...** ${question.question}`
+			content: `**${Emoji.Diango} Diango asks ${user.badgedUsername}...** ${question.question}`
 		},
 		isBusy: false
 	});

--- a/src/mahoji/lib/abstracted_commands/diceCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/diceCommand.ts
@@ -47,7 +47,7 @@ export async function diceCommand(user: MUser, interaction: ChatInputCommandInte
 		await user.removeItemsFromBank(new Bank().add('Coins', amount));
 	}
 
-	return `${user.usernameOrMention} rolled **${roll}** on the percentile dice, and you ${
+	return `${user.badgedUsername} rolled **${roll}** on the percentile dice, and you ${
 		won ? 'won' : 'lost'
 	} ${Util.toKMB(amountToAdd)} GP.`;
 }

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -84,12 +84,12 @@ export async function duelCommand(
 		await duelTargetUser.removeItemsFromBank(b);
 
 		await duelMessage
-			.edit(`${duelTargetUser.usernameOrMention} accepted the duel. You both enter the duel arena...`)
+			.edit(`${duelTargetUser.badgedUsername} accepted the duel. You both enter the duel arena...`)
 			.catch(noOp);
 
 		await sleep(2000);
 		await duelMessage
-			.edit(`${duelSourceUser.usernameOrMention} and ${duelTargetUser.usernameOrMention} begin fighting...`)
+			.edit(`${duelSourceUser.badgedUsername} and ${duelTargetUser.badgedUsername} begin fighting...`)
 			.catch(noOp);
 
 		const [winner, loser] =
@@ -121,9 +121,9 @@ export async function duelCommand(
 		if (amount >= 1_000_000_000) {
 			globalClient.emit(
 				Events.ServerNotification,
-				`${Emoji.MoneyBag} **${winner.usernameOrMention}** just won a **${Util.toKMB(
+				`${Emoji.MoneyBag} **${winner.badgedUsername}** just won a **${Util.toKMB(
 					winningAmount
-				)}** GP duel against ${loser.usernameOrMention}.`
+				)}** GP duel against ${loser.badgedUsername}.`
 			);
 		}
 
@@ -133,7 +133,7 @@ export async function duelCommand(
 		);
 
 		duelMessage.edit(
-			`Congratulations ${winner.usernameOrMention}! You won ${Util.toKMB(winningAmount)}, and paid ${Util.toKMB(
+			`Congratulations ${winner.badgedUsername}! You won ${Util.toKMB(winningAmount)}, and paid ${Util.toKMB(
 				tax
 			)} tax.`
 		);

--- a/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
@@ -295,7 +295,7 @@ export async function shootingStarsActivity(data: ShootingStarsData) {
 		str += "\nYou have a funny feeling you're being followed...";
 		globalClient.emit(
 			Events.ServerNotification,
-			`${Emoji.Mining} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received ${
+			`${Emoji.Mining} **${user.badgedUsername}'s** minion, ${user.minionName}, just received ${
 				loot.amount('Rock golem') > 1 ? `${loot.amount('Rock golem')}x ` : 'a'
 			} Rock golem while mining a fallen Shooting Star at level ${userMiningLevel} Mining!`
 		);

--- a/src/mahoji/lib/preCommand.ts
+++ b/src/mahoji/lib/preCommand.ts
@@ -1,7 +1,7 @@
 import { InteractionReplyOptions, TextChannel, User } from 'discord.js';
 
 import { modifyBusyCounter } from '../../lib/busyCounterCache';
-import { badges, Emoji, usernameCache } from '../../lib/constants';
+import { badges, badgesCache, Emoji, usernameCache } from '../../lib/constants';
 import { prisma } from '../../lib/settings/prisma';
 import { removeMarkdownEmojis, stripEmojis } from '../../lib/util';
 import { CACHED_ACTIVE_USER_IDS } from '../../lib/util/cachedUserIDs';
@@ -30,13 +30,12 @@ export async function syncNewUserUsername(user: MUser, username: string) {
 		});
 	}
 	let name = stripEmojis(username);
+	usernameCache.set(user.id, name);
 	const rawBadges = user.user.badges.map(num => badges[num]);
 	if (user.isIronman) {
 		rawBadges.push(Emoji.Ironman);
 	}
-	name = `${rawBadges.join(' ')} ${name}`;
-
-	usernameCache.set(user.id, name);
+	badgesCache.set(user.id, rawBadges.join(' '));
 }
 
 export async function preCommand({

--- a/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
+++ b/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
@@ -143,7 +143,7 @@ export const aerialFishingTask: MinionTask = {
 			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
-				`${Emoji.Fishing} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a **Heron** while Aerial fishing at level ${currentFishLevel} Fishing!`
+				`${Emoji.Fishing} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a **Heron** while Aerial fishing at level ${currentFishLevel} Fishing!`
 			);
 		}
 

--- a/src/tasks/minions/darkAltarActivity.ts
+++ b/src/tasks/minions/darkAltarActivity.ts
@@ -80,7 +80,7 @@ export const darkAltarTask: MinionTask = {
 			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}'s** minion, ${
+				`**${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a Rift guardian while crafting ${runeData.item.name}s at level ${user.skillLevel(
 					SkillsEnum.Runecraft

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -355,7 +355,7 @@ export const farmingTask: MinionTask = {
 				infoStr.push('```');
 				globalClient.emit(
 					Events.ServerNotification,
-					`${Emoji.Farming} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Tangleroot while farming ${patchType.lastPlanted} at level ${currentFarmingLevel} Farming!`
+					`${Emoji.Farming} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a Tangleroot while farming ${patchType.lastPlanted} at level ${currentFarmingLevel} Farming!`
 				);
 			}
 

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -189,7 +189,7 @@ export const fishingTask: MinionTask = {
 					str += "\nYou have a funny feeling you're being followed...";
 					globalClient.emit(
 						Events.ServerNotification,
-						`${Emoji.Fishing} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Heron while fishing ${fish.name} at level ${currentLevel} Fishing!`
+						`${Emoji.Fishing} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a Heron while fishing ${fish.name} at level ${currentLevel} Fishing!`
 					);
 				}
 			}

--- a/src/tasks/minions/gloryChargingActivity.ts
+++ b/src/tasks/minions/gloryChargingActivity.ts
@@ -42,7 +42,7 @@ export const gloryChargingTask: MinionTask = {
 			str += '\n**Your minion received an Amulet of eternal glory.**';
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}'s** minion, ${user.minionName}, just received **${loot.amount(
+				`**${user.badgedUsername}'s** minion, ${user.minionName}, just received **${loot.amount(
 					'Amulet of eternal glory'
 				)}x Amulet of eternal glory**!`
 			);

--- a/src/tasks/minions/minigames/agilityArenaActivity.ts
+++ b/src/tasks/minions/minigames/agilityArenaActivity.ts
@@ -57,7 +57,7 @@ export const agilityArenaTask: MinionTask = {
 				str += "**\nYou have a funny feeling you're being followed...**";
 				globalClient.emit(
 					Events.ServerNotification,
-					`${Emoji.Agility} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Giant squirrel while running at the Agility Arena at level ${currentLevel} Agility!`
+					`${Emoji.Agility} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a Giant squirrel while running at the Agility Arena at level ${currentLevel} Agility!`
 				);
 			}
 		}

--- a/src/tasks/minions/minigames/fightCavesActivity.ts
+++ b/src/tasks/minions/minigames/fightCavesActivity.ts
@@ -127,7 +127,7 @@ export const fightCavesTask: MinionTask = {
 		if (loot.has('Tzrek-jad')) {
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}** just received their ${formatOrdinal(user.cl.amount('Tzrek-jad') + 1)} ${
+				`**${user.badgedUsername}** just received their ${formatOrdinal(user.cl.amount('Tzrek-jad') + 1)} ${
 					Emoji.TzRekJad
 				} TzRek-jad pet by killing TzTok-Jad, on their ${formatOrdinal(user.getKC(TzTokJad.id))} kill!`
 			);
@@ -136,7 +136,7 @@ export const fightCavesTask: MinionTask = {
 		if (user.cl.amount('Fire cape') === 0) {
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}** just received their first Fire cape on their ${formatOrdinal(
+				`**${user.badgedUsername}** just received their first Fire cape on their ${formatOrdinal(
 					newUser.stats_fightCavesAttempts
 				)} attempt!`
 			);

--- a/src/tasks/minions/minigames/gauntletActivity.ts
+++ b/src/tasks/minions/minigames/gauntletActivity.ts
@@ -58,7 +58,7 @@ export const gauntletTask: MinionTask = {
 			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}'s** minion, ${
+				`**${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a **Youngllef** <:Youngllef:604670894798798858> while doing the ${name} for the ${formatOrdinal(
 					newKc

--- a/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
+++ b/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
@@ -162,7 +162,7 @@ export const guardiansOfTheRiftTask: MinionTask = {
 			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}'s** minion, ${
+				`**${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a Abyssal Protector while doing the Guardians of the Rift minigame at level ${user.skillLevel(
 					SkillsEnum.Runecraft

--- a/src/tasks/minions/minigames/infernoActivity.ts
+++ b/src/tasks/minions/minigames/infernoActivity.ts
@@ -164,7 +164,7 @@ export const infernoTask: MinionTask = {
 			if (baseBank.has('Jal-nib-rek')) {
 				globalClient.emit(
 					Events.ServerNotification,
-					`**${user.usernameOrMention}** just received their ${formatOrdinal(
+					`**${user.badgedUsername}** just received their ${formatOrdinal(
 						user.cl.amount('Jal-nib-rek') + 1
 					)} Jal-nib-rek pet by killing TzKal-Zuk, on their ${formatOrdinal(
 						await getMinigameScore(user.id, 'inferno')
@@ -176,7 +176,7 @@ export const infernoTask: MinionTask = {
 				const usersWithInfernalCape = await countUsersWithItemInCl(itemID('Infernal cape'), false);
 				globalClient.emit(
 					Events.ServerNotification,
-					`**${user.usernameOrMention}** just received their first Infernal cape on their ${formatOrdinal(
+					`**${user.badgedUsername}** just received their first Infernal cape on their ${formatOrdinal(
 						user.user.inferno_attempts
 					)} attempt! They are the ${formatOrdinal(
 						usersWithInfernalCape + 1

--- a/src/tasks/minions/minigames/plunderActivity.ts
+++ b/src/tasks/minions/minigames/plunderActivity.ts
@@ -47,7 +47,7 @@ export const plunderTask: MinionTask = {
 			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}'s** minion, ${
+				`**${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a **Rocky** <:Rocky:324127378647285771> while doing the Pyramid Plunder, their Thieving level is ${user.skillLevel(
 					SkillsEnum.Thieving

--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -129,7 +129,7 @@ export const raidsTask: MinionTask = {
 				const itemsToAnnounce = itemsAdded.filter(item => purpleItems.includes(item.id), false);
 				globalClient.emit(
 					Events.ServerNotification,
-					`${emote} ${user.usernameOrMention} just received **${itemsToAnnounce}** on their ${formatOrdinal(
+					`${emote} ${user.badgedUsername} just received **${itemsToAnnounce}** on their ${formatOrdinal(
 						await getMinigameScore(user.id, minigameID)
 					)} raid.`
 				);

--- a/src/tasks/minions/minigames/temporossActivity.ts
+++ b/src/tasks/minions/minigames/temporossActivity.ts
@@ -29,7 +29,7 @@ export const temporossTask: MinionTask = {
 		if (loot.has('Tiny tempor')) {
 			globalClient.emit(
 				Events.ServerNotification,
-				`${Emoji.TinyTempor} **${user.usernameOrMention}'s** minion, ${
+				`${Emoji.TinyTempor} **${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a Tiny tempor! They got the pet on the ${formatOrdinal(
 					kcForPet

--- a/src/tasks/minions/minigames/titheFarmActivity.ts
+++ b/src/tasks/minions/minigames/titheFarmActivity.ts
@@ -100,7 +100,7 @@ export const titheFarmTask: MinionTask = {
 			lootStr.push('```');
 			globalClient.emit(
 				Events.ServerNotification,
-				`${Emoji.Farming} **${user.usernameOrMention}'s** minion, ${
+				`${Emoji.Farming} **${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a Tangleroot by completing the ${Emoji.MinigameIcon} Tithe Farm on their ${
 					titheFarmsCompleted + 1

--- a/src/tasks/minions/minigames/tobActivity.ts
+++ b/src/tasks/minions/minigames/tobActivity.ts
@@ -120,7 +120,7 @@ Unique chance: ${result.percentChanceOfUnique.toFixed(2)}% (1 in ${convertPercen
 				globalClient.emit(
 					Events.ServerNotification,
 					`${Emoji.Purple} ${
-						user.usernameOrMention
+						user.badgedUsername
 					} just received **${itemsToAnnounce}** on their ${formatOrdinal(
 						await getMinigameScore(user.id, minigameID)
 					)} raid.`

--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -66,7 +66,7 @@ export const wintertodtTask: MinionTask = {
 		if (loot.has('Phoenix')) {
 			globalClient.emit(
 				Events.ServerNotification,
-				`${Emoji.Phoenix} **${user.usernameOrMention}'s** minion, ${
+				`${Emoji.Phoenix} **${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a Phoenix! Their Wintertodt KC is ${
 					(await getMinigameScore(user.id, 'wintertodt')) + quantity

--- a/src/tasks/minions/minigames/zalcanoActivity.ts
+++ b/src/tasks/minions/minigames/zalcanoActivity.ts
@@ -50,7 +50,7 @@ export const zalcanoTask: MinionTask = {
 		if (loot.amount('Smolcano') > 0) {
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}'s** minion, ${
+				`**${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received **Smolcano**, their Zalcano KC is ${randInt(kc || 1, (kc || 1) + quantity)}!`
 			);

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -64,7 +64,7 @@ export const miningTask: MinionTask = {
 				str += "\nYou have a funny feeling you're being followed...";
 				globalClient.emit(
 					Events.ServerNotification,
-					`${Emoji.Mining} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Rock golem while mining ${ore.name} at level ${currentLevel} Mining!`
+					`${Emoji.Mining} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a Rock golem while mining ${ore.name} at level ${currentLevel} Mining!`
 				);
 			}
 		}

--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -122,7 +122,7 @@ export const pickpocketTask: MinionTask = {
 			str += "\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
-				`**${user.usernameOrMention}'s** minion, ${
+				`**${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a **Rocky** <:Rocky:324127378647285771> while ${
 					obj.type === 'pickpockable' ? 'pickpocketing' : 'stealing'

--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -71,7 +71,7 @@ export const runecraftTask: MinionTask = {
 			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
-				`${Emoji.Runecraft} **${user.usernameOrMention}'s** minion, ${
+				`${Emoji.Runecraft} **${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a Rift guardian while crafting ${rune.name}s at level ${user.skillLevel(
 					SkillsEnum.Runecraft

--- a/src/tasks/minions/volcanicMineActivity.ts
+++ b/src/tasks/minions/volcanicMineActivity.ts
@@ -86,7 +86,7 @@ export const vmTask: MinionTask = {
 			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
-				`${Emoji.Mining} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received ${
+				`${Emoji.Mining} **${user.badgedUsername}'s** minion, ${user.minionName}, just received ${
 					loot.amount('Rock golem') > 1 ? `${loot.amount('Rock golem')}x ` : 'a'
 				} Rock golem while mining on the Volcanic Mine at level ${userMiningLevel} Mining!`
 			);

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -81,7 +81,7 @@ export const woodcuttingTask: MinionTask = {
 				str += "\n**You have a funny feeling you're being followed...**";
 				globalClient.emit(
 					Events.ServerNotification,
-					`${Emoji.Woodcutting} **${user.usernameOrMention}'s** minion, ${
+					`${Emoji.Woodcutting} **${user.badgedUsername}'s** minion, ${
 						user.minionName
 					}, just received a Beaver while cutting ${log.name} at level ${user.skillLevel(
 						'woodcutting'


### PR DESCRIPTION
### Changes

- This removes showing badges from mass texts.
- Still shows on leaderboard
- Still shows on notifications

### Description

- Badges in trip send/return text for masses can cause it to quickly exceed the 2k limit, as badges (emojis) often have 30+ characters per emoji, and users can have several of them.
- They also get in the way of mass-descriptions, when text is already not the easiest to read. They cause the text to appear to be split up in a way that is not always accurate.
-  Badges are important whenever the focus is that player, and I believe I have upheld that standard.

### Other checks:

-   [x] I have tested all my changes thoroughly.
