### PR TITLE
Admin commands are busy-immune

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -448,6 +448,7 @@ export type NMZStrategy = (typeof NMZ_STRATEGY)[number];
 export const UNDERWATER_AGILITY_THIEVING_TRAINING_SKILL = ['agility', 'thieving', 'agility+thieving'] as const;
 export type UnderwaterAgilityThievingTrainingSkill = (typeof UNDERWATER_AGILITY_THIEVING_TRAINING_SKILL)[number];
 
+export const busyImmuneCommands = ['admin', 'rp'];
 export const usernameCache = new Map<string, string>();
 export const badgesCache = new Map<string, string>();
 export const minionBuyButton = new ButtonBuilder()

--- a/src/mahoji/lib/postCommand.ts
+++ b/src/mahoji/lib/postCommand.ts
@@ -1,7 +1,7 @@
 import { CommandOptions } from 'mahoji/dist/lib/types';
 
 import { modifyBusyCounter } from '../../lib/busyCounterCache';
-import { shouldTrackCommand } from '../../lib/constants';
+import { busyImmuneCommands, shouldTrackCommand } from '../../lib/constants';
 import { prisma } from '../../lib/settings/prisma';
 import { makeCommandUsage } from '../../lib/util/commandUsage';
 import { logError } from '../../lib/util/logError';
@@ -25,7 +25,9 @@ export async function postCommand({
 	isContinue: boolean;
 	inhibited: boolean;
 }): Promise<string | undefined> {
-	setTimeout(() => modifyBusyCounter(userID, -1), 1000);
+	if (!busyImmuneCommands.includes(abstractCommand.name)) {
+		setTimeout(() => modifyBusyCounter(userID, 1), 1000);
+	}
 	debugLog('Postcommand', {
 		type: 'RUN_COMMAND',
 		command_name: abstractCommand.name,

--- a/src/mahoji/lib/preCommand.ts
+++ b/src/mahoji/lib/preCommand.ts
@@ -2,7 +2,7 @@ import { InteractionReplyOptions, TextChannel, User } from 'discord.js';
 import { CommandOptions } from 'mahoji/dist/lib/types';
 
 import { modifyBusyCounter, userIsBusy } from '../../lib/busyCounterCache';
-import { badges, badgesCache, Emoji, usernameCache } from '../../lib/constants';
+import { badges, badgesCache, busyImmuneCommands, Emoji, usernameCache } from '../../lib/constants';
 import { prisma } from '../../lib/settings/prisma';
 import { removeMarkdownEmojis, stripEmojis } from '../../lib/util';
 import { CACHED_ACTIVE_USER_IDS } from '../../lib/util/cachedUserIDs';
@@ -97,10 +97,10 @@ export async function preCommand({
 		};
 	}
 	const user: PrecommandUser = await fetchPrecommandUser(userID);
-	if (userIsBusy(userID) && !bypassInhibitors && abstractCommand.name !== 'admin') {
+	if (userIsBusy(userID) && !bypassInhibitors && !busyImmuneCommands.includes(abstractCommand.name)) {
 		return { silent: true, reason: { content: 'You cannot use a command right now.' }, dontRunPostCommand: true };
 	}
-	modifyBusyCounter(userID, 1);
+	if (!busyImmuneCommands.includes(abstractCommand.name)) modifyBusyCounter(userID, 1);
 
 	const guild = guildID ? globalClient.guilds.cache.get(guildID.toString()) : null;
 	const member = guild?.members.cache.get(userID.toString());


### PR DESCRIPTION
### Description:

Makes Admin + RP commands immune to 'busyness' -- This allows them to function while the user is busy, and also prevents them from making the user busy + unable to use their minion during long commands (such as sync_roles)

### Changes:

- Adds list of Busy-Immune commands
- Doesn't increase/decrease busy counter for busy-immune commands
- Won't inhibit a busy-immune command for busyness

### Other checks:

- [ ] I have tested all my changes thoroughly.
