### PR TITLE
Make FixBank fix tames, too

### DIFF
--- a/src/lib/util/repairBrokenItems.ts
+++ b/src/lib/util/repairBrokenItems.ts
@@ -4,6 +4,7 @@ import { Items } from 'oldschooljs';
 
 import { GearSetup, GearSetupTypes } from '../gear';
 import { mahojiUserSettingsUpdate } from '../MUser';
+import { prisma } from '../settings/prisma';
 import { ItemBank } from '../types';
 import { moidLink } from '../util';
 
@@ -13,6 +14,20 @@ export async function repairBrokenItemsFromUser({ user }: MUser): Promise<[strin
 	const rawCL = user.collectionLogBank as ItemBank;
 	const rawTempCL = user.temp_cl as ItemBank;
 	const favorites = user.favoriteItems;
+	let rawTameBanks: [number, ItemBank][] = [];
+	let rawTameFeeds: [number, ItemBank][] = [];
+
+	const userTames = await prisma.tame.findMany({
+		where: {
+			user_id: user.id
+		}
+	});
+	if (userTames.length) {
+		for (const tame of userTames) {
+			rawTameBanks.push([tame.id, tame.max_total_loot as ItemBank]);
+			rawTameFeeds.push([tame.id, tame.fed_items as ItemBank]);
+		}
+	}
 
 	const rawAllGear = GearSetupTypes.map(i => user[`gear_${i}`]);
 	const allGearItemIDs = rawAllGear
@@ -25,13 +40,23 @@ export async function repairBrokenItemsFromUser({ user }: MUser): Promise<[strin
 		.flat(Infinity);
 
 	const brokenBank: number[] = [];
-	const allItemsToCheck = [
+	const allItemsToCheck: [string, (number | string)[]][] = [
 		['bank', Object.keys(rawBank)],
 		['cl', Object.keys(rawCL)],
 		['tempcl', Object.keys(rawTempCL)],
 		['favs', favorites],
 		['gear', allGearItemIDs]
-	] as const;
+	];
+	let newTameFeeds: [number, ItemBank][] = [];
+	let newTameBanks: [number, ItemBank][] = [];
+	for (const [tameId, tameBank] of rawTameBanks) {
+		allItemsToCheck.push([`tbank-${tameId}`, Object.keys(tameBank)]);
+		newTameBanks.push([tameId, { ...tameBank }]);
+	}
+	for (const [tameId, tameFeed] of rawTameFeeds) {
+		allItemsToCheck.push([`tfeed-${tameId}`, Object.keys(tameFeed)]);
+		newTameFeeds.push([tameId, { ...tameFeed }]);
+	}
 
 	for (const [, ids] of allItemsToCheck) {
 		for (const id of ids.map(i => Number(i))) {
@@ -47,10 +72,17 @@ export async function repairBrokenItemsFromUser({ user }: MUser): Promise<[strin
 	const newBank = { ...rawBank };
 	const newCL = { ...rawCL };
 	const newTempCL = { ...rawTempCL };
+
 	for (const id of brokenBank) {
 		delete newBank[id];
 		delete newCL[id];
 		delete newTempCL[id];
+		for (const [, tameBank] of newTameBanks) {
+			delete tameBank[id];
+		}
+		for (const [, tameFeed] of newTameFeeds) {
+			delete tameFeed[id];
+		}
 	}
 
 	for (const setupType of GearSetupTypes) {
@@ -77,14 +109,28 @@ export async function repairBrokenItemsFromUser({ user }: MUser): Promise<[strin
 		}
 
 		await mahojiUserSettingsUpdate(user.id, changes);
+		if (userTames.length) {
+			for (const tame of userTames) {
+				const tameBank = newTameBanks.find(tb => tb[0] === tame.id)![1];
+				const tameFeed = newTameFeeds.find(tf => tf[0] === tame.id)![1];
+				await prisma.tame.update({
+					where: {
+						id: tame.id
+					},
+					data: {
+						max_total_loot: tameBank,
+						fed_items: tameFeed
+					}
+				});
+			}
+		}
 
 		return [
 			`You had ${
 				brokenBank.length
-			} broken items in your bank/collection log/favorites/gear, they were removed. ${moidLink(brokenBank).slice(
-				0,
-				500
-			)}`,
+			} broken items in your bank/collection log/favorites/gear/tame, they were removed. ${moidLink(
+				brokenBank
+			).slice(0, 500)}`,
 			Object.keys(brokenBank)
 		];
 	}


### PR DESCRIPTION
### Description:

Currently broken items in Tames CL and Fed Items are causing errors when trying to view tame.

This updates fixbank command to also fix tames fed items + cl banks.

### Changes:

- Adds code to update Tames' CL Banks + Fed Item Banks
- Does **not** update food cost, as that shouldn't ever really break.

### Other checks:

- [x] I have tested all my changes thoroughly.
