### PR TITLE
Hard CA imbue reward & task 254 fix

### DIFF
--- a/src/lib/combat_achievements/hard.ts
+++ b/src/lib/combat_achievements/hard.ts
@@ -629,7 +629,7 @@ export const hardCombatAchievements: CombatAchievement[] = [
 		id: 254,
 		name: 'Confident Raider',
 		type: 'restriction',
-		monster: 'Theatre of Blood: Entry Mode',
+		monster: 'Tombs of Amascut: Entry Mode',
 		desc: 'Complete a Tombs of Amascut raid at level 100 or above.',
 		requirements: new Requirements().add({
 			minigames: {

--- a/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
@@ -480,5 +480,7 @@ export async function nightmareZoneImbueCommand(user: MUser, input = '') {
 		itemsToRemove: cost,
 		collectionLog: true
 	});
-	return `Added ${loot} to your bank, removed ${imbueCost}x Nightmare Zone points and ${cost}.`;
+	return `Added ${loot} to your bank, removed ${imbueCost}x Nightmare Zone points and ${cost}.${
+		user.hasCompletedCATier('hard') ? ' 50% off for having completed the Hard Tier of the Combat Achievement.' : ''
+	}`;
 }

--- a/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
@@ -412,10 +412,6 @@ export async function nightmareZoneShopCommand(
 	}
 
 	let costPerItem = shopItem.cost;
-	if (user.hasCompletedCATier('hard')) {
-		costPerItem /= 2;
-	}
-
 	const cost = quantity * costPerItem;
 	if (cost > currentUserPoints) {
 		return `You don't have enough Nightmare Zone points to buy ${quantity.toLocaleString()}x ${
@@ -459,9 +455,13 @@ export async function nightmareZoneImbueCommand(user: MUser, input = '') {
 			.map(i => i.input.name)
 			.join(', ')}.`;
 	}
+	let imbueCost = item.points;
+	if (user.hasCompletedCATier('hard')) {
+		imbueCost /= 2;
+	}
 	const bal = user.user.nmz_points;
-	if (bal < item.points) {
-		return `You don't have enough Nightmare Zone points to imbue a ${item.input.name}. You have ${bal} but need ${item.points}.`;
+	if (bal < imbueCost) {
+		return `You don't have enough Nightmare Zone points to imbue a ${item.input.name}. You have ${bal} but need ${imbueCost}.`;
 	}
 	const { bank } = user;
 	if (!bank.has(item.input.id)) {
@@ -469,7 +469,7 @@ export async function nightmareZoneImbueCommand(user: MUser, input = '') {
 	}
 	await user.update({
 		nmz_points: {
-			decrement: item.points
+			decrement: imbueCost
 		}
 	});
 	const cost = new Bank().add(item.input.id);
@@ -480,5 +480,5 @@ export async function nightmareZoneImbueCommand(user: MUser, input = '') {
 		itemsToRemove: cost,
 		collectionLog: true
 	});
-	return `Added ${loot} to your bank, removed ${item.points}x Nightmare Zone points and ${cost}.`;
+	return `Added ${loot} to your bank, removed ${imbueCost}x Nightmare Zone points and ${cost}.`;
 }

--- a/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
@@ -186,7 +186,12 @@ export async function soulWarsImbueCommand(user: MUser, input = '') {
 			.join(', ')}.`;
 	}
 	const bal = user.user.zeal_tokens;
-	if (bal < item.tokens) {
+
+	let imbueCost = item.tokens;
+	if (user.hasCompletedCATier('hard')) {
+		imbueCost /= 2;
+	}
+	if (bal < imbueCost) {
 		return `You don't have enough Zeal Tokens to imbue a ${item.input.name}. You have ${bal} but need ${item.tokens}.`;
 	}
 	const { bank } = user;
@@ -195,7 +200,7 @@ export async function soulWarsImbueCommand(user: MUser, input = '') {
 	}
 	await user.update({
 		zeal_tokens: {
-			decrement: item.tokens
+			decrement: imbueCost
 		}
 	});
 	const cost = new Bank().add(item.input.id);
@@ -206,5 +211,5 @@ export async function soulWarsImbueCommand(user: MUser, input = '') {
 		itemsToRemove: cost,
 		collectionLog: true
 	});
-	return `Added ${loot} to your bank, removed ${item.tokens}x Zeal Tokens and ${cost}.`;
+	return `Added ${loot} to your bank, removed ${imbueCost}x Zeal Tokens and ${cost}.`;
 }

--- a/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
@@ -185,14 +185,13 @@ export async function soulWarsImbueCommand(user: MUser, input = '') {
 			.map(i => i.input.name)
 			.join(', ')}.`;
 	}
-	const bal = user.user.zeal_tokens;
-
 	let imbueCost = item.tokens;
 	if (user.hasCompletedCATier('hard')) {
 		imbueCost /= 2;
 	}
+	const bal = user.user.zeal_tokens;
 	if (bal < imbueCost) {
-		return `You don't have enough Zeal Tokens to imbue a ${item.input.name}. You have ${bal} but need ${item.tokens}.`;
+		return `You don't have enough Zeal Tokens to imbue a ${item.input.name}. You have ${bal} but need ${imbueCost}.`;
 	}
 	const { bank } = user;
 	if (!bank.has(item.input.id)) {
@@ -211,5 +210,7 @@ export async function soulWarsImbueCommand(user: MUser, input = '') {
 		itemsToRemove: cost,
 		collectionLog: true
 	});
-	return `Added ${loot} to your bank, removed ${imbueCost}x Zeal Tokens and ${cost}.`;
+	return `Added ${loot} to your bank, removed ${imbueCost}x Zeal Tokens and ${cost}.${
+		user.hasCompletedCATier('hard') ? ' 50% off for having completed the Hard Tier of the Combat Achievement.' : ''
+	}`;
 }

--- a/src/tasks/minions/minigames/soulWarsActivity.ts
+++ b/src/tasks/minions/minigames/soulWarsActivity.ts
@@ -40,7 +40,7 @@ export const soulWarsTask: MinionTask = {
 
 		await incrementMinigameScore(user.id, 'soul_wars', quantity);
 
-		const str = `${user}, ${user.minionName} finished doing ${quantity}x games of Soul Wars, you received ${points} Zeal Tokens, you now have ${user.user.zeal_tokens}.\n\n`;
+		const str = `${user}, ${user.minionName} finished doing ${quantity}x games of Soul Wars, you received ${points} Zeal Tokens, you now have ${user.user.zeal_tokens}.\n`;
 
 		handleTripFinish(user, channelID, str, undefined!, data, null);
 	}


### PR DESCRIPTION
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5345
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5522

### Description:
- Fix Hard Combat Achievement imbue reward
Source: https://oldschool.runescape.wiki/w/Combat_Achievements/Hard#Rewards

### Changes:
- Apply hard CA reward to Nightmare zone imbue price not shop price.
- Add hard CA reward to soul wars halving imbue cost.
- Add message for each about the 50% discount.
- Remove extra /n from soul wars return message.
- Fix task 254 using the wrong monster filter

### Other checks:
- [X] I have tested all my changes thoroughly.
