### PR TITLE
Fix passive implings league task

### DIFF
--- a/src/lib/leagues/eliteTasks.ts
+++ b/src/lib/leagues/eliteTasks.ts
@@ -1,5 +1,5 @@
 import { sumArr } from 'e';
-import { Bank, Monsters } from 'oldschooljs';
+import { Bank, Monsters, Openables } from 'oldschooljs';
 
 import { eggs } from '../../mahoji/commands/offer';
 import { tameFeedableItems } from '../../mahoji/commands/tames';
@@ -35,6 +35,7 @@ import {
 	WesternProv,
 	WildernessDiary
 } from '../diaries';
+import { implings } from '../implings';
 import { Naxxus } from '../minions/data/killableMonsters/custom/bosses/Naxxus';
 import Darts from '../skilling/skills/fletching/fletchables/darts';
 import Javelins from '../skilling/skills/fletching/fletchables/javelins';
@@ -704,10 +705,12 @@ export const eliteTasks: Task[] = [
 		name: 'Catch 30 of every impling passively (excluding lucky implings)',
 		has: async ({ userStats }) => {
 			let loot = new Bank(userStats.passive_implings_bank as ItemBank);
-			return loot
-				.items()
-				.filter(i => i[0].name !== 'Lucky impling jar')
-				.every(i => i[1] >= 30);
+			for (const implingId of Object.keys(implings)) {
+				if (Number(implingId) !== Openables.LuckyImpling.id && loot.amount(Number(implingId)) < 30) {
+					return false;
+				}
+			}
+			return true;
 		}
 	},
 	{

--- a/src/lib/leagues/hardTasks.ts
+++ b/src/lib/leagues/hardTasks.ts
@@ -1,5 +1,5 @@
 import { sumArr } from 'e';
-import { Bank, Monsters } from 'oldschooljs';
+import { Bank, Monsters, Openables } from 'oldschooljs';
 
 import { eggs } from '../../mahoji/commands/offer';
 import { circusBuyables } from '../data/buyables/circusBuyables';
@@ -35,6 +35,7 @@ import {
 	WildernessDiary
 } from '../diaries';
 import { dyedItems } from '../dyedItems';
+import { implings } from '../implings';
 import { Inventions } from '../invention/inventions';
 import { MOKTANG_ID } from '../minions/data/killableMonsters/custom/bosses/Moktang';
 import { Naxxus } from '../minions/data/killableMonsters/custom/bosses/Naxxus';
@@ -1148,10 +1149,12 @@ export const hardTasks: Task[] = [
 		name: 'Catch 20 of every impling passively (excluding Lucky implings)',
 		has: async ({ userStats }) => {
 			let loot = new Bank(userStats.passive_implings_bank as ItemBank);
-			return loot
-				.items()
-				.filter(i => i[0].name !== 'Lucky impling jar')
-				.every(i => i[1] >= 20);
+			for (const implingId of Object.keys(implings)) {
+				if (Number(implingId) !== Openables.LuckyImpling.id && loot.amount(Number(implingId)) < 20) {
+					return false;
+				}
+			}
+			return true;
 		}
 	},
 	{

--- a/src/lib/leagues/masterTasks.ts
+++ b/src/lib/leagues/masterTasks.ts
@@ -1,5 +1,5 @@
 import { sumArr } from 'e';
-import { Bank } from 'oldschooljs';
+import { Bank, Openables } from 'oldschooljs';
 
 import { BitField } from '../constants';
 import {
@@ -15,6 +15,7 @@ import {
 	naxxusCL
 } from '../data/CollectionsExport';
 import { slayerMaskHelms } from '../data/slayerMaskHelms';
+import { implings } from '../implings';
 import { Inventions } from '../invention/inventions';
 import { dungBuyables } from '../skilling/skills/dung/dungData';
 import { ashes } from '../skilling/skills/prayer';
@@ -1093,10 +1094,12 @@ export const masterTasks: Task[] = [
 		name: 'Catch 100 of every impling passively (excluding Lucky implings)',
 		has: async ({ userStats }) => {
 			let loot = new Bank(userStats.passive_implings_bank as ItemBank);
-			return loot
-				.items()
-				.filter(i => i[0].name !== 'Lucky impling jar')
-				.every(i => i[1] >= 100 || (i[0].name === 'Mystery impling jar' && i[1] >= 50));
+			for (const implingId of Object.keys(implings)) {
+				if (Number(implingId) !== Openables.LuckyImpling.id && loot.amount(Number(implingId)) < 100) {
+					return false;
+				}
+			}
+			return true;
 		}
 	},
 	{


### PR DESCRIPTION
### Description:

- Currently the passive impling task will still 'succeed' if you haven't got any of a certain impling.

IE. If you only have 100 young implings, and 100 earth implings, but NONE others, it will still think you have >= 100 of each.

### Changes:

- Checks each impling instead of assuming the userStats passive impling bank represents all implings

### Other checks:

- [x] I have tested all my changes thoroughly.


![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/1d5e5cb3-ffe0-4ba5-8c0a-5cc79e6f69b5)