### PR TITLE
Track opened impling jars in "Personal Open Stats"

### DIFF
--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -13,7 +13,7 @@ import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import getOSItem, { getItem } from '../../lib/util/getOSItem';
 import { getPOH } from '../lib/abstracted_commands/pohCommand';
 import { OSBMahojiCommand } from '../lib/util';
-import { getMahojiBank, mahojiUsersSettingsFetch } from '../mahojiSettings';
+import { addToOpenablesScores, getMahojiBank, mahojiUsersSettingsFetch } from '../mahojiSettings';
 
 function reducedClueTime(clueTier: ClueTier, score: number) {
 	// Every 3 hours become 1% better to a cap of 10%
@@ -347,6 +347,7 @@ export const clueCommand: OSBMahojiCommand = {
 				implingLoot.remove(clueTier.scrollID, implingLoot.amount(clueTier.scrollID));
 			}
 
+			await addToOpenablesScores(user, new Bank().add(implingJarOpenable.id, openedImplings));
 			await user.transactItems({
 				itemsToAdd: implingLoot,
 				itemsToRemove: new Bank().add(clueImpling, openedImplings).add(clueTier.scrollID, bankedClues),

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -7,12 +7,11 @@ import { Bank } from 'oldschooljs';
 import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { PerkTier } from '../../../lib/constants';
 import { allOpenables, getOpenableLoot, UnifiedOpenable } from '../../../lib/openables';
-import { ItemBank } from '../../../lib/types';
 import { makeComponents } from '../../../lib/util';
 import getOSItem, { getItem } from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
-import { patronMsg, updateClientGPTrackSetting, userStatsUpdate } from '../../mahojiSettings';
+import { addToOpenablesScores, patronMsg, updateClientGPTrackSetting } from '../../mahojiSettings';
 
 const regex = /^(.*?)( \([0-9]+x Owned\))?$/;
 
@@ -23,17 +22,6 @@ export const OpenUntilItems = uniqueArr(allOpenables.map(i => i.allItems).flat(2
 		if (a.name.includes('Clue')) return -1;
 		return 0;
 	});
-
-async function addToOpenablesScores(mahojiUser: MUser, kcBank: Bank) {
-	const { openable_scores: newOpenableScores } = await userStatsUpdate(
-		mahojiUser.id,
-		({ openable_scores }) => ({
-			openable_scores: new Bank(openable_scores as ItemBank).add(kcBank).bank
-		}),
-		{ openable_scores: true }
-	);
-	return new Bank(newOpenableScores as ItemBank);
-}
 
 export async function abstractedOpenUntilCommand(
 	interaction: ChatInputCommandInteraction,

--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -332,3 +332,14 @@ export async function addToGPTaxBalance(userID: string | string, amount: number)
 		)
 	]);
 }
+
+export async function addToOpenablesScores(mahojiUser: MUser, kcBank: Bank) {
+	const { openable_scores: newOpenableScores } = await userStatsUpdate(
+		mahojiUser.id,
+		({ openable_scores }) => ({
+			openable_scores: new Bank(openable_scores as ItemBank).add(kcBank).bank
+		}),
+		{ openable_scores: true }
+	);
+	return new Bank(newOpenableScores as ItemBank);
+}


### PR DESCRIPTION
### Description:

- Adds tracking for impling jars opened by the `/clue` command.


### Other checks:

- [x] I have tested all my changes thoroughly.
