### PR TITLE
Nerf non-zeah Blood runes

### DIFF
--- a/src/lib/invention/inventions.ts
+++ b/src/lib/invention/inventions.ts
@@ -64,7 +64,8 @@ export const inventionBoosts = {
 			{ runes: ['Lava rune', 'Steam rune', 'Smoke rune'], boost: 20 },
 			{ runes: ['Death rune', 'Astral rune', 'Wrath rune', 'Law rune', 'Nature rune'], boost: 50 },
 			{ runes: ['Chaos rune', 'Cosmic rune'], boost: 60 },
-			{ runes: ['Blood rune', 'Soul rune'], boost: 95 },
+			{ runes: ['Blood rune', 'Soul rune'], boost: 65 },
+			{ runes: ['Blood rune (zeah)', 'Soul rune (zeah)'], boost: 95 },
 			{ runes: ['Elder rune'], boost: 65 }
 		]
 	},

--- a/src/lib/minions/functions/darkAltarCommand.ts
+++ b/src/lib/minions/functions/darkAltarCommand.ts
@@ -82,7 +82,7 @@ export async function darkAltarCommand({ user, channelID, name }: { user: MUser;
 	// Calculate Abyssal amulet boost:
 	if (user.hasEquippedOrInBank(['Abyssal amulet'])) {
 		const abyssalAmuletBoost = inventionBoosts.abyssalAmulet.boosts.find(b =>
-			b.runes.some(r => stringMatches(r, `${rune} rune`))
+			b.runes.some(r => stringMatches(r, `${rune} rune (zeah)`))
 		);
 		if (abyssalAmuletBoost) {
 			const res = await inventionItemBoost({


### PR DESCRIPTION
### Description:

- Pure essence Blood runes were never balanced with Abyssal talisman and are thus overpowered.

### Changes:

- Separates Pure Ess from Zeah runecraft boosts from the Abyssal talisman
- Adds logic to Zeah RC to check for the Zeah variant

### Other checks:

- [x] I have tested all my changes thoroughly.
