### PR TITLE
Fix /tools user temp_cl reset:True

### DIFF
--- a/src/mahoji/commands/tools.ts
+++ b/src/mahoji/commands/tools.ts
@@ -779,7 +779,7 @@ export const toolsCommand: OSBMahojiCommand = {
 			}
 		}
 		if (options.user?.temp_cl) {
-			if (options.user.temp_cl === true) {
+			if (options.user.temp_cl.reset === true) {
 				await handleMahojiConfirmation(interaction, 'Are you sure you want to reset your temporary CL?');
 				await mahojiUser.update({
 					temp_cl: {},


### PR DESCRIPTION
### Description:

Temp CL Reset not working

### Changes:

- Fixes the command so it checks temp_cl.reset === true, instead of temp_cl.

### Other checks:

-   [ ] I have tested all my changes thoroughly.
