### PR TITLE
Fix bug with autofarming with replant enable

### DIFF
--- a/src/lib/minions/functions/autoFarmFilters.ts
+++ b/src/lib/minions/functions/autoFarmFilters.ts
@@ -15,7 +15,7 @@ export function replant(
 	if (p.level > farmingLevel) return false;
 	const [numOfPatches] = calcNumOfPatches(p, user, user.QP);
 	if (numOfPatches === 0) return false;
-	const reqItems = new Bank(p.inputItems);
+	const reqItems = new Bank(p.inputItems).multiply(numOfPatches);
 	if (!userBank.has(reqItems.bank)) return false;
 	const patchData = patchesDetailed.find(_p => _p.patchName === p.seedType)!;
 	if (patchData.ready === true && p.name === patchData.plant?.name) return true;


### PR DESCRIPTION
### Description:

Bug reported by tehsaxo.

When user has 1..(noOfPatches-1) seeds (i.e. enough to do some, but not all patches) whilst having replant enabled, it would get stuck and not farm the next thing.

Steps for reproduction:

```
/farming auto_farm_filter auto_farm_filter_data: Replant
/testpotato max
/testpotato spawn preset: farming
/farming plant plant_name: Guam
/farming plant plant_name: Magic tree
/drop items: 93 magic tree seeds (should have 1 magic seed at this point)
/testpotato forcegrow patch_name: tree
/testpotato forcegrow patch_name: herb
/farming auto_farm
```

Result: `You don't own 6x Magic seed, 6x Compost.`
Expected Result: `Your minion is now harvesting 9x Guam, and then planting 9x Guam. You are treating your patches with 9x Compost.`

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

-   [ ] I have tested all my changes thoroughly.
