### PR TITLE
Add Mounted Xeric Talisman boost Clues

### DIFF
--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -119,6 +119,7 @@ export const clueCommand: OSBMahojiCommand = {
 		const poh = await getPOH(user.id);
 		const hasOrnateJewelleryBox = poh.jewellery_box === getPOHObject('Ornate jewellery box').id;
 		const hasJewelleryBox = poh.jewellery_box !== null;
+		const hasXericTalisman = poh.amulet === getPOHObject("Mounted xeric's talisman").id;
 
 		// Global Boosts
 		const globalBoosts = [
@@ -154,6 +155,12 @@ export const clueCommand: OSBMahojiCommand = {
 				boosts.push(boost);
 				duration *= durationMultiplier;
 			}
+		}
+
+		// Xeric's Talisman boost
+		if (clueTier.name === 'Medium' && hasXericTalisman) {
+			boosts.push("2% for Mounted Xeric's Talisman");
+			duration *= 0.98;
 		}
 
 		// Specific boosts


### PR DESCRIPTION
Following on from the amulet space PR.
Add a 2% boost to medium clues for having the Mounted Xeric's Talisman in your player owned house.

- [x] I have tested all my changes thoroughly.
