### PR TITLE
Update CA ID 3044

### DIFF
--- a/src/lib/combat_achievements/grandmaster.ts
+++ b/src/lib/combat_achievements/grandmaster.ts
@@ -530,7 +530,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		monster: 'Theatre of Blood',
 		rng: {
 			chancePerKill: 50,
-			hasChance: data => data.type === 'TheatreOfBlood' && (data as TheatreOfBloodTaskOptions).hardMode
+			hasChance: 'TheatreOfBlood'
 		}
 	},
 	{


### PR DESCRIPTION
### Description:

The normal TOB 5-scale speedrun task (ID # 3044) is currently only given for HM TOB runs, but should actually be given for normal TOB.

### Changes:

Removed HM requirement for normal TOB 5-scale speedrun task.

### Other checks:

- [ ] I have tested all my changes thoroughly.
