### PR TITLE
Add spoiler text to loot at Baxtorian Bathhouse

### DIFF
--- a/src/lib/baxtorianBathhouses.ts
+++ b/src/lib/baxtorianBathhouses.ts
@@ -496,13 +496,15 @@ export async function baxtorianBathhousesActivity(data: BathhouseTaskOptions) {
 	let uniqSpecies = uniqueArr(speciesServed);
 	updateBankSetting('bb_loot', loot);
 
+	const str = gotPurple ? `${Emoji.Purple} ||${loot}||` : loot.toString();
+
 	handleTripFinish(
 		user,
 		channelID,
 		`${userMention(userID)}, ${user.minionName} finished running ${quantity}x ${tier.name} baths for ${
 			uniqSpecies.length
 		} species (${uniqSpecies.map(i => i.name).join(', ')}) at the Baxtorian Bathhouses.
-${gotPurple ? `${Emoji.Purple} ` : ''}**Tips received:** ${loot}.${
+**Tips received:** ${str}.${
 			gaveExtraTips
 				? `\nYou got extra tips from ${gaveExtraTips.name} for using their preferred water mixture.`
 				: ''


### PR DESCRIPTION
When you get a purple adds the spoiler text like it does in other places such as raids.

Closes #4730

-   [x] I have tested all my changes thoroughly.
