### PR TITLE
Reduce leagues mystery impling requirement to 50

### DIFF
--- a/src/lib/leagues/masterTasks.ts
+++ b/src/lib/leagues/masterTasks.ts
@@ -1092,7 +1092,7 @@ export const masterTasks: Task[] = [
 			return loot
 				.items()
 				.filter(i => i[0].name !== 'Lucky impling jar')
-				.every(i => i[1] >= 100);
+				.every(i => i[1] >= 100 || (i[0].name === 'Mystery impling jar' && i[1] >= 50));
 		}
 	},
 	{


### PR DESCRIPTION
### Description:

Reduces leagues requirement for 100 passive Mystery implings down to 50.


### Other checks:

- [x] I have tested all my changes thoroughly.
