### PR TITLE
Allow quantity to be specified on Collect command

### DIFF
--- a/src/mahoji/commands/activities.ts
+++ b/src/mahoji/commands/activities.ts
@@ -124,6 +124,13 @@ export const activitiesCommand: OSBMahojiCommand = {
 					required: true
 				},
 				{
+					type: ApplicationCommandOptionType.Integer,
+					name: 'quantity',
+					description: 'The quantity of collecting trips you wish to make.',
+					required: false,
+					min_value: 1
+				},
+				{
 					type: ApplicationCommandOptionType.Boolean,
 					name: 'no_stams',
 					description: "Enable if you don't want to use stamina potions when collecting.",
@@ -431,7 +438,7 @@ export const activitiesCommand: OSBMahojiCommand = {
 		chompy_hunt?: { action: 'start' | 'claim' };
 		champions_challenge?: {};
 		warriors_guild?: { action: string; quantity?: number };
-		collect?: { item: string; no_stams?: boolean };
+		collect?: { item: string; quantity?: number; no_stams?: boolean };
 		quest?: {};
 		favour?: { name?: string; no_stams?: boolean };
 		decant?: { potion_name: string; dose?: number };
@@ -489,7 +496,13 @@ export const activitiesCommand: OSBMahojiCommand = {
 			);
 		}
 		if (options.collect) {
-			return collectCommand(user, channelID, options.collect.item, options.collect.no_stams);
+			return collectCommand(
+				user,
+				channelID,
+				options.collect.item,
+				options.collect.quantity,
+				options.collect.no_stams
+			);
 		}
 		if (options.quest) {
 			return questCommand(user, channelID);

--- a/src/mahoji/lib/abstracted_commands/collectCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/collectCommand.ts
@@ -136,7 +136,13 @@ export const collectables: Collectable[] = [
 	}
 ];
 
-export async function collectCommand(user: MUser, channelID: string, objectName: string, no_stams?: boolean) {
+export async function collectCommand(
+	user: MUser,
+	channelID: string,
+	objectName: string,
+	quantity?: number,
+	no_stams?: boolean
+) {
 	const collectable = collectables.find(c => stringMatches(c.item.name, objectName));
 	if (!collectable) {
 		return `That's not something your minion can collect, you can collect these things: ${collectables
@@ -161,8 +167,9 @@ export async function collectCommand(user: MUser, channelID: string, objectName:
 		no_stams = false;
 	}
 
-	const quantity = Math.floor(maxTripLength / collectable.duration);
-
+	if (!quantity) {
+		quantity = Math.floor(maxTripLength / collectable.duration);
+	}
 	let duration = collectable.duration * quantity;
 	if (duration > maxTripLength) {
 		return `${user.minionName} can't go on a trip longer than ${formatDuration(


### PR DESCRIPTION
Pre slash commands you used to be able to specify the quantity of trips, this got lost when moved to slash.

This PR adds the ability to specify quantity again.

-   [x] I have tested all my changes thoroughly.
