### PR TITLE
Sim repeats

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -216,6 +216,19 @@ async function giveawayButtonHandler(user: MUser, customID: string, interaction:
 	return interactionReply(interaction, { content: 'You left the giveaway.', ephemeral: true });
 }
 
+async function simRepeatHandler(user: MUser, interaction: ButtonInteraction) {
+	const [commandType, jsonData] = interaction.customId.replace('REPEAT_SIM_', '').split('_DATA_');
+	return runCommand({
+		commandName: commandType.toLowerCase(),
+		args: JSON.parse(jsonData),
+		user,
+		member: interaction.member,
+		channelID: interaction.channelId,
+		guildID: interaction.guildId,
+		interaction
+	});
+}
+
 async function repeatTripHandler(user: MUser, interaction: ButtonInteraction) {
 	if (user.minionIsBusy) return 'Your minion is busy.';
 	const trips = await fetchRepeatTrips(interaction.user.id);
@@ -236,6 +249,7 @@ export async function interactionHook(interaction: Interaction) {
 	const user = await mUserFetch(userID);
 	if (id.includes('GIVEAWAY_')) return giveawayButtonHandler(user, id, interaction);
 	if (id.includes('REPEAT_TRIP')) return repeatTripHandler(user, interaction);
+	if (id.includes('REPEAT_SIM_')) return simRepeatHandler(user, interaction);
 
 	if (!isValidGlobalInteraction(id)) return;
 	if (user.isBusy || globalClient.isShuttingDown) {

--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -132,7 +132,10 @@ async function giveawayButtonHandler(user: MUser, customID: string, interaction:
 		}
 	});
 	if (!giveaway) {
-		return interactionReply(interaction, { content: 'Invalid giveaway.', ephemeral: true });
+		return interactionReply(interaction, {
+			content: 'Invalid giveaway.',
+			ephemeral: true
+		});
 	}
 	if (split[1] === 'REPEAT') {
 		if (user.id !== giveaway.user_id) {
@@ -162,7 +165,10 @@ async function giveawayButtonHandler(user: MUser, customID: string, interaction:
 	}
 
 	if (giveaway.finish_date.getTime() < Date.now() || giveaway.completed) {
-		return interactionReply(interaction, { content: 'This giveaway has finished.', ephemeral: true });
+		return interactionReply(interaction, {
+			content: 'This giveaway has finished.',
+			ephemeral: true
+		});
 	}
 
 	const action = split[1] === 'ENTER' ? 'ENTER' : 'LEAVE';
@@ -175,7 +181,10 @@ async function giveawayButtonHandler(user: MUser, customID: string, interaction:
 	}
 
 	if (user.id === giveaway.user_id) {
-		return interactionReply(interaction, { content: 'You cannot join your own giveaway.', ephemeral: true });
+		return interactionReply(interaction, {
+			content: 'You cannot join your own giveaway.',
+			ephemeral: true
+		});
 	}
 
 	if (action === 'ENTER') {
@@ -196,7 +205,10 @@ async function giveawayButtonHandler(user: MUser, customID: string, interaction:
 			}
 		});
 		updateGiveawayMessage(giveaway);
-		return interactionReply(interaction, { content: 'You are now entered in this giveaway.', ephemeral: true });
+		return interactionReply(interaction, {
+			content: 'You are now entered in this giveaway.',
+			ephemeral: true
+		});
 	}
 	if (!giveaway.users_entered.includes(user.id)) {
 		return interactionReply(interaction, {
@@ -213,11 +225,14 @@ async function giveawayButtonHandler(user: MUser, customID: string, interaction:
 		}
 	});
 	updateGiveawayMessage(giveaway);
-	return interactionReply(interaction, { content: 'You left the giveaway.', ephemeral: true });
+	return interactionReply(interaction, {
+		content: 'You left the giveaway.',
+		ephemeral: true
+	});
 }
 
 async function simRepeatHandler(user: MUser, interaction: ButtonInteraction) {
-	const [commandType, jsonData] = interaction.customId.replace('REPEAT_SIM_', '').split('_DATA_');
+	const [commandType, jsonData] = interaction.customId.replace('SIM_', '').split('_X_');
 	return runCommand({
 		commandName: commandType.toLowerCase(),
 		args: JSON.parse(jsonData),
@@ -233,7 +248,10 @@ async function repeatTripHandler(user: MUser, interaction: ButtonInteraction) {
 	if (user.minionIsBusy) return 'Your minion is busy.';
 	const trips = await fetchRepeatTrips(interaction.user.id);
 	if (trips.length === 0)
-		return interactionReply(interaction, { content: "Couldn't find a trip to repeat.", ephemeral: true });
+		return interactionReply(interaction, {
+			content: "Couldn't find a trip to repeat.",
+			ephemeral: true
+		});
 	const id = interaction.customId;
 	const split = id.split('_');
 	const matchingActivity = trips.find(i => i.type === split[2]);
@@ -249,11 +267,14 @@ export async function interactionHook(interaction: Interaction) {
 	const user = await mUserFetch(userID);
 	if (id.includes('GIVEAWAY_')) return giveawayButtonHandler(user, id, interaction);
 	if (id.includes('REPEAT_TRIP')) return repeatTripHandler(user, interaction);
-	if (id.includes('REPEAT_SIM_')) return simRepeatHandler(user, interaction);
+	if (id.startsWith('SIM_')) return simRepeatHandler(user, interaction);
 
 	if (!isValidGlobalInteraction(id)) return;
 	if (user.isBusy || globalClient.isShuttingDown) {
-		return interactionReply(interaction, { content: 'You cannot use a command right now.', ephemeral: true });
+		return interactionReply(interaction, {
+			content: 'You cannot use a command right now.',
+			ephemeral: true
+		});
 	}
 
 	const options = {
@@ -384,7 +405,10 @@ export async function interactionHook(interaction: Interaction) {
 	}
 
 	if (minionIsBusy(user.id)) {
-		return interactionReply(interaction, { content: `${user.minionName} is busy.`, ephemeral: true });
+		return interactionReply(interaction, {
+			content: `${user.minionName} is busy.`,
+			ephemeral: true
+		});
 	}
 
 	switch (id) {

--- a/src/mahoji/commands/finish.ts
+++ b/src/mahoji/commands/finish.ts
@@ -49,7 +49,7 @@ export const finishCommand: OSBMahojiCommand = {
 		const finishStr = kcBank.items().sort(sorts.quantity).reverse();
 		const repeatButton = makeComponents([
 			new ButtonBuilder()
-				.setCustomId(`REPEAT_SIM_FINISH_DATA_${JSON.stringify(options)}`)
+				.setCustomId(`SIM_FINISH_X_${JSON.stringify(options)}`)
 				.setLabel('Repeat Sim')
 				.setStyle(ButtonStyle.Secondary)
 				.setEmoji('📊')

--- a/src/mahoji/commands/finish.ts
+++ b/src/mahoji/commands/finish.ts
@@ -1,10 +1,10 @@
-import { AttachmentBuilder } from 'discord.js';
+import { AttachmentBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank } from 'oldschooljs';
 
 import { finishables } from '../../lib/finishables';
 import { sorts } from '../../lib/sorts';
-import { stringMatches } from '../../lib/util';
+import { makeComponents, stringMatches } from '../../lib/util';
 import { deferInteraction } from '../../lib/util/interactionReply';
 import { makeBankImage } from '../../lib/util/makeBankImage';
 import { Workers } from '../../lib/workers';
@@ -40,15 +40,27 @@ export const finishCommand: OSBMahojiCommand = {
 		if ('customResponse' in val && val.customResponse) {
 			return val.customResponse(kc);
 		}
-		const image = await makeBankImage({ bank: loot, title: `Loot from ${kc}x ${val.name}` });
+		const image = await makeBankImage({
+			bank: loot,
+			title: `Loot from ${kc}x ${val.name}`
+		});
 
 		const result = `It took you ${kc.toLocaleString()} KC to finish the ${val.name} CL.`;
 		const finishStr = kcBank.items().sort(sorts.quantity).reverse();
+		const repeatButton = makeComponents([
+			new ButtonBuilder()
+				.setCustomId(`REPEAT_SIM_FINISH_DATA_${JSON.stringify(options)}`)
+				.setLabel('Repeat Sim')
+				.setStyle(ButtonStyle.Secondary)
+				.setEmoji('📊')
+		]);
+
 		if (finishStr.length < 20) {
 			return {
 				content: `${result}
 ${finishStr.map(i => `**${i[0].name}:** ${i[1]} KC`).join('\n')}`,
-				files: [image.file]
+				files: [image.file],
+				components: repeatButton
 			};
 		}
 		return {
@@ -58,7 +70,8 @@ ${finishStr.map(i => `**${i[0].name}:** ${i[1]} KC`).join('\n')}`,
 				new AttachmentBuilder(Buffer.from(finishStr.map(i => `${i[0].name}: ${i[1]} KC`).join('\n')), {
 					name: 'finish.txt'
 				})
-			]
+			],
+			components: repeatButton
 		};
 	}
 };

--- a/src/mahoji/commands/kill.ts
+++ b/src/mahoji/commands/kill.ts
@@ -51,7 +51,10 @@ export const killCommand: OSBMahojiCommand = {
 			required: true,
 			autocomplete: async (value: string) => {
 				return [
-					...Monsters.map(i => ({ name: i.name, aliases: i.aliases })),
+					...Monsters.map(i => ({
+						name: i.name,
+						aliases: i.aliases
+					})),
 					{ name: 'nex', aliases: ['nex'] },
 					{ name: 'nightmare', aliases: ['nightmare'] }
 				]
@@ -88,7 +91,7 @@ export const killCommand: OSBMahojiCommand = {
 
 		const repeatButton = makeComponents([
 			new ButtonBuilder()
-				.setCustomId(`REPEAT_SIM_KILL_DATA_${JSON.stringify(options)}`)
+				.setCustomId(`SIM_KILL_X_${JSON.stringify(options)}`)
 				.setLabel('Repeat Sim')
 				.setStyle(ButtonStyle.Secondary)
 				.setEmoji('📊')

--- a/src/mahoji/commands/kill.ts
+++ b/src/mahoji/commands/kill.ts
@@ -1,7 +1,9 @@
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank, Monsters } from 'oldschooljs';
 
 import { PerkTier } from '../../lib/constants';
+import { makeComponents } from '../../lib/util';
 import { deferInteraction } from '../../lib/util/interactionReply';
 import { makeBankImage } from '../../lib/util/makeBankImage';
 import { toTitleCase } from '../../lib/util/toTitleCase';
@@ -84,6 +86,14 @@ export const killCommand: OSBMahojiCommand = {
 			return result.error;
 		}
 
+		const repeatButton = makeComponents([
+			new ButtonBuilder()
+				.setCustomId(`REPEAT_SIM_KILL_DATA_${JSON.stringify(options)}`)
+				.setLabel('Repeat Sim')
+				.setStyle(ButtonStyle.Secondary)
+				.setEmoji('📊')
+		]);
+
 		const image = await makeBankImage({
 			bank: new Bank(result.bank?.bank),
 			title: result.title ?? `Loot from ${options.quantity.toLocaleString()} ${toTitleCase(options.name)}`,
@@ -91,7 +101,8 @@ export const killCommand: OSBMahojiCommand = {
 		});
 		return {
 			files: [image.file],
-			content: result.content
+			content: result.content,
+			components: repeatButton
 		};
 	}
 };

--- a/src/mahoji/commands/simulate.ts
+++ b/src/mahoji/commands/simulate.ts
@@ -1,3 +1,4 @@
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
 import { randInt, roll } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
@@ -7,6 +8,7 @@ import { toKMB } from 'oldschooljs/dist/util';
 
 import { PerkTier } from '../../lib/constants';
 import pets from '../../lib/data/pets';
+import { makeComponents } from '../../lib/util';
 import { makeBankImage } from '../../lib/util/makeBankImage';
 import { OSBMahojiCommand } from '../lib/util';
 
@@ -61,11 +63,23 @@ async function coxCommand(user: MUser, quantity: number, cm = false, points = 25
 		title: `Loot from ${quantity} ${cm ? 'challenge mode ' : ''}raids`
 	});
 
+
 	return {
 		content: `Personal Loot from ${quantity}x raids, with ${team.length} people, each with ${toKMB(
 			points
 		)} points.`,
-		files: [image.file]
+		files: [image.file],
+		components: makeComponents([
+			new ButtonBuilder()
+				.setCustomId(
+					`REPEAT_SIM_SIMULATE_DATA_${JSON.stringify({
+						cox: { quantity, points, team_size: teamSize, challenge_mode: cm }
+					})}`
+				)
+				.setLabel('Repeat Sim')
+				.setStyle(ButtonStyle.Secondary)
+				.setEmoji('📊')
+		])
 	};
 }
 
@@ -142,6 +156,7 @@ export const simulateCommand: OSBMahojiCommand = {
 		};
 	}>) => {
 		const user = await mUserFetch(userID.toString());
+
 		if (options.cox) {
 			return coxCommand(
 				user,
@@ -160,8 +175,16 @@ export const simulateCommand: OSBMahojiCommand = {
 				}
 			}
 
-			if (received.length === 0) return "You didn't get any pets!";
-			return received.join(' ');
+			return {
+				content: received.length === 0 ? "You didn't get any pets!" : received.join(' '),
+				components: makeComponents([
+					new ButtonBuilder()
+						.setCustomId(`REPEAT_SIM_SIMULATE_DATA_${JSON.stringify(options)}`)
+						.setLabel('Repeat Sim')
+						.setStyle(ButtonStyle.Secondary)
+						.setEmoji('📊')
+				])
+			};
 		}
 		return 'Invalid command.';
 	}

--- a/src/mahoji/commands/simulate.ts
+++ b/src/mahoji/commands/simulate.ts
@@ -63,7 +63,6 @@ async function coxCommand(user: MUser, quantity: number, cm = false, points = 25
 		title: `Loot from ${quantity} ${cm ? 'challenge mode ' : ''}raids`
 	});
 
-
 	return {
 		content: `Personal Loot from ${quantity}x raids, with ${team.length} people, each with ${toKMB(
 			points
@@ -72,8 +71,13 @@ async function coxCommand(user: MUser, quantity: number, cm = false, points = 25
 		components: makeComponents([
 			new ButtonBuilder()
 				.setCustomId(
-					`REPEAT_SIM_SIMULATE_DATA_${JSON.stringify({
-						cox: { quantity, points, team_size: teamSize, challenge_mode: cm }
+					`SIM_SIMULATE_X_${JSON.stringify({
+						cox: {
+							quantity,
+							points,
+							team_size: teamSize,
+							challenge_mode: cm
+						}
 					})}`
 				)
 				.setLabel('Repeat Sim')
@@ -179,7 +183,7 @@ export const simulateCommand: OSBMahojiCommand = {
 				content: received.length === 0 ? "You didn't get any pets!" : received.join(' '),
 				components: makeComponents([
 					new ButtonBuilder()
-						.setCustomId(`REPEAT_SIM_SIMULATE_DATA_${JSON.stringify(options)}`)
+						.setCustomId(`SIM_SIMULATE_X_${JSON.stringify(options)}`)
 						.setLabel('Repeat Sim')
 						.setStyle(ButtonStyle.Secondary)
 						.setEmoji('📊')


### PR DESCRIPTION
This started in response to #4812

### Description:

Added buttons to /simulate, /kill and /finish to allow for repeating the same sim multiple times.

It does this by storing a copy of the options in the custom id of the button, rather than storing anything in the database. This means others can press the button to try the same sim themselves (assuming their Patreon tier is high enough etc.).

I found that the custom id for the button can only be 100 characters. The longest input of options possible at the moment is 95 characters.

### Changes:

Added Repeat Sim button to /finish, /simulate and /kill.
Added `simRepeatHandler` to the `interactionHook` to catch the new buttons and process them.

### Other checks:
Tested on private server with @TastyPumPum 
-   [x] I have tested all my changes thoroughly.
