### PR TITLE
Show qty owned in /minion lamp command

### DIFF
--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -194,12 +194,22 @@ export const minionCommand: OSBMahojiCommand = {
 					type: ApplicationCommandOptionType.String,
 					name: 'item',
 					description: 'The item you want to use.',
-					autocomplete: async (value: string) => {
-						return Lampables.map(i => i.items)
+					autocomplete: async (value, user) => {
+						const mappedLampables = Lampables.map(i => i.items)
 							.flat(2)
 							.map(getOSItem)
-							.filter(p => (!value ? true : p.name.toLowerCase().includes(value.toLowerCase())))
-							.map(p => ({ name: p.name, value: p.name }));
+							.map(i => ({ id: i.id, name: i.name }));
+
+						const botUser = await mUserFetch(user.id);
+
+						return botUser.bank
+							.items()
+							.filter(i => mappedLampables.map(l => l.id).includes(i[0].id))
+							.filter(i => {
+								if (!value) return true;
+								return i[0].name.toLowerCase().includes(value.toLowerCase());
+							})
+							.map(i => ({ name: `${i[0].name} (${i[1]}x Owned)`, value: i[0].name.toLowerCase() }));
 					},
 					required: true
 				},


### PR DESCRIPTION
### Description:

Shows the quantities of each lamp owned when autocompleting the `/minion lamp` command. 

This closes [#4982](https://github.com/oldschoolgg/oldschoolbot/issues/4982)

### Changes:

Reimplement the command to look at users bank.

### Other checks:

- [X] I have tested all my changes thoroughly.
