### PR TITLE
BankBackground bug fixes / cleanup

### DIFF
--- a/src/lib/minions/data/bankBackgrounds.ts
+++ b/src/lib/minions/data/bankBackgrounds.ts
@@ -430,4 +430,9 @@ const backgroundImages: BankBackground[] = [
 	}
 ];
 
+export function getBankBgById(bgId: number) {
+	const result = backgroundImages.find(bgi => bgi.id === bgId);
+	return result ?? backgroundImages[0];
+}
+
 export default backgroundImages;

--- a/src/lib/patreon.ts
+++ b/src/lib/patreon.ts
@@ -103,7 +103,7 @@ class PatreonTask {
 	async changeTier(userID: string, from: PerkTier, to: PerkTier) {
 		const user = await prisma.user.findFirst({
 			where: { id: userID },
-			select: { bitfield: true, bankBackground: true }
+			select: { bitfield: true }
 		});
 		if (!user) return null;
 

--- a/src/lib/patreon.ts
+++ b/src/lib/patreon.ts
@@ -120,14 +120,6 @@ class PatreonTask {
 				bitfield: newBitfield
 			});
 		} catch (_) {}
-
-		// Remove patron bank background
-		const bg = backgroundImages.find(bg => bg.id === user.bankBackground);
-		if (bg && bg.perkTierNeeded && bg.perkTierNeeded > to) {
-			await mahojiUserSettingsUpdate(userID, {
-				bankBackground: 1
-			});
-		}
 	}
 
 	async givePerks(userID: string, perkTier: PerkTier) {

--- a/src/lib/patreon.ts
+++ b/src/lib/patreon.ts
@@ -158,7 +158,7 @@ class PatreonTask {
 	async removePerks(userID: string) {
 		const user = await prisma.user.findFirst({
 			where: { id: userID },
-			select: { bitfield: true, badges: true, bank_bg_hex: true }
+			select: { bitfield: true, badges: true }
 		});
 		if (!user) return null;
 

--- a/src/lib/patreon.ts
+++ b/src/lib/patreon.ts
@@ -5,7 +5,6 @@ import { production } from '../config';
 import { cacheBadges } from './badges';
 import { BadgesEnum, BitField, Channel, globalConfig, PatronTierID, PerkTier } from './constants';
 import { fetchSponsors, getUserIdFromGithubID } from './http/util';
-import backgroundImages from './minions/data/bankBackgrounds';
 import { mahojiUserSettingsUpdate } from './MUser';
 import { getUsersPerkTier } from './perkTiers';
 import { roboChimpUserFetch } from './roboChimp';
@@ -159,7 +158,7 @@ class PatreonTask {
 	async removePerks(userID: string) {
 		const user = await prisma.user.findFirst({
 			where: { id: userID },
-			select: { bitfield: true, badges: true, bank_bg_hex: true, bankBackground: true }
+			select: { bitfield: true, badges: true, bank_bg_hex: true }
 		});
 		if (!user) return null;
 
@@ -177,19 +176,6 @@ class PatreonTask {
 		await mahojiUserSettingsUpdate(userID, {
 			badges: userBadges.filter(number => !patronBadges.includes(number))
 		});
-
-		// Remove patron bank background
-		const bg = backgroundImages.find(bg => bg.id === user.bankBackground);
-		if (bg?.perkTierNeeded) {
-			await mahojiUserSettingsUpdate(userID, {
-				bankBackground: 1
-			});
-		}
-		if (user.bank_bg_hex !== null) {
-			await mahojiUserSettingsUpdate(userID, {
-				bank_bg_hex: null
-			});
-		}
 	}
 
 	async syncGithub() {

--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -11,7 +11,7 @@ import { ClueTiers } from '../../../lib/clues/clueTiers';
 import { getClueScoresFromOpenables } from '../../../lib/clues/clueUtils';
 import { Emoji, PerkTier } from '../../../lib/constants';
 import { calcCLDetails, isCLItem } from '../../../lib/data/Collections';
-import backgroundImages from '../../../lib/minions/data/bankBackgrounds';
+import { getBankBgById } from '../../../lib/minions/data/bankBackgrounds';
 import killableMonsters from '../../../lib/minions/data/killableMonsters';
 import { RandomEvents } from '../../../lib/randomEvents';
 import { getMinigameScore } from '../../../lib/settings/minigames';
@@ -248,7 +248,7 @@ export const dataPoints: readonly DataPiece[] = [
 			const result: { type: activity_type_enum; qty: number }[] =
 				await prisma.$queryRawUnsafe(`SELECT type, count(type) AS qty
 FROM activity
-WHERE completed = true	
+WHERE completed = true
 AND user_id = ${BigInt(user.id)}
 OR (data->>'users')::jsonb @> ${wrap(user.id)}::jsonb
 GROUP BY type;`);
@@ -742,7 +742,7 @@ GROUP BY "bankBackground";`);
 			return result
 				.map(
 					(res: any) =>
-						`**${backgroundImages[res.bankBackground - 1].name}:** ${parseInt(res.count).toLocaleString()}`
+						`**${getBankBgById(res.bankBackground).name}:** ${parseInt(res.count).toLocaleString()}`
 				)
 				.join('\n');
 		}
@@ -964,7 +964,7 @@ FROM   (
                              SUM(FLOOR(value::numeric)::bigint) AS itemqty
                   FROM       users
                   CROSS JOIN jsonb_each_text("collectionLogBank")
-				  WHERE "users"."minion.ironman" = true 
+				  WHERE "users"."minion.ironman" = true
                   GROUP BY   KEY ) s;`;
 			const bank = new Bank(res[0].banks);
 			return {


### PR DESCRIPTION
### Description:

Does some cleanup + bugfixes after the bankbackground update

### Changes:

- Removes the logic that removes bankbackgrounds from inactive patrons, since it was incomplete/broken/outdated, and no longer necessary
- Fixes the bank background stats command; it previously expected all BG id's to be sequential with no breaks, causing problems with undefined array indexes.

### Other checks:

- [ ] I have tested all my changes thoroughly.
