### PR TITLE
[BSO] Fix Nex + Kalphite King crash/loot issue

### DIFF
--- a/src/tasks/minions/bso/kalphiteKingActivity.ts
+++ b/src/tasks/minions/bso/kalphiteKingActivity.ts
@@ -74,7 +74,7 @@ export const kalphiteKingTask: MinionTask = {
 			if (isDoubleLootActive(duration)) {
 				loot.multiply(2);
 			}
-			const winner = teamTable.roll();
+			const winner = teamTable.table.length ? teamTable.roll() : null;
 			if (!winner) continue;
 			teamsLoot.add(winner, loot);
 

--- a/src/tasks/minions/bso/kalphiteKingActivity.ts
+++ b/src/tasks/minions/bso/kalphiteKingActivity.ts
@@ -1,6 +1,6 @@
+import { SimpleTable } from '@oldschoolgg/toolkit';
 import { calcWhatPercent, noOp, percentChance } from 'e';
 import { Bank } from 'oldschooljs';
-import SimpleTable from 'oldschooljs/dist/structures/SimpleTable';
 
 import { Emoji } from '../../../lib/constants';
 import { kalphiteKingCL } from '../../../lib/data/CollectionsExport';
@@ -74,7 +74,7 @@ export const kalphiteKingTask: MinionTask = {
 			if (isDoubleLootActive(duration)) {
 				loot.multiply(2);
 			}
-			const winner = teamTable.table.length ? teamTable.roll() : null;
+			const winner = teamTable.roll();
 			if (!winner) continue;
 			teamsLoot.add(winner, loot);
 

--- a/src/tasks/minions/bso/nexActivity.ts
+++ b/src/tasks/minions/bso/nexActivity.ts
@@ -76,7 +76,7 @@ export const nexTask: MinionTask = {
 			if (isDoubleLootActive(duration)) {
 				loot.multiply(2);
 			}
-			const winner = teamTable.roll();
+			const winner = teamTable.table.length ? teamTable.roll() : null;
 			if (!winner) continue;
 			teamsLoot.add(winner, loot);
 

--- a/src/tasks/minions/bso/nexActivity.ts
+++ b/src/tasks/minions/bso/nexActivity.ts
@@ -1,6 +1,6 @@
+import { SimpleTable } from '@oldschoolgg/toolkit';
 import { calcWhatPercent, noOp, percentChance, randArrItem } from 'e';
 import { Bank } from 'oldschooljs';
-import SimpleTable from 'oldschooljs/dist/structures/SimpleTable';
 
 import { Emoji } from '../../../lib/constants';
 import { nexCL, nexUniqueDrops } from '../../../lib/data/CollectionsExport';
@@ -76,7 +76,7 @@ export const nexTask: MinionTask = {
 			if (isDoubleLootActive(duration)) {
 				loot.multiply(2);
 			}
-			const winner = teamTable.table.length ? teamTable.roll() : null;
+			const winner = teamTable.roll();
 			if (!winner) continue;
 			teamsLoot.add(winner, loot);
 


### PR DESCRIPTION
### Description:

This fixes an issue where the mass fails to return if there's zero members in a SimpleTable. Another fix for OSJS is pending.

### Changes:

- If the SimpleTable is empty, don't even try to roll, just discard the loot as intended.

### Other checks:

-   [x] I have tested all my changes thoroughly.
