### PR TITLE
Adds subtext to certain items in bank image

### DIFF
--- a/src/lib/bankImage.ts
+++ b/src/lib/bankImage.ts
@@ -345,7 +345,7 @@ class BankImageTask {
 				for (const fileName of filesInThisDir) {
 					const themedItemID = parseInt(path.parse(fileName).name);
 					const image = await loadImage(
-						`./src/lib/resources/images/icon_packs/${pack.id}_${BOT_TYPE.toLowerCase()}/${fileName}`
+						`./src/lib/resources/images/icon_packs/${pack.id}_${dir}/${fileName}`
 					);
 					pack.icons.set(themedItemID, image);
 				}

--- a/src/lib/minions/functions/unequipAllCommand.ts
+++ b/src/lib/minions/functions/unequipAllCommand.ts
@@ -4,12 +4,16 @@ import { Bank } from 'oldschooljs';
 import { GearSetupType, GearSetupTypes } from '../../gear/types';
 import { defaultGear } from '../../structures/Gear';
 
-export async function unEquipAllCommand(userID: string, gearType: GearSetupType | undefined): Promise<string> {
+export async function unEquipAllCommand(
+	userID: string,
+	gearType: GearSetupType | undefined,
+	bypassBusy?: boolean
+): Promise<string> {
 	if (!gearType || !GearSetupTypes.includes(gearType)) {
 		return `That's not a valid setup, the valid setups are: ${GearSetupTypes.join(', ')}.`;
 	}
 	const user = await mUserFetch(userID);
-	if (user.minionIsBusy) {
+	if (!bypassBusy && user.minionIsBusy) {
 		return `${user.minionName} is currently out on a trip, so you can't change their gear!`;
 	}
 	const currentEquippedGear = user.gear[gearType];


### PR DESCRIPTION
### Description:

- Tiny, small, average, large & huge lamps to display xp value on bank image
- the uncharged sanguinesti staff and Scythe of vitur will have subtext displaying so.

### Changes:

- added a new section for XP Lamps adding the xp value as subtext for each lamp.
- added `uncharged` to the uncharged versions of sanguinesti staff & Scythe of vitur.
- added JMod to the Scythe of vitur (JMod) to easily tell it apart from the rest.
![bank-5.jpg](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/fb9c69de-eb2e-4cf1-9019-20aa4d4fe350)



### Other checks:

- [ ] I have tested all my changes thoroughly.
