### PR TITLE
Ironman price nerf for Bronze axe/pickaxe

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -876,7 +876,7 @@ const Buyables: Buyable[] = [
 	{
 		name: 'Bronze pickaxe',
 		gpCost: 500,
-		ironmanPrice: 1
+		ironmanPrice: 100
 	},
 	{
 		name: 'Iron pickaxe',
@@ -1028,7 +1028,7 @@ const Buyables: Buyable[] = [
 	{
 		name: 'Bronze axe',
 		gpCost: 500,
-		ironmanPrice: 16
+		ironmanPrice: 100
 	},
 	{
 		name: 'Iron axe',


### PR DESCRIPTION
The Ironman price for these items were 1gp, while their GE price is 77~ gp. Meaning you could exploit the low price by buying a million pickaxes and sacrificing them for essentially 77x the value. By bringing these prices to 100gp, it fixes that loophole. I'm sure there are other items that can be exploited in a similar way, but these are the biggest offenders by far

### Description:

- Set ironmanPrice for Bronze Pickaxe/Axe from 1gp to 100gp.

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [ ] I have tested all my changes thoroughly.
