### PR TITLE
Fix BSO Unit Tests / ParseStringBank (threads = true)

### DIFF
--- a/src/lib/customItems/util.ts
+++ b/src/lib/customItems/util.ts
@@ -19,12 +19,12 @@ export function isCustomItem(itemID: number) {
 export const hasSet: Item[] = [];
 
 // Prevent old item names from matching customItems
-export function ensureCustomItemName(nameToTest: string) {
+export function isDeletedItemName(nameToTest: string) {
 	const cleanNameToTest = deepCleanString(nameToTest);
 	if (overwrittenItemNames.get(cleanNameToTest)) {
-		return false;
+		return true;
 	}
-	return true;
+	return false;
 }
 
 export function setCustomItem(id: number, name: string, baseItem: string, newItemData?: Partial<Item>, price = 0) {

--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -5,7 +5,7 @@ import { Item } from 'oldschooljs/dist/meta/types';
 import { itemNameMap } from 'oldschooljs/dist/structures/Items';
 
 import { ONE_TRILLION } from '../constants';
-import { ensureCustomItemName } from '../customItems/util';
+import { isDeletedItemName } from '../customItems/util';
 import { filterableTypes } from '../data/filterables';
 import { cleanString, stringMatches } from '../util';
 
@@ -24,10 +24,10 @@ export function parseQuantityAndItem(str = '', inputBank?: Bank): [Item[], numbe
 		return parseQuantityAndItem(split.join(' '));
 	}
 
-	let [potentialQty, ...potentialName] = split.length === 1 ? ['', [split[0]]] : split;
+	let [potentialQty, ...potentialName] = split.length === 1 ? ['', split[0]] : split;
 
-	if (!ensureCustomItemName(str)) return [];
-	if (!isNaN(Number(potentialQty)) && !ensureCustomItemName(potentialName.join(' '))) return [];
+	if (isDeletedItemName(str)) return [];
+	if (!isNaN(Number(potentialQty)) && isDeletedItemName(potentialName.join(' '))) return [];
 
 	let lazyItemGet = Items.get(potentialName.join(' ')) ?? Items.get(Number(potentialName.join(' ')));
 	if (str.includes('#') && lazyItemGet && inputBank) {

--- a/tests/unit/parseStringBank.test.ts
+++ b/tests/unit/parseStringBank.test.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import '../../src/lib/data/itemAliases';
-import '../../src/lib/customItems/customItems';
-
 import { randInt } from 'e';
 import { Bank, Items } from 'oldschooljs';
 import { describe, expect, test } from 'vitest';
@@ -379,6 +376,13 @@ describe('Bank Parsers', () => {
 		}
 	});
 
+	test('edge cases', () => {
+		const usersBank = new Bank().add('Coal', 100).add('Huge lamp', 3);
+
+		expect(parseBank({ inputBank: usersBank, inputStr: '# coal' }).toString()).toEqual('100x Coal');
+		expect(parseBank({ inputBank: usersBank, inputStr: '0 coal' }).toString()).toEqual('100x Coal');
+		expect(parseBank({ inputBank: usersBank, inputStr: 'coal' }).toString()).toEqual('100x Coal');
+	});
 	test('ensureOldNamesDontWorkForCustomItems', () => {
 		const usersBank = new Bank()
 			.add('Doug', 3)

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
 		setupFiles: 'tests/unit/setup.ts',
 		resolveSnapshotPath: (testPath, extension) =>
 			join(join(dirname(testPath), 'snapshots'), `${basename(testPath)}${extension}`),
-		threads: false
+		threads: true
 	}
 });


### PR DESCRIPTION
### Description:

Fixes parseStringBank test

### Changes
- Clarifies logic in parseStringBank with regards to remapped items
- Changes thread => true in vitest config
- Fixes incorrect destructuring of constructed array in parseStringBank

### Other checks:

- [x] I have tested all my changes thoroughly.
- [x] Unit tests passed successfully 5x in a row