### PR TITLE
Fix first character being chopped off stats embed

### DIFF
--- a/src/lib/util/minionStatsEmbed.ts
+++ b/src/lib/util/minionStatsEmbed.ts
@@ -60,7 +60,7 @@ export async function minionStatsEmbed(user: MUser): Promise<EmbedBuilder> {
 	const rawBadges = user.user.badges;
 	const badgesStr = rawBadges.map(num => badges[num]).join(' ');
 
-	const embed = new EmbedBuilder().setTitle(`${badgesStr}${user.minionName}`.slice(1, 255)).addFields(
+	const embed = new EmbedBuilder().setTitle(`${badgesStr}${user.minionName}`.slice(0, 255)).addFields(
 		{
 			name: '\u200b',
 			value: ['attack', 'strength', 'defence', 'ranged', 'prayer', 'magic', 'runecraft', 'construction']
@@ -85,7 +85,7 @@ export async function minionStatsEmbed(user: MUser): Promise<EmbedBuilder> {
 	);
 
 	if (user.isIronman) {
-		embed.setColor(5_460_819);
+		embed.setColor('#535353');
 	}
 
 	const { percent } = calcCLDetails(user);


### PR DESCRIPTION
### Description:

Currently, the first character in the title of a `/minion stats` embed (usually the start of an emoji is cut off do an off-by-one error, causing it to look like this:

![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/721beab9-a806-48e1-b9bf-2549963b7cbb)

### Changes:

- Changes `.slice(1, 255)` to `.slice(0,255)`
- Converts the ironman color code to `#RRGGBB` notation for easier reading + maintenance.

### Other checks:

- [x] I have tested all my changes thoroughly.
