### PR TITLE
Add ironman Price to Salve Amulet

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -853,6 +853,7 @@ const Buyables: Buyable[] = [
 	{
 		name: 'Salve amulet',
 		gpCost: 200_000,
+		ironmanPrice: 20_000,
 		skillsNeeded: {
 			crafting: 35
 		},

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -258,6 +258,7 @@ exports[`OSB Buyables 1`] = `
   },
   {
     "gpCost": 200000,
+    "ironmanPrice": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,


### PR DESCRIPTION
With the recent changes to revs, salve amulets will be needed in bulk.  200k seems astronomical for an ironman to pay for something thats free, I propose we reduce it to 20k at most, honestly it should probably be much cheaper still. 

Alternatively we could look at adding it to /activities collect for free.

- [x] I have tested all my changes thoroughly.
