### PR TITLE
Show TOA Raid Level on Mass Host

### DIFF
--- a/src/lib/simulation/toa.ts
+++ b/src/lib/simulation/toa.ts
@@ -1111,7 +1111,7 @@ export async function toaStartCommand(
 		minSize: 1,
 		maxSize,
 		ironmanAllowed: true,
-		message: `${user.usernameOrMention} is hosting a Tombs of Amascut mass! Use the buttons below to join/leave.`,
+		message: `${user.usernameOrMention} is hosting a Tombs of Amascut mass! **Raid Level: ${raidLevel}**. Use the buttons below to join/leave.`,
 		customDenier: async user => {
 			if (user.minionIsBusy) {
 				return [true, `${user.usernameOrMention} minion is busy`];


### PR DESCRIPTION
### Description:

I have seen users complaining about difficulty to see raid level (without hovering on the cmd), thought we should include it on the mass host message.

Tested on my own server as my bot doesn't work in the testing server (have explained in developers channel)

### Changes:

* Add raid level

### Other checks:

-   [X] I have tested all my changes thoroughly.
