### PR TITLE
Updates Nex Elite rate to be accurate to in-game

### DIFF
--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -150,7 +150,7 @@ export function handleNexKills({ quantity, team }: NexContext) {
 			if (teamMember.id === uniqueRecipient) {
 				teamLoot.add(teamMember.id, NexUniqueTable.roll());
 			}
-			if (roll(20)) {
+			if (roll(48)) {
 				teamLoot.add(teamMember.id, 'Clue scroll (elite)');
 			}
 		}


### PR DESCRIPTION
### Description:

Nex elite clue drop rate is 1/20. It is actually 1/48, as confirmed by Mod ash in this tweet: https://twitter.com/JagexAsh/status/1557262831266971650

### Changes:

- Changes Nex elite clue roll to 48 rather than 20

### Other checks:

-   [ ] I have tested all my changes thoroughly.
