### PR TITLE
Fix KillableMonsters/Revenants + /minion status

### DIFF
--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -31,6 +31,7 @@ const killableMonsters: KillableMonster[] = [
 	...turaelMonsters,
 	...vannakaMonsters,
 	...low,
+	...revenantMonsters,
 	...creatureCreationCreatures,
 	...reanimatedMonsters,
 	{
@@ -365,7 +366,6 @@ export default killableMonsters;
 
 export const effectiveMonsters = [
 	...killableMonsters,
-	...revenantMonsters,
 	NightmareMonster,
 	{
 		name: 'Zalcano',

--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -2,14 +2,12 @@ import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
 import { NEX_ID, PVM_METHODS, PvMMethod, ZALCANO_ID } from '../../lib/constants';
 import killableMonsters from '../../lib/minions/data/killableMonsters';
-import { revenantMonsters } from '../../lib/minions/data/killableMonsters/revs';
 import { prisma } from '../../lib/settings/prisma';
 import { minionKillCommand, monsterInfo } from '../lib/abstracted_commands/minionKill';
 import { OSBMahojiCommand } from '../lib/util';
 
 export const autocompleteMonsters = [
 	...killableMonsters,
-	...revenantMonsters,
 	{
 		id: -1,
 		name: 'Tempoross',

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -6,7 +6,6 @@ import { Emoji } from '../../lib/constants';
 import { KourendKebosDiary, userhasDiaryTier } from '../../lib/diaries';
 import { trackLoot } from '../../lib/lootTrack';
 import killableMonsters from '../../lib/minions/data/killableMonsters';
-import { revenantMonsters } from '../../lib/minions/data/killableMonsters/revs';
 import { addMonsterXP } from '../../lib/minions/functions';
 import announceLoot from '../../lib/minions/functions/announceLoot';
 import { prisma } from '../../lib/settings/prisma';
@@ -38,14 +37,8 @@ export const monsterTask: MinionTask = {
 			hasWildySupplies
 		} = data;
 
-		let monster = killableMonsters.find(mon => mon.id === monsterID)!;
-		let revenants = false;
-
-		const matchedRevenantMonster = revenantMonsters.find(mon => mon.id === monsterID)!;
-		if (matchedRevenantMonster) {
-			monster = matchedRevenantMonster;
-			revenants = true;
-		}
+		const monster = killableMonsters.find(mon => mon.id === monsterID)!;
+		const revenants = monster.name.includes('Revenant');
 
 		let skulled = false;
 		if (revenants) skulled = true;


### PR DESCRIPTION
### Description:

- Fix bug preventing `/minion status` and mentioning the bot from returning the status / shortcuts when killing revs

### Changes:

- Puts revs into killableMonsters where they belong
- Adjust effectiveMonsters, etc, accordingly

### Other checks:

- [x] I have tested all my changes thoroughly.
