### PR TITLE
Fix typo for Antipoison mix

### DIFF
--- a/src/lib/skilling/skills/herblore/mixables/barbMixes.ts
+++ b/src/lib/skilling/skills/herblore/mixables/barbMixes.ts
@@ -22,7 +22,7 @@ export const barbMixes: Mixable[] = [
 		level: 4,
 		xp: 8,
 		inputItems: new Bank({
-			'Antipoison potion(2)': 1,
+			'Antipoison(2)': 1,
 			Roe: 1
 		}),
 		tickRate: 1,


### PR DESCRIPTION
"Antipoison potion(2)" is the potion used in Chamber of Xeric

"Antipoison(2)" is the correct potion for making Antipoison mix


- [x] I have tested all my changes thoroughly.
