### PR TITLE
Fix Top Giveawayer Role - Currently only works for BSO or OSB, not both

### DIFF
--- a/src/lib/rolesTask.ts
+++ b/src/lib/rolesTask.ts
@@ -475,7 +475,7 @@ LIMIT 50;`;
 		results.push(
 			await addRoles({
 				users: [highestID],
-				role: '1052481561603346442',
+				role: '1104155653745946746',
 				badge: null,
 				userMap
 			})


### PR DESCRIPTION
### Description:

- Because there (was) only 1 Top Giveawayer role, each times sync_roles is run, it removes the top giveawayer role from the person who owns it in the other bot.

### Changes:

- Added new BSO Top Giveawayer role, and update `bso` to use the new role id.

### Other checks:

- [ ] I have tested all my changes thoroughly.
