### PR TITLE
Prohibit Gambling for Self-locked users

### DIFF
--- a/src/mahoji/lib/abstracted_commands/diceCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/diceCommand.ts
@@ -1,6 +1,7 @@
 import { ChatInputCommandInteraction } from 'discord.js';
 import { Bank, Util } from 'oldschooljs';
 
+import { BitField } from '../../../lib/constants';
 import { cryptoRand } from '../../../lib/util';
 import { deferInteraction } from '../../../lib/util/interactionReply';
 import {
@@ -23,6 +24,9 @@ export async function diceCommand(user: MUser, interaction: ChatInputCommandInte
 		return `You rolled **${roll}** on the percentile dice.`;
 	}
 	if (user.isIronman) return "You're an ironman and you cant play dice.";
+	if (user.bitfield.includes(BitField.SelfGamblingLocked)) {
+		return 'You locked yourself from gambling!';
+	}
 
 	if (amount > 500_000_000) {
 		return 'You can only dice up to 500m at a time!';

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -4,7 +4,7 @@ import { MahojiUserOption } from 'mahoji/dist/lib/types';
 import { Bank, Util } from 'oldschooljs';
 
 import { BLACKLISTED_USERS } from '../../../lib/blacklists';
-import { Emoji, Events } from '../../../lib/constants';
+import { BitField, Emoji, Events } from '../../../lib/constants';
 import { MUserClass } from '../../../lib/MUser';
 import { prisma } from '../../../lib/settings/prisma';
 import { awaitMessageComponentInteraction, channelIsSendable } from '../../../lib/util';
@@ -28,6 +28,7 @@ export async function duelCommand(
 	const duelTargetUser = duelUser;
 
 	const amount = mahojiParseNumber({ input: duelAmount, min: 1, max: 500_000_000_000 });
+
 	if (!amount) {
 		const winner = Math.random() >= 0.5 ? duelSourceUser : duelTargetUser;
 		return `${winner} won the duel against ${
@@ -35,6 +36,12 @@ export async function duelCommand(
 		} with ${Math.floor(Math.random() * 30 + 1)} HP remaining.`;
 	}
 
+	if (duelSourceUser.bitfield.includes(BitField.SelfGamblingLocked)) {
+		return 'You locked yourself from gambling.';
+	}
+	if (duelTargetUser.bitfield.includes(BitField.SelfGamblingLocked)) {
+		return "You can't duel someone who is locked from gambling.";
+	}
 	if (duelSourceUser.isIronman) return "You can't duel someone as an ironman.";
 	if (duelTargetUser.isIronman) return "You can't duel someone who is an ironman.";
 	if (duelSourceUser.id === duelTargetUser.id) return 'You cant duel yourself.';

--- a/src/mahoji/lib/abstracted_commands/hotColdCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/hotColdCommand.ts
@@ -4,6 +4,7 @@ import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import { LootTable } from 'oldschooljs';
 import { toKMB } from 'oldschooljs/dist/util';
 
+import { BitField } from '../../../lib/constants';
 import { mahojiClientSettingsUpdate } from '../../../lib/util/clientSettings';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
 import resolveItems from '../../../lib/util/resolveItems';
@@ -37,6 +38,9 @@ export async function hotColdCommand(
 	_amount: string | undefined
 ) {
 	if (user.isIronman) return 'Ironmen cannot gamble.';
+	if (user.bitfield.includes(BitField.SelfGamblingLocked)) {
+		return 'You locked yourself from gambling!';
+	}
 	const amount = mahojiParseNumber({ input: _amount, min: 1 });
 	if (!amount || !choice || !['hot', 'cold'].includes(choice) || !Number.isInteger(amount)) return explanation;
 	if (amount < 10_000_000 || amount > 500_000_000) return 'You must gamble between 10m and 500m.';

--- a/src/mahoji/lib/abstracted_commands/luckyPickCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/luckyPickCommand.ts
@@ -10,7 +10,7 @@ import { chunk, noOp, roll, shuffleArr, Time } from 'e';
 import { Bank } from 'oldschooljs';
 import { toKMB } from 'oldschooljs/dist/util';
 
-import { SILENT_ERROR } from '../../../lib/constants';
+import { BitField, SILENT_ERROR } from '../../../lib/constants';
 import { awaitMessageComponentInteraction, channelIsSendable } from '../../../lib/util';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
 import { logError } from '../../../lib/util/logError';
@@ -82,6 +82,9 @@ export async function luckyPickCommand(
 	}
 	if (user.isIronman) {
 		return "Ironmen can't gamble! Go pickpocket some men for GP.";
+	}
+	if (user.bitfield.includes(BitField.SelfGamblingLocked)) {
+		return 'You locked yourself from gambling!';
 	}
 
 	await handleMahojiConfirmation(

--- a/src/mahoji/lib/abstracted_commands/slotsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/slotsCommand.ts
@@ -11,6 +11,7 @@ import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import { Bank } from 'oldschooljs';
 import { toKMB } from 'oldschooljs/dist/util';
 
+import { BitField } from '../../../lib/constants';
 import { channelIsSendable } from '../../../lib/util';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
 import { deferInteraction } from '../../../lib/util/interactionReply';
@@ -95,6 +96,9 @@ export async function slotsCommand(
 ): CommandResponse {
 	await deferInteraction(interaction);
 	const amount = mahojiParseNumber({ input: _amount, min: 1 });
+	if (user.bitfield.includes(BitField.SelfGamblingLocked)) {
+		return 'You locked yourself from gambling!';
+	}
 	if (user.isIronman) {
 		return "Ironmen can't gamble! Go pickpocket some men for GP.";
 	}


### PR DESCRIPTION
Adds the relevant checks for the self-locked bitfield into the gambling commands.

- [x] I have tested all my changes thoroughly.
