### PR TITLE
Add guthix rest potions

### DIFF
--- a/src/lib/minions/data/potions.ts
+++ b/src/lib/minions/data/potions.ts
@@ -38,6 +38,10 @@ const Potions = [
 		items: resolveItems(['Serum 207(1)', 'Serum 207(2)', 'Serum 207(3)', 'Serum 207(4)'])
 	},
 	{
+		name: 'Guthix rest',
+		items: resolveItems(['Guthix rest(1)', 'Guthix rest(2)', 'Guthix rest(3)', 'Guthix rest(4)'])
+	},
+	{
 		name: 'Compost potion',
 		items: resolveItems(['Compost potion(1)', 'Compost potion(2)', 'Compost potion(3)', 'Compost potion(4)'])
 	},

--- a/src/lib/skilling/skills/herblore/mixables/potions.ts
+++ b/src/lib/skilling/skills/herblore/mixables/potions.ts
@@ -44,6 +44,21 @@ const Potions: Mixable[] = [
 		bankTimePerPotion: 0.3
 	},
 	{
+		item: getOSItem('Guthix rest (3)'),
+		aliases: ['guthix rest (3)', 'guthix rest'],
+		level: 18,
+		xp: 59,
+		inputItems: new Bank({
+			'Cup of hot water': 1,
+			'Guam leaf': 1,
+			Harralander: 1,
+			Marrentill: 1
+		}),
+		tickRate: 2,
+		bankTimePerPotion: 1.5,
+		zahur: false
+	},
+	{
 		item: getOSItem('Compost potion (3)'),
 		aliases: ['compost potion (3)', 'compost potion', 'compost'],
 		level: 22,


### PR DESCRIPTION
Adds decanting and making of guthix rest potions, ensured zahur doesn't work as per the wiki. 
Closes #5408

- [x] I have tested all my changes thoroughly.
