### PR TITLE
Fix incorrect cost for Ornate Jewellery Box

### DIFF
--- a/src/lib/poh/objects/jewellery_boxes.ts
+++ b/src/lib/poh/objects/jewellery_boxes.ts
@@ -27,7 +27,7 @@ export const JewelleryBoxes: PoHObject[] = [
 		name: 'Ornate jewellery box',
 		slot: 'jewellery_box',
 		level: 91,
-		itemCost: new Bank().add('Gold leaf', 2).add('Amulet of glory(4)', 20).add('Ring of wealth (5)'),
+		itemCost: new Bank().add('Gold leaf', 2).add('Amulet of glory(4)', 20).add('Ring of wealth (5)', 20),
 		requiredInPlace: 37_501
 	}
 ];


### PR DESCRIPTION
### Description:

- Ornate Jewellery Box is only charging 1x Ring of Wealth (5) instead of 20

### Changes:

- Adds 20 qty to the add() command for Ring of Wealth of the inputBank for the Ornate Jewellery Box

### Other checks:

- [ ] I have tested all my changes thoroughly.
