### PR TITLE
User sacrifice stats

### DIFF
--- a/src/mahoji/commands/sacrifice.ts
+++ b/src/mahoji/commands/sacrifice.ts
@@ -85,10 +85,14 @@ export const sacrificeCommand: OSBMahojiCommand = {
 
 		// Show user sacrifice stats if no options are given for /sacrifice
 		if (!options.filter && !options.items && !options.search) {
-			return `${Emoji.Incinerator} **Your Sacrifice Stats** ${
-				Emoji.Incinerator
-			}\n\n**Current Minion Icon:** ${currentIcon}\n**Sacrificed Value:** ${sacVal.toLocaleString()} GP\n**Unique Items Sacrificed:** ${sacUniqVal.toLocaleString()} items`;
+			return (
+				`${Emoji.Incinerator} **Your Sacrifice Stats** ${Emoji.Incinerator}\n\n` +
+				`**Current Minion Icon:** ${currentIcon === null ? Emoji.Minion : currentIcon}\n` +
+				`**Sacrificed Value:** ${sacVal.toLocaleString()} GP\n` +
+				`**Unique Items Sacrificed:** ${sacUniqVal.toLocaleString()} item${sacUniqVal === 1 ? '' : 's'}`
+			);
 		}
+
 		deferInteraction(interaction);
 
 		const bankToSac = parseBank({

--- a/tests/integration/commands/sacrifice.test.ts
+++ b/tests/integration/commands/sacrifice.test.ts
@@ -2,6 +2,7 @@ import { Bank } from 'oldschooljs';
 import { ItemBank } from 'oldschooljs/dist/meta/types';
 import { describe, expect, test } from 'vitest';
 
+import { Emoji } from '../../../src/lib/constants';
 import { mahojiClientSettingsFetch } from '../../../src/lib/util/clientSettings';
 import { sacrificeCommand } from '../../../src/mahoji/commands/sacrifice';
 import { createTestUser, mockClient } from '../util';
@@ -11,49 +12,57 @@ describe('Sacrifice Command', async () => {
 	const user = await createTestUser();
 
 	test('No options provided', async () => {
+		await user.addItemsToBank({ items: new Bank().add('Trout').add('Coal', 10) });
+		await user.runCommand(sacrificeCommand, { items: '1 trout, 10 coal' });
 		const result = await user.runCommand(sacrificeCommand, {});
-		expect(result).toEqual("You didn't provide any items, filter or search.");
+		expect(result).toEqual(
+			`${Emoji.Incinerator} **Your Sacrifice Stats** ${Emoji.Incinerator}\n\n` +
+				`**Current Minion Icon:** ${Emoji.Minion}\n` +
+				'**Sacrificed Value:** 1,635 GP\n' +
+				'**Unique Items Sacrificed:** 2 items'
+		);
 	});
 
 	test('No items provided', async () => {
 		const result = await user.runCommand(sacrificeCommand, { items: 'aaaa' });
-		expect(result).toEqual(`No items were provided.
-Your current sacrificed value is: 0 (0)`);
+		expect(result).toEqual('No items were provided.\nYour current sacrificed value is: 1,635 (1.64k)');
 	});
 
 	test('Successful', async () => {
 		await user.addItemsToBank({ items: new Bank().add('Trout').add('Coal', 10) });
 		const result = await user.runCommand(sacrificeCommand, { items: '1 trout, 10 coal' });
 		expect(result).toEqual(
-			'You sacrificed 10x Coal, 1x Trout, with a value of 1,635gp (1.64k). Your total amount sacrificed is now: 1,635. '
+			'You sacrificed 10x Coal, 1x Trout, with a value of 1,635gp (1.64k). Your total amount sacrificed is now: 3,270. '
 		);
 		const stats = await user.fetchStats({ sacrificed_bank: true });
 		expect(user.bank.equals(new Bank())).toBe(true);
-		expect(new Bank(stats.sacrificed_bank as ItemBank).equals(new Bank().add('Coal', 10).add('Trout'))).toBe(true);
-		expect(user.user.sacrificedValue).toEqual(BigInt(1635));
+		expect(new Bank(stats.sacrificed_bank as ItemBank).equals(new Bank().add('Coal', 20).add('Trout', 2))).toBe(
+			true
+		);
+		expect(user.user.sacrificedValue).toEqual(BigInt(3270));
 		const clientSettings = await mahojiClientSettingsFetch({ economyStats_sacrificedBank: true });
 		expect(
 			new Bank(clientSettings.economyStats_sacrificedBank as ItemBank).equals(
-				new Bank().add('Coal', 10).add('Trout')
+				new Bank().add('Coal', 20).add('Trout', 2)
 			)
 		).toEqual(true);
 		await user.addItemsToBank({ items: new Bank().add('Trout').add('Cake') });
 		const res = await user.runCommand(sacrificeCommand, { items: '1 trout, 1 cake' });
 		expect(res).toEqual(
-			'You sacrificed 1x Trout, 1x Cake, with a value of 206gp (206). Your total amount sacrificed is now: 1,841. '
+			'You sacrificed 1x Trout, 1x Cake, with a value of 206gp (206). Your total amount sacrificed is now: 3,476. '
 		);
 		await user.sync();
 		expect(user.bank.equals(new Bank())).toBe(true);
 		const stats2 = await user.fetchStats({ sacrificed_bank: true });
 		expect(
-			new Bank(stats2.sacrificed_bank as ItemBank).equals(new Bank().add('Coal', 10).add('Trout', 2).add('Cake'))
+			new Bank(stats2.sacrificed_bank as ItemBank).equals(new Bank().add('Coal', 20).add('Trout', 3).add('Cake'))
 		).toBe(true);
-		expect(user.user.sacrificedValue).toEqual(BigInt(1841));
+		expect(user.user.sacrificedValue).toEqual(BigInt(3476));
 
 		const clientSettings2 = await mahojiClientSettingsFetch({ economyStats_sacrificedBank: true });
 		expect(
 			new Bank(clientSettings2.economyStats_sacrificedBank as ItemBank).equals(
-				new Bank().add('Coal', 10).add('Trout', 2).add('Cake')
+				new Bank().add('Coal', 20).add('Trout', 3).add('Cake')
 			)
 		).toEqual(true);
 	});


### PR DESCRIPTION
### Description:
Show user sacrifice stats when `/sacrifice` is used without any flags.
### Changes:
Change the return message of "You didn't provide any items, filter or search." to the follow picture.
![Discord_UODQDuc0Kb](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/067f94a0-9892-40cc-ab69-e346b30be985)
### Other checks:
- [X] I have tested all my changes thoroughly.
