### PR TITLE
+Ranged master cape to ava's similar items

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -264,7 +264,7 @@ const source: [string, (string | number)[]][] = [
 	['Prayer master cape', ["Combatant's cape"]],
 	['Ranged master cape', ["Combatant's cape"]],
 	['Strength master cape', ["Combatant's cape"]],
-	["Ava's assembler", ["Combatant's cape", 'Assembler max cape']],
+	["Ava's assembler", ["Combatant's cape", 'Assembler max cape', 'Ranged master cape']],
 	['Crafting master cape', ["Artisan's cape"]],
 	['Construction master cape', ["Artisan's cape"]],
 	['Cooking master cape', ["Artisan's cape"]],


### PR DESCRIPTION
### Description:

BSO Specific:
Made ranged master cape give ava's ability to save darts from blowpipe. Currently doing ToB you save darts with Ava's assembler, Assembler max cape or combatant's cape. The Ranged Master cape does not save darts even though that is the part of combatant's cape with the effect.

### Changes:

Added ranged master cape to similar items for Ava's Assembler. 

### Other checks:

-   [x] I have tested all my changes thoroughly.
