### PR TITLE
Track GRI in Economy Transaction

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -610,6 +610,7 @@ enum economy_transaction_type {
   trade
   giveaway
   duel
+  gri
 }
 
 model EconomyTransaction {

--- a/src/mahoji/commands/gamble.ts
+++ b/src/mahoji/commands/gamble.ts
@@ -3,6 +3,7 @@ import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { MahojiUserOption } from 'mahoji/dist/lib/types';
 import { Bank } from 'oldschooljs';
 
+import { prisma } from '../../lib/settings/prisma';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
 import itemIsTradeable from '../../lib/util/itemIsTradeable';
 import { capeGambleCommand, capeGambleStatsCommand } from '../lib/abstracted_commands/capegamble';
@@ -246,6 +247,16 @@ export const gambleCommand: OSBMahojiCommand = {
 				itemsToAdd: loot,
 				collectionLog: false,
 				filterLoot: false
+			});
+			await prisma.economyTransaction.create({
+				data: {
+					guild_id: undefined,
+					sender: BigInt(senderUser.id),
+					recipient: BigInt(recipientuser.id),
+					items_sent: loot.bank,
+					items_received: undefined,
+					type: 'gri'
+				}
 			});
 			let debug = new Bank();
 			for (const t of bank) debug.add(t[0].id);

--- a/src/mahoji/commands/gamble.ts
+++ b/src/mahoji/commands/gamble.ts
@@ -171,6 +171,7 @@ export const gambleCommand: OSBMahojiCommand = {
 	run: async ({
 		options,
 		interaction,
+		guildID,
 		userID
 	}: CommandRunOptions<{
 		cape?: { type?: string; autoconfirm?: boolean };
@@ -250,7 +251,7 @@ export const gambleCommand: OSBMahojiCommand = {
 			});
 			await prisma.economyTransaction.create({
 				data: {
-					guild_id: undefined,
+					guild_id: guildID ? BigInt(guildID) : undefined,
 					sender: BigInt(senderUser.id),
 					recipient: BigInt(recipientuser.id),
 					items_sent: loot.bank,


### PR DESCRIPTION
### Description:

- Track GRI's in economy transaction so we don't have to do it the hard way.

### Changes:

- Adds an economy transaction log for each GRI

### Other checks:

- [x] I have tested all my changes thoroughly.
