### PR TITLE
Bingo fixes!

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -2,6 +2,7 @@ import { gzip } from 'node:zlib';
 
 import { stripEmojis } from '@oldschoolgg/toolkit';
 import { Stopwatch } from '@sapphire/stopwatch';
+import { createHash } from 'crypto';
 import {
 	BaseMessageOptions,
 	ButtonBuilder,
@@ -496,6 +497,10 @@ export async function fetchStatsForCL(user: MUser): Promise<UserStatsDataNeededF
 		gotrRiftSearches: userStats.gotr_rift_searches,
 		stats
 	};
+}
+
+export function md5sum(str: string) {
+	return createHash('md5').update(str).digest('hex');
 }
 
 export { assert } from './util/logError';

--- a/src/mahoji/commands/bingo.ts
+++ b/src/mahoji/commands/bingo.ts
@@ -877,7 +877,7 @@ Example: \`add_tile:Coal|Trout|Egg\` is a tile where you have to receive a coal 
 					}
 				});
 
-				return `Removed \`${tileName}\` from your bingo.`;
+				return `Removed "${tileName}" from your bingo.`;
 			}
 
 			if (options.manage_bingo.add_extra_gp) {

--- a/src/mahoji/commands/bingo.ts
+++ b/src/mahoji/commands/bingo.ts
@@ -18,7 +18,7 @@ import { channelIsSendable, dateFm, isValidDiscordSnowflake, isValidNickname, md
 import { getItem } from '../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
 import { BingoManager } from '../lib/bingo/BingoManager';
-import { generateTileName, getAllTileItems, StoredBingoTile } from '../lib/bingo/bingoUtil';
+import { generateTileName, getAllTileItems, isGlobalTile, StoredBingoTile } from '../lib/bingo/bingoUtil';
 import { globalBingoTiles } from '../lib/bingo/globalTiles';
 import { OSBMahojiCommand } from '../lib/util';
 import { doMenu, getPos } from './leaderboard';
@@ -820,7 +820,7 @@ The creator of the bingo (${userMention(
 				const globalTile = globalBingoTiles.find(t => stringMatches(t.id, options.manage_bingo!.add_tile));
 				let tileToAdd: StoredBingoTile | null = null;
 				if (globalTile) {
-					tileToAdd = globalTile.id;
+					tileToAdd = { global: globalTile.id };
 				} else {
 					tileToAdd = parseTileAddInput(options.manage_bingo.add_tile);
 				}
@@ -851,7 +851,7 @@ Example: \`add_tile:Coal|Trout|Egg\` is a tile where you have to receive a coal 
 				const globalTile = globalBingoTiles.find(t => stringMatches(t.id, options.manage_bingo!.remove_tile));
 				if (globalTile) {
 					newTiles = newTiles.filter(
-						t => (typeof t === 'number' && t !== globalTile.id) || typeof t !== 'number'
+						t => (isGlobalTile(t) && t.global !== globalTile.id) || !isGlobalTile(t)
 					);
 				} else {
 					newTiles = newTiles.filter(t => md5sum(generateTileName(t)) !== options.manage_bingo!.remove_tile!);

--- a/src/mahoji/commands/bingo.ts
+++ b/src/mahoji/commands/bingo.ts
@@ -232,6 +232,20 @@ function parseTileAddInput(input: string): StoredBingoTile | null {
 	};
 }
 
+async function getBingoFromUserInput(input: string) {
+	const where = Number.isNaN(Number(input))
+		? {
+				title: input
+		  }
+		: {
+				id: Number(input)
+		  };
+	const bingo = await prisma.bingo.findFirst({
+		where
+	});
+	return bingo;
+}
+
 export const bingoCommand: OSBMahojiCommand = {
 	name: 'bingo',
 	description: 'Bingo!',
@@ -613,29 +627,17 @@ export const bingoCommand: OSBMahojiCommand = {
 			return image;
 		}
 		if (options.make_team) {
-			const bingo = await prisma.bingo.findFirst({
-				where: {
-					id: Number(options.make_team.bingo)
-				}
-			});
+			const bingo = await getBingoFromUserInput(options.make_team.bingo);
 			if (!bingo) return 'Invalid bingo.';
 			return makeTeamCommand(interaction, new BingoManager(bingo), user, options.make_team);
 		}
 		if (options.leave_team) {
-			const bingo = await prisma.bingo.findFirst({
-				where: {
-					id: Number(options.leave_team.bingo)
-				}
-			});
+			const bingo = await getBingoFromUserInput(options.leave_team.bingo);
 			if (!bingo) return 'Invalid bingo.';
 			return leaveTeamCommand(interaction, new BingoManager(bingo));
 		}
 		if (options.leaderboard) {
-			const bingo = await prisma.bingo.findFirst({
-				where: {
-					id: Number(options.leaderboard.bingo)
-				}
-			});
+			const bingo = await getBingoFromUserInput(options.leaderboard.bingo);
 			if (!bingo) return 'Invalid bingo.';
 			return bingoTeamLeaderboard(user, channelID, new BingoManager(bingo));
 		}
@@ -741,16 +743,7 @@ ${Emoji.Warning} **You will pay a ${toKMB(fee)} GP fee to create this bingo, you
 			if (!options.manage_bingo.bingo) {
 				return 'You need to pick which bingo to manage.';
 			}
-			const where = Number.isNaN(Number(options.manage_bingo.bingo))
-				? {
-						title: options.manage_bingo.bingo
-				  }
-				: {
-						id: Number(options.manage_bingo.bingo)
-				  };
-			const _bingo = await prisma.bingo.findFirst({
-				where
-			});
+			const _bingo = await getBingoFromUserInput(options.manage_bingo.bingo);
 			if (!_bingo) return 'Invalid bingo.';
 			if (_bingo.creator_id !== user.id && !_bingo.organizers.includes(user.id)) {
 				return 'You are not an organizer of this bingo.';
@@ -921,11 +914,7 @@ Example: \`add_tile:Coal|Trout|Egg\` is a tile where you have to receive a coal 
 		}
 
 		if (options.view) {
-			const _bingo = await prisma.bingo.findFirst({
-				where: {
-					id: Number(options.view.bingo)
-				}
-			});
+			const _bingo = await getBingoFromUserInput(options.view.bingo);
 			if (!_bingo) return 'Invalid bingo.';
 			const bingo = new BingoManager(_bingo);
 

--- a/src/mahoji/commands/bingo.ts
+++ b/src/mahoji/commands/bingo.ts
@@ -849,19 +849,32 @@ Example: \`add_tile:Coal|Trout|Egg\` is a tile where you have to receive a coal 
 				}
 				let newTiles = [...bingo.rawBingoTiles];
 				const globalTile = globalBingoTiles.find(t => stringMatches(t.id, options.manage_bingo!.remove_tile));
+				let tileName = '';
 				if (globalTile) {
 					newTiles = newTiles.filter(
 						t => (isGlobalTile(t) && t.global !== globalTile.id) || !isGlobalTile(t)
 					);
+					tileName = generateTileName(globalTile);
 				} else {
-					newTiles = newTiles.filter(t => md5sum(generateTileName(t)) !== options.manage_bingo!.remove_tile!);
+					const tileToRemove = newTiles.find(
+						t => md5sum(generateTileName(t)) === options.manage_bingo!.remove_tile
+					);
+					if (tileToRemove) {
+						newTiles = newTiles.filter(
+							t => md5sum(generateTileName(t)) !== options.manage_bingo!.remove_tile!
+						);
+						tileName = generateTileName(tileToRemove);
+					}
 				}
 
 				if (newTiles.length === bingo.rawBingoTiles.length) {
 					return 'Invalid tile to remove.';
 				}
 
-				await handleMahojiConfirmation(interaction, 'Are you sure you want to remove this tile?');
+				await handleMahojiConfirmation(
+					interaction,
+					`Are you sure you want to remove this tile?\n\n${tileName}`
+				);
 				await prisma.bingo.update({
 					where: {
 						id: bingo.id
@@ -871,7 +884,7 @@ Example: \`add_tile:Coal|Trout|Egg\` is a tile where you have to receive a coal 
 					}
 				});
 
-				return 'Removed that tile from your bingo.';
+				return `Removed \`${tileName}\` from your bingo.`;
 			}
 
 			if (options.manage_bingo.add_extra_gp) {

--- a/src/mahoji/lib/bingo/BingoManager.ts
+++ b/src/mahoji/lib/bingo/BingoManager.ts
@@ -9,7 +9,7 @@ import { prisma } from '../../../lib/settings/prisma';
 import { ItemBank } from '../../../lib/types';
 import { addBanks } from '../../../lib/util/smallUtils';
 import { sendToChannelID } from '../../../lib/util/webhook';
-import { generateTileName, rowsForSquare, StoredBingoTile, UniversalBingoTile } from './bingoUtil';
+import { generateTileName, isGlobalTile, rowsForSquare, StoredBingoTile, UniversalBingoTile } from './bingoUtil';
 import { globalBingoTiles } from './globalTiles';
 
 export class BingoManager {
@@ -38,14 +38,14 @@ export class BingoManager {
 		this.title = options.title;
 		this.notificationsChannelID = options.notifications_channel_id;
 		this.durationInDays = options.duration_days;
-		this.rawBingoTiles = options.bingo_tiles as StoredBingoTile[];
+		this.rawBingoTiles = options.bingo_tiles as unknown as StoredBingoTile[];
 		this.creatorID = options.creator_id;
 		this.wasFinalized = options.was_finalized;
 		this.extraGP = Number(options.extra_gp);
 
 		this.bingoTiles = this.rawBingoTiles.map(tile => {
-			if (typeof tile === 'number') {
-				return globalBingoTiles.find(t => t.id === tile)!;
+			if (isGlobalTile(tile)) {
+				return globalBingoTiles.find(t => t.id === tile.global)!;
 			}
 			return {
 				name: generateTileName(tile),

--- a/src/mahoji/lib/bingo/bingoUtil.ts
+++ b/src/mahoji/lib/bingo/bingoUtil.ts
@@ -20,18 +20,18 @@ export type UniversalBingoTile = {
 	name: string;
 } & (OneOf | AllOf | CustomReq);
 
-export interface GlobalTileID {
+export interface StoredGlobalTile {
 	global: number;
 }
 
-export type StoredBingoTile = OneOf | AllOf | GlobalTileID;
+export type StoredBingoTile = OneOf | AllOf | StoredGlobalTile;
 
 export type GlobalBingoTile = (OneOf | AllOf | CustomReq) & {
 	id: number;
 	name: string;
 };
 
-export function isGlobalTile(data: any): data is GlobalTileID {
+export function isGlobalTile(data: any): data is StoredGlobalTile {
 	return 'global' in data;
 }
 
@@ -39,9 +39,12 @@ export function rowsForSquare(n: number): number {
 	return Math.ceil(Math.sqrt(n));
 }
 
-export function generateTileName(tile: OneOf | AllOf | UniversalBingoTile | StoredBingoTile) {
+export function generateTileName(tile: OneOf | AllOf | UniversalBingoTile | StoredBingoTile | GlobalBingoTile) {
 	if ('global' in tile) {
 		return globalBingoTiles.find(t => t.id === tile.global)?.name ?? 'Unknown';
+	}
+	if ('id' in tile) {
+		return globalBingoTiles.find(t => t.id === tile.id)?.name ?? 'Unknown';
 	}
 	if ('oneOf' in tile) {
 		return `Receive one of: ${tile.oneOf.map(id => getItem(id)?.name).join(', ')}`;

--- a/src/mahoji/lib/bingo/bingoUtil.ts
+++ b/src/mahoji/lib/bingo/bingoUtil.ts
@@ -16,6 +16,7 @@ interface AllOf {
 }
 
 export type UniversalBingoTile = {
+	id?: number;
 	name: string;
 } & (OneOf | AllOf | CustomReq);
 

--- a/src/mahoji/lib/bingo/bingoUtil.ts
+++ b/src/mahoji/lib/bingo/bingoUtil.ts
@@ -20,7 +20,10 @@ export type UniversalBingoTile = {
 	name: string;
 } & (OneOf | AllOf | CustomReq);
 
-type GlobalTileID = number;
+export interface GlobalTileID {
+	global: number;
+}
+
 export type StoredBingoTile = OneOf | AllOf | GlobalTileID;
 
 export type GlobalBingoTile = (OneOf | AllOf | CustomReq) & {
@@ -28,13 +31,17 @@ export type GlobalBingoTile = (OneOf | AllOf | CustomReq) & {
 	name: string;
 };
 
+export function isGlobalTile(data: any): data is GlobalTileID {
+	return 'global' in data;
+}
+
 export function rowsForSquare(n: number): number {
 	return Math.ceil(Math.sqrt(n));
 }
 
 export function generateTileName(tile: OneOf | AllOf | UniversalBingoTile | StoredBingoTile) {
-	if (typeof tile === 'number') {
-		return globalBingoTiles.find(t => t.id === tile)?.name ?? 'Unknown';
+	if ('global' in tile) {
+		return globalBingoTiles.find(t => t.id === tile.global)?.name ?? 'Unknown';
 	}
 	if ('oneOf' in tile) {
 		return `Receive one of: ${tile.oneOf.map(id => getItem(id)?.name).join(', ')}`;


### PR DESCRIPTION
### Description:

Fixes several bugs in the Bingo code

### Changes:

- When you have multiple Global and Custom tiles in your bingo, removing tiles should now work normall!
- You can now see the complete name of the tile you're removing in the confirmation popup!
- You can also see the removed tile in the chat for reference.
- Long tile names (> 100 characters) no longer break the `remove_tile` list!
- Referencing the bingo name by full-text now works, making it a little more reliable to find your bingo! (and reduced DB errors!)
- Minor internal DB changes to make everything work

### Other checks:

- [x] I have tested all my changes thoroughly.

### Important:
This code requires the bingo table to be updated as follows:
bingo_tiles -> array indices in this column that are pure Integers need to be converted to the format `{ global: 123 }`
