### PR TITLE
Fix White Rabbits item consumption

### DIFF
--- a/src/lib/skilling/skills/hunter/creatures/rabbitSnaring.ts
+++ b/src/lib/skilling/skills/hunter/creatures/rabbitSnaring.ts
@@ -10,7 +10,7 @@ const rabbitSnaringCreatures: Creature[] = [
 		aliases: ['white rabbit', 'rabbit'],
 		level: 27,
 		hunterXP: 144,
-		itemsConsumed: new Bank().add('Ferret', 1),
+		itemsConsumed: new Bank().add('Eastern ferret', 1),
 		table: new LootTable().every('Bones').every('Raw rabbit').every('Rabbit foot'),
 		huntTechnique: HunterTechniqueEnum.RabbitSnaring,
 		multiTraps: true,


### PR DESCRIPTION
Currently hunting white rabbits will consume a zippy as bait due to that using the same ID as ferrets, changed the bait for white rabbits to eastern ferrets instead for BSO.

- [x] I have tested all my changes thoroughly.
