### PR TITLE
Fix clue update on BSO

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -634,7 +634,7 @@ export class MUserClass {
 					casket: getOSItem(tier.id),
 					clueScroll: getOSItem(tier.scrollID),
 					opened: this.openableScores()[tier.id] ?? 0,
-					actualOpened: actualClues.amount(tier.id)
+					actualOpened: actualClues.amount(tier.scrollID)
 				};
 			})
 			.filter(notEmpty);


### PR DESCRIPTION
### Description:

"Actual Clues" uses scrollID not casket id

### Changes:

- Updated  code to reference by scroll id.

### Other checks:

-   [x] I have tested all my changes thoroughly.
