### PR TITLE
Give HP boost to ToA

### DIFF
--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -33,6 +33,7 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 		case 'Sepulchre':
 		case 'Raids':
 		case 'TheatreOfBlood':
+		case 'TombsOfAmascut':
 		case 'Pickpocket':
 		case 'SoulWars':
 		case 'Cyclops': {


### PR DESCRIPTION
### Description:

- Adds the HP boost to Tombs of Amascut

### Changes:

- Adds TombsOfAmascut activity to the calcMaxTrip duration calculator.

### Other checks:

- [ ] I have tested all my changes thoroughly.
