### PR TITLE
Deepscan fixes

### DIFF
--- a/src/mahoji/lib/abstracted_commands/alchCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/alchCommand.ts
@@ -78,7 +78,7 @@ export async function alchCommand(
 		'Nature rune': quantity
 	});
 	let speed = speedInput ? clamp(speedInput, 1, 5) : null;
-	if (speed && !isNaN(speed) && typeof speed === 'number' && speed > 1 && speed < 6) {
+	if (speed && speed > 1 && speed < 6) {
 		consumedItems.multiply(speed);
 		consumedItems.add('Nature rune', Math.floor(consumedItems.amount('Nature rune') * 0.5));
 		duration /= speed;

--- a/src/mahoji/lib/abstracted_commands/sawmillCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/sawmillCommand.ts
@@ -62,7 +62,7 @@ export async function sawmillCommand(
 
 	let cost = plank!.gpCost * 2 * quantity;
 
-	if (speed && !isNaN(speed) && typeof speed === 'number' && speed > 1 && speed < 6) {
+	if (speed && speed > 1 && speed < 6) {
 		cost += Math.ceil(cost * (speed * ((speed + 0.2) / 6)));
 		duration /= speed;
 	}


### PR DESCRIPTION
### Description:

Fixes the Deepscan issues flagging my other PR -.-

### Changes:

- When a number is truthy, then it is always a number vs NaN, so !NaN is always true.
- Since the variable, `speed` can only be `number | undefined`, if (speed) is truthy, then it can't be undefined, so it can only be a number, thus `typeof speed === 'number'` is redundant.

### Other checks:

-   [x] I have tested all my changes thoroughly.
