### PR TITLE
Add crafting xp to Wolfbone Arrowtips

### DIFF
--- a/src/lib/skilling/skills/fletching/fletchables/arrows.ts
+++ b/src/lib/skilling/skills/fletching/fletchables/arrows.ts
@@ -27,7 +27,8 @@ const Arrows: Fletchable[] = [
 		xp: 2.5,
 		inputItems: new Bank({ 'Wolf bones': 1 }),
 		tickRate: 0.13,
-		outputMultiple: 4
+		outputMultiple: 4,
+		craftingXp: 2.5
 	},
 	{
 		name: 'Flighted ogre arrow',

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -169,6 +169,7 @@ export interface Fletchable {
 	tickRate: number;
 	outputMultiple?: number;
 	requiredSlayerUnlocks?: SlayerTaskUnlocksEnum[];
+	craftingXp?: number;
 }
 
 export interface Mixable {

--- a/src/tasks/minions/fletchingActivity.ts
+++ b/src/tasks/minions/fletchingActivity.ts
@@ -19,6 +19,18 @@ export const fletchingTask: MinionTask = {
 			duration
 		});
 
+		let craftXpReceived = 0;
+		let craftXpRes = '';
+		if (fletchableItem.craftingXp) {
+			craftXpReceived = fletchableItem.craftingXp * quantity;
+
+			craftXpRes = await user.addXP({
+				skillName: SkillsEnum.Crafting,
+				amount: craftXpReceived,
+				duration
+			});
+		}
+
 		let sets = 'x';
 		if (fletchableItem.outputMultiple) {
 			sets = ' sets of';
@@ -35,7 +47,7 @@ export const fletchingTask: MinionTask = {
 		handleTripFinish(
 			user,
 			channelID,
-			`${user}, ${user.minionName} finished fletching ${quantity}${sets} ${fletchableItem.name}, and received ${loot}. ${xpRes}`,
+			`${user}, ${user.minionName} finished fletching ${quantity}${sets} ${fletchableItem.name}, and received ${loot}. ${xpRes}. ${craftXpRes}`,
 			undefined,
 			data,
 			loot


### PR DESCRIPTION
Adds an optional craftingxp number to the fletchables tables. Adds the relevant crafting xp to the wolf bone arrowtips. Adds the relevant xpRes to the fletching activity.

Closes #4833

-   [x] I have tested all my changes thoroughly.
