### PR TITLE
Fix BSO specific ToB Finishable Bug

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -532,7 +532,7 @@ export const chambersOfXericCL = resolveItems([
 	"Xeric's general",
 	"Xeric's champion"
 ]);
-const theatreOfBloodCapes = resolveItems([
+export const theatreOfBloodCapes = resolveItems([
 	'Sinhaza shroud tier 1',
 	'Sinhaza shroud tier 2',
 	'Sinhaza shroud tier 3',

--- a/src/lib/finishables.ts
+++ b/src/lib/finishables.ts
@@ -7,7 +7,7 @@ import EliteClueTable from 'oldschooljs/dist/simulation/clues/Elite';
 import HardClueTable from 'oldschooljs/dist/simulation/clues/Hard';
 import MasterCasket from 'oldschooljs/dist/simulation/clues/Master';
 import MediumClueTable from 'oldschooljs/dist/simulation/clues/Medium';
-import { ChambersOfXeric, Nightmare, TheatreOfBlood } from 'oldschooljs/dist/simulation/misc';
+import { ChambersOfXeric, Nightmare } from 'oldschooljs/dist/simulation/misc';
 import { EliteMimicTable, MasterMimicTable } from 'oldschooljs/dist/simulation/misc/Mimic';
 
 import { rollNaxxusLoot } from '../tasks/minions/bso/naxxusActivity';
@@ -27,7 +27,9 @@ import {
 	nexCL,
 	nexUniqueDrops,
 	temporossCL,
-	theatreOfBLoodCL,
+	theatreOfBloodCapes,
+	theatreOfBloodHardUniques,
+	theatreOfBloodNormalUniques,
 	theGauntletCL,
 	theNightmareCL,
 	theNightmareNormalCL,
@@ -41,6 +43,7 @@ import { openShadeChest } from './shadesKeys';
 import { birdsNestID, treeSeedsNest } from './simulation/birdsNest';
 import { gauntlet } from './simulation/gauntlet';
 import { getTemporossLoot } from './simulation/tempoross';
+import { TheatreOfBlood } from './simulation/tob';
 import { WintertodtCrate } from './simulation/wintertodt';
 import getOSItem from './util/getOSItem';
 import itemID from './util/itemID';
@@ -89,7 +92,7 @@ export const finishables: Finishable[] = [
 	{
 		name: 'Theatre of Blood (Solo, Non-HM)',
 		aliases: ['tob', 'theatre of blood'],
-		cl: theatreOfBLoodCL,
+		cl: [...theatreOfBloodNormalUniques, ...theatreOfBloodCapes],
 		kill: () => new Bank(TheatreOfBlood.complete({ hardMode: false, team: [{ id: '1', deaths: [] }] }).loot['1']),
 		tertiaryDrops: [
 			{ itemId: itemID('Sinhaza shroud tier 1'), kcNeeded: 100 },
@@ -102,7 +105,7 @@ export const finishables: Finishable[] = [
 	{
 		name: 'Theatre of Blood (Solo, HM)',
 		aliases: ['tob hard', 'tob hard mode', 'tobhm'],
-		cl: theatreOfBLoodCL,
+		cl: [...theatreOfBloodNormalUniques, ...theatreOfBloodCapes, ...theatreOfBloodHardUniques],
 		kill: () => new Bank(TheatreOfBlood.complete({ hardMode: true, team: [{ id: '1', deaths: [] }] }).loot['1']),
 		tertiaryDrops: [
 			{ itemId: itemID('Sinhaza shroud tier 1'), kcNeeded: 100 },


### PR DESCRIPTION
### Description:

Fixes bug where tob + tobhm cannot be /finish'd because they're calling the osjs version of the sim, which doesn't support solo mode

### Changes:

- Fixes the import to use the bot-version of ToB sim
- Fixes the ToB normal mode CL (removes HM uniques
- Fixes ToB hard mode CL (removes metamorphs)

### Other checks:

- [x] I have tested all my changes thoroughly.
