### PR TITLE
Remove tags on invention trips

### DIFF
--- a/src/lib/invention/disassemble.ts
+++ b/src/lib/invention/disassemble.ts
@@ -388,7 +388,7 @@ export async function disassembleCommand({
 		xp: result.xp
 	});
 
-	return `${user}, ${user.minionName} is now disassembling ${result.quantity}x ${
+	return `${user.minionName} is now disassembling ${result.quantity}x ${
 		item.name
 	}, the trip will take approximately ${formatDuration(result.duration)}
 **Junk Chance:** ${result.junkChance.toFixed(2)}%

--- a/src/lib/invention/research.ts
+++ b/src/lib/invention/research.ts
@@ -90,7 +90,7 @@ export async function researchCommand({
 		quantity
 	});
 
-	return `${userMention(user.id)}, ${minionName(
+	return `${minionName(
 		user
 	)} is now researching with ${cost}. The trip will take ${formatDuration(duration)}.`;
 }

--- a/src/lib/invention/research.ts
+++ b/src/lib/invention/research.ts
@@ -91,7 +91,7 @@ export async function researchCommand({
 	});
 
 	return `${minionName(user)} is now researching with ${cost}. The trip will take ${formatDuration(duration)}.`;
-	}
+}
 
 export async function researchTask(data: ResearchTaskOptions) {
 	const { userID, material, quantity } = data;

--- a/src/lib/invention/research.ts
+++ b/src/lib/invention/research.ts
@@ -90,10 +90,8 @@ export async function researchCommand({
 		quantity
 	});
 
-	return `${minionName(
-		user
-	)} is now researching with ${cost}. The trip will take ${formatDuration(duration)}.`;
-}
+	return `${minionName(user)} is now researching with ${cost}. The trip will take ${formatDuration(duration)}.`;
+	}
 
 export async function researchTask(data: ResearchTaskOptions) {
 	const { userID, material, quantity } = data;


### PR DESCRIPTION
Currently invention trips tag the discord user when there trip is sent, this can be slightly annoying and doesn't happen anywhere else afaik.

This pr removes the tag on the trip commands. 

-   [ ] I have tested all my changes thoroughly.
