### PR TITLE
Adds 'Elder logs' subtext on bank image

### DIFF
--- a/src/lib/bankImage.ts
+++ b/src/lib/bankImage.ts
@@ -231,7 +231,8 @@ const forcedShortNameMap = new Map<number, string>([
 	[i('Mahogany logs'), 'Mahog'],
 	[i('Yew logs'), 'Yew'],
 	[i('Magic logs'), 'Magic'],
-	[i('Redwood logs'), 'Redwood']
+	[i('Redwood logs'), 'Redwood'],
+	[i('Elder logs'), 'Elder']
 ]);
 
 function drawTitle(ctx: SKRSContext2D, title: string, canvas: Canvas) {


### PR DESCRIPTION
Added bank images name "Elder" to the logs.

### Description: The subtext describing the type of logs in the bank was missing for Elder logs.
### Before edit:
![SmartSelect_20231102_095045_Discord](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/a5a15f7c-6aaf-46da-bdfe-881c706f70d7)
### after edit:
![file-4](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/5b25aed0-f70d-46e9-880a-09c9aaba1ef0)


### Changes: Added Elder logs to the logs list

- Adds 'Elder logs' to the list of items that get text hints

### Other checks:

- [x] I have tested all my changes thoroughly.
