### PR TITLE
Canifis - marks of grace update

### DIFF
--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -57,7 +57,7 @@ export const agilityTask: MinionTask = {
 				}
 			}
 		}
-		if (user.skillLevel(SkillsEnum.Agility) >= course.level + 20) {
+		if (course.id !== 5 && user.skillLevel(SkillsEnum.Agility) >= course.level + 20) {
 			totalMarks = Math.ceil(totalMarks / 5);
 		}
 


### PR DESCRIPTION
As per the wiki, remove the marks of grace debuff for the canifis course for being 20 levels over
https://oldschool.runescape.wiki/w/Mark_of_grace#Optimal_Strategies

- [x] I have tested all my changes thoroughly.
