### PR TITLE
Add Lava scale shard to /mix

### DIFF
--- a/src/lib/skilling/skills/herblore/mixables/crush.ts
+++ b/src/lib/skilling/skills/herblore/mixables/crush.ts
@@ -91,6 +91,16 @@ const Crush: Mixable[] = [
 		wesley: true
 	},
 	{
+		item: getOSItem('Lava scale shard'),
+		aliases: ['lava dragon scale', 'lava dragon dust', 'lava dragon', 'lava shard'],
+		level: 1,
+		xp: 0,
+		inputItems: new Bank({ 11_992: 1 }),
+		tickRate: 1,
+		bankTimePerPotion: 0,
+		wesley: true
+	},
+	{
 		item: getOSItem('Nihil Dust'),
 		aliases: ['nihil dust', 'nihil shard', 'nihil'],
 		level: 1,

--- a/src/lib/skilling/skills/herblore/mixables/crush.ts
+++ b/src/lib/skilling/skills/herblore/mixables/crush.ts
@@ -95,7 +95,7 @@ const Crush: Mixable[] = [
 		aliases: ['lava dragon scale', 'lava dragon dust', 'lava dragon', 'lava shard'],
 		level: 1,
 		xp: 0,
-		inputItems: new Bank({ 11_992: 1 }),
+		inputItems: new Bank({ 'Lava scale': 1 }),
 		tickRate: 1,
 		bankTimePerPotion: 0,
 		wesley: true

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -250,6 +250,7 @@ export interface HerbloreActivityTaskOptions extends ActivityTaskOptions {
 	mixableID: number;
 	quantity: number;
 	zahur: boolean;
+	wesley: boolean;
 }
 
 export interface CutLeapingFishActivityTaskOptions extends ActivityTaskOptions {

--- a/src/mahoji/commands/mix.ts
+++ b/src/mahoji/commands/mix.ts
@@ -118,6 +118,7 @@ export const mixCommand: OSBMahojiCommand = {
 			userID: user.id,
 			channelID: channelID.toString(),
 			zahur: Boolean(zahur),
+			wesley: Boolean(wesley),
 			quantity,
 			duration: quantity * timeToMixSingleItem,
 			type: 'Herblore'

--- a/src/tasks/minions/herbloreActivity.ts
+++ b/src/tasks/minions/herbloreActivity.ts
@@ -6,6 +6,7 @@ import Herblore from '../../lib/skilling/skills/herblore/herblore';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { HerbloreActivityTaskOptions } from '../../lib/types/minions';
 import { percentChance } from '../../lib/util';
+import getOSItem from '../../lib/util/getOSItem';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
 export const herbloreTask: MinionTask = {
@@ -17,21 +18,21 @@ export const herbloreTask: MinionTask = {
 		const xpReceived = zahur && mixableItem.zahur ? 0 : quantity * mixableItem.xp;
 		let outputQuantity = mixableItem.outputMultiple ? quantity * mixableItem.outputMultiple : quantity;
 
-		// Special case for Lava scale shard(11_994)
-		if (mixableID === 11_994) {
+		// Special case for Lava scale shard
+		if (mixableItem.item === getOSItem('Lava scale shard')) {
 			const [hasWildyDiary] = await userhasDiaryTier(user, WildernessDiary.hard);
 			const currentHerbLevel = user.skillLevel(SkillsEnum.Herblore);
 			let scales = 0;
 			// Having 99 herblore gives a 98% chance to recieve the max amount of shards
 			let maxShardChance = currentHerbLevel >= 99 ? 98 : 0;
-			// Completion of hard wilderness diary gives the user 50% more shards per dragon scale, rounded down
+			// Completion of hard wilderness diary gives 50% more lava scale shards per lava scale, rounded down
 			let diaryMultiplier = hasWildyDiary ? 1.5 : 1;
 
-			if (wesley) {
+			if (Boolean(wesley)) {
 				// Wesley always turns Lava scales into 3 lava scale shards
 				scales = quantity * 3;
 			} else {
-				// Math for if the user is using their minion to make the scales
+				// Math for if the user is using their minion to make lava scale shards
 				for (let i = 0; i < quantity; i++) {
 					scales += Math.floor((percentChance(maxShardChance) ? 6 : randInt(3, 6)) * diaryMultiplier);
 				}


### PR DESCRIPTION
### Description:
- Add Lava scale shards to /mix with the proper multipliers
- Mixing one Lava scale results in 3-6 lava scale shard
- If the user has 99 herblore there is a 98% chance the lava scale gives 6 shards
- If the user has completed the hard wilderness diary the scales are increased by 50% rounded down
- If the user uses wesley to mix their lava dragon scales the result will always be 3 shards per scale regardless of other multipliers

Source: https://oldschool.runescape.wiki/w/Lava_scale

### Changes:
- Add Lava scale shard to crush.ts
- Add wesley variable to interface HerbloreActivityTaskOptions (helps to properly calculate scales to give the user)
- Add the special code for lava dragon scale shards to herbloreActivity.ts

### Other checks:

- [ ] I have tested all my changes thoroughly.
