### PR TITLE
Add Hosidius Range + Kourend Elite cooking boosts

### DIFF
--- a/src/lib/skilling/skills/cooking.ts
+++ b/src/lib/skilling/skills/cooking.ts
@@ -9,7 +9,8 @@ export const Cookables: Cookable[] = [
 		id: itemID('Cooked meat'),
 		name: 'Beef',
 		inputCookables: { [itemID('Raw beef')]: 1 },
-		stopBurnAt: 31,
+		stopBurnAt: 34,
+		burnKourendBonus: [31, 31, 31, 31],
 		burntCookable: itemID('Burnt meat')
 	},
 	{
@@ -28,6 +29,7 @@ export const Cookables: Cookable[] = [
 		name: 'Shrimps',
 		inputCookables: { [itemID('Raw shrimps')]: 1 },
 		stopBurnAt: 34,
+		burnKourendBonus: [31, 31, 31, 31],
 		burntCookable: itemID('Burnt shrimp')
 	},
 	{
@@ -37,6 +39,7 @@ export const Cookables: Cookable[] = [
 		name: 'Chicken',
 		inputCookables: { [itemID('Raw chicken')]: 1 },
 		stopBurnAt: 34,
+		burnKourendBonus: [31, 31, 31, 31],
 		burntCookable: itemID('Burnt chicken')
 	},
 	{
@@ -46,6 +49,7 @@ export const Cookables: Cookable[] = [
 		name: 'Anchovies',
 		inputCookables: { [itemID('Raw anchovies')]: 1 },
 		stopBurnAt: 34,
+		burnKourendBonus: [31, 31, 31, 31],
 		burntCookable: 323
 	},
 	{
@@ -54,7 +58,8 @@ export const Cookables: Cookable[] = [
 		id: itemID('Sardine'),
 		name: 'Sardine',
 		inputCookables: { [itemID('Raw sardine')]: 1 },
-		stopBurnAt: 37,
+		stopBurnAt: 38,
+		burnKourendBonus: [34, 34, 34, 34],
 		burntCookable: 369
 	},
 	{
@@ -64,6 +69,7 @@ export const Cookables: Cookable[] = [
 		name: 'Herring',
 		inputCookables: { [itemID('Raw herring')]: 1 },
 		stopBurnAt: 41,
+		burnKourendBonus: [38, 38, 38, 38],
 		burntCookable: 357
 	},
 	{
@@ -73,6 +79,7 @@ export const Cookables: Cookable[] = [
 		name: 'Mackerel',
 		inputCookables: { [itemID('Raw mackerel')]: 1 },
 		stopBurnAt: 45,
+		burnKourendBonus: [42, 42, 42, 42],
 		burntCookable: 357
 	},
 	{
@@ -82,6 +89,7 @@ export const Cookables: Cookable[] = [
 		name: 'Trout',
 		inputCookables: { [itemID('Raw trout')]: 1 },
 		stopBurnAt: 49,
+		burnKourendBonus: [46, 46, 46, 46],
 		burntCookable: 343
 	},
 	{
@@ -90,7 +98,8 @@ export const Cookables: Cookable[] = [
 		id: itemID('Cod'),
 		name: 'Cod',
 		inputCookables: { [itemID('Raw cod')]: 1 },
-		stopBurnAt: 52,
+		stopBurnAt: 51,
+		burnKourendBonus: [46, 46, 46, 46],
 		burntCookable: 343
 	},
 	{
@@ -99,7 +108,8 @@ export const Cookables: Cookable[] = [
 		id: itemID('Pike'),
 		name: 'Pike',
 		inputCookables: { [itemID('Raw pike')]: 1 },
-		stopBurnAt: 64,
+		stopBurnAt: 54,
+		burnKourendBonus: [50, 50, 50, 50],
 		burntCookable: 343
 	},
 	{
@@ -109,6 +119,7 @@ export const Cookables: Cookable[] = [
 		name: 'Salmon',
 		inputCookables: { [itemID('Raw salmon')]: 1 },
 		stopBurnAt: 58,
+		burnKourendBonus: [55, 55, 55, 55],
 		burntCookable: 343
 	},
 	{
@@ -118,6 +129,7 @@ export const Cookables: Cookable[] = [
 		name: 'Tuna',
 		inputCookables: { [itemID('Raw tuna')]: 1 },
 		stopBurnAt: 63,
+		burnKourendBonus: [59, 59, 59, 59],
 		burntCookable: 367
 	},
 	{
@@ -128,6 +140,7 @@ export const Cookables: Cookable[] = [
 		alias: ['karambwan'],
 		inputCookables: { [itemID('Raw karambwan')]: 1 },
 		stopBurnAt: 99,
+		burnKourendBonus: [93, 87, 93, 87],
 		burntCookable: itemID('Burnt karambwan')
 	},
 	{
@@ -147,6 +160,7 @@ export const Cookables: Cookable[] = [
 		name: 'Cave eel',
 		inputCookables: { [itemID('Raw cave eel')]: 1 },
 		stopBurnAt: 74,
+		burnKourendBonus: [70, 70, 70, 70],
 		burntCookable: itemID('Burnt cave eel')
 	},
 	{
@@ -158,6 +172,7 @@ export const Cookables: Cookable[] = [
 		inputCookables: { [itemID('Raw lobster')]: 1 },
 		stopBurnAt: 74,
 		stopBurnAtCG: 64,
+		burnKourendBonus: [70, 70, 61, 61],
 		burntCookable: itemID('Burnt lobster')
 	},
 	{
@@ -167,7 +182,7 @@ export const Cookables: Cookable[] = [
 		name: 'Jubbly',
 		alias: ['Jubbly', 'cooked jubbly'],
 		inputCookables: { [itemID('Raw jubbly')]: 1 },
-		stopBurnAt: 125,
+		stopBurnAt: 99,
 		burntCookable: itemID('Burnt jubbly')
 	},
 	{
@@ -177,6 +192,7 @@ export const Cookables: Cookable[] = [
 		name: 'Bass',
 		inputCookables: { [itemID('Raw bass')]: 1 },
 		stopBurnAt: 80,
+		burnKourendBonus: [75, 75, 75, 75],
 		burntCookable: 367
 	},
 	{
@@ -188,6 +204,7 @@ export const Cookables: Cookable[] = [
 		inputCookables: { [itemID('Raw swordfish')]: 1 },
 		stopBurnAt: 86,
 		stopBurnAtCG: 81,
+		burnKourendBonus: [76, 76, 76, 76],
 		burntCookable: itemID('Burnt swordfish')
 	},
 	{
@@ -199,6 +216,7 @@ export const Cookables: Cookable[] = [
 		inputCookables: { [itemID('Raw monkfish')]: 1 },
 		stopBurnAt: 90,
 		stopBurnAtCG: 87,
+		burnKourendBonus: [86, 82, 82, 82],
 		burntCookable: itemID('Burnt monkfish')
 	},
 	{
@@ -219,6 +237,7 @@ export const Cookables: Cookable[] = [
 		inputCookables: { [itemID('Raw shark')]: 1 },
 		stopBurnAt: 99,
 		stopBurnAtCG: 94,
+		burnKourendBonus: [99, 99, 89, 84],
 		burntCookable: itemID('Burnt shark')
 	},
 	{
@@ -240,6 +259,7 @@ export const Cookables: Cookable[] = [
 		inputCookables: { [itemID('Raw anglerfish')]: 1 },
 		stopBurnAt: 99,
 		stopBurnAtCG: 98,
+		burnKourendBonus: [99, 99, 93, 88],
 		burntCookable: itemID('Burnt anglerfish')
 	},
 	{

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -107,6 +107,8 @@ export interface Cookable {
 	inputCookables: ItemBank;
 	stopBurnAt: number;
 	stopBurnAtCG?: number;
+	// Burn level with hosidius/diary: [ noGauntletsHosidius, noGauntletsElite, gauntletsHosidius, gauntletsElite ]
+	burnKourendBonus?: number[];
 	burntCookable: number;
 	alias?: string[];
 }

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -2,6 +2,8 @@ import { Time } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank } from 'oldschooljs';
 
+import { KourendKebosDiary, userhasDiaryTier } from '../../lib/diaries';
+import { Favours, gotFavour } from '../../lib/minions/data/kourendFavour';
 import Cooking, { Cookables } from '../../lib/skilling/skills/cooking';
 import { CookingActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, itemID, stringMatches } from '../../lib/util';
@@ -58,6 +60,15 @@ export const cookCommand: OSBMahojiCommand = {
 			return `${user.minionName} needs ${cookable.level} Cooking to cook ${cookable.name}s.`;
 		}
 
+		// These are just for notifying the user, they only take effect in the Activity.
+		const boosts = [];
+		const [hasEliteDiary] = await userhasDiaryTier(user, KourendKebosDiary.elite);
+		const [hasFavour] = gotFavour(user, Favours.Hosidius, 100);
+		if (hasFavour) boosts.push('Using Hosidius Range');
+		if (hasFavour && hasEliteDiary) boosts.push('Kourend Elite Diary');
+		const hasGaunts = user.hasEquipped('Cooking gauntlets');
+		if (hasGaunts) boosts.push('Cooking gauntlets equipped');
+
 		// Based off catherby fish/hr rates
 		let timeToCookSingleCookable = Time.Second * 2.88;
 		if (cookable.id === itemID('Jug of wine') || cookable.id === itemID('Wine of zamorak')) {
@@ -105,6 +116,6 @@ export const cookCommand: OSBMahojiCommand = {
 
 		return `${user.minionName} is now cooking ${quantity}x ${cookable.name}, it'll take around ${formatDuration(
 			duration
-		)} to finish.`;
+		)} to finish.${boosts.length > 0 ? `\n\nBoosts: ${boosts.join(', ')}` : ''}`;
 	}
 };

--- a/src/tasks/minions/cookingActivity.ts
+++ b/src/tasks/minions/cookingActivity.ts
@@ -1,5 +1,7 @@
 import { Bank } from 'oldschooljs';
 
+import { KourendKebosDiary, userhasDiaryTier } from '../../lib/diaries';
+import { Favours, gotFavour } from '../../lib/minions/data/kourendFavour';
 import calcBurntCookables from '../../lib/skilling/functions/calcBurntCookables';
 import Cooking from '../../lib/skilling/skills/cooking';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -17,7 +19,13 @@ export const cookingTask: MinionTask = {
 		let burnedAmount = 0;
 		let stopBurningLvl = 0;
 
-		if (cookable.stopBurnAtCG && user.hasEquipped('Cooking gauntlets')) {
+		const [hasEliteDiary] = await userhasDiaryTier(user, KourendKebosDiary.elite);
+		const [hasFavour] = gotFavour(user, Favours.Hosidius, 100);
+		const hasGaunts = user.hasEquipped('Cooking gauntlets');
+
+		if (hasFavour && cookable.burnKourendBonus) {
+			stopBurningLvl = cookable.burnKourendBonus[(hasEliteDiary ? 1 : 0) * 2 + (hasGaunts ? 1 : 0)];
+		} else if (cookable.stopBurnAtCG && hasGaunts) {
 			stopBurningLvl = cookable.stopBurnAtCG;
 		} else {
 			stopBurningLvl = cookable.stopBurnAt;


### PR DESCRIPTION
### Description:

Adds boosts for Hosidius Range + Kourend & Kebos Elite Diary to cooking

Note: This only affects burn-level.

### Changes:

- Adds boost notice on command
- Adds specific  burn levels for cooking gauntlets / hosidius / diary combinations
- Fixes some incorrect base cooking burn levels

### Other checks:

- [x] I have tested all my changes thoroughly.
