### PR TITLE
Block blacklisted people receiving gp from /pay

### DIFF
--- a/src/mahoji/commands/pay.ts
+++ b/src/mahoji/commands/pay.ts
@@ -2,6 +2,7 @@ import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { MahojiUserOption } from 'mahoji/dist/lib/types';
 import { Bank } from 'oldschooljs';
 
+import { BLACKLISTED_USERS } from '../../lib/blacklists';
 import { Events } from '../../lib/constants';
 import { prisma } from '../../lib/settings/prisma';
 import { toKMB } from '../../lib/util';
@@ -44,6 +45,8 @@ export const payCommand: OSBMahojiCommand = {
 		// Ensure the recipient's users row exists:
 		if (!amount) return "That's not a valid amount.";
 		const { GP } = user;
+		const isBlacklisted = BLACKLISTED_USERS.has(recipient.id);
+		if (isBlacklisted) return "Blacklisted players can't be paid.";
 		if (recipient.id === user.id) return "You can't send money to yourself.";
 		if (user.isIronman) return "Iron players can't send money.";
 		if (recipient.isIronman) return "Iron players can't receive money.";

--- a/src/mahoji/commands/pay.ts
+++ b/src/mahoji/commands/pay.ts
@@ -46,7 +46,7 @@ export const payCommand: OSBMahojiCommand = {
 		if (!amount) return "That's not a valid amount.";
 		const { GP } = user;
 		const isBlacklisted = BLACKLISTED_USERS.has(recipient.id);
-		if (isBlacklisted) return "Blacklisted players can't be paid.";
+		if (isBlacklisted) return "Blacklisted players can't receive money.";
 		if (recipient.id === user.id) return "You can't send money to yourself.";
 		if (user.isIronman) return "Iron players can't send money.";
 		if (recipient.isIronman) return "Iron players can't receive money.";


### PR DESCRIPTION
Adds a blacklist check to the /pay command.
Informs the sender that they can't send gp to someone blacklisted, similar to how it works for /trade

- [x] I have tested all my changes thoroughly.
