### PR TITLE
Adds 'Auto Slay' button to trip finish for Patrons.

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -94,6 +94,15 @@ export function makeBirdHouseTripButton() {
 		.setStyle(ButtonStyle.Secondary)
 		.setEmoji('692946556399124520');
 }
+
+export function makeAutoSlayButton() {
+	return new ButtonBuilder()
+		.setCustomId('AUTO_SLAY')
+		.setLabel('Auto Slay')
+		.setEmoji('630911040560824330')
+		.setStyle(ButtonStyle.Secondary);
+}
+
 const reactionTimeLimits = {
 	0: Time.Hour * 12,
 	[PerkTier.One]: Time.Hour * 12,

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -18,6 +18,7 @@ import { ActivityTaskData } from '../types/minions';
 import { channelIsSendable, makeComponents } from '../util';
 import {
 	makeAutoContractButton,
+	makeAutoSlayButton,
 	makeBirdHouseTripButton,
 	makeNewSlayerTaskButton,
 	makeOpenCasketButton,
@@ -148,6 +149,8 @@ export async function handleTripFinish(
 			['MonsterKilling', 'Inferno', 'FightCaves'].includes(data.type)
 		) {
 			components.push(makeNewSlayerTaskButton());
+		} else {
+			components.push(makeAutoSlayButton());
 		}
 		if (loot?.has('Seed pack')) {
 			components.push(makeOpenSeedPackButton());

--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -236,7 +236,7 @@ export async function autoSlayCommand({
 	const isOnTask = usersTask.assignedTask !== null && usersTask.currentTask !== null;
 
 	if (!isOnTask) {
-		return slayerNewTaskCommand({ userID: user.id, channelID, interaction });
+		return slayerNewTaskCommand({ userID: user.id, channelID, interaction, showButtons: true });
 	}
 	const savedMethod = determineAutoslayMethod(autoslayOptions as AutoslayOptionsEnum[]);
 	const method = modeOverride ?? savedMethod;

--- a/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/minionStatusCommand.ts
@@ -8,7 +8,11 @@ import { clArrayUpdate } from '../../../lib/handleNewCLItems';
 import { roboChimpSyncData, roboChimpUserFetch } from '../../../lib/roboChimp';
 import { prisma } from '../../../lib/settings/prisma';
 import { makeComponents } from '../../../lib/util';
-import { makeAutoContractButton, makeBirdHouseTripButton } from '../../../lib/util/globalInteractions';
+import {
+	makeAutoContractButton,
+	makeAutoSlayButton,
+	makeBirdHouseTripButton
+} from '../../../lib/util/globalInteractions';
 import { minionStatus } from '../../../lib/util/minionStatus';
 import { makeRepeatTripButtons } from '../../../lib/util/repeatStoredTrip';
 import { calculateBirdhouseDetails } from './birdhousesCommand';
@@ -100,13 +104,7 @@ export async function minionStatusCommand(user: MUser): Promise<BaseMessageOptio
 	}
 
 	if (!minionIsBusy) {
-		buttons.push(
-			new ButtonBuilder()
-				.setCustomId('AUTO_SLAY')
-				.setLabel('Auto Slay')
-				.setEmoji('630911040560824330')
-				.setStyle(ButtonStyle.Secondary)
-		);
+		buttons.push(makeAutoSlayButton());
 	}
 
 	buttons.push(


### PR DESCRIPTION
### Description:

Adds 'Auto Slay' button to trip return messages for Patrons.

('New Slayer Task' still shown to avoid confusion / preserve existing behavior, but it is functionally identical to the Auto Slay functionality at that point anyway)

### Changes:

- Adds makeAutoSlayButton() function
- Implements Auto Slay button at the end of trips for Patrons ( PerkTier 2+)

### Other checks:

- [x] I have tested all my changes thoroughly.
