### PR TITLE
Add Arclight and SGS boost to Lesser Demons

### DIFF
--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -815,6 +815,14 @@ export const vannakaMonsters: KillableMonster[] = [
 
 		existsInCatacombs: true,
 		difficultyRating: 2,
+		itemInBankBoosts: [
+			{
+				[itemID('Arclight')]: 12
+			},
+			{
+				[itemID('Saradomin godsword')]: 3
+			}
+		],
 		qpRequired: 0,
 		healAmountNeeded: 18,
 		attackStyleToUse: GearStat.AttackSlash,


### PR DESCRIPTION
As greater demons and black demons get boosts for arclight and SGS it makes sense to add the same boosts to lesser demons.

At present greater demons are able to be killed faster than lesser demons due to this. Thanks to Redquaker for pointing this out

