### PR TITLE
Remove lowest value toa drops from #notifications

### DIFF
--- a/src/tasks/minions/minigames/toaActivity.ts
+++ b/src/tasks/minions/minigames/toaActivity.ts
@@ -17,7 +17,7 @@ import resolveItems from '../../../lib/util/resolveItems';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 import { userStatsUpdate } from '../../../mahoji/mahojiSettings';
 
-const purpleButNotAnnounced = resolveItems(['Dexterous prayer scroll', 'Arcane prayer scroll']);
+const purpleButNotAnnounced = resolveItems(['Lightbearer', "Elidinis' ward"]);
 
 interface RaidResultUser {
 	points: number;


### PR DESCRIPTION

### Description:

Replaced the placeholder scrolls from CoX in purpleButNotAnnounced with the 2 lowest values from ToA to limit spam in #notifications in main channel


### Changes:

Removed Dex and Arcane from const purpleButNotAnnounced that was copied over from CoX activity and replaced with Lightbearer and Elidinis' ward.

### Other checks:

-   [x] I have tested all my changes thoroughly.
