### PR TITLE
Fix Disassemble some items League Task

### DIFF
--- a/src/lib/leagues/mediumTasks.ts
+++ b/src/lib/leagues/mediumTasks.ts
@@ -355,7 +355,7 @@ export const mediumTasks: Task[] = [
 		id: 1051,
 		name: 'Disassemble some items',
 		has: async ({ disassembledItems }) => {
-			return disassembledItems.length >= 0;
+			return disassembledItems.length >= 1;
 		}
 	},
 	{


### PR DESCRIPTION
Closes #4802
Currently the league task checks for greater or equal than 0, changes this to greater or equal than 1 like other tasks.
