### PR TITLE
Fix issue with loot filtered ic's

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -297,7 +297,7 @@ async function donateICHandler(interaction: ButtonInteraction) {
 	try {
 		modifyBusyCounter(donator.id, 1);
 		await donator.removeItemsFromBank(cost);
-		await user.addItemsToBank({ items: cost, collectionLog: false });
+		await user.addItemsToBank({ items: cost, collectionLog: false, filterLoot: false });
 		await userStatsBankUpdate(donator.id, 'ic_donations_given_bank', cost);
 		await userStatsBankUpdate(user.id, 'ic_donations_received_bank', cost);
 


### PR DESCRIPTION
### Description:

Removed loot filtering from item contract donations, because it should never be enabled on p2p trades.

### Changes:

- Added `filterLoot: false` to `user.addItemsToBank()`

### Other checks:

-   [x] I have tested all my changes thoroughly.
