### PR TITLE
Randomizer - Only update decode cooldown on a successful try

### DIFF
--- a/src/mahoji/commands/decode.ts
+++ b/src/mahoji/commands/decode.ts
@@ -30,11 +30,11 @@ export const decodeCommand: OSBMahojiCommand = {
 
 		const item = getItem(options.item);
 		if (!item) return 'Invalid item;';
-		
+
 		const mappedItem = findRandomizedItem(user.id, item);
 		if (!mappedItem)
 			return 'https://media.discordapp.net/attachments/342983479501389826/974780581445517372/caption.gif';
-		
+
 		await user.update({
 			last_decode_date: new Date()
 		});

--- a/src/mahoji/commands/decode.ts
+++ b/src/mahoji/commands/decode.ts
@@ -30,13 +30,15 @@ export const decodeCommand: OSBMahojiCommand = {
 
 		const item = getItem(options.item);
 		if (!item) return 'Invalid item;';
+		
+		const mappedItem = findRandomizedItem(user.id, item);
+		if (!mappedItem)
+			return 'https://media.discordapp.net/attachments/342983479501389826/974780581445517372/caption.gif';
+		
 		await user.update({
 			last_decode_date: new Date()
 		});
 
-		const mappedItem = findRandomizedItem(user.id, item);
-		if (!mappedItem)
-			return 'https://media.discordapp.net/attachments/342983479501389826/974780581445517372/caption.gif';
 		return `For you, getting a ${itemNameFromID(mappedItem)} is how you obtain a ${item.name}`;
 	}
 };


### PR DESCRIPTION
Currently if the item is not mapped it still makes you wait 24h before trying again.  This PR changes so you can use the command until you get a successful return. 

-   [ ] I have tested all my changes thoroughly.
