### PR TITLE
Quantity on Clue Repeat Trips

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -629,7 +629,7 @@ export const tripHandlers = {
 	},
 	[activity_type_enum.ClueCompletion]: {
 		commandName: 'clue',
-		args: (data: ClueActivityTaskOptions) => ({ tier: data.clueID })
+		args: (data: ClueActivityTaskOptions) => ({ tier: data.clueID, quantity: data.quantity })
 	},
 	[activity_type_enum.FistOfGuthix]: {
 		commandName: 'bsominigames',


### PR DESCRIPTION
Allows quantity to be remembered on repeat trips of clues, currently it maxes to default.

Closes #4782

-   [x] I have tested all my changes thoroughly.
