### PR TITLE
Fix Pest Control Strength XP buy.

### DIFF
--- a/src/mahoji/commands/minigames.ts
+++ b/src/mahoji/commands/minigames.ts
@@ -262,7 +262,7 @@ export const minigamesCommand: OSBMahojiCommand = {
 							name: 'skill',
 							required: true,
 							description: 'The skill to put XP in.',
-							choices: ['attack', 'strength ', 'defence', 'hitpoints', 'ranged', 'magic', 'prayer'].map(
+							choices: ['attack', 'strength', 'defence', 'hitpoints', 'ranged', 'magic', 'prayer'].map(
 								i => ({ name: i, value: i })
 							)
 						},


### PR DESCRIPTION
Fixes the bug with strength xp returning "that's not a valid skill to buy xp for."

-   [ ] I have tested all my changes thoroughly.
