### PR TITLE
Balance Gauntlet times & boosts

### DIFF
--- a/src/mahoji/lib/abstracted_commands/gauntletCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/gauntletCommand.ts
@@ -19,7 +19,8 @@ const baseRequirements = {
 	smithing: 70,
 	herblore: 70,
 	construction: 70,
-	hunter: 70
+	hunter: 70,
+	prayer: 77
 };
 
 const standardRequirements = {
@@ -28,8 +29,7 @@ const standardRequirements = {
 	strength: 80,
 	defence: 80,
 	magic: 80,
-	ranged: 80,
-	prayer: 77
+	ranged: 80
 };
 
 const corruptedRequirements = {
@@ -38,14 +38,7 @@ const corruptedRequirements = {
 	strength: 90,
 	defence: 90,
 	magic: 90,
-	ranged: 90,
-	prayer: 77,
-	// Skilling
-	cooking: 70,
-	farming: 70,
-	fishing: 70,
-	mining: 70,
-	woodcutting: 70
+	ranged: 90
 };
 
 export async function gauntletCommand(user: MUser, channelID: string, type: 'corrupted' | 'normal' = 'normal') {

--- a/src/mahoji/lib/abstracted_commands/gauntletCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/gauntletCommand.ts
@@ -91,7 +91,8 @@ export async function gauntletCommand(user: MUser, channelID: string, type: 'cor
 	}
 
 	// Hunllef boss fight boost
-	const scoreBoost = Math.min(100, calcWhatPercent(type === 'corrupted' ? corruptedKC : normalKC, 100)) / 5;
+	const scoreBoost =
+		Math.min(100, calcWhatPercent(type === 'corrupted' ? corruptedKC : normalKC + corruptedKC, 100)) / 5;
 	if (scoreBoost > 1) {
 		baseLength = reduceNumByPercent(baseLength, scoreBoost);
 		boosts.push(`${scoreBoost}% boost for ${type === 'corrupted' ? 'Corrupted ' : ''}Hunllef KC`);

--- a/src/mahoji/lib/abstracted_commands/gauntletCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/gauntletCommand.ts
@@ -3,6 +3,7 @@ import { calcWhatPercent, reduceNumByPercent, Time } from 'e';
 
 import { BitField } from '../../../lib/constants';
 import { getMinigameScore } from '../../../lib/settings/minigames';
+import { SkillsEnum } from '../../../lib/skilling/types';
 import { GauntletOptions } from '../../../lib/types/minions';
 import { formatDuration, formatSkillRequirements, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
@@ -54,6 +55,7 @@ export async function gauntletCommand(user: MUser, channelID: string, type: 'cor
 	}
 	const readableName = `${toTitleCase(type)} Gauntlet`;
 	const requiredSkills = type === 'corrupted' ? corruptedRequirements : standardRequirements;
+	const prayLevel = user.skillLevel(SkillsEnum.Prayer);
 
 	if (!user.hasSkillReqs(requiredSkills)) {
 		return `You don't have the required stats to do the ${readableName}, you need: ${formatSkillRequirements(
@@ -105,11 +107,17 @@ export async function gauntletCommand(user: MUser, channelID: string, type: 'cor
 	if (user.bitfield.includes(BitField.HasArcaneScroll)) {
 		boosts.push('5% for Augury');
 		baseLength = reduceNumByPercent(baseLength, 5);
+	} else if (prayLevel >= 45) {
+		boosts.push('2% for Mystic Might');
+		baseLength = reduceNumByPercent(baseLength, 2);
 	}
 
 	if (user.bitfield.includes(BitField.HasDexScroll)) {
 		boosts.push('5% for Rigour');
 		baseLength = reduceNumByPercent(baseLength, 5);
+	} else if (prayLevel >= 44) {
+		boosts.push('2% for Eagle Eye');
+		baseLength = reduceNumByPercent(baseLength, 2);
 	}
 
 	// Add a 5% variance to account for randomness of gauntlet


### PR DESCRIPTION
### Description:
- Balanced Gauntlet times to closer reflect ingame times

- Updated times reflected in this PR:
- - Base time for normal is ~11.5 minutes
- - Max boost time for normal is ~ 5 minutes
- - Base time for corrupted is ~ 13 minutes
- - Max boost time for corrupted is ~ 7.5 minutes

### Changes:
- Add a new boost for prep time. This boost takes normal and corrupted kc into consideration since prep is the exact same mechanics. This also makes the switch from normal to corrupted not feel like starting over from zero.
- Prep time boost is doubled for normal since normal gauntlet uses about half the materials needed to finish. 
- Augury gives a 5% boost (up from 3%)
- Add 2% boost for Mystic Might if user has the pray level and and hasn't used an arcane scroll.
- Rigour gives a 5% boost (up from 3%)
- Add a 2% boost for Eagle Eye if the use has the pray level and hasn't used an dex scroll.
- Add a 5% variance to trip time to account for the randomness of gauntlet rooms.
- Make normal gauntlet use normal and corrupted kc to determine boost from hunleff since corrupted hunleff is harder than normal. (This makes it so if the user does 100 corrupted kc and gets max boost and then returns to normal they aren't penalized for only having 50 normal kc)
- Made corrupted and normal prep/hunleff variables to easily tweak times for any future updates.

### Other checks:

- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5534
addresses: https://github.com/oldschoolgg/oldschoolbot/issues/3616 (Doesn't address piety)
