### PR TITLE
Fix NodeJS Freezes in test bot from Canvas

### DIFF
--- a/src/lib/bankImage.ts
+++ b/src/lib/bankImage.ts
@@ -16,7 +16,7 @@ import { BankBackground, FlagMap, Flags } from '../lib/minions/types';
 import { BankSortMethod, BankSortMethods, sorts } from '../lib/sorts';
 import { ItemBank } from '../lib/types';
 import { addArrayOfNumbers, cleanString, formatItemStackQuantity, generateHexColorForCashStack } from '../lib/util';
-import { drawImageWithOutline, fillTextXTimesInCtx, getClippedRegion } from '../lib/util/canvasUtil';
+import { createCanvas, drawImageWithOutline, fillTextXTimesInCtx, getClippedRegion } from '../lib/util/canvasUtil';
 import itemID from '../lib/util/itemID';
 import { logError } from '../lib/util/logError';
 import { UserError } from './UserError';
@@ -602,7 +602,7 @@ class BankImageTask {
 
 		const useSmallBank = user ? (hasBgSprite ? true : user.bitfield.includes(BitField.AlwaysSmallBank)) : true;
 
-		const canvas = new Canvas(width, useSmallBank ? canvasHeight : Math.max(331, canvasHeight));
+		const canvas = createCanvas(width, useSmallBank ? canvasHeight : Math.max(331, canvasHeight));
 
 		let resizeBg = -1;
 		if (!wide && !useSmallBank && !isTransparent && actualBackground && canvasHeight > 331) {

--- a/src/lib/collectionLogTask.ts
+++ b/src/lib/collectionLogTask.ts
@@ -1,12 +1,12 @@
 import { User } from '@prisma/client';
 import { calcWhatPercent, objectEntries } from 'e';
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
-import { Canvas, CanvasRenderingContext2D } from 'skia-canvas/lib';
+import { CanvasRenderingContext2D } from 'skia-canvas/lib';
 
 import { allCollectionLogs, getCollection, getTotalCl } from '../lib/data/Collections';
 import { IToReturnCollection } from '../lib/data/CollectionsExport';
 import { formatItemStackQuantity, generateHexColorForCashStack, toKMB } from '../lib/util';
-import { fillTextXTimesInCtx, getClippedRegion } from '../lib/util/canvasUtil';
+import { createCanvas, fillTextXTimesInCtx, getClippedRegion } from '../lib/util/canvasUtil';
 import getOSItem from '../lib/util/getOSItem';
 import { IBgSprite } from './bankImage';
 
@@ -75,7 +75,7 @@ class CollectionLogTask {
 		};
 
 		// Create base canvas
-		const canvasList = new Canvas(200, leftHeight);
+		const canvasList = createCanvas(200, leftHeight);
 		// Get the canvas context
 		const ctxl = canvasList.getContext('2d');
 		ctxl.font = '16px OSRSFontCompact';
@@ -195,7 +195,7 @@ class CollectionLogTask {
 		);
 
 		// Create base canvas
-		const canvas = new Canvas(canvasWidth, canvasHeight);
+		const canvas = createCanvas(canvasWidth, canvasHeight);
 		// Get the canvas context
 		const ctx = canvas.getContext('2d');
 		ctx.font = '16px OSRSFontCompact';

--- a/src/lib/gear/functions/generateGearImage.ts
+++ b/src/lib/gear/functions/generateGearImage.ts
@@ -4,7 +4,13 @@ import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 import { Canvas } from 'skia-canvas/lib';
 
 import { Gear, maxDefenceStats, maxOffenceStats } from '../../structures/Gear';
-import { canvasImageFromBuffer, drawItemQuantityText, drawTitleText, fillTextXTimesInCtx } from '../../util/canvasUtil';
+import {
+	canvasImageFromBuffer,
+	createCanvas,
+	drawItemQuantityText,
+	drawTitleText,
+	fillTextXTimesInCtx
+} from '../../util/canvasUtil';
 import { toTitleCase } from '../../util/toTitleCase';
 import { GearSetup, GearSetupType, GearSetupTypes } from '../types';
 
@@ -86,7 +92,7 @@ export async function generateGearImage(
 
 	const gearStats = gearSetup instanceof Gear ? gearSetup.stats : new Gear(gearSetup).stats;
 	const gearTemplateImage = await canvasImageFromBuffer(gearTemplateFile);
-	const canvas = new Canvas(gearTemplateImage.width, gearTemplateImage.height);
+	const canvas = createCanvas(gearTemplateImage.width, gearTemplateImage.height);
 	const ctx = canvas.getContext('2d');
 	ctx.imageSmoothingEnabled = false;
 
@@ -246,7 +252,7 @@ export async function generateAllGearImage(user: MUser) {
 	const hexColor = user.user.bank_bg_hex;
 
 	const gearTemplateImage = await canvasImageFromBuffer(gearTemplateCompactFile);
-	const canvas = new Canvas((gearTemplateImage.width + 10) * 4 + 20, Number(gearTemplateImage.height) * 2 + 70);
+	const canvas = createCanvas((gearTemplateImage.width + 10) * 4 + 20, Number(gearTemplateImage.height) * 2 + 70);
 	const ctx = canvas.getContext('2d');
 	ctx.imageSmoothingEnabled = false;
 

--- a/src/lib/pohImage.ts
+++ b/src/lib/pohImage.ts
@@ -5,7 +5,7 @@ import { Canvas, CanvasRenderingContext2D, Image } from 'skia-canvas/lib';
 
 import { DUNGEON_FLOOR_Y, GROUND_FLOOR_Y, HOUSE_WIDTH, Placeholders, TOP_FLOOR_Y } from './poh';
 import { getActivityOfUser } from './settings/settings';
-import { canvasImageFromBuffer } from './util/canvasUtil';
+import { canvasImageFromBuffer, createCanvas } from './util/canvasUtil';
 import { PlayerOwnedHouse } from '.prisma/client';
 
 const CONSTRUCTION_IMG_DIR = './src/lib/poh/images';
@@ -52,7 +52,7 @@ class PoHImage {
 
 	generateCanvas(bgId: number): [Canvas, CanvasRenderingContext2D] {
 		const bgImage = this.bgImages[bgId - 1]!;
-		const canvas = new Canvas(bgImage.width, bgImage.height);
+		const canvas = createCanvas(bgImage.width, bgImage.height);
 
 		const ctx = canvas.getContext('2d');
 		ctx.imageSmoothingEnabled = false;

--- a/src/lib/util/canvasUtil.ts
+++ b/src/lib/util/canvasUtil.ts
@@ -1,6 +1,13 @@
 import { Canvas, CanvasRenderingContext2D, Image, loadImage } from 'skia-canvas/lib';
 
+import { production } from '../../config';
 import { formatItemStackQuantity, generateHexColorForCashStack } from '../util';
+
+export function createCanvas(width?: number, height?: number) {
+	const canvas = new Canvas(width, height);
+	if (!production) canvas.gpu = false;
+	return canvas;
+}
 
 export function fillTextXTimesInCtx(ctx: CanvasRenderingContext2D, text: string, x: number, y: number) {
 	let textPath = ctx.outlineText(text);
@@ -47,7 +54,7 @@ export function drawImageWithOutline(
 	alpha: number = 0.5
 ): void {
 	const dArr = [-1, -1, 0, -1, 1, -1, -1, 0, 1, 0, -1, 1, 0, 1, 1, 1];
-	const purplecanvas = new Canvas(image.width + (outlineWidth + 2), image.height + (outlineWidth + 2));
+	const purplecanvas = createCanvas(image.width + (outlineWidth + 2), image.height + (outlineWidth + 2));
 	const pctx = purplecanvas.getContext('2d');
 	for (let i = 0; i < dArr.length; i += 2) pctx.drawImage(image, dArr[i] * outlineWidth, dArr[i + 1] * outlineWidth);
 	pctx.globalAlpha = alpha;
@@ -115,7 +122,7 @@ export function printWrappedText(ctx: CanvasRenderingContext2D, text: string, x:
 }
 
 export function getClippedRegion(image: Image | Canvas, x: number, y: number, width: number, height: number) {
-	const canvas = new Canvas(width, height);
+	const canvas = createCanvas(width, height);
 	const ctx = canvas.getContext('2d');
 	if (image instanceof Canvas) {
 		ctx.drawCanvas(image, x, y, width, height, 0, 0, width, height);

--- a/src/lib/util/chatHeadImage.ts
+++ b/src/lib/util/chatHeadImage.ts
@@ -1,8 +1,7 @@
 import { AttachmentBuilder } from 'discord.js';
 import * as fs from 'fs';
-import { Canvas } from 'skia-canvas/lib';
 
-import { canvasImageFromBuffer, printWrappedText } from './canvasUtil';
+import { canvasImageFromBuffer, createCanvas, printWrappedText } from './canvasUtil';
 
 export const textBoxFile = fs.readFileSync('./src/lib/resources/images/textbox.png');
 const mejJalChatHead = fs.readFileSync('./src/lib/resources/images/mejJal.png');
@@ -37,7 +36,7 @@ const names: Record<keyof typeof chatHeads, string> = {
 };
 
 export async function newChatHeadImage({ content, head }: { content: string; head: keyof typeof chatHeads }) {
-	const canvas = new Canvas(519, 142);
+	const canvas = createCanvas(519, 142);
 	const ctx = canvas.getContext('2d');
 	ctx.imageSmoothingEnabled = false;
 	const headImage = await canvasImageFromBuffer(chatHeads[head]);

--- a/src/mahoji/commands/fake.ts
+++ b/src/mahoji/commands/fake.ts
@@ -1,8 +1,9 @@
 import { randInt } from 'e';
 import fs from 'fs';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
-import { Canvas, CanvasRenderingContext2D, loadImage } from 'skia-canvas/lib';
+import { CanvasRenderingContext2D, loadImage } from 'skia-canvas/lib';
 
+import { createCanvas } from '../../lib/util/canvasUtil';
 import { OSBMahojiCommand } from '../lib/util';
 
 const bg = fs.readFileSync('./src/lib/resources/images/tob-bg.png');
@@ -180,7 +181,7 @@ export const fakeCommand: OSBMahojiCommand = {
 		}
 	],
 	run: async ({ options }: CommandRunOptions<{ type: string; username: string }>) => {
-		const canvas = new Canvas(399, 100);
+		const canvas = createCanvas(399, 100);
 		const ctx = canvas.getContext('2d');
 
 		ctx.font = '16px OSRSFont';

--- a/src/mahoji/commands/fakepm.ts
+++ b/src/mahoji/commands/fakepm.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
-import { Canvas, loadImage } from 'skia-canvas/lib';
+import { loadImage } from 'skia-canvas/lib';
 
+import { createCanvas } from '../../lib/util/canvasUtil';
 import { OSBMahojiCommand } from '../lib/util';
 
 const bg = loadImage(fs.readFileSync('./src/lib/resources/images/pm-bg.png'));
@@ -24,7 +25,7 @@ export const fakepmCommand: OSBMahojiCommand = {
 		}
 	],
 	run: async ({ options }: CommandRunOptions<{ message: string; username: string }>) => {
-		const canvas = new Canvas(376, 174);
+		const canvas = createCanvas(376, 174);
 		const ctx = canvas.getContext('2d');
 		ctx.font = '16px OSRSFont';
 		const img = await bg;


### PR DESCRIPTION
### Description:

This PR works-around an issue with Canvas exporting to jpg/png.

When the bot is not in production, it sets canvas.gpu = false, and changes nothing for production.

### Changes:

- Centralizes canvas creation to avoid needing to check production any time a canvas is created
- In createCanvas(), if (not production) disable GPU acceleration on Canvas

### Other checks:

-   [x] I have tested all my changes thoroughly.
