### PR TITLE
Buyable RequiredQuests + Ring of shadows

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -1,6 +1,6 @@
 import { Bank } from 'oldschooljs';
 
-import { MAX_QP } from '../../../mahoji/lib/abstracted_commands/questCommand';
+import { MAX_QP, QuestID } from '../../../mahoji/lib/abstracted_commands/questCommand';
 import { chompyHats } from '../../constants';
 import { CombatCannonItemBank } from '../../minions/data/combatConstants';
 import { Favours } from '../../minions/data/kourendFavour';
@@ -31,6 +31,7 @@ export interface Buyable {
 	name: string;
 	outputItems?: Bank | ((user: MUser) => Bank);
 	qpRequired?: number;
+	requiredQuests?: QuestID[];
 	gpCost?: number;
 	itemCost?: Bank;
 	aliases?: string[];
@@ -715,6 +716,11 @@ const questBuyables: Buyable[] = [
 		gpCost: 2_500_000,
 		qpRequired: 175,
 		ironmanPrice: 2000
+	},
+	{
+		name: 'Ring of shadows',
+		gpCost: 75_000,
+		requiredQuests: [QuestID.DesertTreasureII]
 	}
 ];
 

--- a/src/mahoji/commands/buy.ts
+++ b/src/mahoji/commands/buy.ts
@@ -1,3 +1,4 @@
+import { bold } from 'discord.js';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
@@ -13,6 +14,7 @@ import { deferInteraction } from '../../lib/util/interactionReply';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
 import { buyFossilIslandNotes } from '../lib/abstracted_commands/buyFossilIslandNotes';
 import { buyKitten } from '../lib/abstracted_commands/buyKitten';
+import { quests } from '../lib/abstracted_commands/questCommand';
 import { OSBMahojiCommand } from '../lib/util';
 import { mahojiParseNumber, multipleUserStatsBankUpdate } from '../mahojiSettings';
 
@@ -83,6 +85,14 @@ export const buyCommand: OSBMahojiCommand = {
 			const { QP } = user;
 			if (QP < buyable.qpRequired) {
 				return `You need ${buyable.qpRequired} QP to purchase this item.`;
+			}
+		}
+		if (buyable.requiredQuests) {
+			const incompleteQuest = buyable.requiredQuests.find(quest => !user.user.finished_quest_ids.includes(quest));
+			if (incompleteQuest) {
+				return `You need to have completed the ${bold(
+					quests.find(i => i.id === incompleteQuest)!.name
+				)} quest to buy the ${buyable.name}.`;
 			}
 		}
 

--- a/src/mahoji/commands/buy.ts
+++ b/src/mahoji/commands/buy.ts
@@ -87,6 +87,7 @@ export const buyCommand: OSBMahojiCommand = {
 				return `You need ${buyable.qpRequired} QP to purchase this item.`;
 			}
 		}
+
 		if (buyable.requiredQuests) {
 			const incompleteQuest = buyable.requiredQuests.find(quest => !user.user.finished_quest_ids.includes(quest));
 			if (incompleteQuest) {

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -1955,6 +1955,18 @@ exports[`OSB Buyables 1`] = `
     "qpRequired": 175,
   },
   {
+    "gpCost": 75000,
+    "itemCost": Bank {
+      "bank": {},
+      "frozen": false,
+    },
+    "name": "Ring of shadows",
+    "outputItems": undefined,
+    "requiredQuests": [
+      1,
+    ],
+  },
+  {
     "gpCost": 1000000,
     "itemCost": Bank {
       "bank": {},


### PR DESCRIPTION
### Description:
Allow user to buy ring of shadows. Multiple ring of shadows can be bought ingame following the completion of the quest. This acts a good "throw away" ring when doing activities in the wilderness.

### Changes:
1. Add ring of shadows to buyables
2. Add RequiredQuests as an option for buyables to support future quests

### Other checks:
- [X] I have tested all my changes thoroughly.
