### PR TITLE
[OSB] Remove wildy flag from non-Krystilia tasks

### DIFF
--- a/src/lib/minions/data/killableMonsters/mazchnaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/mazchnaMonsters.ts
@@ -185,7 +185,7 @@ export const mazchnaMonsters: KillableMonster[] = [
 		aliases: Monsters.Hobgoblin.aliases,
 		timeToFinish: Time.Second * 27,
 		table: Monsters.Hobgoblin,
-		wildy: true,
+		wildy: false,
 
 		difficultyRating: 1,
 		qpRequired: 0,
@@ -202,7 +202,7 @@ export const mazchnaMonsters: KillableMonster[] = [
 		aliases: Monsters.IceWarrior.aliases,
 		timeToFinish: Time.Second * 28,
 		table: Monsters.IceWarrior,
-		wildy: true,
+		wildy: false,
 
 		difficultyRating: 3,
 		qpRequired: 0,

--- a/src/lib/minions/data/killableMonsters/turaelMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/turaelMonsters.ts
@@ -477,7 +477,7 @@ export const turaelMonsters: KillableMonster[] = [
 		aliases: Monsters.GrizzlyBear.aliases,
 		timeToFinish: Time.Second * 10,
 		table: Monsters.GrizzlyBear,
-		wildy: true,
+		wildy: false,
 
 		difficultyRating: 1,
 		qpRequired: 0,
@@ -629,7 +629,7 @@ export const turaelMonsters: KillableMonster[] = [
 		timeToFinish: Time.Second * 15,
 		table: Monsters.KingScorpion,
 
-		wildy: true,
+		wildy: false,
 
 		difficultyRating: 3,
 		qpRequired: 0,

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -103,7 +103,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		timeToFinish: Time.Second * 14,
 		table: Monsters.Ankou,
 
-		wildy: true,
+		wildy: false,
 
 		existsInCatacombs: true,
 		difficultyRating: 2,
@@ -498,7 +498,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		timeToFinish: Time.Second * 18,
 		table: Monsters.FireGiant,
 
-		wildy: true,
+		wildy: false,
 
 		existsInCatacombs: true,
 		difficultyRating: 2,

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -670,7 +670,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		aliases: Monsters.IceGiant.aliases,
 		timeToFinish: Time.Second * 16,
 		table: Monsters.IceGiant,
-		wildy: true,
+		wildy: false,
 
 		difficultyRating: 3,
 		notifyDrops: resolveItems(['Giant champion scroll']),
@@ -821,7 +821,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		timeToFinish: Time.Second * 22,
 		table: Monsters.LesserDemon,
 
-		wildy: true,
+		wildy: false,
 
 		existsInCatacombs: true,
 		difficultyRating: 2,
@@ -867,7 +867,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		timeToFinish: Time.Second * 14,
 		table: Monsters.MossGiant,
 
-		wildy: true,
+		wildy: false,
 
 		existsInCatacombs: true,
 		difficultyRating: 2,


### PR DESCRIPTION
### Description:

When wildy bosses were added, they made an additional cost to killing commonly assigned/farmed monsters due to having a wildy flag associated with them. This removes the wildy flag from masters where killing monsters in the wildy isn't forced.

Earth warrior & green dragons were the only monster not changed although the associated cost seems excessive 

### Changes:

Changed vannaka, mazacha and turael to use non wildy mobs

### Other checks:

Doesnt impact wildy bosses

- [x] I have tested all my changes thoroughly.
