### PR TITLE
Update farming protection cost string

### DIFF
--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -254,7 +254,7 @@ export async function farmingPlantCommand({
 		if (userBank.has(paymentCost)) {
 			cost.add(paymentCost);
 			didPay = true;
-			infoStr.push(`You are paying a nearby farmer ${cost} to look after your patches.`);
+			infoStr.push(`You are paying a nearby farmer ${paymentCost} to look after your patches.`);
 		} else {
 			infoStr.push('You did not have enough payment to automatically pay for crop protection.');
 		}


### PR DESCRIPTION
Updates the farming protection cost string to only show the cost of the protection, currently it shows the seeds too.

-   [x] I have tested all my changes thoroughly.
