### PR TITLE
Fix CA ID 220 having wrong monster

### DIFF
--- a/src/lib/combat_achievements/hard.ts
+++ b/src/lib/combat_achievements/hard.ts
@@ -241,7 +241,7 @@ export const hardCombatAchievements: CombatAchievement[] = [
 		id: 220,
 		name: 'Why Are You Running?',
 		type: 'mechanical',
-		monster: 'General Graardor',
+		monster: 'Giant Mole',
 		desc: 'Kill the Giant Mole without her burrowing more than 2 times.',
 		rng: {
 			chancePerKill: 20,


### PR DESCRIPTION
### Description:

CA ID 220 is categorized as a General Graardor CA, but should be a Giant Mole CA.

### Changes:

Updated the monster field to be Giant Mole so it sorts properly.

### Other checks:

- [ ] I have tested all my changes thoroughly.
