### PR TITLE
Break dyed Hellfire bows instead of delete

### DIFF
--- a/src/lib/util/calculateGearLostOnDeathWilderness.ts
+++ b/src/lib/util/calculateGearLostOnDeathWilderness.ts
@@ -159,7 +159,10 @@ export const lockedItems = resolveItems([
 
 const itemsThatBreakOnDeath: Record<number, number> = {
 	[itemID('Hellfire bow')]: itemID('Hellfire bow (broken)'),
-	[itemID('Hellfire bownana')]: itemID('Hellfire bownana (broken)')
+	[itemID('Hellfire bownana')]: itemID('Hellfire bownana (broken)'),
+	[itemID('Mistleboe')]: itemID('Hellfire bow (broken)'),
+	[itemID('Hellfire bow (ice)')]: itemID('Hellfire bow (broken)'),
+	[itemID('Hellfire bow (Oceanic)')]: itemID('Hellfire bow (broken)')
 };
 
 export default function calculateGearLostOnDeathWilderness(


### PR DESCRIPTION
### Description:

- Most dyed hellfire bows are just being deleted instead of breaking on death in the wild

### Changes:

- All dyed Hellfire bows break into the non-dyed Hellfire bow (losing the dye)

### Other checks:

- [ ] I have tested all my changes thoroughly.
