### PR TITLE
Fix issue with buying unlimited Forestry Kits

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -41,6 +41,7 @@ export interface Buyable {
 	ironmanPrice?: number;
 	collectionLogReqs?: number[];
 	customReq?: (user: MUser, userStats: MUserStats) => Promise<[true] | [false, string]>;
+	maxQuantity?: number;
 }
 
 const randomEventBuyables: Buyable[] = [

--- a/src/lib/data/buyables/forestryBuyables.ts
+++ b/src/lib/data/buyables/forestryBuyables.ts
@@ -5,13 +5,13 @@ import { Buyable } from './buyables';
 export const forestryBuyables: Buyable[] = [
 	{
 		name: 'Forestry kit',
-		outputItems: () => new Bank().add('Forestry kit'),
 		customReq: async user => {
 			if (user.allItemsOwned.has('Forestry kit')) {
 				return [false, 'You already own this item.'];
 			}
 			return [true];
-		}
+		},
+		maxQuantity: 1
 	},
 	{
 		name: 'Secateurs blade',

--- a/src/mahoji/commands/buy.ts
+++ b/src/mahoji/commands/buy.ts
@@ -43,7 +43,7 @@ export const buyCommand: OSBMahojiCommand = {
 	run: async ({ options, userID, interaction }: CommandRunOptions<{ name: string; quantity?: string }>) => {
 		const user = await mUserFetch(userID.toString());
 		const { name } = options;
-		const quantity = mahojiParseNumber({ input: options.quantity, min: 1 }) ?? 1;
+		let quantity = mahojiParseNumber({ input: options.quantity, min: 1 }) ?? 1;
 		if (stringMatches(name, 'kitten')) {
 			return buyKitten(user);
 		}
@@ -73,6 +73,10 @@ export const buyCommand: OSBMahojiCommand = {
 			if (!hasCustomReq) {
 				return reason!;
 			}
+		}
+
+		if (buyable.maxQuantity) {
+			quantity = quantity > buyable.maxQuantity ? buyable.maxQuantity : quantity;
 		}
 
 		if (buyable.qpRequired) {

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -5651,13 +5651,9 @@ exports[`OSB Buyables 1`] = `
       "bank": {},
       "frozen": false,
     },
+    "maxQuantity": 1,
     "name": "Forestry kit",
-    "outputItems": Bank {
-      "bank": {
-        "28136": 1,
-      },
-      "frozen": false,
-    },
+    "outputItems": undefined,
   },
   {
     "itemCost": Bank {


### PR DESCRIPTION
### Description:

Fix issue with buying unlimited Forestry Kits

### Changes:

- Adds `maxQuantity` to Buyable interface, which enforces the max that can be purchased in a single /buy

### Other checks:

- [x] I have tested all my changes thoroughly.
