### PR TITLE
Make `/giveaway list` hidden

### DIFF
--- a/src/mahoji/commands/giveaway.ts
+++ b/src/mahoji/commands/giveaway.ts
@@ -273,7 +273,8 @@ export const giveawayCommand: OSBMahojiCommand = {
 							.slice(0, 30)
 							.join('\n')
 					)
-				]
+				],
+				ephemeral: true
 			};
 		}
 	}


### PR DESCRIPTION
### Description:
- `/giveaway list` creates alot of spam in the server general chats. Make `/giveaway list` only viewable to the user who used the command.
- Community poll here: https://discord.com/channels/342983479501389826/1032668754561224734/1184130834320592896
![Discord_PhBZM3KypI](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/3d1a50fd-f632-4ac5-9486-c9d5557d6d32)


### Changes:
- Add `ephemeral: true` to giveaway list code 

### Other checks:
- [X] I have tested all my changes thoroughly.

![Discord_df9vyuI1Nf](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/8ae98b84-a005-4dfe-9aaf-fded48ae5bae)

