### PR TITLE
Use one transaction to replace 2 separate add/remove from banks.

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -303,7 +303,10 @@ export class MUserClass {
 	}
 
 	async transactItems(options: Omit<TransactItemsArgs, 'userID'>) {
-		return transactItems({ userID: this.user.id, ...options });
+		const res = await transactItems({ userID: this.user.id, ...options });
+		this.user = res.newUser;
+		this.updateProperties();
+		return res;
 	}
 
 	hasEquipped(_item: number | string | string[] | number[], every = false) {

--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -36,6 +36,7 @@ import { logError } from './util/logError';
 import { minionIsBusy } from './util/minionIsBusy';
 import { minionName } from './util/minionUtils';
 import resolveItems from './util/resolveItems';
+import { TransactItemsArgs } from './util/transactItemsFromBank';
 
 export async function mahojiUserSettingsUpdate(user: string | bigint, data: Prisma.UserUncheckedUpdateInput) {
 	try {
@@ -299,6 +300,10 @@ export class MUserClass {
 		this.user = res.newUser;
 		this.updateProperties();
 		return res;
+	}
+
+	async transactItems(options: Omit<TransactItemsArgs, 'userID'>) {
+		return transactItems({ userID: this.user.id, ...options });
 	}
 
 	hasEquipped(_item: number | string | string[] | number[], every = false) {

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -218,10 +218,11 @@ export async function degradeItem({
 			}
 		} else if (hasInBank) {
 			// If its in bank, just remove 1 from bank.
-			await user.removeItemsFromBank(new Bank().add(item.id, 1));
+			let itemsToAdd = undefined;
 			if (degItem.itemsToRefundOnBreak) {
-				await user.addItemsToBank({ items: degItem.itemsToRefundOnBreak, collectionLog: false });
+				itemsToAdd = degItem.itemsToRefundOnBreak;
 			}
+			await user.transactItems({ itemsToRemove: new Bank().add(item.id, 1), itemsToAdd });
 		} else {
 			// If its not in bank OR equipped, something weird has gone on.
 			throw new Error(

--- a/src/lib/minions/functions/blowpipeCommand.ts
+++ b/src/lib/minions/functions/blowpipeCommand.ts
@@ -77,8 +77,10 @@ async function addCommand(user: MUser, itemName: string, quantity = 1) {
 		return "You can't add to your blowpipe, because your minion is out on a trip.";
 	}
 	if (!user.owns('Toxic blowpipe') && user.owns('Toxic blowpipe (empty)')) {
-		await user.removeItemsFromBank(new Bank().add('Toxic blowpipe (empty)'));
-		await user.addItemsToBank({ items: new Bank().add('Toxic blowpipe'), collectionLog: false });
+		await user.transactItems({
+			itemsToAdd: new Bank().add('Toxic blowpipe'),
+			itemsToRemove: new Bank().add('Toxic blowpipe (empty)')
+		});
 	}
 
 	const hasBlowpipe = user.owns('Toxic blowpipe');

--- a/src/lib/minions/functions/degradeableItemsCommand.ts
+++ b/src/lib/minions/functions/degradeableItemsCommand.ts
@@ -53,8 +53,8 @@ ${degradeableItems
 		await user.transactItems({
 			filterLoot: false,
 			collectionLog: true,
-			itemsToAdd: new Bank().add(item.unchargedItem!.id),
-			itemsToRemove: new Bank().add(item.item.id).add(cost)
+			itemsToAdd: new Bank().add(item.item.id),
+			itemsToRemove: new Bank().add(item.unchargedItem!.id).add(cost)
 		});
 	} else {
 		await transactItems({ userID: user.id, itemsToRemove: cost });

--- a/src/lib/minions/functions/degradeableItemsCommand.ts
+++ b/src/lib/minions/functions/degradeableItemsCommand.ts
@@ -50,10 +50,15 @@ ${degradeableItems
 		if (!user.owns(item.unchargedItem!.id)) {
 			return `Your ${item.unchargedItem!.name} disappeared and cannot be charged`;
 		}
-		await user.removeItemsFromBank(new Bank({ [item.unchargedItem!.id]: 1 }));
-		await user.addItemsToBank({ items: { [item.item.id]: 1 }, collectionLog: true, filterLoot: false });
+		await user.transactItems({
+			filterLoot: false,
+			collectionLog: true,
+			itemsToAdd: new Bank().add(item.unchargedItem!.id),
+			itemsToRemove: new Bank().add(item.item.id).add(cost)
+		});
+	} else {
+		await transactItems({ userID: user.id, itemsToRemove: cost });
 	}
-	await transactItems({ userID: user.id, itemsToRemove: cost });
 	const currentCharges = user.user[item.settingsKey];
 	const newCharges = currentCharges + amountOfCharges;
 	await user.update({

--- a/src/lib/util/transactItemsFromBank.ts
+++ b/src/lib/util/transactItemsFromBank.ts
@@ -10,7 +10,7 @@ import { ItemBank } from '../types';
 import { logError } from './logError';
 import { userQueueFn } from './userQueues';
 
-interface TransactItemsArgs {
+export interface TransactItemsArgs {
 	userID: string;
 	itemsToAdd?: Bank;
 	itemsToRemove?: Bank;

--- a/src/mahoji/commands/gamble.ts
+++ b/src/mahoji/commands/gamble.ts
@@ -36,6 +36,12 @@ export const gambleCommand: OSBMahojiCommand = {
 						{ name: 'fire', value: 'fire' },
 						{ name: 'infernal', value: 'infernal' }
 					]
+				},
+				{
+					type: ApplicationCommandOptionType.Boolean,
+					name: 'autoconfirm',
+					description: "Don't ask confirmation message",
+					required: false
 				}
 			]
 		},
@@ -166,7 +172,7 @@ export const gambleCommand: OSBMahojiCommand = {
 		interaction,
 		userID
 	}: CommandRunOptions<{
-		cape?: { type?: string };
+		cape?: { type?: string; autoconfirm?: boolean };
 		dice?: { amount?: string };
 		duel?: { user: MahojiUserOption; amount?: string };
 		lucky_pick?: { amount: string };
@@ -178,7 +184,7 @@ export const gambleCommand: OSBMahojiCommand = {
 
 		if (options.cape) {
 			if (options.cape.type) {
-				return capeGambleCommand(user, options.cape.type, interaction);
+				return capeGambleCommand(user, options.cape.type, interaction, options.cape.autoconfirm);
 			}
 			return capeGambleStatsCommand(user);
 		}

--- a/src/mahoji/commands/offer.ts
+++ b/src/mahoji/commands/offer.ts
@@ -107,13 +107,12 @@ export const mineCommand: OSBMahojiCommand = {
 			if (quantity > offerableOwned) {
 				return `You don't have ${quantity} ${whichOfferable.name} to offer the ${whichOfferable.offerWhere}. You have ${offerableOwned}.`;
 			}
-			await user.removeItemsFromBank(new Bank({ [whichOfferable.itemID]: quantity }));
 			let loot = new Bank().add(whichOfferable.table.roll(quantity));
 
-			const { previousCL, itemsAdded } = await transactItems({
-				userID: user.id,
+			const { previousCL, itemsAdded } = await user.transactItems({
 				collectionLog: true,
-				itemsToAdd: loot
+				itemsToAdd: loot,
+				itemsToRemove: new Bank().add(whichOfferable.itemID, quantity)
 			});
 			if (whichOfferable.economyCounter) {
 				const newStats = await userStatsUpdate(
@@ -159,8 +158,7 @@ export const mineCommand: OSBMahojiCommand = {
 			if (!quantity) quantity = quantityOwned;
 			const cost = new Bank().add(egg.id, quantity);
 			if (!user.owns(cost)) return "You don't own enough of these eggs.";
-			await user.removeItemsFromBank(cost);
-			await userStatsBankUpdate(user.id, 'bird_eggs_offered_bank', cost);
+
 			let loot = new Bank();
 			for (let i = 0; i < quantity; i++) {
 				if (roll(300)) {
@@ -176,11 +174,12 @@ export const mineCommand: OSBMahojiCommand = {
 				amount: quantity * 100
 			});
 
-			const { previousCL, itemsAdded } = await transactItems({
-				userID: user.id,
+			const { previousCL, itemsAdded } = await user.transactItems({
 				collectionLog: true,
-				itemsToAdd: loot
+				itemsToAdd: loot,
+				itemsToRemove: cost
 			});
+			await userStatsBankUpdate(user.id, 'bird_eggs_offered_bank', cost);
 
 			notifyUniques(user, egg.name, evilChickenOutfit, loot, quantity);
 

--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -120,8 +120,7 @@ export const sacrificeCommand: OSBMahojiCommand = {
 			);
 
 			const loot = new Bank().add('Death rune', deathRunes);
-			await user.removeItemsFromBank(bankToSac);
-			await user.addItemsToBank({ items: loot, collectionLog: false });
+			await user.transactItems({ itemsToAdd: loot, itemsToRemove: bankToSac });
 			const sacBank = await trackSacBank(user, bankToSac);
 			let totalCatsSacrificed = 0;
 			for (const cat of cats) {

--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -110,11 +110,10 @@ export const sellCommand: OSBMahojiCommand = {
 			for (let i = 0; i < moleBank.amount('Mole claw') + moleBank.amount('Mole skin'); i++) {
 				loot.add(NestBoxesTable.roll());
 			}
-			await user.removeItemsFromBank(moleBank);
-			await transactItems({
-				userID: user.id,
+			await user.transactItems({
 				collectionLog: true,
-				itemsToAdd: loot
+				itemsToAdd: loot,
+				itemsToRemove: moleBank
 			});
 			return `You exchanged ${moleBank} and received: ${loot}.`;
 		}
@@ -149,11 +148,10 @@ export const sellCommand: OSBMahojiCommand = {
 				`${user}, please confirm you want to sell ${abbyBank} for **${loot}**.`
 			);
 
-			await user.removeItemsFromBank(abbyBank);
-			await transactItems({
-				userID: user.id,
+			await user.transactItems({
 				collectionLog: false,
-				itemsToAdd: loot
+				itemsToAdd: loot,
+				itemsToRemove: abbyBank
 			});
 			return `You exchanged ${abbyBank} and received: ${loot}.`;
 		}
@@ -169,8 +167,8 @@ export const sellCommand: OSBMahojiCommand = {
 				interaction,
 				`${user}, please confirm you want to sell ${tenchBank} for **${loot}**.`
 			);
-			await user.removeItemsFromBank(tenchBank);
-			await user.addItemsToBank({ items: loot, collectionLog: false });
+
+			await user.transactItems({ itemsToRemove: tenchBank, itemsToAdd: loot });
 			return `You exchanged ${tenchBank} and received: ${loot}.`;
 		}
 

--- a/src/mahoji/lib/abstracted_commands/agilityArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/agilityArenaCommand.ts
@@ -124,8 +124,11 @@ export async function agilityArenaBuyCommand(user: MUser, input: string, qty = 1
 		if (amountTicketsHas < cost) {
 			return "You don't have enough Agility arena tickets.";
 		}
-		await user.removeItemsFromBank(new Bank().add('Agility arena ticket', cost));
-		await user.addItemsToBank({ items: { [buyable.item.id]: qty }, collectionLog: true });
+		await user.transactItems({
+			itemsToAdd: new Bank().add(buyable.item.id, qty),
+			itemsToRemove: new Bank().add('Agility arena ticket', cost),
+			collectionLog: true
+		});
 		return `Successfully purchased ${qty}x ${buyable.item.name} for ${cost}x Agility arena tickets.`;
 	}
 

--- a/src/mahoji/lib/abstracted_commands/butlerCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/butlerCommand.ts
@@ -130,9 +130,8 @@ export async function butlerCommand(user: MUser, plankName: string, quantity: nu
 		)}.`;
 	}
 
-	const costBank = new Bank().add('Coins', cost).add(plank!.inputItem, quantity);
+	const costBank = new Bank(consumedItems).add('Coins', cost).add(plank!.inputItem, quantity);
 	await user.removeItemsFromBank(costBank);
-	await user.removeItemsFromBank(consumedItems);
 
 	await updateBankSetting('construction_cost_bank', new Bank().add('Coins', cost));
 

--- a/src/mahoji/lib/abstracted_commands/capegamble.ts
+++ b/src/mahoji/lib/abstracted_commands/capegamble.ts
@@ -18,7 +18,12 @@ export async function capeGambleStatsCommand(user: MUser) {
 **Infernal Cape's Gambled:** ${stats.infernal_cape_sacrifices}`;
 }
 
-export async function capeGambleCommand(user: MUser, type: string, interaction: ChatInputCommandInteraction) {
+export async function capeGambleCommand(
+	user: MUser,
+	type: string,
+	interaction: ChatInputCommandInteraction,
+	autoconfirm: boolean = false
+) {
 	const item = getOSItem(type === 'fire' ? 'Fire cape' : 'Infernal cape');
 	const key: 'infernal_cape_sacrifices' | 'firecapes_sacrificed' =
 		type === 'fire' ? 'firecapes_sacrificed' : 'infernal_cape_sacrifices';
@@ -26,7 +31,9 @@ export async function capeGambleCommand(user: MUser, type: string, interaction: 
 
 	if (capesOwned < 1) return `You have no ${item.name}'s to gamble!`;
 
-	await handleMahojiConfirmation(interaction, `Are you sure you want to gamble a ${item.name}?`);
+	if (!autoconfirm) {
+		await handleMahojiConfirmation(interaction, `Are you sure you want to gamble a ${item.name}?`);
+	}
 
 	// Double check after confirmation dialogue:
 	await user.sync();

--- a/src/mahoji/lib/abstracted_commands/capegamble.ts
+++ b/src/mahoji/lib/abstracted_commands/capegamble.ts
@@ -45,13 +45,15 @@ export async function capeGambleCommand(user: MUser, type: string, interaction: 
 		}
 	);
 	const newSacrificedCount = newStats[key];
-	await user.removeItemsFromBank(new Bank().add(item.id));
 
 	const chance = type === 'fire' ? 200 : 100;
 	const pet = getOSItem(type === 'fire' ? 'Tzrek-Jad' : 'Jal-nib-rek');
+	const gotPet = roll(chance);
+	const loot = gotPet ? new Bank().add(pet.id) : undefined;
 
-	if (roll(chance)) {
-		await user.addItemsToBank({ items: new Bank().add(pet.id), collectionLog: true });
+	await user.transactItems({ itemsToAdd: loot, itemsToRemove: new Bank().add(item.id), collectionLog: true });
+
+	if (gotPet) {
 		globalClient.emit(
 			Events.ServerNotification,
 			`**${user.badgedUsername}'s** just received their ${formatOrdinal(

--- a/src/mahoji/lib/abstracted_commands/castCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/castCommand.ts
@@ -1,5 +1,4 @@
 import { reduceNumByPercent, Time } from 'e';
-import { Bank } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import { Castables } from '../../../lib/skilling/skills/magic/castables';
@@ -105,7 +104,7 @@ export async function castCommand(channelID: string, user: MUser, name: string, 
 		if (gpCost > userGP) {
 			return `You need ${gpCost} GP to create ${quantity} planks.`;
 		}
-		await user.removeItemsFromBank(new Bank().add('Coins', gpCost));
+		cost.add('Coins', gpCost);
 	}
 
 	await user.removeItemsFromBank(cost);

--- a/src/mahoji/lib/abstracted_commands/decantCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/decantCommand.ts
@@ -11,8 +11,13 @@ export async function decantCommand(user: MUser, itemName: string, dose = 4) {
 	if (!user.owns(potionsToRemove)) {
 		return `You don't own ${potionsToRemove}.`;
 	}
-	await user.removeItemsFromBank(potionsToRemove);
-	await user.addItemsToBank({ items: potionsToAdd });
+
+	await transactItems({
+		userID: user.id,
+		filterLoot: false,
+		itemsToRemove: potionsToRemove,
+		itemsToAdd: potionsToAdd
+	});
 
 	if (user.hasEquipped(['Iron dagger', 'Bronze arrow']) && !user.hasEquippedOrInBank('Clue hunter gloves')) {
 		await user.addItemsToBank({ items: new Bank({ 'Clue hunter gloves': 1 }), collectionLog: true });

--- a/src/mahoji/lib/abstracted_commands/gearCommands.ts
+++ b/src/mahoji/lib/abstracted_commands/gearCommands.ts
@@ -302,8 +302,7 @@ export async function autoEquipCommand(user: MUser, gearSetup: GearSetupType, eq
 		return `You dont own ${toRemoveFromBank}!`;
 	}
 
-	await user.removeItemsFromBank(toRemoveFromBank);
-	await user.addItemsToBank({ items: toRemoveFromGear, collectionLog: false });
+	await user.transactItems({ itemsToRemove: toRemoveFromBank, itemsToAdd: toRemoveFromGear });
 	await user.update({
 		[`gear_${gearSetup}`]: gearToEquip
 	});

--- a/src/mahoji/lib/abstracted_commands/pohCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/pohCommand.ts
@@ -185,10 +185,8 @@ export async function pohMountItemCommand(user: MUser, name: string) {
 		return `You don't have all the required materials: ${costBank}\n\nYou're missing ${missingBank}`;
 	}
 
-	await user.removeItemsFromBank(costBank);
-	if (currItem) {
-		await user.addItemsToBank({ items: { [currItem]: 1 } });
-	}
+	const refundBank = currItem ? new Bank().add(currItem) : undefined;
+	await user.transactItems({ itemsToRemove: costBank, itemsToAdd: refundBank });
 
 	await prisma.playerOwnedHouse.update({
 		where: {

--- a/src/mahoji/lib/abstracted_commands/useCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/useCommand.ts
@@ -95,11 +95,11 @@ const genericUsables: {
 for (const genericU of genericUsables) {
 	usables.push({
 		items: genericU.items,
-		run: async klasaUser => {
-			if (genericU.cost) await klasaUser.removeItemsFromBank(genericU.cost);
+		run: async user => {
+			const cost = genericU.cost ? genericU.cost : undefined;
 			const loot =
-				genericU.loot === null ? null : genericU.loot instanceof Bank ? genericU.loot : genericU.loot();
-			if (loot) await klasaUser.addItemsToBank({ items: loot });
+				genericU.loot === null ? undefined : genericU.loot instanceof Bank ? genericU.loot : genericU.loot();
+			if (loot || cost) await user.transactItems({ itemsToAdd: loot, itemsToRemove: cost, collectionLog: true });
 			return genericU.response(loot ?? new Bank());
 		}
 	});


### PR DESCRIPTION
### Description:

- Replaces back-to-back add and/or remove to/from bank with a single transactItems() call.
- This will help prevent item loss



### Other checks:

- [ ] I have tested all my changes thoroughly.
