### PR TITLE
Fixes Tame / Favorite Food / Raw Food bug

### DIFF
--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -87,7 +87,7 @@ async function favFoodConfig(
 		currentFavorites.length === 0 ? 'None' : currentFavorites.map(itemNameFromID).join(', ')
 	}.`;
 	if (!item || secretItems.includes(item.id)) return currentItems;
-	if (!Eatables.some(i => i.id === item.id)) return "That's not a valid item.";
+	if (!Eatables.some(i => i.id === item.id || i.raw === item.id)) return "That's not a valid item.";
 
 	if (itemToAdd) {
 		if (currentFavorites.includes(item.id)) return 'This item is already favorited.';

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -757,12 +757,24 @@ export const configCommand: OSBMahojiCommand = {
 							description: 'Add an item to your favorite food.',
 							required: false,
 							autocomplete: async (value: string) => {
-								return Eatables.filter(i =>
+								const rawFood = Eatables.filter(i => i.raw).map(i => getItem(i.raw!)!);
+								const autocompleteList = Eatables.filter(i =>
 									!value ? true : i.name.toLowerCase().includes(value.toLowerCase())
 								).map(i => ({
 									name: `${i.name}`,
 									value: i.id.toString()
 								}));
+								autocompleteList.push(
+									...rawFood
+										.filter(i =>
+											!value ? true : i.name.toLowerCase().includes(value.toLowerCase())
+										)
+										.map(i => ({
+											name: `${i.name}`,
+											value: i.id.toString()
+										}))
+								);
+								return autocompleteList;
 							}
 						},
 						{
@@ -771,14 +783,21 @@ export const configCommand: OSBMahojiCommand = {
 							description: 'Remove an item from your favorite food.',
 							required: false,
 							autocomplete: async (value: string, user: User) => {
+								const rawFood = Eatables.filter(i => i.raw).map(i => getItem(i.raw!)!);
+								const allFood = Eatables.map(i => {
+									return { name: i.name, id: i.id };
+								});
+								allFood.push(...rawFood);
 								const mUser = await mahojiUsersSettingsFetch(user.id, { favorite_food: true });
-								return Eatables.filter(i => {
-									if (!mUser.favorite_food.includes(i.id)) return false;
-									return !value ? true : i.name.toLowerCase().includes(value.toLowerCase());
-								}).map(i => ({
-									name: `${i.name}`,
-									value: i.id.toString()
-								}));
+								return allFood
+									.filter(i => {
+										if (!mUser.favorite_food.includes(i.id)) return false;
+										return !value ? true : i.name.toLowerCase().includes(value.toLowerCase());
+									})
+									.map(i => ({
+										name: `${i.name}`,
+										value: i.id.toString()
+									}));
 							}
 						},
 						{


### PR DESCRIPTION
### Description:

This re-adds the ability to put Raw food in the fav food list. This was lost because OSB has no use for raw food favorites, and a merge removed it from BSO.

This is important to choose which raw food for the tame to eat.. you don't want to eat your cooking supplies, etc, and you will almost certainly want different cooked vs raw food on your favorites list.

The raw-food feed algorithm doesn't need to be changed; it wasn't broken in the merge mentioned above, thus it still workswi

### Changes:

- Adds ability to store Raw food in your `favorite_food` list.
- Adds raw food to the autocomplete lists

### Other checks:

- [x] I have tested all my changes thoroughly.
