### PR TITLE
Make /trade consistent, reliable, and remove item deletion bugs (transactional)

### DIFF
--- a/src/lib/util/tradePlayerItems.ts
+++ b/src/lib/util/tradePlayerItems.ts
@@ -4,7 +4,7 @@ import { prisma } from '../settings/prisma';
 import { logError } from './logError';
 import { userQueueFn } from './userQueues';
 
-const activeTradeCache = new Map();
+export const activeTradeCache = new Map();
 
 function timeout(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));

--- a/src/lib/util/tradePlayerItems.ts
+++ b/src/lib/util/tradePlayerItems.ts
@@ -1,6 +1,5 @@
 import { Bank } from 'oldschooljs';
 
-import { COINS_ID } from '../constants';
 import { prisma } from '../settings/prisma';
 import { logError } from './logError';
 import { userQueueFn } from './userQueues';
@@ -44,16 +43,16 @@ export async function tradePlayerItems(sender: MUser, recipient: MUser, _itemsTo
 			let senderGP = sender.GP;
 			let recipientGP = recipient.GP;
 
-			if (itemsToSend.has(COINS_ID)) {
-				const sentCoins = itemsToSend.amount(COINS_ID);
+			if (itemsToSend.has('Coins')) {
+				const sentCoins = itemsToSend.amount('Coins');
 				senderGP -= sentCoins;
-				itemsToSend.remove(COINS_ID, sentCoins);
+				itemsToSend.remove('Coins', sentCoins);
 				recipientGP += sentCoins;
 			}
-			if (itemsToReceive.has(COINS_ID)) {
-				const receivedCoins = itemsToReceive.amount(COINS_ID);
+			if (itemsToReceive.has('Coins')) {
+				const receivedCoins = itemsToReceive.amount('Coins');
 				recipientGP -= receivedCoins;
-				itemsToReceive.remove(COINS_ID, receivedCoins);
+				itemsToReceive.remove('Coins', receivedCoins);
 				senderGP += receivedCoins;
 			}
 

--- a/src/lib/util/tradePlayerItems.ts
+++ b/src/lib/util/tradePlayerItems.ts
@@ -1,0 +1,99 @@
+import { Bank } from 'oldschooljs';
+
+import { COINS_ID } from '../constants';
+import { prisma } from '../settings/prisma';
+import { logError } from './logError';
+import { userQueueFn } from './userQueues';
+
+const activeTradeCache = new Map();
+
+function timeout(ms: number) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function tradePlayerItems(sender: MUser, recipient: MUser, _itemsSent: Bank, _itemsReceived: Bank) {
+	if (activeTradeCache.get(sender.id) || activeTradeCache.get(recipient.id)) {
+		return { success: false, message: 'Only one trade per player can be active at a time!' };
+	}
+	activeTradeCache.set(sender.id, true);
+	activeTradeCache.set(recipient.id, true);
+
+	const itemsSent = _itemsSent.clone();
+	const itemsReceived = _itemsReceived.clone();
+
+	// Queue function for the recipient so no funny business / mistakes happen:
+	userQueueFn(recipient.id, async () => {
+		while (activeTradeCache.get(recipient.id)) {
+			await timeout(500);
+		}
+	});
+	// Queue the primary trade function: (Clears cache on completion/failure)
+	return userQueueFn(sender.id, async () => {
+		try {
+			if (!sender.owns(itemsSent)) {
+				return { success: false, message: `${sender.usernameOrMention} doesn't own all items.` };
+			}
+			if (!recipient.owns(itemsReceived)) {
+				return { success: false, message: `${recipient.usernameOrMention} doesn't own all items.` };
+			}
+			const newSenderBank = sender.bank.clone();
+			const newRecipientBank = recipient.bank.clone();
+
+			let senderGP = sender.GP;
+			let recipientGP = recipient.GP;
+
+			if (itemsSent.has(COINS_ID)) {
+				const sentCoins = itemsSent.amount(COINS_ID);
+				senderGP -= sentCoins;
+				itemsSent.remove(COINS_ID, sentCoins);
+				recipientGP += sentCoins;
+			}
+			if (itemsReceived.has(COINS_ID)) {
+				const rcvdCoins = itemsReceived.amount(COINS_ID);
+				recipientGP -= rcvdCoins;
+				itemsReceived.remove(COINS_ID, rcvdCoins);
+				senderGP += rcvdCoins;
+			}
+
+			newSenderBank.remove(itemsSent);
+			newRecipientBank.remove(itemsReceived);
+			newSenderBank.add(itemsReceived);
+			newRecipientBank.add(itemsSent);
+
+			const updateSender = prisma.user.update({
+				data: {
+					GP: senderGP,
+					bank: newSenderBank.bank
+				},
+				where: {
+					id: sender.id
+				}
+			});
+			const updateRecipient = prisma.user.update({
+				data: {
+					GP: recipientGP,
+					bank: newRecipientBank.bank
+				},
+				where: {
+					id: recipient.id
+				}
+			});
+			// Run both in a single transaction, so it all succeeds or all fails:
+			await prisma.$transaction([updateSender, updateRecipient]);
+			return { success: true, message: null };
+		} catch (e: any) {
+			// We should only get here if something bad happened... most likely prisma, but possibly command competition
+			logError(e, undefined, {
+				sender: sender.id,
+				recipient: recipient.id,
+				command: 'trade',
+				items_sent: itemsSent.toString(),
+				items_received: itemsReceived.toString()
+			});
+			return { success: false, message: 'Temporary error, please try again.' };
+		} finally {
+			activeTradeCache.delete(sender.id);
+			activeTradeCache.delete(recipient.id);
+		}
+	});
+}

--- a/src/lib/util/tradePlayerItems.ts
+++ b/src/lib/util/tradePlayerItems.ts
@@ -49,10 +49,10 @@ export async function tradePlayerItems(sender: MUser, recipient: MUser, _itemsSe
 				recipientGP += sentCoins;
 			}
 			if (itemsReceived.has(COINS_ID)) {
-				const rcvdCoins = itemsReceived.amount(COINS_ID);
-				recipientGP -= rcvdCoins;
-				itemsReceived.remove(COINS_ID, rcvdCoins);
-				senderGP += rcvdCoins;
+				const receivedCoins = itemsReceived.amount(COINS_ID);
+				recipientGP -= receivedCoins;
+				itemsReceived.remove(COINS_ID, receivedCoins);
+				senderGP += receivedCoins;
 			}
 
 			newSenderBank.remove(itemsSent);

--- a/src/lib/util/tradePlayerItems.ts
+++ b/src/lib/util/tradePlayerItems.ts
@@ -23,7 +23,7 @@ export async function tradePlayerItems(sender: MUser, recipient: MUser, _itemsTo
 	// Queue function for the recipient so no funny business / mistakes happen:
 	userQueueFn(recipient.id, async () => {
 		while (activeTradeCache.get(recipient.id)) {
-			await timeout(500);
+			await timeout(100);
 		}
 	});
 	// Queue the primary trade function: (Clears cache on completion/failure)

--- a/src/lib/util/tradePlayerItems.ts
+++ b/src/lib/util/tradePlayerItems.ts
@@ -28,9 +28,9 @@ export async function tradePlayerItems(sender: MUser, recipient: MUser, _itemsTo
 	});
 	// Queue the primary trade function: (Clears cache on completion/failure)
 	return userQueueFn(sender.id, async () => {
-		await sender.sync();
-		await recipient.sync();
 		try {
+			await sender.sync();
+			await recipient.sync();
 			if (!sender.owns(itemsToSend)) {
 				return { success: false, message: `${sender.usernameOrMention} doesn't own all items.` };
 			}

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -40,6 +40,7 @@ import { syncLinkedAccounts } from '../../lib/util/linkedAccountsUtil';
 import { logError } from '../../lib/util/logError';
 import { makeBankImage } from '../../lib/util/makeBankImage';
 import { parseBank } from '../../lib/util/parseStringBank';
+import { activeTradeCache } from '../../lib/util/tradePlayerItems';
 import { sendToChannelID } from '../../lib/util/webhook';
 import { Cooldowns } from '../lib/Cooldowns';
 import { syncCustomPrices } from '../lib/events';
@@ -607,6 +608,7 @@ export const adminCommand: OSBMahojiCommand = {
 			globalClient.busyCounterCache.delete(user.id);
 			Cooldowns.delete(user.id);
 			minionActivityCacheDelete(user.id);
+			activeTradeCache.delete(user.id);
 			return 'Done.';
 		}
 		if (options.sync_roles) {

--- a/src/mahoji/commands/pay.ts
+++ b/src/mahoji/commands/pay.ts
@@ -62,7 +62,10 @@ export const payCommand: OSBMahojiCommand = {
 
 		const bank = new Bank().add('Coins', amount);
 
-		await tradePlayerItems(user, recipient, bank);
+		const { success, message } = await tradePlayerItems(user, recipient, bank);
+		if (!success) {
+			return message;
+		}
 
 		await prisma.economyTransaction.create({
 			data: {

--- a/src/mahoji/commands/pay.ts
+++ b/src/mahoji/commands/pay.ts
@@ -6,6 +6,7 @@ import { Events } from '../../lib/constants';
 import { addToGPTaxBalance, prisma } from '../../lib/settings/prisma';
 import { toKMB } from '../../lib/util';
 import { deferInteraction } from '../../lib/util/interactionReply';
+import { tradePlayerItems } from '../../lib/util/tradePlayerItems';
 import { OSBMahojiCommand } from '../lib/util';
 import { handleMahojiConfirmation, mahojiParseNumber, mahojiUsersSettingsFetch } from '../mahojiSettings';
 
@@ -61,16 +62,7 @@ export const payCommand: OSBMahojiCommand = {
 
 		const bank = new Bank().add('Coins', amount);
 
-		await transactItems({
-			userID: user.id,
-			itemsToRemove: bank
-		});
-
-		await transactItems({
-			userID: recipient.id,
-			itemsToAdd: bank,
-			collectionLog: false
-		});
+		await tradePlayerItems(user, recipient, bank);
 
 		await prisma.economyTransaction.create({
 			data: {

--- a/src/mahoji/commands/trade.ts
+++ b/src/mahoji/commands/trade.ts
@@ -9,6 +9,7 @@ import { discrimName, truncateString } from '../../lib/util';
 import { deferInteraction } from '../../lib/util/interactionReply';
 import itemIsTradeable from '../../lib/util/itemIsTradeable';
 import { parseBank } from '../../lib/util/parseStringBank';
+import { tradePlayerItems } from '../../lib/util/tradePlayerItems';
 import { filterOption } from '../lib/mahojiCommandOptions';
 import { OSBMahojiCommand } from '../lib/util';
 import { handleMahojiConfirmation, mahojiParseNumber } from '../mahojiSettings';
@@ -127,11 +128,10 @@ Both parties must click confirm to make the trade.`,
 		if (!recipientUser.owns(itemsReceived)) return "They don't own those items.";
 		if (!senderUser.owns(itemsSent)) return "You don't own those items.";
 
-		await senderUser.removeItemsFromBank(itemsSent);
-		await recipientUser.removeItemsFromBank(itemsReceived);
-		await senderUser.addItemsToBank({ items: itemsReceived, collectionLog: false, filterLoot: false });
-		await recipientUser.addItemsToBank({ items: itemsSent, collectionLog: false, filterLoot: false });
-
+		const { success, message } = await tradePlayerItems(senderUser, recipientUser, itemsSent, itemsReceived);
+		if (!success) {
+			return `Trade failed because: ${message}`;
+		}
 		await prisma.economyTransaction.create({
 			data: {
 				guild_id: BigInt(guildID),


### PR DESCRIPTION
### Description:

The risk for item deletion in the /trade command is relatively large. Several database calls are performed sequentially, committing after each one, which is bad if there's any sort of bot lag/freeze/stall, or similar with the psql server, or even the network stack.

Some of these are much less likely than others, nevertheless, we do see this issue crop up with some regularity. 
(We see it all the time, but usually it doesn't result in item loss.)

Twice just today it resulted in item loss, however, so I'm making this a top priority.

### Changes:

- Removes the 4 separate steps and replaces it with a new function, tradePlayerItems
- Trade player items prepares 2 queries, one to update each user, and runs both of them in a single transaction, **so either both succeed, or neither do.**
- Adds functions to both users `userQueue` simultaneously, so that other operations which act on the bank are properly queued. (Even though this should be unnecessary with a single transaction)

### Other checks:

-   [x] I have tested all my changes thoroughly.

I even tested the recipients user queue to make sure it properly delays other addItemsToBank() functions, like buy items.

Everything is working as intended.