### PR TITLE
add clue button to solo raids

### DIFF
--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -217,6 +217,8 @@ export const raidsTask: MinionTask = {
 				],
 				type: 'Chambers of Xerician'
 			});
+
+			handleTripFinish(allUsers[0], channelID, resultMessage, attachment, data, totalLoot);
 		} else if (shouldShowImage) {
 			attachment = await drawChestLootImage({
 				entries: allUsers.map((u, index) => ({
@@ -227,8 +229,8 @@ export const raidsTask: MinionTask = {
 				})),
 				type: 'Chambers of Xerician'
 			});
-		}
 
-		handleTripFinish(allUsers[0], channelID, resultMessage, attachment, data, null);
+			handleTripFinish(allUsers[0], channelID, resultMessage, attachment, data, null);
+		}
 	}
 };

--- a/src/tasks/minions/minigames/toaActivity.ts
+++ b/src/tasks/minions/minigames/toaActivity.ts
@@ -269,7 +269,7 @@ export const toaTask: MinionTask = {
 					  })
 					: undefined,
 				data,
-				null
+				itemsAddedTeamLoot.totalLoot()
 			);
 		}
 

--- a/src/tasks/minions/minigames/tobActivity.ts
+++ b/src/tasks/minions/minigames/tobActivity.ts
@@ -200,7 +200,9 @@ export const tobTask: MinionTask = {
 				duration
 			}))
 		});
-
+		if (data.solo) {
+			return handleTripFinish(allUsers[0], channelID, resultMessage, undefined, data, totalLoot, undefined);
+		}
 		return handleTripFinish(allUsers[0], channelID, resultMessage, undefined, data, null, undefined);
 	}
 };


### PR DESCRIPTION
closes: https://github.com/oldschoolgg/oldschoolbot/issues/4957
addresses: https://github.com/oldschoolgg/oldschoolbot/pull/5002

### Description:

Adds clue button to solo raid

### Changes:

Adds code to allow clue button to show up if the user is soloing and receives a clue. 
I believe this is a "elegant/maintainable solution" for addressing this.

### Other checks:

- [X] I have tested all my changes thoroughly.
