### PR TITLE
Ca/multi task and rates

### DIFF
--- a/src/lib/combat_achievements/combatAchievements.ts
+++ b/src/lib/combat_achievements/combatAchievements.ts
@@ -142,20 +142,21 @@ export const combatAchievementTripEffect: TripFinishEffect['fn'] = async ({ data
 
 	for (const user of users) {
 		const completedTasks = [];
-
+		let qty = quantity;
 		for (const task of indexesWithRng) {
+			if (qty === 0) break;
 			if (user.user.completed_ca_task_ids.includes(task.id)) continue;
 			if (!('rng' in task)) continue;
-
 			const hasChance =
 				typeof task.rng.hasChance === 'string'
 					? dataCopy.type === task.rng.hasChance
 					: task.rng.hasChance(dataCopy, user);
 			if (!hasChance) continue;
-
-			for (let i = 0; i < quantity; i++) {
+			for (let i = 0; i < qty; i++) {
 				if (roll(task.rng.chancePerKill)) {
 					completedTasks.push(task);
+					qty--;
+					break;
 				}
 			}
 		}

--- a/src/lib/combat_achievements/combatAchievements.ts
+++ b/src/lib/combat_achievements/combatAchievements.ts
@@ -143,7 +143,7 @@ export const combatAchievementTripEffect: TripFinishEffect['fn'] = async ({ data
 	for (const user of users) {
 		const completedTasks = [];
 
-		taskLoop: for (const task of indexesWithRng) {
+		for (const task of indexesWithRng) {
 			if (user.user.completed_ca_task_ids.includes(task.id)) continue;
 			if (!('rng' in task)) continue;
 
@@ -156,7 +156,6 @@ export const combatAchievementTripEffect: TripFinishEffect['fn'] = async ({ data
 			for (let i = 0; i < quantity; i++) {
 				if (roll(task.rng.chancePerKill)) {
 					completedTasks.push(task);
-					break taskLoop;
 				}
 			}
 		}

--- a/src/lib/combat_achievements/easy.ts
+++ b/src/lib/combat_achievements/easy.ts
@@ -38,7 +38,7 @@ export const easyCombatAchievements: CombatAchievement[] = [
 		monster: 'Barrows',
 		desc: 'Kill any Barrows Brother using only magical damage.',
 		rng: {
-			chancePerKill: 4,
+			chancePerKill: 1,
 			hasChance: isCertainMonsterTrip(Monsters.Barrows.id)
 		}
 	},
@@ -311,7 +311,7 @@ export const easyCombatAchievements: CombatAchievement[] = [
 		monster: 'Tempoross',
 		desc: 'Extinguish at least 5 fires during a single Tempoross fight.',
 		rng: {
-			chancePerKill: 22,
+			chancePerKill: 5,
 			hasChance: 'Tempoross'
 		}
 	},

--- a/src/lib/combat_achievements/easy.ts
+++ b/src/lib/combat_achievements/easy.ts
@@ -1,6 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
 import { warmGear } from '../data/filterables';
+import { SkillsEnum } from '../skilling/types';
 import { Requirements } from '../structures/Requirements';
 import getOSItem from '../util/getOSItem';
 import { isCertainMonsterTrip } from './caUtils';
@@ -39,7 +40,8 @@ export const easyCombatAchievements: CombatAchievement[] = [
 		desc: 'Kill any Barrows Brother using only magical damage.',
 		rng: {
 			chancePerKill: 1,
-			hasChance: isCertainMonsterTrip(Monsters.Barrows.id)
+			hasChance: (data, user) =>
+				isCertainMonsterTrip(Monsters.Barrows.id)(data) && user.getAttackStyles().includes(SkillsEnum.Magic)
 		}
 	},
 	{

--- a/src/lib/combat_achievements/elite.ts
+++ b/src/lib/combat_achievements/elite.ts
@@ -493,7 +493,7 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 		type: 'mechanical',
 		monster: 'Dagannoth Supreme',
 		rng: {
-			chancePerKill: 5,
+			chancePerKill: 15,
 			hasChance: isCertainMonsterTrip(Monsters.DagannothSupreme.id)
 		}
 	},
@@ -504,7 +504,7 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 		type: 'mechanical',
 		monster: 'Dagannoth Supreme',
 		rng: {
-			chancePerKill: 5,
+			chancePerKill: 30,
 			hasChance: data =>
 				isCertainMonsterTrip(Monsters.DagannothPrime.id)(data) ||
 				isCertainMonsterTrip(Monsters.DagannothRex.id)(data) ||
@@ -933,7 +933,7 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 	{
 		id: 1080,
 		name: 'Nightmare (Solo) Speed-Trialist',
-		desc: 'Defeat the Nightmare (Solo) in less than 23 minutes.',
+		desc: 'Defeat the Nightmare (Solo) in less than 23 minutes. (Party size required)',
 		type: 'speed',
 		monster: 'The Nightmare',
 		rng: {
@@ -947,7 +947,7 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 	{
 		id: 1081,
 		name: 'Sleep Tight',
-		desc: 'Kill the Nightmare solo.',
+		desc: 'Kill the Nightmare solo. (Party size required)',
 		type: 'restriction',
 		monster: 'The Nightmare',
 		rng: {
@@ -1199,7 +1199,7 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 	{
 		id: 1103,
 		name: 'Hardcore Tombs',
-		desc: 'Complete the Tombs of Amascut solo without dying.',
+		desc: 'Complete the Tombs of Amascut solo without dying. (Party size required)',
 		type: 'perfection',
 		monster: 'Tombs of Amascut',
 		rng: {
@@ -1213,14 +1213,14 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 	{
 		id: 1104,
 		name: 'Hardcore Raiders',
-		desc: 'Complete the Tombs of Amascut in a group of two or more without anyone dying.',
+		desc: 'Complete the Tombs of Amascut in a group of two or more without anyone dying. (Party size required)',
 		type: 'perfection',
 		monster: 'Tombs of Amascut',
 		rng: {
 			chancePerKill: 1,
 			hasChance: data =>
 				data.type === 'TombsOfAmascut' &&
-				(data as TOAOptions).users.length === 2 &&
+				(data as TOAOptions).users.length >= 2 &&
 				!anyoneDiedInTOARaid(data as TOAOptions)
 		}
 	},

--- a/src/lib/combat_achievements/grandmaster.ts
+++ b/src/lib/combat_achievements/grandmaster.ts
@@ -1,7 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
 import { PHOSANI_NIGHTMARE_ID } from '../constants';
-import { barrowsChestCL } from '../data/CollectionsExport';
 import { anyoneDiedInTOARaid } from '../simulation/toa';
 import { Requirements } from '../structures/Requirements';
 import {
@@ -66,7 +65,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 3004,
 		name: 'Chambers of Xeric (Solo) Speed-Runner',
-		desc: 'Complete a Chambers of Xeric (Solo) in less than 17 minutes.',
+		desc: 'Complete a Chambers of Xeric (Solo) in less than 17 minutes. (Party size required)',
 		type: 'speed',
 		monster: 'Chambers of Xeric',
 		rng: {
@@ -88,7 +87,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 3006,
 		name: 'Chambers of Xeric: CM (Solo) Speed-Runner',
-		desc: 'Complete a Chambers of Xeric: Challenge Mode (Solo) in less than 38 minutes and 30 seconds.',
+		desc: 'Complete a Chambers of Xeric: Challenge Mode (Solo) in less than 38 minutes and 30 seconds. (Party size required)',
 		type: 'speed',
 		monster: 'Chambers of Xeric: Challenge Mode',
 		rng: {
@@ -308,7 +307,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 3025,
 		name: 'Nex Duo',
-		desc: 'Kill Nex with two or less players at the start of the fight.',
+		desc: 'Kill Nex with two or less players at the start of the fight. (Party size required)',
 		type: 'restriction',
 		monster: 'Nex',
 		rng: {
@@ -409,23 +408,29 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 3034,
 		name: 'Terrible Parent',
-		desc: 'Kill the Nightmare solo without the Parasites healing the boss for more than 100 health.',
+		desc: 'Kill the Nightmare solo without the Parasites healing the boss for more than 100 health. (Party size required)',
 		type: 'mechanical',
 		monster: 'The Nightmare',
 		rng: {
 			chancePerKill: 22,
-			hasChance: data => data.type === 'Nightmare' && !(data as NightmareActivityTaskOptions).isPhosani
+			hasChance: data =>
+				data.type === 'Nightmare' &&
+				(data as NightmareActivityTaskOptions).method === 'solo' &&
+				!(data as NightmareActivityTaskOptions).isPhosani
 		}
 	},
 	{
 		id: 3035,
 		name: 'Nightmare (Solo) Speed-Runner',
-		desc: 'Defeat the Nightmare (Solo) in less than 16 minutes.',
+		desc: 'Defeat the Nightmare (Solo) in less than 16 minutes. (Party size required)',
 		type: 'speed',
 		monster: 'The Nightmare',
 		rng: {
 			chancePerKill: 30,
-			hasChance: data => data.type === 'Nightmare' && !(data as NightmareActivityTaskOptions).isPhosani
+			hasChance: data =>
+				data.type === 'Nightmare' &&
+				(data as NightmareActivityTaskOptions).method === 'solo' &&
+				!(data as NightmareActivityTaskOptions).isPhosani
 		}
 	},
 	{
@@ -458,7 +463,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		monster: 'Theatre of Blood',
 		rng: {
 			chancePerKill: 39,
-			hasChance: data => data.type === 'TheatreOfBlood' && (data as TheatreOfBloodTaskOptions).users.length === 4
+			hasChance: 'TheatreOfBlood'
 		}
 	},
 	{
@@ -492,7 +497,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		monster: 'Theatre of Blood',
 		rng: {
 			chancePerKill: 50,
-			hasChance: (data, user) => data.type === 'TheatreOfBlood' && barrowsChestCL.every(i => !user.hasEquipped(i))
+			hasChance: 'TheatreOfBlood'
 		}
 	},
 	{
@@ -503,7 +508,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		monster: 'Theatre of Blood',
 		rng: {
 			chancePerKill: 35,
-			hasChance: data => data.type === 'TheatreOfBlood' && (data as TheatreOfBloodTaskOptions).users.length === 3
+			hasChance: 'TheatreOfBlood'
 		}
 	},
 	{
@@ -514,7 +519,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		monster: 'Theatre of Blood',
 		rng: {
 			chancePerKill: 33,
-			hasChance: data => data.type === 'TheatreOfBlood' && (data as TheatreOfBloodTaskOptions).users.length === 2
+			hasChance: 'TheatreOfBlood'
 		}
 	},
 	{
@@ -717,7 +722,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		type: 'perfection',
 		monster: 'Tombs of Amascut: Expert Mode',
 		rng: {
-			chancePerKill: 25,
+			chancePerKill: 30,
 			hasChance: 'TombsOfAmascut'
 		}
 	},
@@ -728,7 +733,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		type: 'perfection',
 		monster: 'Tombs of Amascut: Expert Mode',
 		rng: {
-			chancePerKill: 25,
+			chancePerKill: 60,
 			hasChance: 'TombsOfAmascut'
 		}
 	},
@@ -761,7 +766,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		type: 'perfection',
 		monster: 'Tombs of Amascut: Expert Mode',
 		rng: {
-			chancePerKill: 33,
+			chancePerKill: 50,
 			hasChance: 'TombsOfAmascut'
 		}
 	},
@@ -783,7 +788,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		type: 'perfection',
 		monster: 'Tombs of Amascut: Expert Mode',
 		rng: {
-			chancePerKill: 35,
+			chancePerKill: 55,
 			hasChance: 'TombsOfAmascut'
 		}
 	},
@@ -805,7 +810,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		type: 'mechanical',
 		monster: 'Tombs of Amascut: Expert Mode',
 		rng: {
-			chancePerKill: 66,
+			chancePerKill: 30,
 			hasChance: 'TombsOfAmascut'
 		}
 	},
@@ -862,7 +867,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		type: 'restriction',
 		monster: 'TzKal-Zuk',
 		rng: {
-			chancePerKill: 5,
+			chancePerKill: 1,
 			hasChance: (data, user) => data.type === 'Inferno' && !user.hasEquipped('Twisted bow')
 		}
 	},
@@ -1018,7 +1023,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		type: 'speed',
 		monster: 'Zulrah',
 		rng: {
-			chancePerKill: 100,
+			chancePerKill: 110,
 			hasChance: isCertainMonsterTrip(Monsters.Zulrah.id)
 		}
 	}

--- a/src/lib/combat_achievements/master.ts
+++ b/src/lib/combat_achievements/master.ts
@@ -143,45 +143,45 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2011,
 		name: 'Perfect Olm (Solo)',
-		desc: 'Kill the Great Olm in a solo raid without taking damage from any of the following: Teleport portals, Fire Walls, Healing pools, Crystal Bombs, Crystal Burst or Prayer Orbs. You also cannot let his claws regenerate or take damage from the same acid pool back to back.',
+		desc: 'Kill the Great Olm in a solo raid without taking damage from any of the following: Teleport portals, Fire Walls, Healing pools, Crystal Bombs, Crystal Burst or Prayer Orbs. You also cannot let his claws regenerate or take damage from the same acid pool back to back. (Party size required)',
 		type: 'perfection',
 		monster: 'Chambers of Xeric',
 		rng: {
 			chancePerKill: 44,
-			hasChance: 'Raids'
+			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).users.length === 1
 		}
 	},
 	{
 		id: 2012,
 		name: 'Chambers of Xeric (Solo) Speed-Chaser',
-		desc: 'Complete a Chambers of Xeric (Solo) in less than 21 minutes.',
+		desc: 'Complete a Chambers of Xeric (Solo) in less than 21 minutes. (Party size required)',
 		type: 'speed',
 		monster: 'Chambers of Xeric',
 		rng: {
 			chancePerKill: 25,
-			hasChance: 'Raids'
+			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).users.length === 1
 		}
 	},
 	{
 		id: 2013,
 		name: 'Chambers of Xeric (5-Scale) Speed-Chaser',
-		desc: 'Complete a Chambers of Xeric (5-scale) in less than 15 minutes.',
+		desc: 'Complete a Chambers of Xeric (5-scale) in less than 15 minutes. (Party size required)',
 		type: 'speed',
 		monster: 'Chambers of Xeric',
 		rng: {
 			chancePerKill: 33,
-			hasChance: 'Raids'
+			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).users.length === 1
 		}
 	},
 	{
 		id: 2014,
 		name: 'Putting It Olm on the Line',
-		desc: 'Complete a Chambers of Xeric solo raid with more than 40,000 points.',
+		desc: 'Complete a Chambers of Xeric solo raid with more than 40,000 points. (Party size required)',
 		type: 'mechanical',
 		monster: 'Chambers of Xeric',
 		rng: {
 			chancePerKill: 22,
-			hasChance: 'Raids'
+			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).users.length === 1
 		}
 	},
 	{
@@ -254,7 +254,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2021,
 		name: 'Undying Raider',
-		desc: 'Complete a Chambers of Xeric solo raid without dying.',
+		desc: 'Complete a Chambers of Xeric solo raid without dying. (Party size required)',
 		type: 'perfection',
 		monster: 'Chambers of Xeric',
 		rng: {
@@ -276,12 +276,12 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2023,
 		name: 'A Not So Special Lizard',
-		desc: 'Kill the Great Olm in a solo raid without letting him use any of the following special attacks in his second to last phase: Crystal Burst, Lightning Walls, Teleportation Portals or left-hand autohealing.',
+		desc: 'Kill the Great Olm in a solo raid without letting him use any of the following special attacks in his second to last phase: Crystal Burst, Lightning Walls, Teleportation Portals or left-hand autohealing. (Party size required)',
 		type: 'mechanical',
 		monster: 'Chambers of Xeric',
 		rng: {
 			chancePerKill: 33,
-			hasChance: 'Raids'
+			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).users.length === 1
 		}
 	},
 	{
@@ -298,12 +298,15 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2025,
 		name: 'Immortal Raider',
-		desc: 'Complete a Chambers of Xeric Challenge mode (Solo) raid without dying.',
+		desc: 'Complete a Chambers of Xeric Challenge mode (Solo) raid without dying. (Party size required)',
 		type: 'perfection',
 		monster: 'Chambers of Xeric: Challenge Mode',
 		rng: {
 			chancePerKill: 10,
-			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).challengeMode
+			hasChance: data =>
+				data.type === 'Raids' &&
+				(data as RaidsOptions).challengeMode &&
+				(data as RaidsOptions).users.length === 1
 		}
 	},
 	{
@@ -320,12 +323,15 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2027,
 		name: 'Chambers of Xeric: CM (Solo) Speed-Chaser',
-		desc: 'Complete a Chambers of Xeric: Challenge Mode (Solo) in less than 45 minutes.',
+		desc: 'Complete a Chambers of Xeric: Challenge Mode (Solo) in less than 45 minutes. (Party size required)',
 		type: 'speed',
 		monster: 'Chambers of Xeric: Challenge Mode',
 		rng: {
 			chancePerKill: 15,
-			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).challengeMode
+			hasChance: data =>
+				data.type === 'Raids' &&
+				(data as RaidsOptions).challengeMode &&
+				(data as RaidsOptions).users.length === 1
 		}
 	},
 	{
@@ -808,12 +814,15 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2070,
 		name: 'Nightmare (Solo) Speed-Chaser',
-		desc: 'Defeat the Nightmare (Solo) in less than 19 minutes.',
+		desc: 'Defeat the Nightmare (Solo) in less than 19 minutes. (Party size required)',
 		type: 'speed',
 		monster: 'The Nightmare',
 		rng: {
 			chancePerKill: 33,
-			hasChance: data => data.type === 'Nightmare' && !(data as NightmareActivityTaskOptions).isPhosani
+			hasChance: data =>
+				data.type === 'Nightmare' &&
+				(data as NightmareActivityTaskOptions).method === 'solo' &&
+				!(data as NightmareActivityTaskOptions).isPhosani
 		}
 	},
 	{
@@ -934,7 +943,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 		monster: 'Theatre of Blood',
 		rng: {
 			chancePerKill: 22,
-			hasChance: data => data.type === 'TheatreOfBlood' && (data as TheatreOfBloodTaskOptions).users.length === 3
+			hasChance: 'TheatreOfBlood'
 		}
 	},
 	{
@@ -1079,7 +1088,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 		type: 'perfection',
 		monster: 'Tombs of Amascut',
 		rng: {
-			chancePerKill: 44,
+			chancePerKill: 30,
 			hasChance: 'TombsOfAmascut'
 		}
 	},
@@ -1112,7 +1121,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 		type: 'perfection',
 		monster: 'Tombs of Amascut',
 		rng: {
-			chancePerKill: 55,
+			chancePerKill: 35,
 			hasChance: 'TombsOfAmascut'
 		}
 	},
@@ -1448,7 +1457,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 		type: 'speed',
 		monster: 'Zulrah',
 		rng: {
-			chancePerKill: 99,
+			chancePerKill: 75,
 			hasChance: isCertainMonsterTrip(Monsters.Zulrah.id)
 		}
 	}

--- a/src/lib/combat_achievements/master.ts
+++ b/src/lib/combat_achievements/master.ts
@@ -165,12 +165,12 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2013,
 		name: 'Chambers of Xeric (5-Scale) Speed-Chaser',
-		desc: 'Complete a Chambers of Xeric (5-scale) in less than 15 minutes. (Party size required)',
+		desc: 'Complete a Chambers of Xeric (5-scale) in less than 15 minutes.',
 		type: 'speed',
 		monster: 'Chambers of Xeric',
 		rng: {
 			chancePerKill: 33,
-			hasChance: data => data.type === 'Raids' && (data as RaidsOptions).users.length === 1
+			hasChance: data => data.type === 'Raids'
 		}
 	},
 	{

--- a/src/lib/combat_achievements/medium.ts
+++ b/src/lib/combat_achievements/medium.ts
@@ -13,7 +13,7 @@ export const mediumCombatAchievements: CombatAchievement[] = [
 		monster: 'Barrows',
 		desc: 'Kill all six Barrows Brothers and loot the Barrows chest without taking any damage from any of the brothers.',
 		rng: {
-			chancePerKill: 50,
+			chancePerKill: 10,
 			hasChance: isCertainMonsterTrip(Monsters.Barrows.id)
 		}
 	},
@@ -454,7 +454,7 @@ export const mediumCombatAchievements: CombatAchievement[] = [
 		monster: 'Tempoross',
 		desc: 'Subdue Tempoross alone without getting hit by any fires, torrents or waves.',
 		rng: {
-			chancePerKill: 50,
+			chancePerKill: 25,
 			hasChance: data => data.type === 'Tempoross'
 		}
 	},


### PR DESCRIPTION
### Description:

Updated rng on some tasks, removed party size outside of solo scenarios (added a note on description where party size is enforced). Allowed multiple combat achievements per trip where quantity higher than 1.

All rng changes were discussed and agreed by users in a discussion thread: https://discord.com/channels/342983479501389826/1150393479252414544

Multi task per trip was voted on in a github issue https://github.com/oldschoolgg/oldschoolbot/issues/5308 (i tried to get as many votes from osb + bso posting in general chats a few times)

### Changes:

Full changes:
Remove specific party requirements (mainly tob) Any party size requirements should now show that on the task name ' (Party size required)'
Max 1 combat achievement per trip > Max 1 combat achievement per kill/quantity

RNG changes (1 in x chance):
Extinguish at least 5 fires during a single Tempoross fight 22> 5
'Kill Tzkal-Zuk without equipping a Twisted Bow within the Inferno.' 1/5 > 1/1
Barrows without taking any damage - 1/50 > 1/10
'Subdue Tempoross alone without getting hit by any fires, torrents or waves.' 1/50 > 1/25
ToB with barrows items > remove item check for now (This required you to not have any barrows items equipped in any slot), keep same rng (can't run tob with barrow gear set so needs more coding on ToB itself for fix)
Zulrah 1 min 99>75, zulrah 54 second 100>110
Kill any barrows brother using only magical damage 4> 1

DKs:
Kill prime while attacked by supreme + rex 44 (unchanged)
Kill rex while attacked by prime + supreme 33 (unchanged)
Kill supreme while attacked by prime + rex 5>15
Kill all dks within 9 seconds 5>30

ToA perfections (some unchanged but all for reference):
Scarabas: 22> 20, Kephri: 55> 25. Scarabas+kephri:22> 55
Het:15, Akkha:44> 30, het+akkha: 25> 60
Apmeken:15. Baba: 22, apmeken+baba: 25> 30
Crondis: 10, Zebak: 55> 35, crondis+zebak: 35> 55
Wardens:22, Expert wardens: 33> 50
All boss invocations: 66> 30

Other:
Any task that states Solo should now only work in a solo trip (nightmare/cox affected) 

### Other checks:

- [x] I have tested all my changes thoroughly.
