### PR TITLE
Add easier contract button when receiving contract

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -38,6 +38,7 @@ const globalInteractionActions = [
 	'CANCEL_TRIP',
 	'AUTO_FARM',
 	'AUTO_FARMING_CONTRACT',
+	'FARMING_CONTRACT_EASIER',
 	'OPEN_SEED_PACK',
 	'BUY_MINION',
 	'BUY_BINGO_TICKET',
@@ -84,6 +85,14 @@ export function makeAutoContractButton() {
 	return new ButtonBuilder()
 		.setCustomId('AUTO_FARMING_CONTRACT')
 		.setLabel('Auto Farming Contract')
+		.setStyle(ButtonStyle.Secondary)
+		.setEmoji('977410792754413668');
+}
+
+export function makeEasierFarmingContractButton() {
+	return new ButtonBuilder()
+		.setCustomId('FARMING_CONTRACT_EASIER')
+		.setLabel('Ask for easier Contract')
 		.setStyle(ButtonStyle.Secondary)
 		.setEmoji('977410792754413668');
 }
@@ -425,6 +434,18 @@ export async function interactionHook(interaction: Interaction) {
 			const response = await autoContract(await mUserFetch(user.id), options.channelID, user.id);
 			if (response) interactionReply(interaction, response);
 			return;
+		}
+		case 'FARMING_CONTRACT_EASIER': {
+			return runCommand({
+				commandName: 'farming',
+				args: {
+					contract: {
+						input: 'easier'
+					}
+				},
+				bypassInhibitors: true,
+				...options
+			});
 		}
 		case 'OPEN_SEED_PACK': {
 			return runCommand({

--- a/src/mahoji/lib/abstracted_commands/farmingContractCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingContractCommand.ts
@@ -5,9 +5,10 @@ import { defaultFarmingContract } from '../../../lib/minions/farming';
 import { ContractOption, FarmingContract, FarmingContractDifficultyLevel } from '../../../lib/minions/farming/types';
 import { getPlantToGrow } from '../../../lib/skilling/functions/calcFarmingContracts';
 import { getFarmingInfo } from '../../../lib/skilling/functions/getFarmingInfo';
-import { roughMergeMahojiResponse } from '../../../lib/util';
+import { makeComponents, roughMergeMahojiResponse } from '../../../lib/util';
 import { newChatHeadImage } from '../../../lib/util/chatHeadImage';
 import { findPlant } from '../../../lib/util/farmingHelpers';
+import { makeEasierFarmingContractButton } from '../../../lib/util/globalInteractions';
 import { minionIsBusy } from '../../../lib/util/minionIsBusy';
 import { mahojiUsersSettingsFetch } from '../../mahojiSettings';
 import { farmingPlantCommand, harvestCommand } from './farmingCommand';
@@ -78,18 +79,34 @@ export async function farmingContractCommand(userID: string, input?: ContractOpt
 			await user.update({
 				minion_farmingContract: farmingContractUpdate as any
 			});
-			return janeImage(
-				`I suppose you were too chicken for the challenge. Please could you grow a ${plantToGrow} instead for us? I'll reward you once you have checked its health.`
-			);
+
+			return {
+				files: (
+					await janeImage(
+						`I suppose you were too chicken for the challenge. Please could you grow a ${plantToGrow} instead for us? I'll reward you once you have checked its health.`
+					)
+				).files,
+				components:
+					newContractLevel !== 'easy' ? makeComponents([makeEasierFarmingContractButton()]) : undefined
+			};
 		}
 
 		let easierStr = '';
 		if (currentContract.difficultyLevel !== 'easy') {
 			easierStr = "\nYou can request an easier contract if you'd like.";
 		}
-		return janeImage(
-			`Your current contract (${currentContract.difficultyLevel}) is to grow ${currentContract.plantToGrow}. Please come back when you have finished this contract first.${easierStr}`
-		);
+
+		return {
+			files: (
+				await janeImage(
+					`Your current contract (${currentContract.difficultyLevel}) is to grow ${currentContract.plantToGrow}. Please come back when you have finished this contract first.${easierStr}`
+				)
+			).files,
+			components:
+				currentContract.difficultyLevel !== 'easy'
+					? makeComponents([makeEasierFarmingContractButton()])
+					: undefined
+		};
 	}
 
 	if (minionIsBusy(user.id)) {
@@ -117,9 +134,14 @@ export async function farmingContractCommand(userID: string, input?: ContractOpt
 		minion_farmingContract: farmingContractUpdate as any
 	});
 
-	return janeImage(
-		`Please could you grow a ${plantToGrow} for us? I'll reward you once you have checked its health.`
-	);
+	return {
+		files: (
+			await janeImage(
+				`Please could you grow a ${plantToGrow} for us? I'll reward you once you have checked its health.`
+			)
+		).files,
+		components: input !== 'easy' ? makeComponents([makeEasierFarmingContractButton()]) : undefined
+	};
 }
 
 export async function canRunAutoContract(user: MUser) {


### PR DESCRIPTION
### Description:

This closes #4775.

Add a button to get an easier contract when receiving a new or replacement contract from Jane. 

### Changes:

- Add a button for easier contract

### Other checks:

-   [X] I have tested all my changes thoroughly.

Tested on my own server as my bot doesn't work in test server