### PR TITLE
Update mageTrainingTask trip finish message to include total pizazz points

### DIFF
--- a/src/tasks/minions/minigames/mageTrainingArenaActivity.ts
+++ b/src/tasks/minions/minigames/mageTrainingArenaActivity.ts
@@ -36,8 +36,16 @@ export const mageTrainingTask: MinionTask = {
 				}
 			}
 		});
+		const totalPizazzPoints = await prisma.newUser.findUnique({
+			where: { id: userID },
+			select: {
+				pizazz_points: true
+			}
+		});
 
-		let str = `${user}, ${user.minionName} finished completing ${quantity}x Magic Training Arena rooms. You received **${pizazzPoints} Pizazz points**. ${xpRes}`;
+		let str = `${user}, ${
+			user.minionName
+		} finished completing ${quantity}x Magic Training Arena rooms. You received **${pizazzPoints} Pizazz points**. You now have **${totalPizazzPoints?.pizazz_points.toLocaleString()} Pizazz points**. ${xpRes}`;
 
 		handleTripFinish(user, channelID, str, undefined, data, loot);
 	}


### PR DESCRIPTION
### Description:

Select total pizazz points for mageTrainingTask and add the number of total pizazz to the finishTrip message

### Changes:

src/tasks/minions/minigames/mageTrainingArenaActivity.ts

### Other checks:

- [x] I have tested all my changes thoroughly.
