### PR TITLE
Completionist Fixes

### DIFF
--- a/src/lib/compCape.ts
+++ b/src/lib/compCape.ts
@@ -803,10 +803,7 @@ for (const group of leagueTasks) {
 	trimmedRequirements.add({
 		name: `Complete all ${group.name} Leagues tasks`,
 		has: ({ roboChimpUser }) => {
-			if (!group.tasks.every(t => roboChimpUser.leagues_completed_tasks_ids.includes(t.id))) {
-				// Returning a truthy result means you don't have the requirement.
-				return true;
-			}
+			return group.tasks.every(t => roboChimpUser.leagues_completed_tasks_ids.includes(t.id));
 		}
 	});
 }

--- a/src/lib/compCape.ts
+++ b/src/lib/compCape.ts
@@ -563,10 +563,14 @@ miscRequirements
 			const poh = await getPOH(user.id);
 			const failures: RequirementFailure[] = [];
 			for (const [key, val] of objectEntries(poh)) {
-				if (key === 'user_id' || key === 'background_id') continue;
-				const sorted = PoHObjects.filter(i => i.slot === key && typeof i.level === 'number').sort(
-					(a, b) => (b.level as number) - (a.level as number)
-				);
+				if (key === 'user_id' || key === 'background_id' || key === 'altar') continue;
+				const sorted = PoHObjects.filter(
+					i => i.slot === key && (typeof i.level === 'number' || 'construction' in i.level)
+				).sort((a, b) => {
+					const sortA = typeof a.level === 'number' ? a.level : a.level.construction!;
+					const sortB = typeof b.level === 'number' ? b.level : b.level.construction!;
+					return sortB - sortA;
+				});
 				const highestIDs = sorted.filter(i => i.level === sorted[0].level).map(i => i.id);
 				if (!val || typeof val !== 'number' || !highestIDs.includes(val)) {
 					failures.push({
@@ -707,7 +711,9 @@ const tameRequirements = new Requirements()
 				.filter(t => t.species.id === TameSpeciesID.Monkey)
 				.some(tame =>
 					itemsToBeFed.every(itemNeedsToBeFed =>
-						getSimilarItems(itemNeedsToBeFed.item.id).some(similarItem => tame.fedItems.has(similarItem))
+						[itemNeedsToBeFed.item.id, ...getSimilarItems(itemNeedsToBeFed.item.id)].some(similarItem =>
+							tame.fedItems.has(similarItem)
+						)
 					)
 				);
 			if (!oneTameHasAll) {
@@ -725,7 +731,13 @@ const tameRequirements = new Requirements()
 
 			const oneTameHasAll = tames
 				.filter(t => t.species.id === TameSpeciesID.Igne)
-				.some(tame => itemsToBeFed.every(i => tame.fedItems.has(i.item.id)));
+				.some(tame =>
+					itemsToBeFed.every(itemNeedsToBeFed =>
+						[itemNeedsToBeFed.item.id, ...getSimilarItems(itemNeedsToBeFed.item.id)].some(similarItem =>
+							tame.fedItems.has(similarItem)
+						)
+					)
+				);
 			if (!oneTameHasAll) {
 				return `You need to feed all of these items to one of your Igne tames: ${itemsToBeFed
 					.map(i => i.item.name)
@@ -791,7 +803,10 @@ for (const group of leagueTasks) {
 	trimmedRequirements.add({
 		name: `Complete all ${group.name} Leagues tasks`,
 		has: ({ roboChimpUser }) => {
-			return group.tasks.every(t => roboChimpUser.leagues_completed_tasks_ids.includes(t.id));
+			if (!group.tasks.every(t => roboChimpUser.leagues_completed_tasks_ids.includes(t.id))) {
+				// Returning a truthy result means you don't have the requirement.
+				return true;
+			}
 		}
 	});
 }
@@ -867,7 +882,7 @@ export async function generateAllCompCapeTasksList() {
 	}
 
 	return `Completionist Cape Tasks - ${totalRequirements} tasks\n\n
-	
+
 ${finalStr}`;
 }
 
@@ -895,7 +910,7 @@ export async function calculateCompCapeProgress(user: MUser) {
 		resultStr: `Completionist Cape Progress - ${totalCompleted}/${totalRequirements} (${totalPercent.toFixed(
 			2
 		)}%) completed\n\n
-	
+
 ${finalStr}`,
 		totalPercent
 	};

--- a/src/lib/structures/Requirements.ts
+++ b/src/lib/structures/Requirements.ts
@@ -174,7 +174,9 @@ export class Requirements {
 				if (typeof result === 'string') {
 					results.push({ reason: result });
 				} else if (typeof result === 'boolean') {
-					results.push({ reason: requirement.name });
+					if (!result) {
+						results.push({ reason: requirement.name });
+					}
 				} else {
 					results.push(...result);
 				}
@@ -371,7 +373,7 @@ export class Requirements {
 		const completionPercentage = calcWhatPercent(metRequirements, totalRequirements);
 
 		return {
-			hasAll: totalRequirements === metRequirements,
+			hasAll: results.filter(i => i.result.length !== 0).length === 0,
 			reasonsDoesnt: results
 				.filter(i => i.result.length > 0)
 				.map(i => `${i.requirement.name}: ${i.result.map(t => t.reason).join(', ')}`),

--- a/src/lib/structures/Requirements.ts
+++ b/src/lib/structures/Requirements.ts
@@ -170,13 +170,13 @@ export class Requirements {
 
 		if ('has' in requirement) {
 			const result = await requirement.has(userArgs);
-			if (result) {
+			if (typeof result === 'boolean') {
+				if (!result) {
+					results.push({ reason: requirement.name });
+				}
+			} else if (result) {
 				if (typeof result === 'string') {
 					results.push({ reason: result });
-				} else if (typeof result === 'boolean') {
-					if (!result) {
-						results.push({ reason: requirement.name });
-					}
 				} else {
 					results.push(...result);
 				}

--- a/src/lib/structures/Requirements.ts
+++ b/src/lib/structures/Requirements.ts
@@ -371,7 +371,7 @@ export class Requirements {
 		const completionPercentage = calcWhatPercent(metRequirements, totalRequirements);
 
 		return {
-			hasAll: results.length === 0,
+			hasAll: totalRequirements === metRequirements,
 			reasonsDoesnt: results
 				.filter(i => i.result.length > 0)
 				.map(i => `${i.requirement.name}: ${i.result.map(t => t.reason).join(', ')}`),


### PR DESCRIPTION
### Description:

This fixes a variety of bugs with the completionist check.

### Changes:

- Fixed a bug in the Requirements preventing 'hasAll' from being true when it should be.
- (The above also fixes the issue with `/buy item:music cape`
- Fixes issue where the 'max boost igne' doesn't look for similar items (so dyed dwwh wouldn't count)
- Fixes issue where max Monkey tame doesn't add the original ID when looking for similars*
- Fixes issue where the separated easy/medium/etc leagues tasks were returning the opposite value in the `has()` function
- Fixes issue where PoH wasn't considering items with multiple level requirements
- Fixes issue with PoH checks where `altar` was being checked even though there are no items for that slot.**

* `getSimilarItems()` returns an empty list when there are no similars... this should be changed imo to match the behavior when similars DO exist, it pushes the original item id into the list.
** The altar column should be removed from playerOwnedHouse schema. prayer_altar and spellbook_altar both exist.

### Other checks:

- [x] I have tested all my changes thoroughly.
