### PR TITLE
Update CA ID 244

### DIFF
--- a/src/lib/combat_achievements/hard.ts
+++ b/src/lib/combat_achievements/hard.ts
@@ -515,7 +515,7 @@ export const hardCombatAchievements: CombatAchievement[] = [
 		id: 244,
 		name: 'Inspect Repellent',
 		type: 'perfection',
-		monster: 'Phantom Muspah',
+		monster: 'Sarachnis',
 		desc: 'Kill Sarachnis without her dealing damage to anyone.',
 		rng: {
 			chancePerKill: 10,


### PR DESCRIPTION
### Description:

CA ID 244 is categorized as a Phantom Muspah CA, but should be a Sarachnis CA.

### Changes:

Updated the monster field to be Sarachnis so it sorts properly.

### Other checks:

- [ ] I have tested all my changes thoroughly.
