### PR TITLE
Speed Combat Achievments

### DIFF
--- a/src/lib/combat_achievements/grandmaster.ts
+++ b/src/lib/combat_achievements/grandmaster.ts
@@ -1,3 +1,4 @@
+import { Time } from 'e';
 import { Monsters } from 'oldschooljs';
 
 import { PHOSANI_NIGHTMARE_ID } from '../constants';
@@ -933,8 +934,8 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		desc: 'Complete the Inferno in less than 65 minutes.',
 		type: 'speed',
 		monster: 'TzKal-Zuk',
-		rng: {
-			chancePerKill: 15,
+		time: {
+			maxTimeAllowed: Time.Minute * 65,
 			hasChance: 'Inferno'
 		}
 	},


### PR DESCRIPTION
### Description:
- Make speed combat achievements use trip time instead of rng.

### Changes:
- Create a new check for speed CA that use trip duration.
- Only 1 speed CA is currently changed as an example.

### Other checks:
- [X] I have tested all my changes thoroughly.
- In testing I did about 100+ infernos and still couldn't get lower than 90 minutes. Maybe some re-balancing is needed for certain trips before something like this can be utilized properly. 
