### PR TITLE
Fix cox mass return message

### DIFF
--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -231,6 +231,8 @@ export const raidsTask: MinionTask = {
 			});
 
 			handleTripFinish(allUsers[0], channelID, resultMessage, attachment, data, null);
+		} else {
+			handleTripFinish(allUsers[0], channelID, resultMessage, attachment, data, null);
 		}
 	}
 };


### PR DESCRIPTION
### Description:
Fixes the cox return message for 4 or more users on a mass

### Changes:
add a third handleTripFinish to ensure solo raid, 2-3 mass raid, and 4+ mass raid are handled properly.

### Other checks:

- [X] I have tested all my changes thoroughly.
