### PR TITLE
Fix remaining Gear command bug

### DIFF
--- a/src/lib/structures/Gear.ts
+++ b/src/lib/structures/Gear.ts
@@ -506,25 +506,25 @@ export class Gear {
 			case EquipmentSlot.TwoHanded: {
 				// If trying to equip a 2h weapon, remove the weapon and shield.
 				if (this.weapon) {
-					refundBank.add(this.weapon.item);
+					refundBank.add(this.weapon.item, this.weapon.quantity);
 					this.weapon = null;
 				}
 				if (this.shield) {
-					refundBank.add(this.shield.item);
+					refundBank.add(this.shield.item, this.shield.quantity);
 					this.shield = null;
 				}
 				if (this['2h']) {
-					refundBank.add(this['2h'].item);
+					refundBank.add(this['2h'].item, this['2h'].quantity);
 					this['2h'] = null;
 				}
-				this['2h'] = { item: itemToEquip.id, quantity: 1 };
+				this['2h'] = { item: itemToEquip.id, quantity };
 				break;
 			}
 			case EquipmentSlot.Weapon:
 			case EquipmentSlot.Shield: {
 				const twoHanded = this['2h'];
 				if (twoHanded) {
-					refundBank.add(twoHanded.item);
+					refundBank.add(twoHanded.item, twoHanded.quantity);
 					this['2h'] = null;
 				}
 

--- a/tests/Gear.test.ts
+++ b/tests/Gear.test.ts
@@ -396,6 +396,13 @@ describe('Gear', () => {
 		const resultDarts = gear.equip(getOSItem('Dragon dart'), 111);
 		expect(bankIsEqual(resultDarts.refundBank as any, new Bank().add('Dragon knife', 100))).toEqual(true);
 		expect(gear.weapon).toEqual({ item: getOSItem('Dragon dart').id, quantity: 111 });
+
+		const result2h = gear.equip(getOSItem('Twisted bow'));
+		expect(
+			bankIsEqual(result2h.refundBank as any, new Bank().add('Dragon dart', 111).add('Bronze kiteshield'))
+		).toEqual(true);
+		expect(gear.weapon).toBeNull();
+		expect(gear['2h']).toEqual({ item: getOSItem('Twisted bow').id, quantity: 1 });
 	});
 
 	it('should equip/refund properly if equipping a 2h over a 2h', () => {


### PR DESCRIPTION
### Description:

This fixes a remaining bug in the gear command where quantities weren't being refunded for non-ammo items.

### Changes:

Adds fix for the bug, and adds a test for this case.

### Other checks:

-   [x] I have tested all my changes thoroughly.
