### PR TITLE
Fix Projectiles not checking similar weapons

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -30,6 +30,7 @@ import { ADMIN_IDS, OWNER_IDS, SupportServer } from '../config';
 import { ClueTiers } from './clues/clueTiers';
 import { badgesCache, BitField, projectiles, usernameCache } from './constants';
 import { UserStatsDataNeededForCL } from './data/Collections';
+import { getSimilarItems } from './data/similarItems';
 import { DefenceGearStat, GearSetupType, GearSetupTypes, GearStat, OffenceGearStat } from './gear/types';
 import type { Consumable } from './minions/types';
 import { MUserClass } from './MUser';
@@ -515,7 +516,12 @@ export function checkRangeGearWeapon(gear: Gear) {
 	const { ammo } = gear;
 	if (!ammo) return 'You have no ammo equipped.';
 
-	const projectileCategory = objectEntries(projectiles).find(i => i[1].weapons.includes(weapon.id));
+	const projectileCategory = objectEntries(projectiles).find(i =>
+		i[1].weapons
+			.map(w => getSimilarItems(w))
+			.flat()
+			.includes(weapon.id)
+	);
 	if (!projectileCategory) return 'You have an invalid range weapon.';
 	if (!projectileCategory[1].items.includes(ammo.item)) {
 		return `You have invalid ammo for your equipped weapon. For ${


### PR DESCRIPTION
### Description:

- `projectiles` constant and associated function were not checking for similar items, so 'Hellfire bow' wouldn't count as a Tiwsted bow, for example.

### Changes:

- Updates `checkRangeGearWeapon()` to generate list of similar items when searching for a matching projectile.

### Other checks:

- [x] I have tested all my changes thoroughly.
