### PR TITLE
Always show item names when opening

### DIFF
--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -115,7 +115,8 @@ async function finalizeOpening({
 				? `Loot from ${cost.amount(openables[0].openedItem.id)}x ${openables[0].name}`
 				: 'Loot From Opening',
 		user,
-		previousCL
+		previousCL,
+		mahojiFlags: ['show_names']
 	});
 
 	if (loot.has('Coins')) {


### PR DESCRIPTION
### Description:

Always use show_names flag when opening items

### Changes:

- Adds 'show_names' flag by default to the open command's makeBankImage call

### Other checks:

- [x] I have tested all my changes thoroughly.
