### PR TITLE
Re-add BSO 2x clue boost

### DIFF
--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -108,6 +108,9 @@ export const clueCommand: OSBMahojiCommand = {
 			(user.user.openable_scores as ItemBank)[clueTier.id] ?? 1
 		);
 
+		timeToFinish /= 2;
+		boosts.push('👻 2x Boost');
+
 		if (user.hasEquipped(clueHunterOutfit, true)) {
 			timeToFinish /= 2;
 			boosts.push('2x Boost for Clue hunter outfit');


### PR DESCRIPTION
### Description:

Added bso 2x boost back in

### Changes:

Copied back from old branch the boost, tested the times with new items and it's as expected

### Other checks:

-   [x] I have tested all my changes thoroughly.
