### PR TITLE
Fix Wilderness Issues

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -688,6 +688,7 @@ model UserStats {
   total_toa_duration_minutes Int  @default(0)
 
   deaths                   Int @default(0)
+  pk_evasion_exp           Int @default(0)
   dice_wins                Int @default(0)
   dice_losses              Int @default(0)
   duel_losses              Int @default(0)

--- a/src/lib/minions/data/killableMonsters/revs.ts
+++ b/src/lib/minions/data/killableMonsters/revs.ts
@@ -12,7 +12,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantCyclops,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 6,
+		pkBaseDeathChance: 5
 	},
 	{
 		id: Monsters.RevenantDarkBeast.id,
@@ -22,7 +24,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantDarkBeast,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 9,
+		pkBaseDeathChance: 4
 	},
 	{
 		id: Monsters.RevenantDemon.id,
@@ -32,7 +36,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantDemon,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 6,
+		pkBaseDeathChance: 5
 	},
 	{
 		id: Monsters.RevenantDragon.id,
@@ -42,7 +48,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantDragon,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 8,
+		pkBaseDeathChance: 7
 	},
 	{
 		id: Monsters.RevenantGoblin.id,
@@ -52,7 +60,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantGoblin,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 5,
+		pkBaseDeathChance: 5
 	},
 	{
 		id: Monsters.RevenantHellhound.id,
@@ -62,7 +72,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantHellhound,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 6,
+		pkBaseDeathChance: 5
 	},
 	{
 		id: Monsters.RevenantHobgoblin.id,
@@ -72,7 +84,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantHobgoblin,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 5,
+		pkBaseDeathChance: 5
 	},
 	{
 		id: Monsters.RevenantImp.id,
@@ -82,7 +96,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantImp,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 4,
+		pkBaseDeathChance: 3
 	},
 	{
 		id: Monsters.RevenantKnight.id,
@@ -92,7 +108,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantKnight,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 8,
+		pkBaseDeathChance: 6
 	},
 	{
 		id: Monsters.RevenantOrk.id,
@@ -102,7 +120,9 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantOrk,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 7,
+		pkBaseDeathChance: 6
 	},
 	{
 		id: Monsters.RevenantPyrefiend.id,
@@ -112,6 +132,8 @@ export const revenantMonsters: KillableMonster[] = [
 		table: Monsters.RevenantPyrefiend,
 		wildy: true,
 		difficultyRating: 9,
-		qpRequired: 0
+		qpRequired: 0,
+		pkActivityRating: 7,
+		pkBaseDeathChance: 5
 	}
 ];

--- a/src/lib/minions/functions/getUserFoodFromBank.ts
+++ b/src/lib/minions/functions/getUserFoodFromBank.ts
@@ -14,15 +14,18 @@ export default function getUserFoodFromBank({
 	totalHealingNeeded,
 	favoriteFood,
 	minimumHealAmount,
-	isWilderness
+	isWilderness,
+	unavailableBank
 }: {
 	user: MUser;
 	totalHealingNeeded: number;
 	favoriteFood: readonly number[];
 	minimumHealAmount?: number;
 	isWilderness?: boolean;
+	unavailableBank?: Bank;
 }): false | Bank {
-	const userBank = user.bank;
+	let userBank = user.bank;
+	if (unavailableBank) userBank = userBank.clone().remove(unavailableBank);
 	let totalHealingCalc = totalHealingNeeded;
 	let foodToRemove = new Bank();
 

--- a/src/lib/minions/functions/removeFoodFromUser.ts
+++ b/src/lib/minions/functions/removeFoodFromUser.ts
@@ -16,7 +16,8 @@ export default async function removeFoodFromUser({
 	activityName,
 	attackStylesUsed,
 	learningPercentage,
-	isWilderness
+	isWilderness,
+	unavailableBank
 }: {
 	user: MUser;
 	totalHealingNeeded: number;
@@ -25,6 +26,7 @@ export default async function removeFoodFromUser({
 	attackStylesUsed: GearSetupType[];
 	learningPercentage?: number;
 	isWilderness?: boolean;
+	unavailableBank?: Bank;
 }): Promise<{ foodRemoved: Bank; reductions: string[]; reductionRatio: number }> {
 	const originalTotalHealing = totalHealingNeeded;
 	const rawGear = user.gear;
@@ -54,7 +56,8 @@ export default async function removeFoodFromUser({
 		totalHealingNeeded,
 		favoriteFood,
 		minimumHealAmount: undefined,
-		isWilderness
+		isWilderness,
+		unavailableBank
 	});
 	if (!foodToRemove) {
 		throw new UserError(

--- a/src/lib/util/calcWildyPkChance.ts
+++ b/src/lib/util/calcWildyPkChance.ts
@@ -12,7 +12,7 @@ import { percentChance } from '../util';
 const peakFactor = [
 	{
 		peakTier: PeakTier.High,
-		factor: 5
+		factor: 2.5
 	},
 	{
 		peakTier: PeakTier.Medium,
@@ -54,7 +54,6 @@ export async function calcWildyPKChance(
 	let chanceString = `**PK Chance:** ${pkChance.toFixed(2)}% per min (${peak.peakTier} peak time)`;
 
 	const evasionReduction = await getWildEvasionPercent(user);
-	pkChance = reduceNumByPercent(pkChance, evasionReduction);
 
 	const tripMinutes = Math.round(duration / Time.Minute);
 	let pkCount = 0;
@@ -72,7 +71,8 @@ export async function calcWildyPKChance(
 	const deathChanceFromLevels = Math.max(0, (100 - (statLvls / 297) * 100) / 5);
 	deathChance += deathChanceFromLevels;
 
-	const wildyMultiMultiplier = monster.wildyMulti === true ? 4 : 1;
+	// Multi does make it riskier, but only if there's actually a team on you
+	const wildyMultiMultiplier = monster.wildyMulti === true ? 2 : 1;
 	const hasSupplies = supplies ? 0.5 : 1;
 	const hasOverheads = user.skillLevel(SkillsEnum.Prayer) >= 43 ? 0.25 : 1;
 

--- a/src/lib/util/calcWildyPkChance.ts
+++ b/src/lib/util/calcWildyPkChance.ts
@@ -126,7 +126,7 @@ export async function calcWildyPKChance(
 	)}x from wildy gear (weight 60% magic, 40% ranged, 20% melee), ${hasSupplies}x from anti-pk supplies, ${hasOverheads}x from overhead prayers, ${(
 		(100 - evasionReduction) /
 		100
-	).toFixed(2)}x from KC/juking experience, ${wildyMultiMultiplier}x from being in${
+	).toFixed(2)}x from risky Wilderness experience, ${wildyMultiMultiplier}x from being in${
 		wildyMultiMultiplier === 1 ? ' no' : ''
 	} multi)`;
 

--- a/src/lib/util/calcWildyPkChance.ts
+++ b/src/lib/util/calcWildyPkChance.ts
@@ -1,7 +1,8 @@
-import { calcWhatPercent, Time } from 'e';
+import { calcPercentOfNum, calcWhatPercent, reduceNumByPercent, Time } from 'e';
+import { randomVariation } from 'oldschooljs/dist/util';
 
+import { userStatsUpdate } from '../../mahoji/mahojiSettings';
 import { PeakTier } from '../constants';
-import reducedTimeFromKC from '../minions/functions/reducedTimeFromKC';
 import { KillableMonster } from '../minions/types';
 import { SkillsEnum } from '../skilling/types';
 import { maxDefenceStats } from '../structures/Gear';
@@ -23,6 +24,23 @@ const peakFactor = [
 	}
 ];
 
+// Returns a value 0 - 100 representing the % of 10 hours spent in pk-able wilderness.
+export async function getPkEvasionExp(user: MUser) {
+	const maxBoostDuration = Time.Hour * 10;
+	const stats: { pk_evasion_exp: number } = await user.fetchStats({ pk_evasion_exp: true });
+	return Math.min(100, (stats.pk_evasion_exp / maxBoostDuration) * 100);
+}
+
+export async function getWildEvasionPercent(user: MUser) {
+	const maxReductionPercent = 75;
+	return randomVariation(calcPercentOfNum(await getPkEvasionExp(user), maxReductionPercent), 10);
+}
+
+export async function increaseWildEvasionXp(user: MUser, duration: number) {
+	const oldPkXp: { pk_evasion_exp: number } = await user.fetchStats({ pk_evasion_exp: true });
+	const newPkXp = Math.floor(Math.min(1_000_000_000, oldPkXp.pk_evasion_exp + duration));
+	await userStatsUpdate(user.id, { pk_evasion_exp: newPkXp });
+}
 export async function calcWildyPKChance(
 	user: MUser,
 	peak: Peak,
@@ -32,7 +50,11 @@ export async function calcWildyPKChance(
 ): Promise<[number, boolean, string]> {
 	// Chance per minute, Difficulty from 1 to 10, and factor a million difference, High peak 5x as likley encounter, Medium peak 1x, Low peak 5x as unlikley
 	const peakInfluence = peakFactor.find(_peaktier => _peaktier.peakTier === peak?.peakTier)?.factor ?? 1;
-	const pkChance = (1 / (7_000_000 / (Math.pow(monster.pkActivityRating ?? 1, 6) * peakInfluence))) * 100;
+	let pkChance = (1 / (7_000_000 / (Math.pow(monster.pkActivityRating ?? 1, 6) * peakInfluence))) * 100;
+	let chanceString = `**PK Chance:** ${pkChance.toFixed(2)}% per min (${peak.peakTier} peak time)`;
+
+	const evasionReduction = await getWildEvasionPercent(user);
+	pkChance = reduceNumByPercent(pkChance, evasionReduction);
 
 	const tripMinutes = Math.round(duration / Time.Minute);
 	let pkCount = 0;
@@ -42,8 +64,6 @@ export async function calcWildyPKChance(
 		}
 	}
 
-	let chanceString = `**PK Chance:** ${pkChance.toFixed(2)}% per min (${peak.peakTier} peak time)`;
-
 	let died = false;
 	let deathChance = monster.pkBaseDeathChance ?? 0;
 
@@ -52,7 +72,6 @@ export async function calcWildyPKChance(
 	const deathChanceFromLevels = Math.max(0, (100 - (statLvls / 297) * 100) / 5);
 	deathChance += deathChanceFromLevels;
 
-	const [, jukingExperience] = reducedTimeFromKC(monster, await user.getKC(monster.id));
 	const wildyMultiMultiplier = monster.wildyMulti === true ? 4 : 1;
 	const hasSupplies = supplies ? 0.5 : 1;
 	const hasOverheads = user.skillLevel(SkillsEnum.Prayer) >= 43 ? 0.25 : 1;
@@ -86,7 +105,7 @@ export async function calcWildyPKChance(
 	deathChance *= hasSupplies;
 	deathChance *= hasOverheads;
 	deathChance *= wildyMultiMultiplier;
-	deathChance *= (100 - jukingExperience) / 100;
+	deathChance = reduceNumByPercent(deathChance, evasionReduction);
 
 	deathChance = Math.min(Math.max(0, deathChance), 100);
 	if (pkCount > 0) {
@@ -104,9 +123,10 @@ export async function calcWildyPKChance(
 		deathChanceFromLevels > 0 ? `${deathChanceFromLevels.toFixed(2)}% from low combat levels, ` : ''
 	}${deathChanceFromGear.toFixed(
 		2
-	)}x from wildy gear (weight 60% magic, 40% ranged, 20% melee), ${hasSupplies}x from anti-pk supplies, ${hasOverheads}x from overhead prayers, ${
-		(100 - jukingExperience) / 100
-	}x from KC/juking experience, ${wildyMultiMultiplier}x from being in${
+	)}x from wildy gear (weight 60% magic, 40% ranged, 20% melee), ${hasSupplies}x from anti-pk supplies, ${hasOverheads}x from overhead prayers, ${(
+		(100 - evasionReduction) /
+		100
+	).toFixed(2)}x from KC/juking experience, ${wildyMultiMultiplier}x from being in${
 		wildyMultiMultiplier === 1 ? ' no' : ''
 	} multi)`;
 

--- a/src/lib/util/calculateGearLostOnDeathWilderness.ts
+++ b/src/lib/util/calculateGearLostOnDeathWilderness.ts
@@ -87,7 +87,18 @@ export const gearSwap: IGearSwap = {
 	[itemID('Frozen abyssal whip')]: [itemID('Abyssal whip'), itemID('Frozen whip mix')],
 	12_848: [itemID('Granite maul'), itemID('Granite clamp')],
 	24_227: [24_225, itemID('Granite clamp')],
-	[itemID('Abyssal tentacle')]: [itemID('Abyssal whip'), itemID('Kraken tentacle')]
+	[itemID('Abyssal tentacle')]: [itemID('Abyssal whip'), itemID('Kraken tentacle')],
+	[itemID("Thammaron's sceptre (a)")]: [itemID("Thammaron's sceptre (au)")],
+	[itemID('Webweaver bow')]: [itemID('Webweaver bow (u)')],
+	[itemID('Ursine chainmace')]: [itemID('Ursine chainmace (u)')],
+	[itemID('Accursed sceptre')]: [itemID('Accursed sceptre (u)')],
+	[itemID('Accursed sceptre (a)')]: [itemID('Accursed sceptre (au)')],
+	[itemID('Webweaver bow')]: [itemID('Webweaver bow (u)')],
+	[itemID('Venator bow')]: [itemID('Venator bow (uncharged)')],
+	// These 3 are NOT for BSO
+	[itemID('Sanguine torva platebody')]: [itemID('Torva platebody')],
+	[itemID('Sanguine torva platelegs')]: [itemID('Torva platelegs')],
+	[itemID('Sanguine torva full helm')]: [itemID('Torva full helm')]
 };
 
 export const lockedItems = resolveItems([
@@ -154,7 +165,7 @@ export const lockedItems = resolveItems([
 	'Ranger hat (l)',
 	'Healer hat (l)',
 	'Fighter torso (l)',
-	'Penance skirt (l)'
+	'Ancient sceptre (l)'
 ]);
 
 export default function calculateGearLostOnDeathWilderness(

--- a/src/mahoji/commands/rp.ts
+++ b/src/mahoji/commands/rp.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from '@discordjs/builders';
 import { toTitleCase } from '@oldschoolgg/toolkit';
 import { Duration } from '@sapphire/time-utilities';
 import { SnowflakeUtil } from 'discord.js';
@@ -72,6 +73,12 @@ export const rpCommand: OSBMahojiCommand = {
 							name: 'user',
 							description: 'The user.',
 							required: true
+						},
+						{
+							type: ApplicationCommandOptionType.Boolean,
+							name: 'json',
+							description: 'Get bank in JSON format',
+							required: false
 						}
 					]
 				},
@@ -148,7 +155,7 @@ export const rpCommand: OSBMahojiCommand = {
 			validate_ge?: {};
 		};
 		player?: {
-			viewbank?: { user: MahojiUserOption };
+			viewbank?: { user: MahojiUserOption; json?: boolean };
 			add_patron_time?: { user: MahojiUserOption; tier: number; time: string };
 			steal_items?: {
 				user: MahojiUserOption;
@@ -197,6 +204,13 @@ export const rpCommand: OSBMahojiCommand = {
 		if (options.player?.viewbank) {
 			const userToCheck = await mUserFetch(options.player.viewbank.user.user.id);
 			const bank = userToCheck.allItemsOwned;
+			if (options.player?.viewbank.json) {
+				const json = JSON.stringify(bank.bank);
+				if (json.length > 1900) {
+					return { files: [{ attachment: Buffer.from(json), name: 'bank.json' }] };
+				}
+				return `${codeBlock('json', json)}`;
+			}
 			return { files: [(await makeBankImage({ bank, title: userToCheck.usernameOrMention })).file] };
 		}
 

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -65,7 +65,7 @@ import {
 } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
-import { calcWildyPKChance } from '../../../lib/util/calcWildyPkChance';
+import { calcWildyPKChance, increaseWildEvasionXp } from '../../../lib/util/calcWildyPkChance';
 import { generateChart } from '../../../lib/util/chart';
 import findMonster from '../../../lib/util/findMonster';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
@@ -144,9 +144,7 @@ export async function minionKillCommand(
 
 	const monster = findMonster(name);
 	if (!monster) return invalidMonsterMsg;
-	if (['Callisto', 'Artio', "Vet'ion", "Calvar'ion", 'Spindel', 'Venenatis'].includes(monster.name)) {
-		return `The monster ${monster.name} is disabled.`;
-	}
+
 	const usersTask = await getUsersCurrentSlayerInfo(user.id);
 	const isOnTask =
 		usersTask.assignedTask !== null &&
@@ -663,8 +661,8 @@ export async function minionKillCommand(
 	let hasDied: boolean | undefined = undefined;
 	let hasWildySupplies = undefined;
 
-	// Leaving the code in here to give Fishy a chance to fix it.
-	if (0 > 1 && monster.canBePked) {
+	if (monster.canBePked) {
+		await increaseWildEvasionXp(user, duration);
 		thePkCount = 0;
 		hasDied = false;
 		const date = new Date().getTime();

--- a/src/mahoji/lib/abstracted_commands/revsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/revsCommand.ts
@@ -41,7 +41,7 @@ export async function revsCommand(
 			m.name.split(' ').some(a => stringMatches(a, name))
 	);
 	if (!monster || !name) {
-		return `That's not a valid revenant. The valid revenants are: ${revenantMonsters.map(m => m.name).join(', ')}.`;
+		return `That's not a valid Revenant. The valid Revenants are: ${revenantMonsters.map(m => m.name).join(', ')}.`;
 	}
 
 	const key = ({ melee: 'attack_crush', mage: 'attack_magic', range: 'attack_ranged' } as const)[style];
@@ -50,11 +50,11 @@ export async function revsCommand(
 
 	const weapon = userGear.equippedWeapon();
 	if (!weapon) {
-		return 'You have no weapon equipped in your wildy outfit.';
+		return 'You have no weapon equipped in your Wildy outfit.';
 	}
 
 	if (weapon.equipment![key] < 10) {
-		return `Your weapon is terrible, you can't kill revenants. You should have ${style} gear equipped in your wildy outfit, as this is what you're currently training. You can change this using \`/minion train\``;
+		return `Your weapon is terrible, you can't kill Revenants. You should have ${style} gear equipped in your wildy outfit, as this is what you're currently training. You can change this using \`/minion train\``;
 	}
 
 	let timePerMonster = monster.timeToFinish;

--- a/src/mahoji/lib/abstracted_commands/revsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/revsCommand.ts
@@ -13,6 +13,7 @@ import { RevenantOptions } from '../../../lib/types/minions';
 import { formatDuration, percentChance, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
+import { getWildEvasionPercent, increaseWildEvasionXp } from '../../../lib/util/calcWildyPkChance';
 import getOSItem from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
@@ -113,7 +114,12 @@ export async function revsCommand(
 	let deathChanceFromGear = Math.max(20, 100 - defensiveGearPercent) / 4;
 	deathChance += deathChanceFromGear;
 
+	const evasionDeathReduction = await getWildEvasionPercent(user);
+	deathChance = reduceNumByPercent(deathChance, evasionDeathReduction);
+
 	const died = percentChance(deathChance);
+
+	await increaseWildEvasionXp(user, duration);
 
 	await addSubTaskToActivityTask<RevenantOptions>({
 		monsterID: monster.id,


### PR DESCRIPTION
### Description:

Fixes most of the remaining issues from the Wilderness rework

### Changes:

- Links most new weapons to their uncharged variants for death chances
- Improves the pk evasion death chance reduction from risky Wilderness experience
- Reduces peak PK chance, and death chances. -- Remember, these compound, making it nearly impossible to do a full trip without dying, even without Peak activity.
- Fixes issue where antiPkSupplies can conflict with food removes (ie. karambwans -- This is a general fix as well)
- Enables the Wildy bosses and PK death mechanics

### Other checks:

- [x] I have tested all my changes thoroughly.

### Note:
This merge must be done carefully. 
- The food removal code must be done after all other `lootToRemove` is calculated
- The Sanguine torva => Torva link/map should not carry over to BSO, as bso torva is different.
- There's a new userStats column

### Important Reminder
- When deploying OSB, do not forget to migrate the Farming Reminder block to bitfield.
