### PR TITLE
Fix bug with obtaining multiple Hammys

### DIFF
--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -138,7 +138,6 @@ export const sacrificeCommand: OSBMahojiCommand = {
 		for (let i = 0; i < Math.floor(totalPrice / 51_530_000); i++) {
 			if (roll(140)) {
 				hammyCount++;
-				break;
 			}
 		}
 		if (hammyCount) {


### PR DESCRIPTION
### Description:

- A bug is preventing the ability to obtain multiple Hammy from a big-sacrifice from working.

### Changes:

- Removes a `break;` that exits the loop after the first Hammy is obtained.

### Other checks:

-   [x] I have tested all my changes thoroughly.
