### PR TITLE
Fix "Monster Drop" box spawn

### DIFF
--- a/src/lib/boxSpawns.ts
+++ b/src/lib/boxSpawns.ts
@@ -124,19 +124,22 @@ const createdChallenge: Challenge = async (msg: Message): Promise<User | null> =
 		return null;
 	}
 };
-const monsters = [...Object.values(BSOMonsters), ...killableMonsters].map(i => {
-	let allItems = [];
-	if (i.table instanceof LootTable) {
-		allItems = i.table.allItems;
-	} else {
-		allItems = Monsters.get(i.id)!.allItems;
-	}
+const monsters = [...Object.values(BSOMonsters), ...killableMonsters]
+	.map(i => {
+		let allItems = [];
+		if (i.table instanceof LootTable) {
+			allItems = i.table.allItems;
+		} else {
+			allItems = Monsters.get(i.id)!.allItems;
+		}
 
-	return {
-		name: i.name,
-		allItems
-	};
-});
+		return {
+			name: i.name,
+			allItems
+		};
+	})
+	.filter(m => m.allItems.length >= 3);
+
 const monsterDropChallenge: Challenge = async (msg: Message): Promise<User | null> => {
 	let monster = randArrItem(monsters);
 


### PR DESCRIPTION
### Description:

- Fixes the 'name a monster that drops these 3 items' box spawns.
- Previously, it could choose a monster with no drops, and accepts any monster as the correct answer.
- Also it could have just a single drop, like bones or ashes, and then any monster that drops bones is accepted.

### Changes:

- Limits monster pool to monsters that have at least 3 items on their drop table.

### Other checks:

- [ ] I have tested all my changes thoroughly.
