### PR TITLE
Allow Tame to collect more items & dt2 tablet fix

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/dt.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dt.ts
@@ -78,7 +78,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Frozen tablet')) return;
+			if (user.bank.has('Frozen tablet') && user.cl.has('Frozen tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -117,10 +117,6 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		notifyDrops: resolveItems(['Baron']),
 		qpRequired: 100,
 		equippedItemBoosts: [
-			{
-				items: [{ boostPercent: 3, itemID: itemID('Avernic defender') }],
-				gearSetup: 'melee'
-			},
 			{
 				items: [{ boostPercent: 3, itemID: itemID('Ferocious gloves') }],
 				gearSetup: 'melee'
@@ -166,7 +162,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Frozen tablet')) return;
+			if (user.bank.has('Frozen tablet') && user.cl.has('Frozen tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -268,7 +264,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackRanged,
 		attackStylesUsed: [GearStat.AttackRanged],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Scarred tablet')) return;
+			if (user.bank.has('Scarred tablet') && user.cl.has('Scarred tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -357,7 +353,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackRanged,
 		attackStylesUsed: [GearStat.AttackRanged],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Scarred tablet')) return;
+			if (user.bank.has('Scarred tablet') && user.cl.has('Scarred tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -447,7 +443,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackMagic,
 		attackStylesUsed: [GearStat.AttackMagic],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Sirenic tablet')) return;
+			if (user.bank.has('Sirenic tablet') && user.cl.has('Sirenic tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -552,7 +548,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackMagic,
 		attackStylesUsed: [GearStat.AttackMagic],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Sirenic tablet')) return;
+			if (user.bank.has('Sirenic tablet') && user.cl.has('Sirenic tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -645,7 +641,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Strangled tablet')) return;
+			if (user.bank.has('Strangled tablet') && user.cl.has('Strangled tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -684,10 +680,6 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		notifyDrops: resolveItems(['Baron']),
 		qpRequired: 100,
 		equippedItemBoosts: [
-			{
-				items: [{ boostPercent: 3, itemID: itemID('Avernic defender') }],
-				gearSetup: 'melee'
-			},
 			{
 				items: [{ boostPercent: 3, itemID: itemID('Ferocious gloves') }],
 				gearSetup: 'melee'
@@ -733,7 +725,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Strangled tablet')) return;
+			if (user.bank.has('Strangled tablet') && user.cl.has('Strangled tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -22,6 +22,7 @@ import { PHOSANI_NIGHTMARE_ID } from './constants';
 import { getSimilarItems } from './data/similarItems';
 import { trackLoot } from './lootTrack';
 import killableMonsters, { NightmareMonster } from './minions/data/killableMonsters';
+import { BSOMonsters } from './minions/data/killableMonsters/custom/customMonsters';
 import { customDemiBosses } from './minions/data/killableMonsters/custom/demiBosses';
 import { Planks } from './minions/data/planks';
 import { KillableMonster } from './minions/types';
@@ -169,8 +170,7 @@ export const specialLoot: SpecialLoot[] = [
 		]
 	},
 	{
-		// Vladimir Drakan
-		monster: [291_242],
+		monster: [BSOMonsters.VladimirDrakan.id],
 		specialItems: [
 			{
 				item: [


### PR DESCRIPTION
### Description:
- Allows Igne tame to collect "Special items" that are handled by unique code, inaccessible to tames such as: 
  - specialLoot under Vladimir Drakan(outfit, Echo, Plushie)
  - effect under dt2 bosses(ring of shadow tablets)
  - effect under Phantom Muspah(Charged ice)
- Add Phosani Nightmare to tame killable (Slepey tablet & Parasitic egg)
- Correct an issue preventing users from being able to collect the dt2 tablet cl slot
### Changes:
- SpecialLoot interface to tames.ts to handle the monster, items, and chance
- Code to handle giving items from SpecialLoot (Currently only allows for 1 of each item). This code will work for any future special/unique code that isn't handled with a loottable
- Phosani Nightmare to tame killable
- Special case for Slepey tablet, similar to minion to only allow for 1
- Added a second check to dt2 tabs to prevent making the cl inaccessible if the user has one in bank (obtained through trading or tame killing)
- Removed Avernic defender hilt boost from awakened duke/vard due to scythe being a 2h weapon and required to kill.
### Other checks:
- [X] I have tested all my changes thoroughly.
