### PR TITLE
Fix Whisperers Boost

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/dt.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dt.ts
@@ -368,7 +368,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 					{ boostPercent: 5, itemID: itemID('Magus ring') },
 					{ boostPercent: 5, itemID: itemID('Lightbearer') }
 				],
-				gearSetup: 'range'
+				gearSetup: 'mage'
 			},
 			{
 				items: [{ boostPercent: 5, itemID: itemID("Tumeken's shadow") }],
@@ -460,7 +460,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 					{ boostPercent: 5, itemID: itemID('Magus ring') },
 					{ boostPercent: 5, itemID: itemID('Lightbearer') }
 				],
-				gearSetup: 'range'
+				gearSetup: 'mage'
 			},
 			{
 				items: [{ boostPercent: 5, itemID: itemID("Tumeken's shadow") }],


### PR DESCRIPTION
Fixes the whisperer boosts for the ring slot to check for mage rather than the range typo.

- [ ] I have tested all my changes thoroughly.
