### PR TITLE
Fix Ciruclars

### DIFF
--- a/src/lib/clues/clueUtils.ts
+++ b/src/lib/clues/clueUtils.ts
@@ -1,3 +1,4 @@
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
 import { Bank } from 'oldschooljs';
 
 import { ClueTiers } from './clueTiers';
@@ -20,4 +21,21 @@ export function deduplicateClueScrolls({ loot, currentBank }: { loot: Bank; curr
 		}
 	}
 	return newLoot;
+}
+
+export function buildClueButtons(loot: Bank | null, perkTier: number) {
+	const components: ButtonBuilder[] = [];
+	if (loot && perkTier > 1) {
+		const clueReceived = ClueTiers.filter(tier => loot.amount(tier.scrollID) > 0);
+		components.push(
+			...clueReceived.map(clue =>
+				new ButtonBuilder()
+					.setCustomId(`DO_${clue.name.toUpperCase()}_CLUE`)
+					.setLabel(`Do ${clue.name} Clue`)
+					.setStyle(ButtonStyle.Secondary)
+					.setEmoji('365003979840552960')
+			)
+		);
+	}
+	return components;
 }

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -7,6 +7,7 @@ import { canRunAutoContract } from '../../mahoji/lib/abstracted_commands/farming
 import { handleTriggerShootingStar } from '../../mahoji/lib/abstracted_commands/shootingStarsCommand';
 import { updateClientGPTrackSetting, userStatsBankUpdate } from '../../mahoji/mahojiSettings';
 import { ClueTiers } from '../clues/clueTiers';
+import { buildClueButtons } from '../clues/clueUtils';
 import { combatAchievementTripEffect } from '../combat_achievements/combatAchievements';
 import { BitField, COINS_ID, Emoji, PerkTier } from '../constants';
 import { handleGrowablePetGrowth } from '../growablePets';
@@ -14,7 +15,7 @@ import { handlePassiveImplings } from '../implings';
 import { triggerRandomEvent } from '../randomEvents';
 import { getUsersCurrentSlayerInfo } from '../slayer/slayerUtil';
 import { ActivityTaskData } from '../types/minions';
-import { buildClueButtons, channelIsSendable, makeComponents } from '../util';
+import { channelIsSendable, makeComponents } from '../util';
 import {
 	makeAutoContractButton,
 	makeBirdHouseTripButton,

--- a/src/lib/util/smallUtils.ts
+++ b/src/lib/util/smallUtils.ts
@@ -8,7 +8,6 @@ import { Bank, Items } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
 import { MersenneTwister19937, shuffle } from 'random-js';
 
-import { ClueTiers } from '../clues/clueTiers';
 import { skillEmoji } from '../data/emojis';
 import type { ArrayItemsResolved, Skills } from '../types';
 import getOSItem from './getOSItem';
@@ -151,23 +150,6 @@ export function makeEasierFarmingContractButton() {
 		.setLabel('Ask for easier Contract')
 		.setStyle(ButtonStyle.Secondary)
 		.setEmoji('977410792754413668');
-}
-
-export function buildClueButtons(loot: Bank | null, perkTier: number) {
-	const components: ButtonBuilder[] = [];
-	if (loot && perkTier > 1) {
-		const clueReceived = ClueTiers.filter(tier => loot.amount(tier.scrollID) > 0);
-		components.push(
-			...clueReceived.map(clue =>
-				new ButtonBuilder()
-					.setCustomId(`DO_${clue.name.toUpperCase()}_CLUE`)
-					.setLabel(`Do ${clue.name} Clue`)
-					.setStyle(ButtonStyle.Secondary)
-					.setEmoji('365003979840552960')
-			)
-		);
-	}
-	return components;
 }
 
 export function makeAutoFarmButton() {

--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -4,20 +4,14 @@ import { calcWhatPercent, clamp, reduceNumByPercent, roll, round, Time } from 'e
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import { Bank } from 'oldschooljs';
 
+import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { Events } from '../../../lib/constants';
 import { countUsersWithItemInCl } from '../../../lib/settings/prisma';
 import { getMinigameScore } from '../../../lib/settings/settings';
 import { HighGambleTable, LowGambleTable, MediumGambleTable } from '../../../lib/simulation/baGamble';
 import { maxOtherStats } from '../../../lib/structures/Gear';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import {
-	buildClueButtons,
-	formatDuration,
-	itemID,
-	makeComponents,
-	randomVariation,
-	stringMatches
-} from '../../../lib/util';
+import { formatDuration, itemID, makeComponents, randomVariation, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -4,10 +4,11 @@ import { notEmpty, uniqueArr } from 'e';
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
 import { Bank, LootTable } from 'oldschooljs';
 
+import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { PerkTier } from '../../../lib/constants';
 import { allOpenables, UnifiedOpenable } from '../../../lib/openables';
 import { ItemBank } from '../../../lib/types';
-import { buildClueButtons, makeComponents } from '../../../lib/util';
+import { makeComponents } from '../../../lib/util';
 import getOSItem, { getItem } from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
 import { makeBankImage } from '../../../lib/util/makeBankImage';


### PR DESCRIPTION
### Description:

This clue function being in smallUtil.ts instead of clueUtil is causing a circular import in BSO via ClueTiers=>Collections=>Implings=>Constants(bitfield for scroll of the hunt).

Moving the clue function to the clueUtil.ts file seems the most logical fix.