### PR TITLE
Wilderness Trip Vanishing Fix

### DIFF
--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -115,7 +115,7 @@ export const monsterTask: MinionTask = {
 						gear_wildy: calc.newGear as Prisma.InputJsonObject
 					});
 				} else {
-					await user.specialRemoveItems(calc.lostItems);
+					await user.specialRemoveItems(calc.lostItems, { wildy: monster.wildy ? true : false });
 					reEquipedItems = true;
 				}
 


### PR DESCRIPTION
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5510
Temporary fix: Don't use any ammo or leave the ammo slot blank in the wildy setup. Use a blessing and the trip won't error and vanish

### Description:
Fixes a bug where if you get pked on a wilderness trip your trip return vanishes.

### Changes:
-Pass in a wilderness monster check to specialRemoveItems to look at the proper ammo slot.

### Other checks:
- [X] I have tested all my changes thoroughly.
