### PR TITLE
Fix Hammy's appearing needlessly

### DIFF
--- a/src/lib/bankImage.ts
+++ b/src/lib/bankImage.ts
@@ -320,7 +320,15 @@ class BankImageTask {
 		}
 
 		const imageBuffer = await fs.readFile(path.join(CACHE_DIR, `${itemID}.png`));
-		if (imageBuffer.length < 200) return this.getItemImage(1);
+		if (imageBuffer.length < 200) {
+			// Look for PNG Header to ensure it's really a bad image:
+			const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+			const testHeader = Buffer.alloc(4);
+			imageBuffer.copy(testHeader, 0, 0, 4);
+			if (pngHeader.compare(testHeader) !== 0) {
+				return this.getItemImage(1);
+			}
+		}
 		try {
 			const image = await loadImage(imageBuffer);
 			this.itemIconImagesCache.set(itemID, image);


### PR DESCRIPTION
### Description:

Fix issue with Hammy appearing instead of Abyssal Pearls.

The issue was the code was doing a blanket check for files < 200 bytes, however Abyssal pearls (and other images can be, too) are less than 200 bytes.

### Changes:

- If the image is less than 200 bytes, look for a PNG header, only if that fails do we return a placeholder.

### Other checks:

-   [x] I have tested all my changes thoroughly.
