### PR TITLE
Tinkerer's Workshop - Fix error inserting fractional XP

### DIFF
--- a/src/tasks/minions/bso/tinkeringWorkshopActivity.ts
+++ b/src/tasks/minions/bso/tinkeringWorkshopActivity.ts
@@ -46,7 +46,7 @@ export const twTask: MinionTask = {
 			xp += randInt(8000, 15_000);
 		}
 
-		if (data.material === 'junk') xp /= 2;
+		if (data.material === 'junk') xp = Math.floor(xp / 2);
 
 		const xpStr = await user.addXP({ amount: xp, skillName: SkillsEnum.Invention, duration });
 		await userStatsUpdate(user.id, oldStats => {


### PR DESCRIPTION
### Description:

Junk tinkerer workshop trips aren't "returning" 50% of the time because they are throwing due to trying to insert fractional XP.

### Changes:

- Math.floor() the reduced XP.

### Other checks:

- [x] I have tested all my changes thoroughly.
