### PR TITLE
Convert mins into hours when displaying time per unique

### DIFF
--- a/src/lib/simulation/toa.ts
+++ b/src/lib/simulation/toa.ts
@@ -1553,7 +1553,7 @@ export async function toaHelpCommand(user: MUser, channelID: string) {
 			  ).toLocaleString()} pts, one unique every ${Math.floor(
 					totalKC / totalUniques
 			  )} raids, one unique every ${formatDuration(
-					(userStats.total_toa_duration_minutes * 1000) / totalUniques
+					(userStats.total_toa_duration_minutes * 60000) / totalUniques
 			  )})`
 			: ''
 	}

--- a/src/lib/simulation/toa.ts
+++ b/src/lib/simulation/toa.ts
@@ -1553,7 +1553,7 @@ export async function toaHelpCommand(user: MUser, channelID: string) {
 			  ).toLocaleString()} pts, one unique every ${Math.floor(
 					totalKC / totalUniques
 			  )} raids, one unique every ${formatDuration(
-					(userStats.total_toa_duration_minutes * 60000) / totalUniques
+					(userStats.total_toa_duration_minutes * Time.Minute) / totalUniques
 			  )})`
 			: ''
 	}


### PR DESCRIPTION
When displaying unique count per time spent raiding toa, we multiply duration in minutes by 60000 to get the duraction in ms to pass to`formatDuration`.

Previously was treating `total_toa_duration_minutes` as if it was in seconds, and multipling only by 1000. Time per unique was displaying "one unique every 37 minutes, 48 seconds" when in reality the minion had received one unique in 37 hours, 48 minutes of ToA
