### PR TITLE
Armadyl Chestplate Reverting

### DIFF
--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -121,7 +121,7 @@ const componentRevertables: Createable[] = [
 			[itemID('Armadyl chestplate')]: 1
 		},
 		outputItems: {
-			[itemID('Armadylean components')]: 2
+			[itemID('Armadylean components')]: 3
 		}
 	},
 	{


### PR DESCRIPTION
Changes the Armadyl Chestplate reverting to 3 components instead of 2. This then fits the pattern of bandos and ancestral.

Closes #4699

