### PR TITLE
Add Mr E bonus to /tames cast 

### DIFF
--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -801,6 +801,8 @@ export async function runTameTask(activity: TameActivity, tame: Tame) {
 				.items()
 				.map(([item, qty]) => `${Math.floor(calcPerHour(qty, activity.duration)).toFixed(1)}/hr ${item.name}`)
 				.join(', ')}`;
+			const { doubleLootMsg } = doubleLootCheck(tame, loot);
+			str += doubleLootMsg;
 			const { itemsAdded } = await user.addItemsToBank({ items: loot, collectionLog: false });
 			handleFinish({
 				loot: itemsAdded,


### PR DESCRIPTION
### Description:
Community poll shows support for adding Mr E. bonus to /tames cast
![Discord_0HFnAwhgYl](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/c40d6123-8c5b-43d3-b3a8-dd4c5c933f31)
https://discord.com/channels/342983479501389826/1032668754561224734/1174844072255565944

### Changes:
- Adds the 1/12 chance to double loot when monkey tame is casting spells (if the user has feed a Mr E. to their tame)

### Other checks:
- [X] I have tested all my changes thoroughly.
![Discord_yg2N3mCoer](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/27361b59-7cd0-4cfb-bf23-eb5daf9b45dc)
https://discord.com/channels/940758552425955348/1162793245194072074/1178588420205973525


