### PR TITLE
Don't require Nex activity (requires hosting) because you require 1 kc already

### DIFF
--- a/src/lib/musicCape.ts
+++ b/src/lib/musicCape.ts
@@ -153,7 +153,8 @@ AND data->>'runeID' IS NOT NULL;`;
 				activity_type_enum.BirthdayEvent,
 				activity_type_enum.Questing,
 				activity_type_enum.BlastFurnace, // During the slash command migration this moved to under the smelting activity
-				activity_type_enum.ChampionsChallenge
+				activity_type_enum.ChampionsChallenge,
+				activity_type_enum.Nex
 			];
 			const activityCounts = await getUsersActivityCounts(user);
 


### PR DESCRIPTION
### Description:

- Currently there is confusion because people have tons of nex KC, but it still says they haven't done the Nex activity.
- This is because only the host gets the Nex activity on their record.
- It's also unnecessary because there is already a 1x Nex KC requirement.

### Changes:

Add Nex to the excluded activities for music cape requirements

### Other checks:

- [ ] I have tested all my changes thoroughly.
