### PR TITLE
Make getSimilarItems() behavior consistent

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -419,7 +419,7 @@ GROUP BY data->>'clueID';`);
 		const { bank } = this;
 		const items = resolveItems(_items);
 		for (const baseID of items) {
-			const similarItems = [...getSimilarItems(baseID), baseID];
+			const similarItems = getSimilarItems(baseID);
 			const hasOneEquipped = similarItems.some(id => this.hasEquipped(id, true));
 			const hasOneInBank = similarItems.some(id => bank.has(id));
 			// If only one needs to be equipped, return true now if it is equipped.

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -369,5 +369,5 @@ for (const [baseItem, similarItems] of source) {
 
 export function getSimilarItems(itemID: number): number[] {
 	const similars = similarItems.get(itemID);
-	return similars ? [itemID, ...similars] : [];
+	return similars ? [itemID, ...similars] : [itemID];
 }

--- a/src/lib/structures/Gear.ts
+++ b/src/lib/structures/Gear.ts
@@ -438,10 +438,7 @@ export class Gear {
 				if (inverse) {
 					values.push(...inverse.values());
 				}
-				const similarItems = getSimilarItems(item);
-				if (similarItems) {
-					values.push(...similarItems);
-				}
+				values.push(...getSimilarItems(item));
 			}
 		}
 
@@ -471,8 +468,8 @@ export class Gear {
 			let currentCount = 0;
 			for (const i of [...items]) {
 				const similarItems = getSimilarItems(i);
-				if (similarItems.length > 0) {
-					if (similarItems.some(si => allItems.includes(si))) currentCount++;
+				if (similarItems.some(si => allItems.includes(si))) {
+					currentCount++;
 				} else if (allItems.includes(i)) currentCount++;
 			}
 			return currentCount === targetCount;
@@ -480,7 +477,6 @@ export class Gear {
 		// similar = true, every = false
 		for (const i of [...items]) {
 			const similarItems = getSimilarItems(i);
-			similarItems.push(i);
 			if (similarItems.some(si => allItems.includes(si))) return true;
 		}
 		return false;

--- a/src/mahoji/lib/abstracted_commands/infernoCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/infernoCommand.ts
@@ -267,7 +267,7 @@ async function infernoRun({
 		const weapon = setup.equippedWeapon();
 		const validWeapons = Object.keys(weapons)
 			.map(itemID)
-			.map(id => [...getSimilarItems(id), id])
+			.map(id => getSimilarItems(id))
 			.flat();
 		if (!weapon || !validWeapons.includes(weapon.id)) {
 			return `You need one of these weapons in your ${name} setup: ${Object.keys(weapons).join(', ')}.`;
@@ -282,15 +282,11 @@ async function infernoRun({
 	duration.add(getSimilarItems(itemID('Armadyl crossbow')).includes(rangeGear.equippedWeapon()!.id), 4.5, 'ACB');
 
 	zukDeathChance.add(
-		[...getSimilarItems(itemID('Twisted bow')), itemID('Twisted bow')].includes(rangeGear.equippedWeapon()!.id),
+		getSimilarItems(itemID('Twisted bow')).includes(rangeGear.equippedWeapon()!.id),
 		1.5,
 		'Zuk with TBow'
 	);
-	duration.add(
-		[...getSimilarItems(itemID('Twisted bow')), itemID('Twisted bow')].includes(rangeGear.equippedWeapon()!.id),
-		-7.5,
-		'TBow'
-	);
+	duration.add(getSimilarItems(itemID('Twisted bow')).includes(rangeGear.equippedWeapon()!.id), -7.5, 'TBow');
 
 	/**
 	 *

--- a/tests/unit/similarItems.test.ts
+++ b/tests/unit/similarItems.test.ts
@@ -150,7 +150,7 @@ describe('Gear', () => {
 		}
 	}
 
-	expect(getSimilarItems(itemID('Infernal max cape'))).toEqual([]);
+	expect(getSimilarItems(itemID('Infernal max cape'))).toEqual([itemID('Infernal max cape')]);
 
 	test('toa', () => {
 		let testGear = new Gear({ cape: 'Masori assembler max cape' });


### PR DESCRIPTION
### Description:

- getSimilarItems() has always caused a lot of bugs, because when similars exist, it returns the original item as well, but when they don't exist, it returns an empty array (which is a truthy value...)
- So this fixed one or two existing bugs, where a call to getSimilarItems() expected a falsy result that would never happen.
- This also removes a lot of unnecessary code where the original itemID is added to the resulting array (often causing duplicates).

### Changes:

- getSimilarItems() now returns the original itemID if no similars exist.
- Checked/updated all calls to getSimilarItems() to ensure they're using it as intended.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:

Currently testing