### PR TITLE
Limit new wildy death mechanics to new bosses

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -17,6 +17,7 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		emoji: '<:Callisto_cub:324127376273440768>',
 		wildy: true,
 		wildyMulti: true,
+		canBePked: true,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 10,
 
@@ -142,6 +143,7 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		emoji: '<:Callisto_cub:324127376273440768>',
 		wildy: true,
 		wildyMulti: false,
+		canBePked: true,
 		pkActivityRating: 10,
 		pkBaseDeathChance: 10,
 
@@ -262,6 +264,7 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		emoji: '<:Vetion_jr:324127378999738369>',
 		wildy: true,
 		wildyMulti: true,
+		canBePked: true,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 9,
 
@@ -379,6 +382,7 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		emoji: '<:Vetion_jr:324127378999738369>',
 		wildy: true,
 		wildyMulti: false,
+		canBePked: true,
 		pkActivityRating: 10,
 		pkBaseDeathChance: 9,
 
@@ -491,6 +495,7 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		emoji: '<:Venenatis_spiderling:324127379092144129>',
 		wildy: true,
 		wildyMulti: true,
+		canBePked: true,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 9,
 
@@ -633,6 +638,7 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		emoji: '<:Venenatis_spiderling:324127379092144129>',
 		wildy: true,
 		wildyMulti: false,
+		canBePked: true,
 		pkActivityRating: 10,
 		pkBaseDeathChance: 9,
 

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -57,6 +57,7 @@ export interface KillableMonster {
 	 */
 	wildy?: boolean;
 	wildyMulti?: boolean;
+	canBePked?: boolean;
 	pkActivityRating?: number;
 	pkBaseDeathChance?: number;
 

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -674,7 +674,7 @@ export async function minionKillCommand(
 	let hasDied = false;
 	let hasWildySupplies = undefined;
 
-	if (monster.wildy) {
+	if (monster.canBePked) {
 		const date = new Date().getTime();
 		const cachedPeakInterval: Peak[] = globalClient._peakIntervalCache;
 		for (const peak of cachedPeakInterval) {


### PR DESCRIPTION
### Description:

Limits the new wildy death mechanics to just the updated wildy bosses.

We can review a more widespread 'add danger to the wildy' update in the future, however there are many implications that need to be addressed before making such a widespread change.

### Changes:

- Adds `canBePked` flag to KillableMonsters, and uses this to apply the new PK/death mechanics
- Enables this flag on the 6 updated Wildy bosses

### Other checks:

- [ ] I have tested all my changes thoroughly.
