### PR TITLE
BSO - Dragon hunter crossbow/lance boost fix

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -311,7 +311,7 @@ export async function minionKillCommand(
 	let salveAmuletBoost = 0;
 	let salveAmuletBoostMsg = '';
 
-	const dragonBoost = 15; // Common boost percentage for dragon-related gear
+	const dragonBoost = 20; // Common boost percentage for dragon-related gear
 
 	const isUndead = osjsMon?.data?.attributes?.includes(MonsterAttribute.Undead);
 	const isDragon = osjsMon?.data?.attributes?.includes(MonsterAttribute.Dragon);


### PR DESCRIPTION
Unsure if it's intentionally this way, but the Dragon hunter lance/crossbow boost on BSO was 20% rather than the 15% that is on OSB. 

This PR puts the BSO boost back up to the 20%.
