### PR TITLE
Wilderness Fixes + Disable PK'ing at Wildy Bosses Until it's Fixed

### DIFF
--- a/src/lib/data/eatables.ts
+++ b/src/lib/data/eatables.ts
@@ -5,6 +5,7 @@ export interface Eatable {
 	id: number;
 	healAmount: ((user: MUser) => number) | number;
 	pvmBoost?: number;
+	wildyOnly?: boolean;
 }
 
 export const Eatables: readonly Eatable[] = [
@@ -156,6 +157,12 @@ export const Eatables: readonly Eatable[] = [
 		healAmount: 18
 	},
 	{
+		name: 'Blighted karambwan',
+		id: itemID('Blighted karambwan'),
+		healAmount: 18,
+		wildyOnly: true
+	},
+	{
 		name: 'Curry',
 		id: itemID('Curry'),
 		healAmount: 19
@@ -199,6 +206,13 @@ export const Eatables: readonly Eatable[] = [
 		pvmBoost: 3
 	},
 	{
+		name: 'Blighted manta ray',
+		id: itemID('Blighted manta ray'),
+		healAmount: 22,
+		pvmBoost: 3,
+		wildyOnly: true
+	},
+	{
 		name: 'Tuna potato',
 		id: itemID('Tuna potato'),
 		healAmount: 22
@@ -224,5 +238,22 @@ export const Eatables: readonly Eatable[] = [
 			return hp * (1 / 10) + c;
 		},
 		pvmBoost: 4
+	},
+	{
+		name: 'Blighted anglerfish',
+		id: itemID('Blighted anglerfish'),
+		healAmount: (user: MUser) => {
+			const hp = user.skillLevel('hitpoints');
+			let c = 2;
+			if (hp > 10) c = 2;
+			if (hp > 25) c = 4;
+			if (hp > 50) c = 6;
+			if (hp > 75) c = 8;
+			if (hp > 93) c = 13;
+
+			return hp * (1 / 10) + c;
+		},
+		pvmBoost: 4,
+		wildyOnly: true
 	}
 ];

--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -32,7 +32,8 @@ export const wildyKillableMonsters: KillableMonster[] = [
 			alternativeConsumables: [
 				{
 					itemCost: new Bank().add('Blood rune', 2).add('Death rune', 4).add('Water rune', 6),
-					qtyPerMinute: 3
+					qtyPerMinute: 3,
+					isRuneCost: true
 				},
 				{ itemCost: new Bank().add('Stamina potion(4)', 1), qtyPerMinute: 0.125 }
 			]
@@ -117,9 +118,9 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		],
 		minimumGearRequirements: {
 			wildy: {
-				[GearStat.AttackRanged]: 150,
-				[GearStat.DefenceCrush]: 84,
-				[GearStat.DefenceMagic]: 83
+				[GearStat.AttackRanged]: 115,
+				[GearStat.DefenceCrush]: 71,
+				[GearStat.DefenceMagic]: 68
 			}
 		},
 		levelRequirements: {
@@ -154,7 +155,8 @@ export const wildyKillableMonsters: KillableMonster[] = [
 			alternativeConsumables: [
 				{
 					itemCost: new Bank().add('Blood rune', 2).add('Death rune', 4).add('Water rune', 6),
-					qtyPerMinute: 2.5
+					qtyPerMinute: 2.5,
+					isRuneCost: true
 				},
 				{ itemCost: new Bank().add('Stamina potion(4)', 1), qtyPerMinute: 0.125 }
 			]
@@ -239,9 +241,9 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		],
 		minimumGearRequirements: {
 			wildy: {
-				[GearStat.AttackRanged]: 150,
-				[GearStat.DefenceCrush]: 84,
-				[GearStat.DefenceMagic]: 83
+				[GearStat.AttackRanged]: 115,
+				[GearStat.DefenceCrush]: 71,
+				[GearStat.DefenceMagic]: 68
 			}
 		},
 		levelRequirements: {

--- a/src/lib/minions/functions/getUserFoodFromBank.ts
+++ b/src/lib/minions/functions/getUserFoodFromBank.ts
@@ -13,14 +13,22 @@ export default function getUserFoodFromBank(
 	user: MUser,
 	totalHealingNeeded: number,
 	favoriteFood: readonly number[],
-	minimumHealAmount?: number
+	minimumHealAmount?: number,
+	isWilderness?: boolean
 ): false | Bank {
 	const userBank = user.bank;
 	let totalHealingCalc = totalHealingNeeded;
 	let foodToRemove = new Bank();
 
-	let sorted = [...Eatables]
+	let sorted = [...Eatables.filter(e => (isWilderness ? true : !e.wildyOnly))]
 		.sort((i, j) => (getRealHealAmount(user, i.healAmount) > getRealHealAmount(user, j.healAmount) ? 1 : -1))
+		.sort((k, l) => {
+			if (isWilderness) {
+				if (k.wildyOnly && !l.wildyOnly) return -1;
+				if (!k.wildyOnly && l.wildyOnly) return 1;
+			}
+			return 0;
+		})
 		.sort((a, b) => {
 			if (!userBank.has(a.id)) return 1;
 			if (!userBank.has(b.id)) return -1;

--- a/src/lib/minions/functions/removeFoodFromUser.ts
+++ b/src/lib/minions/functions/removeFoodFromUser.ts
@@ -15,7 +15,8 @@ export default async function removeFoodFromUser({
 	healPerAction,
 	activityName,
 	attackStylesUsed,
-	learningPercentage
+	learningPercentage,
+	isWilderness
 }: {
 	user: MUser;
 	totalHealingNeeded: number;
@@ -23,6 +24,7 @@ export default async function removeFoodFromUser({
 	activityName: string;
 	attackStylesUsed: GearSetupType[];
 	learningPercentage?: number;
+	isWilderness?: boolean;
 }): Promise<{ foodRemoved: Bank; reductions: string[]; reductionRatio: number }> {
 	const originalTotalHealing = totalHealingNeeded;
 	const rawGear = user.gear;
@@ -47,7 +49,7 @@ export default async function removeFoodFromUser({
 	}
 	const favoriteFood = user.user.favorite_food;
 
-	const foodToRemove = getUserFoodFromBank(user, totalHealingNeeded, favoriteFood);
+	const foodToRemove = getUserFoodFromBank(user, totalHealingNeeded, favoriteFood, undefined, isWilderness);
 	if (!foodToRemove) {
 		throw new UserError(
 			`You don't have enough food to do ${activityName}! You need enough food to heal at least ${totalHealingNeeded} HP (${healPerAction} per action). You can use these food items: ${Eatables.map(

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -657,12 +657,14 @@ export async function minionKillCommand(
 
 	let wildyPeak = null;
 	let pkString = '';
-	let thePkCount = 0;
-	let hasDied = false;
+	let thePkCount: number | undefined = undefined;
+	let hasDied: boolean | undefined = undefined;
 	let hasWildySupplies = undefined;
 
 	// Leaving the code in here to give Fishy a chance to fix it.
 	if (0 > 1 && monster.canBePked) {
+		thePkCount = 0;
+		hasDied = false;
 		const date = new Date().getTime();
 		const cachedPeakInterval: Peak[] = globalClient._peakIntervalCache;
 		for (const peak of cachedPeakInterval) {
@@ -754,9 +756,9 @@ export async function minionKillCommand(
 		cannonMulti: !cannonMulti ? undefined : cannonMulti,
 		chinning: !chinning ? undefined : chinning,
 		burstOrBarrage: !burstOrBarrage ? undefined : burstOrBarrage,
-		died: !hasDied ? undefined : hasDied,
-		pkEncounters: !thePkCount ? undefined : thePkCount,
-		hasWildySupplies: !hasWildySupplies ? undefined : hasWildySupplies
+		died: hasDied,
+		pkEncounters: thePkCount,
+		hasWildySupplies
 	});
 	let response = `${minionName} is now killing ${quantity}x ${monster.name}, it'll take around ${formatDuration(
 		duration


### PR DESCRIPTION
### Description:

Wilderness Fixes

### Changes:

- Disables being PK'd at wildy bosses until the issues are resolved (see notes below)
- Fixes Blighted Ice Sacks so it properly falls back to Runes even when you have a small number of ice sacks
- Adds blighted food, blighted food now works in the wilderness.
- Lowers requirements for Callisto/Artio bosses

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes for Fishy / updated wilderness/PK PR::
The Wilderness bosses / pk PR needs the following fixes (at least)
- Items lost of death needs to use the uncharged cost of charged items. Needs a map linking Uncharged items to their charged and/or dyed variants, so that their price is properly used and not counted as 0. (Webweaver bow lost before d'hide boots)
- Callisto/Artio needs to be killable with at least Ranged and Magic
- BSO needs to be accounted for; a plan at the very least must be in place -- Hellfire bow breaking, Void Staff values, etc
- Bosses  need to be killable with 'wildy' gear, some of the requirements seem awfully high, you shouldn't have to risk valuables, low-risk gear sets should be effective, if not ideal.
- The exception to only add the pk mechanics to the 6 "new" wildy bosses must stay 
- 72% pk chance at peak **might** be too high
- Must handle mobs both inside + outside wildy appropriately
- Reconsider the boosts for wildy mobs, too many boosts on expensive items people won't bring to the wild.
- It needs to be thoroughly tested so any additional issues/feedback are caught before it's merged.