### PR TITLE
Shades of Mort'ton Fixes

### DIFF
--- a/src/lib/shadesKeys.ts
+++ b/src/lib/shadesKeys.ts
@@ -43,7 +43,6 @@ const SplitBarkScrollsTable = new LootTable()
 const SteelChest = new LootTable({ limit: 134 })
 	.tertiary(597, SplitBarkScrollsTable)
 	.tertiary(62, 'Fine cloth')
-	.every('Swamp paste', [15, 30])
 	.tertiary(63, 'Steel locks')
 	.every('Swamp paste', [15, 30])
 	.add('Coins', [1, 700])
@@ -78,6 +77,7 @@ const SteelChest = new LootTable({ limit: 134 })
 const BlackChest = new LootTable({ limit: 140 })
 	.tertiary(61, 'Black locks')
 	.tertiary(61, SplitBarkScrollsTable)
+	.every('Swamp paste', [25, 40])
 	.add('Coins', [1, 1000])
 	.add('Staff of air', 1, 1)
 	.add('Staff of water', 1, 1)
@@ -249,7 +249,12 @@ const chests = [
 	}
 ] as const;
 
-const zealOutfit = resolveItems(["Zealot's boots", "Zealot's helm", "Zealot's robe bottom", "Zealot's robe top"]);
+export const zealOutfit = resolveItems([
+	"Zealot's boots",
+	"Zealot's helm",
+	"Zealot's robe bottom",
+	"Zealot's robe top"
+]);
 
 export function openShadeChest({ item, qty, allItemsOwned }: { allItemsOwned: Bank; item: Item; qty: number }) {
 	const chest = chests.find(i => i.items.includes(item.id));

--- a/src/mahoji/lib/abstracted_commands/shadesOfMortonCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shadesOfMortonCommand.ts
@@ -264,6 +264,7 @@ export async function shadesOfMortonStartCommand(user: MUser, channelID: string,
 	for (const coffin of coffins.reverse()) {
 		if (user.hasEquipped(coffin)) {
 			let bonusTime = coffins.indexOf(coffin) * Time.Minute;
+			totalTime += bonusTime;
 			messages.push(`${formatDuration(bonusTime)} bonus max trip length for ${itemNameFromID(coffin)}`);
 			break;
 		}

--- a/src/tasks/minions/PrayerActivity/offeringActivity.ts
+++ b/src/tasks/minions/PrayerActivity/offeringActivity.ts
@@ -1,3 +1,4 @@
+import { zealOutfit } from '../../../lib/shadesKeys';
 import Prayer from '../../../lib/skilling/skills/prayer';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import { OfferingActivityTaskOptions } from '../../../lib/types/minions';
@@ -35,7 +36,14 @@ export const offeringTask: MinionTask = {
 		for (let i = 0; i < deathCounter; i++) {
 			bonesLost += rand(1, maxPK);
 		}
-		const bonesSaved = Math.floor(quantity * (rand(90, 110) / 100));
+		let bonesSaved = Math.floor(quantity * (rand(90, 110) / 100));
+		let zealOutfitAmount = 0;
+		for (const piece of zealOutfit) {
+			if (user.gear.skilling.hasEquipped([piece])) {
+				zealOutfitAmount++;
+			}
+		}
+		bonesSaved += Math.floor(zealOutfitAmount * 0.0125 * quantity);
 		const newQuantity = quantity - bonesLost + bonesSaved;
 
 		const xpReceived = newQuantity * bone.xp * XPMod;
@@ -46,7 +54,9 @@ export const offeringTask: MinionTask = {
 		let str = `${user}, ${user.minionName} finished offering ${newQuantity} ${
 			bone.name
 		}, you managed to offer ${bonesSaved} extra bones because of the effects the Chaos altar and you lost ${bonesLost} to pkers, you also received ${xpReceived.toLocaleString()} XP.`;
-
+		if (zealOutfitAmount > 0) {
+			str += `\nYour ${zealOutfitAmount} pieces of zealot's robes are helping you save bones.`;
+		}
 		if (newLevel > currentLevel) {
 			str += `\n\n${user.minionName}'s Prayer level is now ${newLevel}!`;
 		}


### PR DESCRIPTION
- Fixes #4850 - Adds swamp paste to the black chest table, and takes the duplicate one off the steel chest.
- Fixes #4855 - Adds the bonusTime to the totalTime for the coffins effect to actually work.
- #4847 Partial Fix - Adds the effect of the zealot robes to offering bones.

-   [x] I have tested all my changes thoroughly.
