### PR TITLE
Let /clue activity get more clues from impling jars. (Longer trips)

### DIFF
--- a/src/lib/clues/clueTiers.ts
+++ b/src/lib/clues/clueTiers.ts
@@ -8,6 +8,7 @@ import { MasterCasket, MasterClueTable } from 'oldschooljs/dist/simulation/clues
 import { MediumCasket, MediumClueTable } from 'oldschooljs/dist/simulation/clues/Medium';
 
 import itemID from '../util/itemID';
+import resolveItems from '../util/resolveItems';
 import { beginnerReqs, ClueReqs } from './clueReqs';
 import {
 	beginnerStashes,
@@ -37,6 +38,7 @@ export interface ClueTier {
 	allItems: number[];
 	stashUnits: StashUnitTier;
 	reqs: ClueReqs;
+	implings?: number[];
 }
 
 export const ClueTiers: ClueTier[] = [
@@ -49,7 +51,8 @@ export const ClueTiers: ClueTier[] = [
 		mimicChance: false,
 		allItems: BeginnerClueTable.allItems,
 		stashUnits: beginnerStashes,
-		reqs: beginnerReqs
+		reqs: beginnerReqs,
+		implings: resolveItems(['Baby impling jar', 'Young impling jar'])
 	},
 	{
 		name: 'Easy',
@@ -64,7 +67,8 @@ export const ClueTiers: ClueTier[] = [
 		mimicChance: false,
 		allItems: EasyClueTable.allItems,
 		stashUnits: easyStashes,
-		reqs: beginnerReqs
+		reqs: beginnerReqs,
+		implings: resolveItems(['Baby impling jar', 'Young impling jar', 'Gourmet impling jar'])
 	},
 	{
 		name: 'Medium',
@@ -79,7 +83,8 @@ export const ClueTiers: ClueTier[] = [
 		mimicChance: false,
 		allItems: MediumClueTable.allItems,
 		stashUnits: mediumStashes,
-		reqs: beginnerReqs
+		reqs: beginnerReqs,
+		implings: resolveItems(['Earth impling jar', 'Essence impling jar', 'Eclectic impling jar'])
 	},
 	{
 		name: 'Hard',
@@ -90,7 +95,8 @@ export const ClueTiers: ClueTier[] = [
 		mimicChance: false,
 		allItems: HardClueTable.allItems,
 		stashUnits: hardStashes,
-		reqs: beginnerReqs
+		reqs: beginnerReqs,
+		implings: resolveItems(['Nature impling jar', 'Magpie impling jar', 'Ninja impling jar'])
 	},
 	{
 		name: 'Elite',
@@ -105,7 +111,8 @@ export const ClueTiers: ClueTier[] = [
 		mimicChance: 35,
 		allItems: EliteClueTable.allItems,
 		stashUnits: eliteStashes,
-		reqs: beginnerReqs
+		reqs: beginnerReqs,
+		implings: resolveItems(['Crystal impling jar', 'Dragon impling jar'])
 	},
 	{
 		name: 'Master',

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -450,3 +450,17 @@ for (const openable of allOpenables) {
 }
 
 export const allOpenablesIDs = new Set(allOpenables.map(i => i.id));
+
+export function getOpenableLoot({
+	openable,
+	quantity,
+	user
+}: {
+	openable: UnifiedOpenable;
+	quantity: number;
+	user: MUser;
+}) {
+	return openable.output instanceof LootTable
+		? { bank: openable.output.roll(quantity), message: null }
+		: openable.output({ user, self: openable, quantity });
+}

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -137,6 +137,7 @@ export interface ClueActivityTaskOptions extends ActivityTaskOptions {
 
 	clueID: number;
 	quantity: number;
+	implingID?: number;
 }
 
 export interface FishingActivityTaskOptions extends ActivityTaskOptions {

--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -1,15 +1,16 @@
-import { randInt, Time } from 'e';
+import { notEmpty, randInt, Time } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank } from 'oldschooljs';
 import { Item, ItemBank } from 'oldschooljs/dist/meta/types';
 
 import { ClueTier, ClueTiers } from '../../lib/clues/clueTiers';
+import { allOpenables, getOpenableLoot } from '../../lib/openables';
 import { getPOHObject } from '../../lib/poh';
 import { ClueActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, isWeekend, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
-import getOSItem from '../../lib/util/getOSItem';
+import getOSItem, { getItem } from '../../lib/util/getOSItem';
 import { getPOH } from '../lib/abstracted_commands/pohCommand';
 import { OSBMahojiCommand } from '../lib/util';
 import { getMahojiBank, mahojiUsersSettingsFetch } from '../mahojiSettings';
@@ -72,13 +73,35 @@ export const clueCommand: OSBMahojiCommand = {
 			name: 'tier',
 			description: 'The clue you want to do.',
 			required: true,
-			autocomplete: async (_, user) => {
+			autocomplete: async (value, user) => {
 				const bank = getMahojiBank(await mahojiUsersSettingsFetch(user.id, { bank: true }));
-				return ClueTiers.map(i => ({ name: `${i.name} (${bank.amount(i.scrollID)}x Owned)`, value: i.name }));
+				return ClueTiers.map(i => ({
+					name: `${i.name} (${bank.amount(i.scrollID)}x Owned)`,
+					value: i.name
+				})).filter(i => !value || i.value.toLowerCase().includes(value));
+			}
+		},
+		{
+			type: ApplicationCommandOptionType.String,
+			name: 'implings',
+			description: 'Implings to use for multiple clues per trip.',
+			required: false,
+			autocomplete: async (value, user) => {
+				const allClueImps = ClueTiers.filter(t => t.name !== 'Beginner')
+					.map(i => i.implings)
+					.filter(notEmpty)
+					.flat()
+					.map(getItem)
+					.filter(notEmpty);
+				const bank = getMahojiBank(await mahojiUsersSettingsFetch(user.id, { bank: true }));
+				const hasClueImps = allClueImps.filter(imp => bank.has(imp.id));
+				return hasClueImps
+					.filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())))
+					.map(i => ({ name: `${i.name} (${bank.amount(i.id)} Owned)`, value: i.name }));
 			}
 		}
 	],
-	run: async ({ options, userID, channelID }: CommandRunOptions<{ tier: string }>) => {
+	run: async ({ options, userID, channelID }: CommandRunOptions<{ tier: string; implings?: string }>) => {
 		const user = await mUserFetch(userID);
 		let quantity = 1;
 
@@ -87,11 +110,21 @@ export const clueCommand: OSBMahojiCommand = {
 		);
 		if (!clueTier) return 'Invalid clue tier.';
 
+		const clueImpling = options.implings
+			? getItem(/^[0-9]+$/.test(options.implings) ? Number(options.implings) : options.implings)
+			: null;
+
+		if (options.implings) {
+			if (!clueImpling) return 'Invalid impling, please check you entry.';
+			if (!user.bank.has(clueImpling.id)) return `You don't have any ${clueImpling.name}s in your bank.`;
+			if (!clueTier.implings?.includes(clueImpling.id)) return `These clues aren't found in ${clueImpling.name}s`;
+		}
+
 		const boosts = [];
 
 		const stats = await user.fetchStats({ openable_scores: true });
 
-		const [timeToFinish, percentReduced] = reducedClueTime(
+		let [timeToFinish, percentReduced] = reducedClueTime(
 			clueTier,
 			(stats.openable_scores as ItemBank)[clueTier.id] ?? 1
 		);
@@ -109,10 +142,6 @@ export const clueCommand: OSBMahojiCommand = {
 				maxTripLength / timeToFinish
 			)}.`;
 		}
-
-		const cost = new Bank().add(clueTier.scrollID, quantity);
-		if (!user.owns(cost)) return `You don't own ${cost}.`;
-		await user.removeItemsFromBank(new Bank().add(clueTier.scrollID, quantity));
 
 		const randomAddedDuration = randInt(1, 20);
 		duration += (randomAddedDuration * duration) / 100;
@@ -288,10 +317,51 @@ export const clueCommand: OSBMahojiCommand = {
 		const boostList = clueTierBoosts[clueTierName];
 		const result = applyClueBoosts(user, boostList, boosts, duration, clueTier);
 
-		duration = result.duration;
+		timeToFinish = result.duration;
+
+		let implingLootString = '';
+		if (!clueImpling) {
+			const cost = new Bank().add(clueTier.scrollID, quantity);
+			if (!user.owns(cost)) return `You don't own ${cost}.`;
+			await user.removeItemsFromBank(new Bank().add(clueTier.scrollID, quantity));
+		} else {
+			const implingJarOpenable = allOpenables.find(o => o.aliases.some(a => stringMatches(a, clueImpling.name)));
+			// If this triggers, it means OSJS probably broke / is missing an alias for an impling jar:
+			if (!implingJarOpenable) return 'Invalid impling jar.';
+
+			const bankedClues = user.bank.amount(clueTier.scrollID);
+			const maxCanDo = Math.floor(maxTripLength / timeToFinish);
+			const bankedImplings = user.bank.amount(clueImpling.id);
+			let openedImplings = 0;
+			let implingLoot = new Bank();
+			let implingClues = 0;
+			while (implingClues + bankedClues < maxCanDo && ++openedImplings < bankedImplings) {
+				const impLoot = await getOpenableLoot({ openable: implingJarOpenable, user, quantity: 1 });
+				implingLoot.add(impLoot.bank);
+				implingClues = implingLoot.amount(clueTier.scrollID);
+			}
+			if (implingLoot.has(clueTier.scrollID)) {
+				implingLoot.remove(clueTier.scrollID, implingLoot.amount(clueTier.scrollID));
+			}
+
+			await user.transactItems({
+				itemsToAdd: implingLoot,
+				itemsToRemove: new Bank().add(clueImpling, openedImplings).add(clueTier.scrollID, bankedClues)
+			});
+			if (bankedClues + implingClues === 0) {
+				return `You don't have any clues, and didn't find any in ${openedImplings}x ${clueImpling.name}s. At least you received the following loot: ${implingLoot}.`;
+			}
+			quantity = bankedClues + implingClues;
+			implingLootString = `\n\nYou will find ${implingClues} clue${
+				implingClues === 0 || implingClues > 1 ? 's' : ''
+			} from ${openedImplings}x ${clueImpling.name}s, and receive the following loot: ${implingLoot}.`;
+		}
+
+		duration = timeToFinish * quantity;
 
 		await addSubTaskToActivityTask<ClueActivityTaskOptions>({
 			clueID: clueTier.id,
+			implingID: clueImpling ? clueImpling.id : undefined,
 			userID: user.id,
 			channelID: channelID.toString(),
 			quantity,
@@ -302,6 +372,6 @@ export const clueCommand: OSBMahojiCommand = {
 			clueTier.name
 		} clues, it'll take around ${formatDuration(duration)} to finish.${
 			boosts.length > 0 ? `\n\n**Boosts:** ${boosts.join(', ')}.` : ''
-		}`;
+		}${implingLootString}`;
 	}
 };

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -2,11 +2,11 @@ import { stringMatches } from '@oldschoolgg/toolkit';
 import { ButtonBuilder, ChatInputCommandInteraction } from 'discord.js';
 import { notEmpty, uniqueArr } from 'e';
 import { CommandResponse } from 'mahoji/dist/lib/structures/ICommand';
-import { Bank, LootTable } from 'oldschooljs';
+import { Bank } from 'oldschooljs';
 
 import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { PerkTier } from '../../../lib/constants';
-import { allOpenables, UnifiedOpenable } from '../../../lib/openables';
+import { allOpenables, getOpenableLoot, UnifiedOpenable } from '../../../lib/openables';
 import { ItemBank } from '../../../lib/types';
 import { makeComponents } from '../../../lib/util';
 import getOSItem, { getItem } from '../../../lib/util/getOSItem';
@@ -23,12 +23,6 @@ export const OpenUntilItems = uniqueArr(allOpenables.map(i => i.allItems).flat(2
 		if (a.name.includes('Clue')) return -1;
 		return 0;
 	});
-
-function getOpenableLoot({ openable, quantity, user }: { openable: UnifiedOpenable; quantity: number; user: MUser }) {
-	return openable.output instanceof LootTable
-		? { bank: openable.output.roll(quantity), message: null }
-		: openable.output({ user, self: openable, quantity });
-}
 
 async function addToOpenablesScores(mahojiUser: MUser, kcBank: Bank) {
 	const { openable_scores: newOpenableScores } = await userStatsUpdate(


### PR DESCRIPTION
### Description:

- Adds ability to extend your clue trips by using banked implings -- if you have enough!

### Changes:

- Moves `getOpenableLoot` to an exported + shared location
- Adds relevant impling jar data to clue tiers.
- Makes autocomplete work for clue tiers on /clue
- Adds `impling` option to `/clue` to automatically open the chosen impling
- Implements logic to open implings, add the loot, and extend the trip accordingly by the number of found clues.

### Other checks:

- [x] I have tested all my changes thoroughly.
