### PR TITLE
Inactive subtext

### DIFF
--- a/src/lib/bankImage.ts
+++ b/src/lib/bankImage.ts
@@ -227,12 +227,14 @@ const forcedShortNameMap = new Map<number, string>([
 	[i('Redwood logs'), 'Redwood'],
 	...XPLamps.map(lamp => [lamp.itemID, toKMB(lamp.amount)] as const),
 
-	// Uncharged
+	// Uncharged & Inactive
 	[i('Holy sanguinesti staff (uncharged)'), 'Unch.'],
 	[i('Sanguinesti staff (uncharged)'), 'Unch.'],
 	[i('Scythe of vitur (uncharged)'), 'Unch.'],
 	[i('Holy scythe of vitur (uncharged)'), 'Unch.'],
-	[i('Sanguine scythe of vitur (uncharged)'), 'Unch.']
+	[i('Sanguine scythe of vitur (uncharged)'), 'Unch.'],
+	[i('Blade of saeldor (inactive)'), 'Inact.'],
+	[i('Bow of faerdhinen (inactive)'), 'Inact.']
 ]);
 
 function drawTitle(ctx: SKRSContext2D, title: string, canvas: Canvas) {


### PR DESCRIPTION
for blade of saeldor + bow of faerdhinen (inactive)

### Description:

addeded Inact. subtext to blade of saeldor (inactive) & bow of faerdhinen (inactive)

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [ ] I have tested all my changes thoroughly.
