### PR TITLE
Fix Giants Foundry CL

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1234,9 +1234,6 @@ export const fishingTrawlerCL = resolveItems(['Angler hat', 'Angler top', 'Angle
 export const giantsFoundryCL = resolveItems([
 	'Smiths tunic',
 	'Smiths trousers',
-	'Hallowed grapple',
-	'Smiths tunic',
-	'Smiths trousers',
 	'Smiths boots',
 	'Smiths gloves',
 	'Colossal blade',


### PR DESCRIPTION
Remove the hollowed grapple from Giants Foundry CL to make it inline with osrs.