### PR TITLE
ToB Fixes

### DIFF
--- a/src/lib/combat_achievements/combatAchievements.ts
+++ b/src/lib/combat_achievements/combatAchievements.ts
@@ -82,9 +82,6 @@ const indexesWithRng = entries.map(i => i[1].tasks.filter(t => 'rng' in t)).flat
 
 export const combatAchievementTripEffect: TripFinishEffect['fn'] = async ({ data, messages }) => {
 	const dataCopy = deepClone(data);
-	if (dataCopy.type === 'TheatreOfBlood') {
-		(dataCopy as any).quantity = 1;
-	}
 	if (dataCopy.type === 'Inferno' && !dataCopy.diedPreZuk && !dataCopy.diedZuk) {
 		(dataCopy as any).quantity = 1;
 	}
@@ -97,7 +94,7 @@ export const combatAchievementTripEffect: TripFinishEffect['fn'] = async ({ data
 		const wipedRooms = (Array.isArray(wipedRoom) ? wipedRoom : [wipedRoom]).filter(notEmpty);
 		for (let i = 0; i < wipedRooms.length; i++) quantity--;
 	} else if (data.type === 'TheatreOfBlood') {
-		quantity -= sumArr(data.wipedRooms.map(i => (i ? 1 : 0)));
+		quantity -= sumArr(data.wipedRooms.map(i => (i !== null ? 1 : 0)));
 	} else if (data.type === 'FightCaves') {
 		if (data.preJadDeathTime) {
 			quantity--;

--- a/src/lib/combat_achievements/combatAchievements.ts
+++ b/src/lib/combat_achievements/combatAchievements.ts
@@ -97,11 +97,7 @@ export const combatAchievementTripEffect: TripFinishEffect['fn'] = async ({ data
 		const wipedRooms = (Array.isArray(wipedRoom) ? wipedRoom : [wipedRoom]).filter(notEmpty);
 		for (let i = 0; i < wipedRooms.length; i++) quantity--;
 	} else if (data.type === 'TheatreOfBlood') {
-		if (data.wipedRoom) {
-			quantity--;
-		} else if (data.wipedRooms) {
-			quantity -= sumArr(data.wipedRooms.map(i => (i ? i : 0)));
-		}
+		quantity -= sumArr(data.wipedRooms.map(i => (i ? 1 : 0)));
 	} else if (data.type === 'FightCaves') {
 		if (data.preJadDeathTime) {
 			quantity--;

--- a/src/lib/combat_achievements/combatAchievements.ts
+++ b/src/lib/combat_achievements/combatAchievements.ts
@@ -99,6 +99,8 @@ export const combatAchievementTripEffect: TripFinishEffect['fn'] = async ({ data
 	} else if (data.type === 'TheatreOfBlood') {
 		if (data.wipedRoom) {
 			quantity--;
+		} else if (data.wipedRooms) {
+			quantity -= sumArr(data.wipedRooms.map(i => (i ? i : 0)));
 		}
 	} else if (data.type === 'FightCaves') {
 		if (data.preJadDeathTime) {

--- a/src/lib/data/tob.ts
+++ b/src/lib/data/tob.ts
@@ -498,7 +498,7 @@ export function createTOBRaid({
 	baseDuration: number;
 	hardMode: boolean;
 	disableVariation?: true;
-}) {
+}): { duration: number; parsedTeam: ParsedTeamMember[]; wipedRoom: TOBRoom | null; deathDuration: number | null } {
 	let parsedTeam: ParsedTeamMember[] = [];
 
 	for (const u of team) {

--- a/src/lib/data/tob.ts
+++ b/src/lib/data/tob.ts
@@ -372,38 +372,22 @@ interface ParsedTeamMember {
 	deaths: number[];
 	wipeDeaths: number[];
 }
+interface TobTeam {
+	user: MUser;
+	gear: { melee: Gear; range: Gear; mage: Gear };
+	bank: Bank;
+	kc: number;
+	hardKC: number;
+	attempts: number;
+	hardAttempts: number;
+}
 
-export function createTOBTeam({
-	team,
-	hardMode,
-	disableVariation
-}: {
-	team: {
-		user: MUser;
-		gear: { melee: Gear; range: Gear; mage: Gear };
-		bank: Bank;
-		kc: number;
-		hardKC: number;
-		attempts: number;
-		hardAttempts: number;
-	}[];
-	hardMode: boolean;
-	disableVariation?: true;
-}): {
-	reductions: Record<string, number>;
-	duration: number;
-	maxUserReduction: number;
-	parsedTeam: ParsedTeamMember[];
-	wipedRoom: TOBRoom | null;
-	deathDuration: number | null;
-} {
+export function calcTOBBaseDuration({ team, hardMode }: { team: TobTeam[]; hardMode: boolean }) {
 	const teamSize = team.length;
 
 	let individualReductions = [];
 
 	let reductions: Record<string, number> = {};
-
-	let parsedTeam: ParsedTeamMember[] = [];
 
 	for (const u of team) {
 		let userPercentChange = 0;
@@ -464,16 +448,6 @@ export function createTOBTeam({
 			userPercentChange = reduceNumByPercent(userPercentChange, 10);
 		}
 
-		const deathChances = calculateTOBDeaths(u.kc, u.hardKC, u.attempts, u.hardAttempts, hardMode, gearPercents);
-		parsedTeam.push({
-			kc: u.kc,
-			hardKC: u.hardKC,
-			deathChances,
-			wipeDeaths: deathChances.wipeDeaths,
-			deaths: deathChances.deaths,
-			id: u.user.id
-		});
-
 		let reduction = round(userPercentChange / teamSize, 1);
 
 		individualReductions.push(userPercentChange);
@@ -505,8 +479,42 @@ export function createTOBTeam({
 	if (team.length < 5) {
 		duration += (5 - team.length) * (Time.Minute * 1.3);
 	}
+	if (duration < Time.Minute * 15) {
+		duration = Math.max(Time.Minute * 15, duration);
+	}
+	return {
+		baseDuration: duration,
+		reductions,
+		maxUserReduction: maxSpeedReductionUser / teamSize
+	};
+}
+export function createTOBRaid({
+	team,
+	hardMode,
+	baseDuration,
+	disableVariation
+}: {
+	team: TobTeam[];
+	baseDuration: number;
+	hardMode: boolean;
+	disableVariation?: true;
+}) {
+	let parsedTeam: ParsedTeamMember[] = [];
 
-	duration = Math.floor(randomVariation(duration, 5));
+	for (const u of team) {
+		const gearPercents = calculateTOBUserGearPercents(u.user);
+		const deathChances = calculateTOBDeaths(u.kc, u.hardKC, u.attempts, u.hardAttempts, hardMode, gearPercents);
+		parsedTeam.push({
+			kc: u.kc,
+			hardKC: u.hardKC,
+			deathChances,
+			wipeDeaths: team.length === 1 ? deathChances.deaths : deathChances.wipeDeaths,
+			deaths: deathChances.deaths,
+			id: u.user.id
+		});
+	}
+
+	let duration = Math.floor(randomVariation(baseDuration, 5));
 
 	let wipedRoom: TOBRoom | null = null;
 	let deathDuration: number | null = 0;
@@ -533,11 +541,8 @@ export function createTOBTeam({
 		});
 		wipedRoom = null;
 	}
-
 	return {
 		duration,
-		reductions,
-		maxUserReduction: maxSpeedReductionUser / teamSize,
 		parsedTeam,
 		wipedRoom,
 		deathDuration

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -428,7 +428,6 @@ export interface TheatreOfBloodTaskOptions extends ActivityTaskOptionsWithUsers 
 	hardMode: boolean;
 	fakeDuration: number;
 	wipedRooms: (null | number)[];
-	wipedRoom?: null | number;
 	deaths: number[][][];
 	quantity: number;
 	solo?: boolean;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -427,8 +427,10 @@ export interface TheatreOfBloodTaskOptions extends ActivityTaskOptionsWithUsers 
 	users: string[];
 	hardMode: boolean;
 	fakeDuration: number;
-	wipedRoom: null | number;
-	deaths: number[][];
+	wipedRooms: (null | number)[];
+	wipedRoom?: null | number;
+	deaths: number[][][];
+	quantity: number;
 	solo?: boolean;
 }
 

--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -32,6 +32,7 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 		case 'AnimatedArmour':
 		case 'Sepulchre':
 		case 'Raids':
+		case 'TheatreOfBlood':
 		case 'Pickpocket':
 		case 'SoulWars':
 		case 'Cyclops': {

--- a/src/mahoji/commands/raid.ts
+++ b/src/mahoji/commands/raid.ts
@@ -58,6 +58,12 @@ export const raidCommand: OSBMahojiCommand = {
 					options: [
 						{
 							type: ApplicationCommandOptionType.Boolean,
+							name: 'solo',
+							description: 'Solo with a team of 3 bots.',
+							required: false
+						},
+						{
+							type: ApplicationCommandOptionType.Boolean,
 							name: 'hard_mode',
 							description: 'Choose whether you want to do Hard Mode.',
 							required: false
@@ -69,10 +75,12 @@ export const raidCommand: OSBMahojiCommand = {
 							required: false
 						},
 						{
-							type: ApplicationCommandOptionType.Boolean,
-							name: 'solo',
-							description: 'Solo with a team of 3 bots.',
-							required: false
+							type: ApplicationCommandOptionType.Integer,
+							name: 'quantity',
+							description: 'The quantity to do.',
+							required: false,
+							min_value: 1,
+							max_value: 10
 						}
 					]
 				},
@@ -153,7 +161,7 @@ export const raidCommand: OSBMahojiCommand = {
 	}: CommandRunOptions<{
 		cox?: { start?: { type: 'solo' | 'mass'; challenge_mode?: boolean; quantity?: number }; stats?: {} };
 		tob?: {
-			start?: { hard_mode?: boolean; max_team_size?: number; solo?: boolean };
+			start?: { solo?: boolean; hard_mode?: boolean; max_team_size?: number; quantity?: number };
 			stats?: {};
 			check?: { hard_mode?: boolean };
 		};
@@ -181,7 +189,8 @@ export const raidCommand: OSBMahojiCommand = {
 				channelID,
 				Boolean(tob.start.hard_mode),
 				tob.start.max_team_size,
-				Boolean(tob.start.solo)
+				Boolean(tob.start.solo),
+				tob.start.quantity
 			);
 		}
 

--- a/src/mahoji/lib/abstracted_commands/tobCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/tobCommand.ts
@@ -402,7 +402,7 @@ export async function tobStartCommand(
 		wipedRooms.push(wipedRoom);
 		totalFakeDuration += duration;
 		totalDuration += deathDuration === null ? duration : deathDuration;
-
+		if (solo) parsedTeam.length = 1;
 		deaths.push(parsedTeam.map(i => i.deaths));
 	}
 	if (solo) {

--- a/src/mahoji/lib/abstracted_commands/tobCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/tobCommand.ts
@@ -6,9 +6,10 @@ import { Emoji } from '../../../lib/constants';
 import { getSimilarItems } from '../../../lib/data/similarItems';
 import {
 	baseTOBUniques,
+	calcTOBBaseDuration,
 	calculateTOBDeaths,
 	calculateTOBUserGearPercents,
-	createTOBTeam,
+	createTOBRaid,
 	minimumTOBSuppliesNeeded,
 	TENTACLE_CHARGES_PER_RAID
 } from '../../../lib/data/tob';
@@ -22,6 +23,7 @@ import { MakePartyOptions } from '../../../lib/types';
 import { TheatreOfBloodTaskOptions } from '../../../lib/types/minions';
 import { channelIsSendable, formatDuration, formatSkillRequirements, skillsMeetRequirements } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
+import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';
 import itemID from '../../../lib/util/itemID';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
@@ -71,7 +73,8 @@ export async function calcTOBInput(u: MUser) {
 export async function checkTOBUser(
 	user: MUser,
 	isHardMode: boolean,
-	teamSize?: number
+	teamSize?: number,
+	quantity: number = 1
 ): Promise<[false] | [true, string]> {
 	if (!user.user.minion_hasBought) {
 		return [true, `${user.usernameOrMention} doesn't have a minion`];
@@ -88,7 +91,7 @@ export async function checkTOBUser(
 		];
 	}
 
-	if (!user.owns(minimumTOBSuppliesNeeded)) {
+	if (!user.owns(minimumTOBSuppliesNeeded.clone().multiply(quantity))) {
 		return [
 			true,
 			`${user.usernameOrMention} doesn't have enough items, you need a minimum of this amount of items: ${minimumTOBSuppliesNeeded}.`
@@ -109,6 +112,7 @@ export async function checkTOBUser(
 
 	const cost = await calcTOBInput(user);
 	cost.add('Coins', 100_000);
+	cost.multiply(quantity);
 	if (!user.owns(cost)) {
 		return [true, `${user.usernameOrMention} doesn't own ${cost.remove(user.bankWithGP)}`];
 	}
@@ -141,7 +145,7 @@ export async function checkTOBUser(
 	if (meleeGear.hasEquipped('Abyssal tentacle')) {
 		const tentacleResult = checkUserCanUseDegradeableItem({
 			item: getOSItem('Abyssal tentacle'),
-			chargesToDegrade: TENTACLE_CHARGES_PER_RAID,
+			chargesToDegrade: TENTACLE_CHARGES_PER_RAID * quantity,
 			user
 		});
 		if (!tentacleResult.hasEnough) {
@@ -157,11 +161,13 @@ export async function checkTOBUser(
 			`${user.usernameOrMention} needs a Toxic blowpipe (with darts and scales equipped) in their bank to do the Theatre of Blood.`
 		];
 	}
-	if (blowpipeData.dartQuantity < 150) {
-		return [true, `${user.usernameOrMention}, you need atleast 150 darts in your blowpipe.`];
+	const dartsNeeded = 150 * quantity;
+	if (blowpipeData.dartQuantity < dartsNeeded) {
+		return [true, `${user.usernameOrMention}, you need atleast ${dartsNeeded} darts in your blowpipe.`];
 	}
-	if (blowpipeData.scales < 1000) {
-		return [true, `${user.usernameOrMention}, you need atleast 1000 scales in your blowpipe.`];
+	const scalesNeeded = 1000 * quantity;
+	if (blowpipeData.scales < scalesNeeded) {
+		return [true, `${user.usernameOrMention}, you need atleast ${scalesNeeded} scales in your blowpipe.`];
 	}
 	const dartIndex = blowpipeDarts.indexOf(getOSItem(blowpipeData.dartID));
 	if (dartIndex < 5) {
@@ -182,8 +188,12 @@ export async function checkTOBUser(
 		return [true, `${user.usernameOrMention}, you can't use Dragon arrows with a Magic shortbow 🤨`];
 	}
 
-	if (rangeGear.ammo!.quantity < 150) {
-		return [true, `${user.usernameOrMention}, you need atleast 150 arrows equipped in your range setup.`];
+	const arrowsRequired = 150 * quantity;
+	if (rangeGear.ammo!.quantity < arrowsRequired) {
+		return [
+			true,
+			`${user.usernameOrMention}, you need atleast ${arrowsRequired} arrows equipped in your range setup.`
+		];
 	}
 
 	if (isHardMode) {
@@ -207,7 +217,12 @@ export async function checkTOBUser(
 	return [false];
 }
 
-export async function checkTOBTeam(users: MUser[], isHardMode: boolean, solo: boolean): Promise<string | null> {
+export async function checkTOBTeam(
+	users: MUser[],
+	isHardMode: boolean,
+	solo: boolean,
+	quantity: number = 1
+): Promise<string | null> {
 	const userWithoutSupplies = users.find(u => !u.bank.has(minimumTOBSuppliesNeeded));
 	if (userWithoutSupplies) {
 		return `${userWithoutSupplies.usernameOrMention} doesn't have enough supplies`;
@@ -218,7 +233,7 @@ export async function checkTOBTeam(users: MUser[], isHardMode: boolean, solo: bo
 
 	for (const user of users) {
 		if (user.minionIsBusy) return `${user.usernameOrMention}'s minion is busy.`;
-		const checkResult = await checkTOBUser(user, isHardMode, users.length);
+		const checkResult = await checkTOBUser(user, isHardMode, users.length, quantity);
 		if (!checkResult[0]) {
 			continue;
 		} else {
@@ -267,7 +282,8 @@ export async function tobStartCommand(
 	channelID: string,
 	isHardMode: boolean,
 	maxSizeInput: number | undefined,
-	solo: boolean
+	solo: boolean,
+	quantity: number | undefined
 ) {
 	if (user.minionIsBusy) {
 		return `${user.usernameOrMention} minion is busy`;
@@ -323,39 +339,63 @@ export async function tobStartCommand(
 	}
 	const users = usersWhoConfirmed.filter(u => !u.minionIsBusy).slice(0, maxSize);
 
-	const teamCheckFailure = await checkTOBTeam(users, isHardMode, solo);
+	const team = await Promise.all(
+		users.map(async u => {
+			const [minigameScores, { tob_attempts, tob_hard_attempts }] = await Promise.all([
+				u.fetchMinigames(),
+				u.fetchStats({ tob_attempts: true, tob_hard_attempts: true })
+			]);
+			return {
+				user: u,
+				bank: u.bank,
+				gear: u.gear,
+				attempts: tob_attempts,
+				hardAttempts: tob_hard_attempts,
+				kc: minigameScores.tob,
+				hardKC: minigameScores.tob_hard
+			};
+		})
+	);
+	const { baseDuration, reductions, maxUserReduction } = calcTOBBaseDuration({ team, hardMode: isHardMode });
+	const maxTripLength = calcMaxTripLength(user, 'TheatreOfBlood');
+
+	const maxTripsCanFit = Math.floor(maxTripLength / baseDuration);
+
+	const qty = quantity ?? maxTripsCanFit;
+	if (qty > maxTripsCanFit) {
+		return `Your minion cannot go on trips longer than ${formatDuration(
+			maxTripLength
+		)}. The most you can do with your teams setup is ${maxTripsCanFit}.`;
+	}
+
+	const teamCheckFailure = await checkTOBTeam(users, isHardMode, solo, qty);
 	if (teamCheckFailure) {
 		return `Your mass failed to start because of this reason: ${teamCheckFailure} ${users}`;
 	}
 
-	const {
-		duration,
-		maxUserReduction,
-		reductions,
-		wipedRoom: _wipedRoom,
-		deathDuration,
-		parsedTeam
-	} = createTOBTeam({
-		team: await Promise.all(
-			users.map(async u => {
-				const [minigameScores, { tob_attempts, tob_hard_attempts }] = await Promise.all([
-					u.fetchMinigames(),
-					u.fetchStats({ tob_attempts: true, tob_hard_attempts: true })
-				]);
-				return {
-					user: u,
-					bank: u.bank,
-					gear: u.gear,
-					attempts: tob_attempts,
-					hardAttempts: tob_hard_attempts,
-					kc: minigameScores.tob,
-					hardKC: minigameScores.tob_hard
-				};
-			})
-		),
-		hardMode: isHardMode
-	});
-	const wipedRoom = _wipedRoom ? TOBRooms.find(room => _wipedRoom.name === room.name)! : null;
+	let totalDuration = 0;
+	let totalFakeDuration = 0;
+	let deaths: number[][][] = [];
+
+	const wipedRooms: (number | null)[] = [];
+	for (let i = 0; i < qty; i++) {
+		const {
+			duration,
+			wipedRoom: _wipedRoom,
+			deathDuration,
+			parsedTeam
+		} = createTOBRaid({
+			team,
+			hardMode: isHardMode,
+			baseDuration
+		});
+		const wipedRoom = _wipedRoom ? TOBRooms.indexOf(TOBRooms.find(room => _wipedRoom.name === room.name)!) : null;
+		wipedRooms.push(wipedRoom);
+		totalFakeDuration += duration;
+		totalDuration += deathDuration === null ? duration : deathDuration;
+
+		deaths.push(parsedTeam.map(i => i.deaths));
+	}
 	let debugStr = '';
 
 	const totalCost = new Bank();
@@ -371,6 +411,7 @@ export async function tobStartCommand(
 					.add('Coins', 100_000)
 					.add(blowpipeData.dartID!, Math.floor(Math.min(blowpipeData.dartQuantity, 156)))
 					.add(u.gear.range.ammo!.item, 100)
+					.multiply(qty)
 			);
 			await userStatsBankUpdate(u.id, 'tob_cost', realCost);
 			const effectiveCost = realCost.clone().remove('Coins', realCost.amount('Coins'));
@@ -379,7 +420,7 @@ export async function tobStartCommand(
 				await degradeItem({
 					item: getOSItem('Abyssal tentacle'),
 					user: u,
-					chargesToDegrade: TENTACLE_CHARGES_PER_RAID
+					chargesToDegrade: TENTACLE_CHARGES_PER_RAID * qty
 				});
 			}
 			debugStr += `**- ${u.usernameOrMention}** (${Emoji.Gear}${total.toFixed(1)}% ${
@@ -401,29 +442,30 @@ export async function tobStartCommand(
 		users: costResult.map(i => ({
 			id: i.userID,
 			cost: i.effectiveCost,
-			duration
+			totalDuration
 		}))
 	});
 
 	await addSubTaskToActivityTask<TheatreOfBloodTaskOptions>({
 		userID: user.id,
 		channelID: channelID.toString(),
-		duration: deathDuration ?? duration,
+		duration: totalDuration,
 		type: 'TheatreOfBlood',
 		leader: user.id,
-		users: parsedTeam.map(u => u.id),
+		users: team.map(u => u.user.id),
 		hardMode: isHardMode,
-		wipedRoom: wipedRoom === null ? null : TOBRooms.indexOf(wipedRoom),
-		fakeDuration: duration,
-		deaths: parsedTeam.map(i => i.deaths),
+		wipedRooms,
+		fakeDuration: totalFakeDuration,
+		quantity: qty,
+		deaths,
 		solo
 	});
 
 	let str = `${partyOptions.leader.usernameOrMention}'s party (${users
 		.map(u => u.usernameOrMention)
-		.join(', ')}) is now off to do a Theatre of Blood raid - the total trip will take ${formatDuration(duration)}.${
-		solo ? " You're in a team of 3." : ''
-	}`;
+		.join(', ')}) is now off to do ${qty}x Theatre of Blood raid${
+		qty > 1 ? 's' : ''
+	} - the total trip will take ${formatDuration(totalFakeDuration)}.${solo ? " You're in a team of 3." : ''}`;
 
 	str += ` \n\n${debugStr}`;
 

--- a/src/tasks/minions/minigames/tobActivity.ts
+++ b/src/tasks/minions/minigames/tobActivity.ts
@@ -14,7 +14,6 @@ import { TheatreOfBloodTaskOptions } from '../../../lib/types/minions';
 import { convertPercentChance } from '../../../lib/util';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
-import { sendToChannelID } from '../../../lib/util/webhook';
 import { userStatsBankUpdate, userStatsUpdate } from '../../../mahoji/mahojiSettings';
 
 const totalXPFromRaid = {

--- a/src/tasks/minions/minigames/tobActivity.ts
+++ b/src/tasks/minions/minigames/tobActivity.ts
@@ -7,6 +7,7 @@ import { tobMetamorphPets } from '../../../lib/data/CollectionsExport';
 import { TOBRooms, TOBUniques, TOBUniquesToAnnounce } from '../../../lib/data/tob';
 import { trackLoot } from '../../../lib/lootTrack';
 import { getMinigameScore, incrementMinigameScore } from '../../../lib/settings/settings';
+import { TeamLoot } from '../../../lib/simulation/TeamLoot';
 import { TheatreOfBlood } from '../../../lib/simulation/tob';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import { TheatreOfBloodTaskOptions } from '../../../lib/types/minions';
@@ -28,23 +29,150 @@ const totalXPFromRaid = {
 export const tobTask: MinionTask = {
 	type: 'TheatreOfBlood',
 	async run(data: TheatreOfBloodTaskOptions) {
-		const { channelID, users, hardMode, leader, wipedRoom, duration, fakeDuration, deaths } = data;
-		const allUsers = await Promise.all(users.map(async u => mUserFetch(u)));
-
-		const tobUsers = users.map((i, index) => ({ id: i, deaths: deaths[index] }));
-		if (data.solo) {
-			tobUsers.push({ id: miniID(3), deaths: [] });
-			tobUsers.push({ id: miniID(3), deaths: [] });
-		}
-		const result = TheatreOfBlood.complete({
+		const {
+			channelID,
+			users,
 			hardMode,
-			team: tobUsers
-		});
+			leader,
+			wipedRooms,
+			duration,
+			fakeDuration,
+			deaths: allDeaths,
+			quantity
+		} = data;
+		const allUsers = await Promise.all(users.map(async u => mUserFetch(u)));
 
 		const minigameID = hardMode ? 'tob_hard' : 'tob';
 
 		const allTag = allUsers.map(u => u.toString()).join('');
+		const teamsLoot = new TeamLoot([]);
+		const globalTobCost = new Bank();
+		const totalLoot = new Bank();
+		let wipeCount = 0;
+		let earnedAttempts = 0;
+		let resultMessage = `**${allTag} Your ${hardMode ? 'Hard Mode' : ''} Theatre of Blood has finished**\n`;
 
+		for (let i = 0; i < quantity; i++) {
+			const raidId = i + 1;
+			const deaths = allDeaths[i];
+			const wipedRoom = wipedRooms[i];
+			const tobUsers = users.map((i, index) => ({ id: i, deaths: deaths[index] }));
+			if (data.solo) {
+				tobUsers.push({ id: miniID(3), deaths: [] });
+				tobUsers.push({ id: miniID(3), deaths: [] });
+			}
+
+			const result = TheatreOfBlood.complete({
+				hardMode,
+				team: tobUsers
+			});
+
+			// Give them all +1 attempts
+			const diedToMaiden = wipedRoom !== null && wipedRoom === 0;
+			if (!diedToMaiden) earnedAttempts++;
+
+			// 100k tax if they wipe
+			if (wipedRoom !== null) {
+				wipeCount++;
+				resultMessage += `\n${raidId}: Your team wiped in the Theatre of Blood, in the ${
+					TOBRooms[wipedRoom].name
+				} room!${diedToMaiden ? ' The team died very early, and nobody learnt much from this raid.' : ''}`;
+				// handleTripFinish(allUsers[0], channelID, resultMessage, undefined, data, null);
+				// They each paid 100k tax, it doesn't get refunded, so track it in economy stats.
+				globalTobCost.add('Coins', users.length * 100_000);
+				continue;
+			}
+
+			resultMessage += `\n${raidId}: Unique chance: ${result.percentChanceOfUnique.toFixed(
+				2
+			)}% (1 in ${convertPercentChance(result.percentChanceOfUnique)})`;
+
+			// Track loot for T3+ patrons
+			await Promise.all(
+				allUsers.map(user => {
+					return userStatsBankUpdate(user.id, 'tob_loot', new Bank(result.loot[user.id]));
+				})
+			);
+
+			for (let [userID, _userLoot] of Object.entries(result.loot)) {
+				if (data.solo && userID !== leader) continue;
+				const user = allUsers.find(i => i.id === userID);
+				if (!user) continue;
+				const userDeaths = deaths[users.indexOf(user.id)];
+
+				const userLoot = new Bank(_userLoot);
+
+				// Merge existing loot to prevent duplicate pets:
+				const bank = user.allItemsOwned.clone().add(teamsLoot.get(userID));
+
+				const { cl } = user;
+				if (hardMode && roll(30) && cl.has("Lil' zik") && cl.has('Sanguine dust')) {
+					const unownedPet = shuffleArr(tobMetamorphPets).find(pet => !bank.has(pet));
+					if (unownedPet) {
+						userLoot.add(unownedPet);
+					}
+				}
+				// Refund initial 100k entry cost
+				userLoot.add('Coins', 100_000);
+
+				// Add this raids loot to the raid's total loot:
+				totalLoot.add(userLoot);
+
+				// Add this raids loot to user's total loot:
+				teamsLoot.add(userID, userLoot);
+
+				const items = userLoot.items();
+
+				const isPurple = items.some(([item]) => TOBUniques.includes(item.id));
+				const shouldAnnounce = items.some(([item]) => TOBUniquesToAnnounce.includes(item.id));
+				if (shouldAnnounce) {
+					const itemsToAnnounce = userLoot.filter(item => TOBUniques.includes(item.id), false);
+					globalClient.emit(
+						Events.ServerNotification,
+						`${Emoji.Purple} ${
+							user.badgedUsername
+						} just received **${itemsToAnnounce}** on their ${formatOrdinal(
+							(await getMinigameScore(user.id, minigameID)) + (raidId - wipeCount)
+						)} raid.`
+					);
+				}
+				const deathStr =
+					userDeaths.length === 0 ? '' : `${Emoji.Skull}(${userDeaths.map(i => TOBRooms[i].name)})`;
+
+				const lootStr = userLoot.remove('Coins', 100_000).toString();
+				const str = isPurple ? `${Emoji.Purple} ||${lootStr.padEnd(30, ' ')}||` : `||${lootStr}||`;
+
+				resultMessage += `\n${raidId}: ${deathStr}**${user}** received: ${str}`;
+			}
+		}
+		// Give everyone their loot:
+		await Promise.all(
+			allUsers.map(u => {
+				u.addItemsToBank({ items: teamsLoot.get(u.id), collectionLog: true });
+			})
+		);
+
+		// Give them their earned attempts:
+		if (earnedAttempts > 0) {
+			await Promise.all(
+				allUsers.map(u => {
+					const key = hardMode ? 'tob_hard_attempts' : 'tob_attempts';
+					return userStatsUpdate(u.id, {
+						[key]: {
+							increment: earnedAttempts
+						}
+					});
+				})
+			);
+		}
+		const successfulRaidCount = quantity - wipeCount;
+		if (successfulRaidCount > 0) {
+			await Promise.all(allUsers.map(u => incrementMinigameScore(u.id, minigameID, successfulRaidCount)));
+		}
+		if (wipeCount > 0) {
+			// Update economy stats:
+			await updateBankSetting('tob_cost', globalTobCost);
+		}
 		// Add XP
 		await Promise.all(
 			allUsers.map(u =>
@@ -52,105 +180,13 @@ export const tobTask: MinionTask = {
 					objectEntries(totalXPFromRaid).map(val =>
 						u.addXP({
 							skillName: val[0],
-							amount: wipedRoom
-								? val[1]
-								: calcPercentOfNum(calcWhatPercent(duration, fakeDuration), val[1]),
+							amount: calcPercentOfNum(calcWhatPercent(duration, fakeDuration), val[1]),
 							source: 'TheatreOfBlood'
 						})
 					)
 				)
 			)
 		);
-
-		// Give them all +1 attempts
-		const diedToMaiden = wipedRoom !== null && wipedRoom === 0;
-		if (!diedToMaiden) {
-			await Promise.all(
-				allUsers.map(u => {
-					const key = hardMode ? 'tob_hard_attempts' : 'tob_attempts';
-					return userStatsUpdate(u.id, {
-						[key]: {
-							increment: 1
-						}
-					});
-				})
-			);
-		}
-
-		// 100k tax if they wipe
-		if (wipedRoom !== null) {
-			await sendToChannelID(channelID, {
-				content: `${allTag} Your team wiped in the Theatre of Blood, in the ${TOBRooms[wipedRoom].name} room!${
-					diedToMaiden ? ' The team died very early, and nobody learnt much from this raid.' : ''
-				}`
-			});
-			// They each paid 100k tax, it doesn't get refunded, so track it in economy stats.
-			await updateBankSetting('tob_cost', new Bank().add('Coins', users.length * 100_000));
-			return;
-		}
-
-		// Track loot for T3+ patrons
-		await Promise.all(
-			allUsers.map(user => {
-				return userStatsBankUpdate(user.id, 'tob_loot', new Bank(result.loot[user.id]));
-			})
-		);
-
-		const totalLoot = new Bank();
-
-		let resultMessage = `**<@${leader}> Your ${hardMode ? 'Hard Mode' : ''} Theatre of Blood has finished**
-
-Unique chance: ${result.percentChanceOfUnique.toFixed(2)}% (1 in ${convertPercentChance(result.percentChanceOfUnique)})
-`;
-		await Promise.all(allUsers.map(u => incrementMinigameScore(u.id, minigameID, 1)));
-
-		for (let [userID, _userLoot] of Object.entries(result.loot)) {
-			if (data.solo && userID !== leader) continue;
-			const user = allUsers.find(i => i.id === userID);
-			if (!user) continue;
-			const userDeaths = deaths[users.indexOf(user.id)];
-
-			const userLoot = new Bank(_userLoot);
-			const bank = user.allItemsOwned;
-
-			const { cl } = user;
-			if (hardMode && roll(30) && cl.has("Lil' zik") && cl.has('Sanguine dust')) {
-				const unownedPet = shuffleArr(tobMetamorphPets).find(pet => !bank.has(pet));
-				if (unownedPet) {
-					userLoot.add(unownedPet);
-				}
-			}
-
-			const { itemsAdded } = await transactItems({
-				userID: user.id,
-				itemsToAdd: userLoot.clone().add('Coins', 100_000),
-				collectionLog: true
-			});
-
-			totalLoot.add(itemsAdded);
-
-			const items = itemsAdded.items();
-
-			const isPurple = items.some(([item]) => TOBUniques.includes(item.id));
-			const shouldAnnounce = items.some(([item]) => TOBUniquesToAnnounce.includes(item.id));
-			if (shouldAnnounce) {
-				const itemsToAnnounce = itemsAdded.filter(item => TOBUniques.includes(item.id), false);
-				globalClient.emit(
-					Events.ServerNotification,
-					`${Emoji.Purple} ${
-						user.badgedUsername
-					} just received **${itemsToAnnounce}** on their ${formatOrdinal(
-						await getMinigameScore(user.id, minigameID)
-					)} raid.`
-				);
-			}
-			const deathStr = userDeaths.length === 0 ? '' : `${Emoji.Skull}(${userDeaths.map(i => TOBRooms[i].name)})`;
-
-			const lootStr = itemsAdded.remove('Coins', 100_000).toString();
-			const str = isPurple ? `${Emoji.Purple} ||${lootStr.padEnd(30, ' ')}||` : `||${lootStr}||`;
-
-			resultMessage += `\n${deathStr}**${user}** received: ${str}`;
-		}
 
 		await updateBankSetting('tob_loot', totalLoot);
 		await trackLoot({
@@ -159,10 +195,10 @@ Unique chance: ${result.percentChanceOfUnique.toFixed(2)}% (1 in ${convertPercen
 			type: 'Minigame',
 			changeType: 'loot',
 			duration,
-			kc: 1,
+			kc: successfulRaidCount,
 			users: allUsers.map(i => ({
 				id: i.id,
-				loot: result.loot[i.id] ? new Bank(result.loot[i.id]) : new Bank(),
+				loot: teamsLoot.get(i.id),
 				duration
 			}))
 		});


### PR DESCRIPTION
### Description:

- Enables multiple trips on ToB (if you're fast enough... might not be possible, who knows?)
- Fixes Combat achievements counting Maiden deaths as completions (id = 0)
- Switches the Scythe cost to use charges instead of direct Vials of Blood + Runes
- Fixes Solo (trio) death mechanics

### Changes:

ToB Activity data: 
- wipedRoom => wipedRooms[]; 
- quantity
- deaths[][] => deaths[][][]

General:
- Scythe uses charges at ToB now
- In the solo-trio, calculate 3 users for wipe + deaths chances instead of one, where one death = wipe. (bug)
- Fixes Combat Achivements where id 0 (death at maiden) counted as a success and not a wipe.
- Splits the createTob function into 2 functions that separates the boosts from the simulation, so we can run multiple trips.
- In the activity, loop over everything and tally up the XP, loot, etc.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:

Requires command to migrate existing tasks to the new format:
```sql
update activity set data =  data::jsonb - 'wipedRoom' || CONCAT('{"deaths":[',(data->>'deaths'), ']}')::jsonb || CONCAT('{"wipedRooms":[', coalesce(data->>'wipedRoom', 'null'), ']}')::jsonb || '{"quantity":1}'::jsonb where type = 'TheatreOfBlood';
```