### PR TITLE
Removing errant '}' in bonus message for Shades command

### DIFF
--- a/src/mahoji/lib/abstracted_commands/shadesOfMortonCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shadesOfMortonCommand.ts
@@ -313,7 +313,7 @@ export async function shadesOfMortonStartCommand(user: MUser, channelID: string,
 		user.minionName
 	} is now off to do Shades of Mort'ton using ${cost} - the total trip will take ${formatDuration(duration)}.`;
 	if (messages.length > 0) {
-		str += `\n**Messages:** ${messages.join(', ')}}`;
+		str += `\n**Messages:** ${messages.join(', ')}`;
 	}
 	return str;
 }


### PR DESCRIPTION
### Description:

<img width="231" alt="image" src="https://user-images.githubusercontent.com/8355627/211398313-a9fccfc9-3438-406b-aa62-46bf892b1295.png">

Removing the extra } at the end of the Messages for Shades send command.

### Other checks:

-   [x] I have tested all my changes thoroughly.
