### PR TITLE
Update Patron Daily Reminder

### DIFF
--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -148,7 +148,7 @@ export const tickers: { name: string; interval: number; timer: NodeJS.Timeout | 
 SELECT users.id, user_stats.last_daily_timestamp
 FROM users
 JOIN user_stats ON users.id::bigint = user_stats.user_id
-WHERE bitfield && '{2,3,4,5,6,7,8}'::int[] AND user_stats."last_daily_timestamp" != -1 AND to_timestamp(user_stats."last_daily_timestamp" / 1000) < now() - INTERVAL '12 hours';
+WHERE bitfield && '{2,3,4,5,6,7,8,12,21,24}'::int[] AND user_stats."last_daily_timestamp" != -1 AND to_timestamp(user_stats."last_daily_timestamp" / 1000) < now() - INTERVAL '12 hours';
 `
 			);
 


### PR DESCRIPTION
Updates the patron daily reminder to dm people with T6, perm tier 1 and the free tier 1 for maxing both bots.

