### PR TITLE
Defer Interaction Updates

### DIFF
--- a/src/mahoji/commands/ge.ts
+++ b/src/mahoji/commands/ge.ts
@@ -11,6 +11,7 @@ import { prisma } from '../../lib/settings/prisma';
 import { formatDuration, itemNameFromID, makeComponents, toKMB } from '../../lib/util';
 import getOSItem from '../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
+import { deferInteraction } from '../../lib/util/interactionReply';
 import { cancelGEListingCommand } from '../lib/abstracted_commands/cancelGEListingCommand';
 import { ownedItemOption, tradeableItemArr } from '../lib/mahojiCommandOptions';
 import { OSBMahojiCommand } from '../lib/util';
@@ -215,7 +216,7 @@ export const geCommand: OSBMahojiCommand = {
 		stats?: {};
 		price?: { item: string };
 	}>) => {
-		await interaction.deferReply();
+		await deferInteraction(interaction);
 		const user = await mUserFetch(userID);
 
 		if (options.price) {
@@ -228,7 +229,7 @@ export const geCommand: OSBMahojiCommand = {
 			)} (${data.guidePrice.toLocaleString()}) GP.
 
 **Recent price:** ${toKMB(data.averagePriceLast100)} (${data.averagePriceLast100.toLocaleString()}) GP.
-			
+
 This price is a guide only, calculated from average sale prices, it may not be accurate, it may change, or not reflect the true market price.`;
 		}
 

--- a/src/mahoji/commands/leagues.ts
+++ b/src/mahoji/commands/leagues.ts
@@ -7,6 +7,7 @@ import { leagueBuyables } from '../../lib/data/leaguesBuyables';
 import { roboChimpUserFetch } from '../../lib/roboChimp';
 import { getUsername } from '../../lib/util';
 import getOSItem from '../../lib/util/getOSItem';
+import { deferInteraction } from '../../lib/util/interactionReply';
 import { OSBMahojiCommand } from '../lib/util';
 import { doMenu } from './leaderboard';
 
@@ -162,7 +163,7 @@ ${leaguesTrophiesBuyables
 				},
 				take: 100
 			});
-			interaction.deferReply();
+			await deferInteraction(interaction);
 			doMenu(
 				user,
 				channelID,

--- a/src/mahoji/commands/offer.ts
+++ b/src/mahoji/commands/offer.ts
@@ -15,6 +15,7 @@ import { formatDuration } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import getOSItem from '../../lib/util/getOSItem';
+import { deferInteraction } from '../../lib/util/interactionReply';
 import { makeBankImage } from '../../lib/util/makeBankImage';
 import resolveItems from '../../lib/util/resolveItems';
 import { OSBMahojiCommand } from '../lib/util';
@@ -88,10 +89,16 @@ export const mineCommand: OSBMahojiCommand = {
 			min_value: 1
 		}
 	],
-	run: async ({ options, userID, channelID }: CommandRunOptions<{ name: string; quantity?: number }>) => {
+	run: async ({
+		options,
+		userID,
+		channelID,
+		interaction
+	}: CommandRunOptions<{ name: string; quantity?: number }>) => {
 		const user = await mUserFetch(userID);
 		const userBank = user.bank;
 
+		await deferInteraction(interaction);
 		let { quantity } = options;
 		const whichOfferable = Offerables.find(
 			item =>

--- a/src/mahoji/commands/slayer.ts
+++ b/src/mahoji/commands/slayer.ts
@@ -4,6 +4,7 @@ import { Monsters } from 'oldschooljs';
 
 import { autoslayChoices, slayerMasterChoices } from '../../lib/slayer/constants';
 import { SlayerRewardsShop } from '../../lib/slayer/slayerUnlocks';
+import { deferInteraction } from '../../lib/util/interactionReply';
 import { autoSlayCommand } from '../lib/abstracted_commands/autoSlayCommand';
 import {
 	slayerShopBuyCommand,
@@ -273,6 +274,7 @@ export const slayerCommand: OSBMahojiCommand = {
 	}>) => {
 		const mahojiUser = await mUserFetch(userID);
 
+		await deferInteraction(interaction);
 		if (options.autoslay) {
 			autoSlayCommand({
 				mahojiUser,


### PR DESCRIPTION
### Description:

Adds deferInteraction() to some frequently-timed out commands, and replaces `interaction.deferReply()` with `deferInteraction()`

### Changes:

- Replaces 2 instances of `interaction.deferReply()` with `deferInteraction()`
- Adds `deferInteraction()`  to /offer which has multiple bank operations + has to generate the result image
- Adds `deferInteraction()` to /slayer, which can often require mulitiple cross-lookups to perform it's complex duties.

### Other checks:

- [x] I have tested all my changes thoroughly.
