### PR TITLE
Make HP Cape work for DoA

### DIFF
--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -49,6 +49,7 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 		case 'Ignecarus':
 		case 'KingGoldemar':
 		case 'Moktang':
+		case 'DepthsOfAtlantis':
 		case 'Naxxus':
 		case 'Dungeoneering': {
 			masterHPCapeBoost = 10;


### PR DESCRIPTION
### Description:

Currently the HP Cape / Master Cape doesn't work with DoA, this fixes that, enabling people with max gear to run 2x trips in 70 minutes.

Boosts: Max Gear + T3 + 10b Sac + HP Master Cape + Zak

### Changes:

- Adds DoA to the list in calcMaxTripLength()

### Other checks:

- [x] I have tested all my changes thoroughly.
