### PR TITLE
Fix Typo in Agility Arena return trip text

### DIFF
--- a/src/tasks/minions/minigames/agilityArenaActivity.ts
+++ b/src/tasks/minions/minigames/agilityArenaActivity.ts
@@ -25,7 +25,7 @@ export const agilityArenaTask: MinionTask = {
 		let agilityXP = randomVariation((duration / Time.Minute) * 416, 1);
 		agilityXP = reduceNumByPercent(agilityXP, 100 - calcWhatPercent(currentLevel, 99));
 
-		// 10% bonus tickets for karamja med
+		// 10% bonus tickets for karamja elite
 		let bonusTickets = 0;
 		const [hasKaramjaElite] = await userhasDiaryTier(user, KaramjaDiary.elite);
 		if (hasKaramjaElite) {
@@ -67,7 +67,7 @@ export const agilityArenaTask: MinionTask = {
 		}
 
 		if (bonusTickets > 0) {
-			str += `\nYou received ${bonusTickets} bonus tickets for the Karamja Medium Diary.`;
+			str += `\nYou received ${bonusTickets} bonus tickets for the Karamja Elite Diary.`;
 		}
 
 		let xpFromTickets = determineXPFromTickets(ticketsReceived, user, hasKaramjaElite);


### PR DESCRIPTION
Updates the return text for the Brimhaven Agility Arena to show the correct diary

Closes #3464 

- [ ] I have tested all my changes thoroughly.
