### PR TITLE
Add Phantom Muspah pet to #notifications

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -337,6 +337,7 @@ const killableBosses: KillableMonster[] = [
 		disallowedAttackStyles: [SkillsEnum.Attack, SkillsEnum.Strength],
 		attackStylesUsed: [GearStat.AttackMagic, GearStat.AttackRanged],
 		attackStyleToUse: GearStat.AttackMagic,
+		notifyDrops: resolveItems(['Muphin']),
 		degradeableItemUsage: [
 			{
 				required: true,


### PR DESCRIPTION
Adds the phantom muspah pet to the notifications channel, other bosses get the same and nice if people get multiple pets etc. 

