### PR TITLE
Fix cox notification square color

### DIFF
--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -154,7 +154,7 @@ export const raidsTask: MinionTask = {
 				const itemsToAnnounce = itemsAdded.filter(item => purpleItems.includes(item.id), false);
 				globalClient.emit(
 					Events.ServerNotification,
-					`${emote} ${user.badgedUsername} just received **${itemsToAnnounce}** on their ${formatOrdinal(
+					`${Emoji.Blue} ${user.badgedUsername} just received **${itemsToAnnounce}** on their ${formatOrdinal(
 						await getMinigameScore(user.id, minigameID)
 					)} raid.`
 				);

--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -154,7 +154,7 @@ export const raidsTask: MinionTask = {
 				const itemsToAnnounce = itemsAdded.filter(item => purpleItems.includes(item.id), false);
 				globalClient.emit(
 					Events.ServerNotification,
-					`${Emoji.Blue} ${user.badgedUsername} just received **${itemsToAnnounce}** on their ${formatOrdinal(
+					`${Emoji.Purple} ${user.badgedUsername} just received **${itemsToAnnounce}** on their ${formatOrdinal(
 						await getMinigameScore(user.id, minigameID)
 					)} raid.`
 				);


### PR DESCRIPTION
### Description:

Since notifications for Cox only show Purple items, then it shouldn't use the Blue/Green/Orange color for other uniques, it should always be purple.

### Changes:

- Replace dynamic emote with purple square constant

### Other checks:

-   [ ] I have tested all my changes thoroughly.
