### PR TITLE
Fix issue with growables and CL

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -12,6 +12,7 @@ import { badges, BitField, Emoji, projectiles, usernameCache } from './constants
 import { allPetIDs } from './data/CollectionsExport';
 import { getSimilarItems } from './data/similarItems';
 import { GearSetup, UserFullGearSetup } from './gear/types';
+import { handleNewCLItems } from './handleNewCLItems';
 import { CombatOptionsEnum } from './minions/data/combatConstants';
 import { baseUserKourendFavour, UserKourendFavour } from './minions/data/kourendFavour';
 import { defaultFarmingContract } from './minions/farming';
@@ -430,12 +431,14 @@ export class MUserClass {
 	}
 
 	async addItemsToCollectionLog(itemsToAdd: Bank) {
+		const previousCL = new Bank(this.cl.bank);
 		const updates = this.calculateAddItemsToCLUpdates({
 			items: itemsToAdd
 		});
 		const { newUser } = await mahojiUserSettingsUpdate(this.id, updates);
 		this.user = newUser;
 		this.updateProperties();
+		await handleNewCLItems({ itemsAdded: itemsToAdd, user: this, newCL: this.cl, previousCL });
 	}
 
 	async specialRemoveItems(bankToRemove: Bank) {

--- a/src/lib/growablePets.ts
+++ b/src/lib/growablePets.ts
@@ -53,9 +53,9 @@ export async function handleGrowablePetGrowth(user: MUser, data: ActivityTaskOpt
 		// Sync to avoid out of date CL
 		await user.sync();
 		await user.update({
-			minion_equippedPet: nextPet,
-			collectionLogBank: new Bank().add(user.cl).add(nextPet).bank
+			minion_equippedPet: nextPet
 		});
+		await user.addItemsToCollectionLog(new Bank().add(nextPet));
 		messages.push(`Your ${getOSItem(equippedPet).name} grew into a ${getOSItem(nextPet).name}!`);
 	}
 }

--- a/src/lib/handleNewCLItems.ts
+++ b/src/lib/handleNewCLItems.ts
@@ -23,7 +23,7 @@ export async function createHistoricalData(user: MUser) {
 	};
 }
 
-async function clArrayUpdate(user: MUser, newCL: Bank) {
+export async function clArrayUpdate(user: MUser, newCL: Bank) {
 	const id = BigInt(user.id);
 	const newCLArray = Object.keys(newCL.bank).map(i => Number(i));
 	const updateObj = {

--- a/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
@@ -4,6 +4,7 @@ import { stripNonAlphanumeric } from 'e';
 
 import { ClueTiers } from '../../../lib/clues/clueTiers';
 import { BitField, Emoji, minionBuyButton } from '../../../lib/constants';
+import { clArrayUpdate } from '../../../lib/handleNewCLItems';
 import { roboChimpSyncData, roboChimpUserFetch } from '../../../lib/roboChimp';
 import { prisma } from '../../../lib/settings/prisma';
 import { makeComponents } from '../../../lib/util';
@@ -60,6 +61,7 @@ export async function minionStatusCommand(user: MUser): Promise<BaseMessageOptio
 	]);
 
 	roboChimpSyncData(roboChimpUser, user);
+	await clArrayUpdate(user, user.cl);
 
 	if (!user.user.minion_hasBought) {
 		return {


### PR DESCRIPTION
### Description:

Growing pets doesn't properly add to the CL leaderboard, and there's no way to force an update if you are near-CL completion.

### Changes:

- Fixes Growables not updating the fast-search array cl_array
- Adds ability to force-update

### Other checks:

- [x] I have tested all my changes thoroughly.
