### PR TITLE
Fix armadyl plate/component clash

### DIFF
--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -107,7 +107,7 @@ const componentRevertables: Createable[] = [
 		}
 	},
 	{
-		name: 'Revert armadyl helmet',
+		name: 'Revert armadyl helmet (Components)',
 		inputItems: {
 			[itemID('Armadyl helmet')]: 1
 		},
@@ -116,7 +116,7 @@ const componentRevertables: Createable[] = [
 		}
 	},
 	{
-		name: 'Revert armadyl chestplate',
+		name: 'Revert armadyl chestplate (Components)',
 		inputItems: {
 			[itemID('Armadyl chestplate')]: 1
 		},
@@ -125,7 +125,7 @@ const componentRevertables: Createable[] = [
 		}
 	},
 	{
-		name: 'Revert armadyl chainskirt',
+		name: 'Revert armadyl chainskirt (Components)',
 		inputItems: {
 			[itemID('Armadyl chainskirt')]: 1
 		},

--- a/src/lib/data/creatables/toa.ts
+++ b/src/lib/data/creatables/toa.ts
@@ -92,21 +92,21 @@ export const toaCreatables: Createable[] = [
 		outputItems: new Bank({ 'Masori chaps (f)': 1 })
 	},
 	{
-		name: 'Revert Armadyl helmet',
+		name: 'Revert armadyl helmet (Plate)',
 		inputItems: new Bank({
 			'Armadyl helmet': 1
 		}),
 		outputItems: new Bank({ 'Armadylean plate': 1 })
 	},
 	{
-		name: 'Revert Armadyl chestplate',
+		name: 'Revert armadyl chestplate (Plate)',
 		inputItems: new Bank({
 			'Armadyl chestplate': 1
 		}),
 		outputItems: new Bank({ 'Armadylean plate': 4 })
 	},
 	{
-		name: 'Revert Armadyl chainskirt',
+		name: 'Revert armadyl chainskirt (Plate)',
 		inputItems: new Bank({
 			'Armadyl chainskirt': 1
 		}),


### PR DESCRIPTION
### Description:
Fix bug where you couldn't make armadyl plate on BSO


### Changes:
Updated the clashing create item names, added either (Components) or (Plate) so it's clear what you get.


### Other checks:

-   [x] I have tested all my changes thoroughly.
