### PR TITLE
Add tertiary toggle for /finish

### DIFF
--- a/src/lib/workers/finish.worker.ts
+++ b/src/lib/workers/finish.worker.ts
@@ -1,23 +1,30 @@
 import '../data/itemAliases';
 
+import { removeFromArr } from 'e';
 import { Bank } from 'oldschooljs';
 
 import getOSItem from '../util/getOSItem';
 import type { FinishWorkerArgs, FinishWorkerReturn } from '.';
 
-export default async ({ name }: FinishWorkerArgs): FinishWorkerReturn => {
+export default async ({ name, tertiaries }: FinishWorkerArgs): FinishWorkerReturn => {
 	const { finishables } = await import('../finishables');
 	const val = finishables.find(i => i.name === name)!;
+	let finishCL = [...val.cl];
+	if (val.tertiaryDrops && !tertiaries) {
+		for (const { itemId } of val.tertiaryDrops) {
+			finishCL = removeFromArr(finishCL, itemId);
+		}
+	}
 	let loot = new Bank();
 	const kcBank = new Bank();
 	let kc = 0;
 	const maxAttempts = val.maxAttempts ?? 100_000;
 	for (let i = 0; i < maxAttempts; i++) {
-		if (val.cl.every(id => loot.has(id))) break;
+		if (finishCL.every(id => loot.has(id))) break;
 		kc++;
 		const thisLoot = val.kill({ accumulatedLoot: loot, totalRuns: i });
 
-		if (val.tertiaryDrops) {
+		if (tertiaries && val.tertiaryDrops) {
 			for (const drop of val.tertiaryDrops) {
 				if (kc === drop.kcNeeded) {
 					thisLoot.add(drop.itemId);
@@ -25,11 +32,11 @@ export default async ({ name }: FinishWorkerArgs): FinishWorkerReturn => {
 			}
 		}
 
-		const purpleItems = thisLoot.items().filter(i => val.cl.includes(i[0].id) && !loot.has(i[0].id));
+		const purpleItems = thisLoot.items().filter(i => finishCL.includes(i[0].id) && !loot.has(i[0].id));
 		for (const p of purpleItems) kcBank.add(p[0].id, kc);
 		loot.add(thisLoot);
 		if (kc === maxAttempts) {
-			return `After ${maxAttempts.toLocaleString()} KC, you still didn't finish the CL, so we're giving up! Missing: ${val.cl
+			return `After ${maxAttempts.toLocaleString()} KC, you still didn't finish the CL, so we're giving up! Missing: ${finishCL
 				.filter(id => !loot.has(id))
 				.map(getOSItem)
 				.map(i => i.name)

--- a/src/lib/workers/index.ts
+++ b/src/lib/workers/index.ts
@@ -29,6 +29,7 @@ export type KillWorkerReturn = Promise<{
 
 export interface FinishWorkerArgs {
 	name: string;
+	tertiaries?: boolean;
 }
 
 export type FinishWorkerReturn = Promise<
@@ -48,6 +49,6 @@ export const casketWorker = new Piscina({ filename: resolve(__dirname, 'casket.w
 
 export const Workers = {
 	casketOpen: (args: CasketWorkerArgs): Promise<[Bank, string]> => casketWorker.run(args),
-	kill: (args: KillWorkerArgs): Promise<KillWorkerReturn> => killWorker.run(args),
-	finish: (args: FinishWorkerArgs): Promise<FinishWorkerReturn> => finishWorker.run(args)
+	kill: (args: KillWorkerArgs): KillWorkerReturn => killWorker.run(args),
+	finish: (args: FinishWorkerArgs): FinishWorkerReturn => finishWorker.run(args)
 };

--- a/src/mahoji/commands/finish.ts
+++ b/src/mahoji/commands/finish.ts
@@ -24,15 +24,22 @@ export const finishCommand: OSBMahojiCommand = {
 					.filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())))
 					.map(i => ({ name: i.name, value: i.name }));
 			}
+		},
+		{
+			type: ApplicationCommandOptionType.Boolean,
+			name: 'tertiaries',
+			description: 'Whether or not to include Tertiaries (e.g. capes)',
+			required: false
 		}
 	],
-	run: async ({ interaction, options }: CommandRunOptions<{ input: string }>) => {
+	run: async ({ interaction, options }: CommandRunOptions<{ input: string; tertiaries?: boolean }>) => {
 		await deferInteraction(interaction);
+		const { input: finishable, tertiaries } = options;
 		const val = finishables.find(
-			i => stringMatches(i.name, options.input) || i.aliases?.some(alias => stringMatches(alias, options.input))
+			i => stringMatches(i.name, finishable) || i.aliases?.some(alias => stringMatches(alias, finishable))
 		);
 		if (!val) return "That's not a valid thing you can simulate finishing.";
-		const workerRes = await Workers.finish({ name: val.name });
+		const workerRes = await Workers.finish({ name: val.name, tertiaries });
 		if (typeof workerRes === 'string') return workerRes;
 		const { kc } = workerRes;
 		const kcBank = new Bank(workerRes.kcBank);


### PR DESCRIPTION
### Description:

- Adds `tertiary` toggle for finish, which automatically removes tertiary items from /finish if they're undesired

### Changes:

- Adds tertiary toggle
- Removes redundant  Promise<>'s around worker return types

### Other checks:

- [x] I have tested all my changes thoroughly.
