### PR TITLE
Allow Zahur to make Cadantine Blood Potion (unf)

### DIFF
--- a/src/lib/skilling/skills/herblore/mixables/potions.ts
+++ b/src/lib/skilling/skills/herblore/mixables/potions.ts
@@ -299,18 +299,6 @@ const Potions: Mixable[] = [
 		bankTimePerPotion: 0.45
 	},
 	{
-		item: getOSItem('Cadantine blood potion (unf)'),
-		aliases: ['cadantine blood potion (unf)', 'cadantine blood potion', 'cadantine blood'],
-		level: 80,
-		xp: 0,
-		inputItems: new Bank({
-			'Vial of blood': 1,
-			Cadantine: 1
-		}),
-		tickRate: 1,
-		bankTimePerPotion: 0.3
-	},
-	{
 		item: getOSItem('Bastion potion (3)'),
 		aliases: ['bastion potion (3)', 'bastion potion', 'bastion'],
 		level: 80,

--- a/src/lib/skilling/skills/herblore/mixables/unfinishedPotions.ts
+++ b/src/lib/skilling/skills/herblore/mixables/unfinishedPotions.ts
@@ -27,7 +27,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Tarromin potion (unf)'),
 		aliases: ['tarromin potion (unf)', 'tarromin potion', 'tarromin (unf)'],
-		level: 11,
+		level: 12,
 		xp: 0,
 		inputItems: new Bank({ Tarromin: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -37,7 +37,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Harralander potion (unf)'),
 		aliases: ['harralander potion (unf)', 'harralander potion', 'harralander (unf)'],
-		level: 20,
+		level: 22,
 		xp: 0,
 		inputItems: new Bank({ Harralander: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -47,7 +47,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Ranarr potion (unf)'),
 		aliases: ['ranarr potion (unf)', 'ranarr potion', 'ranarr (unf)'],
-		level: 25,
+		level: 30,
 		xp: 0,
 		inputItems: new Bank({ 'Ranarr weed': 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -57,7 +57,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Toadflax potion (unf)'),
 		aliases: ['toadflax potion (unf)', 'toadflax potion', 'toadflax (unf)'],
-		level: 30,
+		level: 34,
 		xp: 0,
 		inputItems: new Bank({ Toadflax: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -67,7 +67,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Irit potion (unf)'),
 		aliases: ['irit potion (unf)', 'irit potion', 'irit (unf)'],
-		level: 40,
+		level: 45,
 		xp: 0,
 		inputItems: new Bank({ 'Irit leaf': 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -77,7 +77,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Avantoe potion (unf)'),
 		aliases: ['avantoe potion (unf)', 'avantoe potion', 'avantoe (unf)'],
-		level: 48,
+		level: 50,
 		xp: 0,
 		inputItems: new Bank({ Avantoe: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -87,7 +87,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Kwuarm potion (unf)'),
 		aliases: ['kwuarm potion (unf)', 'kwuarm potion', 'kwuarm (unf)'],
-		level: 54,
+		level: 55,
 		xp: 0,
 		inputItems: new Bank({ Kwuarm: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -97,7 +97,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Snapdragon potion (unf)'),
 		aliases: ['snapdragon potion (unf)', 'snapdragon potion', 'snapdragon (unf)'],
-		level: 59,
+		level: 63,
 		xp: 0,
 		inputItems: new Bank({ Snapdragon: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -107,7 +107,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Cadantine potion (unf)'),
 		aliases: ['cadantine potion (unf)', 'cadantine potion', 'cadantine (unf)'],
-		level: 65,
+		level: 66,
 		xp: 0,
 		inputItems: new Bank({ Cadantine: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -117,7 +117,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Lantadyme potion (unf)'),
 		aliases: ['lantadyme potion (unf)', 'lantadyme potion', 'lantadyme (unf)'],
-		level: 67,
+		level: 69,
 		xp: 0,
 		inputItems: new Bank({ Lantadyme: 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -127,7 +127,7 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Dwarf weed potion (unf)'),
 		aliases: ['dwarf weed potion', 'dwarf weed (unf)', 'dwarf weed potion (unf)'],
-		level: 70,
+		level: 72,
 		xp: 0,
 		inputItems: new Bank({ 'Dwarf weed': 1, 'Vial of water': 1 }),
 		tickRate: 1,
@@ -137,9 +137,22 @@ const unfinishedPotions: Mixable[] = [
 	{
 		item: getOSItem('Torstol potion (unf)'),
 		aliases: ['torstol potion', 'torstol (unf)', 'torstol potion (unf)'],
-		level: 75,
+		level: 78,
 		xp: 0,
 		inputItems: new Bank({ Torstol: 1, 'Vial of water': 1 }),
+		tickRate: 1,
+		bankTimePerPotion: 0.3,
+		zahur: true
+	},
+	{
+		item: getOSItem('Cadantine blood potion (unf)'),
+		aliases: ['cadantine blood potion (unf)', 'cadantine blood potion', 'cadantine blood'],
+		level: 80,
+		xp: 0,
+		inputItems: new Bank({
+			'Vial of blood': 1,
+			Cadantine: 1
+		}),
 		tickRate: 1,
 		bankTimePerPotion: 0.3,
 		zahur: true


### PR DESCRIPTION
Moves cadantine blood potion (unf) to unfinishedPotions.ts and allows zahur to work. 
Also updates lots of unfinished potions to the correct herblore level. 

Closes #5419

- Source - https://oldschool.runescape.wiki/w/Herblore#Cleaning_herbs_&_unfinished_potions 

- Source - https://oldschool.runescape.wiki/w/Zahur
