### PR TITLE
Add Disable Item Contract Donations toggle

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -302,7 +302,8 @@ export enum BitField {
 	HasPlantedIvy = 209,
 	HasGuthixEngram = 210,
 	ScrollOfLongevityDisabled = 211,
-	HasUnlockedYeti = 212
+	HasUnlockedYeti = 212,
+	NoItemContractDonations = 213
 }
 
 interface BitFieldData {
@@ -413,6 +414,11 @@ export const BitFieldData: Record<BitField, BitFieldData> = {
 	},
 	[BitField.DisabledFarmingReminders]: {
 		name: 'Disable Farming Reminders',
+		protected: false,
+		userConfigurable: true
+	},
+	[BitField.NoItemContractDonations]: {
+		name: 'Disable Item Contract donations',
 		protected: false,
 		userConfigurable: true
 	}

--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -242,6 +242,9 @@ function icDonateValidation(user: MUser, donator: MUser) {
 	if (user.id === donator.id) {
 		return 'You cannot donate to yourself.';
 	}
+	if (user.bitfield.includes(BitField.NoItemContractDonations)) {
+		return "That user doesn't want donations.";
+	}
 	const details = getItemContractDetails(user);
 	if (!details.nextContractIsReady || !details.currentItem) {
 		return "That user's Item Contract isn't ready.";
@@ -298,7 +301,7 @@ async function donateICHandler(interaction: ButtonInteraction) {
 
 		return interactionReply(interaction, {
 			content: `${donator}, you donated ${cost} to ${user}!
-	
+
 ${user.mention} ${await handInContract(null, user)}`,
 			allowedMentions: {
 				users: [user.id]

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -129,6 +129,10 @@ const toggles: UserConfigToggle[] = [
 	{
 		name: 'Disable farming reminders',
 		bit: BitField.DisabledFarmingReminders
+	},
+	{
+		name: 'Disable Item Contract Donations',
+		bit: BitField.NoItemContractDonations
 	}
 ];
 

--- a/src/mahoji/commands/ic.ts
+++ b/src/mahoji/commands/ic.ts
@@ -6,7 +6,7 @@ import { Bank, LootTable } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
 
 import { allMbTables, MysteryBoxes, PMBTable } from '../../lib/bsoOpenables';
-import { Emoji } from '../../lib/constants';
+import { BitField, Emoji } from '../../lib/constants';
 import { AbyssalDragonLootTable } from '../../lib/minions/data/killableMonsters/custom/AbyssalDragon';
 import { Ignecarus } from '../../lib/minions/data/killableMonsters/custom/bosses/Ignecarus';
 import { kalphiteKingLootTable } from '../../lib/minions/data/killableMonsters/custom/bosses/KalphiteKing';
@@ -258,7 +258,10 @@ export const icCommand: OSBMahojiCommand = {
 		const user = await mUserFetch(userID);
 		const details = getItemContractDetails(user);
 		const components =
-			details.nextContractIsReady && details.currentItem !== null && !user.isIronman
+			details.nextContractIsReady &&
+			details.currentItem !== null &&
+			!user.isIronman &&
+			!user.bitfield.includes(BitField.NoItemContractDonations)
 				? makeComponents([
 						new ButtonBuilder()
 							.setStyle(ButtonStyle.Primary)
@@ -276,7 +279,7 @@ export const icCommand: OSBMahojiCommand = {
 					} You have no item contract available at the moment. Come back in ${formatDuration(
 						details.durationRemaining
 					)}.
-			
+
 ${details.infoStr}`
 				};
 			}


### PR DESCRIPTION
### Description:

Adds toggle to disable receipt of Item Contract donations.

Can be used to protect your streak, or if you want to see how far you can go on your own, without being an iron.

### Changes:

- Adds toggle to disable the Item Contract donation buttons.

### Other checks:

- [x] I have tested all my changes thoroughly.
