### PR TITLE
Tidy Ardy Boost for Farming Command

### DIFF
--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -224,6 +224,14 @@ export async function farmingPlantCommand({
 		duration *= 0.9;
 	}
 
+	for (const [diary, tier] of [[ArdougneDiary, ArdougneDiary.elite]] as const) {
+		const [has] = await userhasDiaryTier(user, tier);
+		if (has) {
+			boostStr.push(`4% time for ${diary.name} ${tier.name}`);
+			duration *= 0.96;
+		}
+	}
+
 	if (duration > maxTripLength) {
 		return `${user.minionName} can't go on trips longer than ${formatDuration(
 			maxTripLength
@@ -281,14 +289,6 @@ export async function farmingPlantCommand({
 		infoStr.unshift(
 			`${user.minionName} is now harvesting ${patchType.lastQuantity}x ${patchType.lastPlanted}, and then planting ${quantity}x ${plant.name}.`
 		);
-	}
-
-	for (const [diary, tier] of [[ArdougneDiary, ArdougneDiary.elite]] as const) {
-		const [has] = await userhasDiaryTier(user, tier);
-		if (has) {
-			boostStr.push(`4% for ${diary.name} ${tier.name}`);
-			duration *= 0.96;
-		}
 	}
 
 	if (noFarmGuild) boostStr.push(noFarmGuild);


### PR DESCRIPTION
This pr moves it next to the graceful time boost, and also adds "time" to the string so the user knows what the boost is doing, rather than an ambiguous 4%.

-   [x] I have tested all my changes thoroughly.
