### PR TITLE
Add Reclaim prayer books + god capes

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -17,7 +17,7 @@ import { fremennikClothes } from './frem';
 import { gnomeClothes } from './gnomeClothes';
 import { guardiansOfTheRiftBuyables } from './guardiansOfTheRifBuyables';
 import { miningBuyables } from './mining';
-import { perduBuyables } from './perdu';
+import { perduBuyables, prayerBooks } from './perdu';
 import { runeBuyables } from './runes';
 import { shootingStarsBuyables } from './shootingStarsBuyables';
 import { skillCapeBuyables } from './skillCapeBuyables';
@@ -1027,6 +1027,7 @@ const Buyables: Buyable[] = [
 	...randomEventBuyables,
 	...tobCapes,
 	...perduBuyables,
+	...prayerBooks,
 	...skillCapeBuyables,
 	...aerialFishBuyables,
 	...troubleBrewingBuyables,

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -17,7 +17,7 @@ import { fremennikClothes } from './frem';
 import { gnomeClothes } from './gnomeClothes';
 import { guardiansOfTheRiftBuyables } from './guardiansOfTheRifBuyables';
 import { miningBuyables } from './mining';
-import { perduBuyables, prayerBooks } from './perdu';
+import { godCapes, perduBuyables, prayerBooks } from './perdu';
 import { runeBuyables } from './runes';
 import { shootingStarsBuyables } from './shootingStarsBuyables';
 import { skillCapeBuyables } from './skillCapeBuyables';
@@ -1028,6 +1028,7 @@ const Buyables: Buyable[] = [
 	...tobCapes,
 	...perduBuyables,
 	...prayerBooks,
+	...godCapes,
 	...skillCapeBuyables,
 	...aerialFishBuyables,
 	...troubleBrewingBuyables,

--- a/src/lib/data/buyables/perdu.ts
+++ b/src/lib/data/buyables/perdu.ts
@@ -22,7 +22,6 @@ export const prayerBooks: Buyable[] = [
 	name: `Reclaim ${book}`,
 	outputItems: new Bank({ [book]: 1 }),
 	gpCost: 12_000,
-	ironmanPrice: 1000,
 	collectionLogReqs: resolveItems(book)
 }));
 
@@ -30,6 +29,5 @@ export const godCapes: Buyable[] = ['Guthix cape', 'Saradomin cape', 'Zamorak ca
 	name: `Reclaim ${cape}`,
 	outputItems: new Bank({ [cape]: 1 }),
 	gpCost: 23_000,
-	ironmanPrice: 1000,
 	collectionLogReqs: resolveItems(cape)
 }));

--- a/src/lib/data/buyables/perdu.ts
+++ b/src/lib/data/buyables/perdu.ts
@@ -21,7 +21,15 @@ export const prayerBooks: Buyable[] = [
 ].map(book => ({
 	name: `Reclaim ${book}`,
 	outputItems: new Bank({ [book]: 1 }),
-	gpCost: 5000,
-	ironmanPrice: 200,
+	gpCost: 12_000,
+	ironmanPrice: 1000,
 	collectionLogReqs: resolveItems(book)
+}));
+
+export const godCapes: Buyable[] = ['Guthix cape', 'Saradomin cape', 'Zamorak cape'].map(cape => ({
+	name: `Reclaim ${cape}`,
+	outputItems: new Bank({ [cape]: 1 }),
+	gpCost: 23_000,
+	ironmanPrice: 1000,
+	collectionLogReqs: resolveItems(cape)
 }));

--- a/src/lib/data/buyables/perdu.ts
+++ b/src/lib/data/buyables/perdu.ts
@@ -1,3 +1,5 @@
+import { Bank } from 'oldschooljs';
+
 import resolveItems from '../../util/resolveItems';
 import { diariesCL } from '../CollectionsExport';
 import { Buyable } from './buyables';
@@ -7,4 +9,19 @@ export const perduBuyables: Buyable[] = diariesCL.map(itemName => ({
 	gpCost: 1000,
 	ironmanPrice: 200,
 	collectionLogReqs: resolveItems(itemName)
+}));
+
+export const prayerBooks: Buyable[] = [
+	'Holy book',
+	'Unholy book',
+	'Book of law',
+	'Book of balance',
+	'Book of war',
+	'Book of darkness'
+].map(book => ({
+	name: `Reclaim ${book}`,
+	outputItems: new Bank({ [book]: 1 }),
+	gpCost: 5000,
+	ironmanPrice: 200,
+	collectionLogReqs: resolveItems(book)
 }));

--- a/src/lib/data/buyables/perdu.ts
+++ b/src/lib/data/buyables/perdu.ts
@@ -21,13 +21,15 @@ export const prayerBooks: Buyable[] = [
 ].map(book => ({
 	name: `Reclaim ${book}`,
 	outputItems: new Bank({ [book]: 1 }),
-	gpCost: 12_000,
+	gpCost: 50_000,
+	ironmanPrice: 12_000,
 	collectionLogReqs: resolveItems(book)
 }));
 
 export const godCapes: Buyable[] = ['Guthix cape', 'Saradomin cape', 'Zamorak cape'].map(cape => ({
 	name: `Reclaim ${cape}`,
 	outputItems: new Bank({ [cape]: 1 }),
-	gpCost: 23_000,
+	gpCost: 100_000,
+	ironmanPrice: 23_000,
 	collectionLogReqs: resolveItems(cape)
 }));


### PR DESCRIPTION
### Description:

In OSRS you can stack as many Prayer books & God capes as you want, once you complete the book or minigame, respectively.

This update allows you to `/buy name: Reclaim Holy book` or `/buy name: Reclaim zamorak cape` once you have a completed one in your CL.

- In OSRS, they can be obtained free, however they are easier to purchase from Perdu, at a cost. (12k/ea & 23k/ea)
- This is the cost that's used, except ironmen just pay 1k/ea

### Changes:

- Adds the Prayer books to buyables as a reclaim once you complete the set, like in OSRS.
- Adds god capes to reclaim

### Other checks:

-   [x] I have tested all my changes thoroughly.
