### PR TITLE
Fix tithe farm leaderboards

### DIFF
--- a/src/lib/util/getKCByName.ts
+++ b/src/lib/util/getKCByName.ts
@@ -16,7 +16,7 @@ export async function getKCByName(user: MUser, kcName: string): Promise<[string,
 	const minigame = Minigames.find(
 		game => stringMatches(game.name, kcName) || game.aliases.some(alias => stringMatches(alias, kcName))
 	);
-	if (minigame) {
+	if (minigame && minigame.name !== 'Tithe farm') {
 		return [minigame.name, await getMinigameScore(user.id, minigame.column)];
 	}
 
@@ -28,7 +28,7 @@ export async function getKCByName(user: MUser, kcName: string): Promise<[string,
 	const stats = await user.fetchStats({ slayer_superior_count: true, tithe_farms_completed: true });
 	const special: [string[], number][] = [
 		[['superior', 'superiors', 'superior slayer monster'], stats.slayer_superior_count],
-		[['tithefarm', 'tithe'], stats.tithe_farms_completed]
+		[['tithe farm', 'Tithe farm', 'tithefarm', 'tithe'], stats.tithe_farms_completed]
 	];
 	const res = special.find(s => s[0].includes(kcName));
 	if (res) {

--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -193,7 +193,7 @@ async function minigamesLb(user: MUser, channelID: string, name: string) {
 					   FROM user_stats
 					   WHERE "tithe_farms_completed" > 10
 					   ORDER BY "tithe_farms_completed"
-					   DESC LIMIT 2000;`
+					   DESC LIMIT 10;`
 		);
 		doMenu(
 			user,

--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -206,31 +206,29 @@ async function minigamesLb(user: MUser, channelID: string, name: string) {
 			'Tithe farm Leaderboard'
 		);
 		return lbMsg(`${minigame.name} Leaderboard`);
-	} 
-		const res = await prisma.minigame.findMany({
-			where: {
-				[minigame.column]: {
-					gt: minigame.column === 'champions_challenge' ? 1 : 10
-				}
-			},
-			orderBy: {
-				[minigame.column]: 'desc'
-			},
-			take: 10
-		});
+	}
+	const res = await prisma.minigame.findMany({
+		where: {
+			[minigame.column]: {
+				gt: minigame.column === 'champions_challenge' ? 1 : 10
+			}
+		},
+		orderBy: {
+			[minigame.column]: 'desc'
+		},
+		take: 10
+	});
 
-		doMenu(
-			user,
-			channelID,
-			chunk(res, LB_PAGE_SIZE).map((subList, i) =>
-				subList
-					.map(
-						(u, j) => `${getPos(i, j)}**${getUsername(u.user_id)}:** ${u[minigame.column].toLocaleString()}`
-					)
-					.join('\n')
-			),
-			`${minigame.name} Leaderboard`
-		);
+	doMenu(
+		user,
+		channelID,
+		chunk(res, LB_PAGE_SIZE).map((subList, i) =>
+			subList
+				.map((u, j) => `${getPos(i, j)}**${getUsername(u.user_id)}:** ${u[minigame.column].toLocaleString()}`)
+				.join('\n')
+		),
+		`${minigame.name} Leaderboard`
+	);
 	return lbMsg(`${minigame.name} Leaderboard`);
 }
 

--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -205,7 +205,8 @@ async function minigamesLb(user: MUser, channelID: string, name: string) {
 			),
 			'Tithe farm Leaderboard'
 		);
-	} else {
+		return lbMsg(`${minigame.name} Leaderboard`);
+	} 
 		const res = await prisma.minigame.findMany({
 			where: {
 				[minigame.column]: {
@@ -230,7 +231,6 @@ async function minigamesLb(user: MUser, channelID: string, name: string) {
 			),
 			`${minigame.name} Leaderboard`
 		);
-	}
 	return lbMsg(`${minigame.name} Leaderboard`);
 }
 


### PR DESCRIPTION
### Description:

Resolves #5122

Whilst this "fixes" the issue it doesnt resolve the underlying problem.  We currently have two database variables for storing tithe farm completions, one which isnt utilized at all but was the primary fetch for the KC & LB command.

I did consider using the tithe_farm database entry within the minigames table but felt it could potentially introduce some database bugs. (The implemented fix would consist of 5 lines of code in a single file than these two file changes)

### Changes:

Point the leaderboard to the current place where tithefarmcompletions are stored
Prevent minion KC looking at the same wrong place and getting caught as a "Minigame"
Restrict the new fetch to require 10 completions and log the first 10 entries similar to other minigames
### Other checks:

- [x] I have tested all my changes thoroughly.
