### PR TITLE
Properly check item requirments for gear presets

### DIFF
--- a/src/mahoji/lib/abstracted_commands/gearCommands.ts
+++ b/src/mahoji/lib/abstracted_commands/gearCommands.ts
@@ -40,6 +40,18 @@ export async function gearPresetEquipCommand(user: MUser, gearSetup: string, pre
 	}
 	const preset = (userPreset ?? globalPreset) as GearPreset;
 
+	// Checks the preset to make sure the user has the required stats for every item in the preset
+	for (const gearItemId of Object.values(preset)) {
+		if (gearItemId !== null) {
+			const itemToEquip = getItem(gearItemId);
+			if (itemToEquip?.equipment?.requirements && !user.hasSkillReqs(itemToEquip.equipment.requirements)) {
+				return `You can't equip this preset because ${
+					itemToEquip.name
+				} requires these stats: ${formatSkillRequirements(itemToEquip.equipment.requirements)}.`;
+			}
+		}
+	}
+
 	const toRemove = new Bank();
 	function gearItem(val: null | number) {
 		if (val === null) return null;


### PR DESCRIPTION
closes: https://github.com/oldschoolgg/oldschoolbot/issues/4613
closes: https://github.com/oldschoolgg/oldschoolbot/issues/4784
closes: https://github.com/oldschoolgg/oldschoolbot/issues/2684

### Description:
Currently there is no requirement check for items that are inside a preset. Example: user with level 1 combat stats creates a preset with a Hellfire Bow which requires 110 range. The user then equips the preset which negates the 110 range requirement.

### Changes:
- Add a check to gear presets that prevents users equipping gear they don't have the requirements for. This still allows for users to create a preset with zero restrictions, this only restricts equipping the preset.

### Other checks:
- [X] I have tested all my changes thoroughly.
