### PR TITLE
Fix Slayer Shop "All Unlocks" bitfield not applying

### DIFF
--- a/src/mahoji/commands/slayer.ts
+++ b/src/mahoji/commands/slayer.ts
@@ -102,19 +102,25 @@ export const slayerCommand: OSBMahojiCommand = {
 							name: 'unlockable',
 							description: 'Unlockable to purchase',
 							required: true,
-							autocomplete: async (value: string) => {
-								return SlayerRewardsShop.filter(
-									r =>
-										!r.item &&
-										(!value
+							autocomplete: async (value: string, user: User) => {
+								const { slayer_unlocks: myUnlocks } = await mahojiUsersSettingsFetch(user.id, {
+									slayer_unlocks: true
+								});
+								const slayerUnlocks = SlayerRewardsShop.filter(
+									r => !r.item && !myUnlocks.includes(r.id)
+								);
+								return slayerUnlocks
+									.filter(r =>
+										!value
 											? true
 											: r.name.toLowerCase().includes(value) ||
 											  r.aliases?.some(alias =>
 													alias.toLowerCase().includes(value.toLowerCase())
-											  ))
-								).map(m => {
-									return { name: m.name, value: m.name };
-								});
+											  )
+									)
+									.map(m => {
+										return { name: m.name, value: m.name };
+									});
 							}
 						}
 					]

--- a/src/mahoji/lib/abstracted_commands/slayerShopCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/slayerShopCommand.ts
@@ -70,7 +70,7 @@ export async function slayerShopBuyCommand({
 					slayer_unlocks: newUnlocks
 				});
 				if (
-					newUnlocks.length === SlayerRewardsShop.length &&
+					newUnlocks.length === SlayerRewardsShop.filter(u => !u.item).length &&
 					!user.bitfield.includes(BitField.HadAllSlayerUnlocks)
 				) {
 					await user.update({


### PR DESCRIPTION
### Description:

Currently, the 'all unlocks' bitfield can't ever be set because it's counting all rewards, including non-unlockables.

### Changes:

- Filter out rewards without an item when checking for completion of unlocks
- Only show yet-to-be-unlocked rewards in `/slayer rewards unlock`

### Other checks:

- [x] I have tested all my changes thoroughly.
