### PR TITLE
Add notification for Draconic Visage from Addy Drags

### DIFF
--- a/src/lib/minions/data/killableMonsters/konarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/konarMonsters.ts
@@ -16,7 +16,7 @@ export const konarMonsters: KillableMonster[] = [
 
 		wildy: false,
 
-		notifyDrops: resolveItems(['Dragon metal slice']),
+		notifyDrops: resolveItems(['Dragon metal slice', 'Draconic visage']),
 
 		difficultyRating: 5,
 		itemsRequired: resolveItems(['Anti-dragon shield']),


### PR DESCRIPTION
Adds draconic visage to the notifyDrops for addy dragons, as it notifys for rune dragons and its rarer from addy ones.

https://oldschool.runescape.wiki/w/Draconic_visage

-   [ ] I have tested all my changes thoroughly.
