### PR TITLE
Fix tame status when monkey casting

### DIFF
--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -596,22 +596,20 @@ export function getTameStatus(tameActivity: TameActivity | null) {
 				return [
 					`Killing ${activityData.quantity.toLocaleString()}x ${tameKillableMonsters
 						.find(m => m.id === activityData.monsterID)
-						?.name.toLowerCase()}`,
-					timeRemaining
+						?.name.toLowerCase()} ${timeRemaining}.`
 				];
 			case TameType.Gatherer:
-				return [`Collecting ${itemNameFromID(activityData.itemID)?.toLowerCase()}`, timeRemaining];
+				return [`Collecting ${itemNameFromID(activityData.itemID)?.toLowerCase()} ${timeRemaining}.`];
 			case 'SpellCasting':
 				return [
-					`Casting ${seaMonkeySpells.find(i => i.id === activityData.itemID)!.name} ${
+					`Casting ${seaMonkeySpells.find(i => i.id === activityData.spellID)!.name} ${
 						activityData.quantity
-					}x times`,
-					timeRemaining
+					}x times. ${timeRemaining}.`
 				];
 			case 'Tempoross':
-				return [`Fighting the Tempoross. ${timeRemaining}`];
+				return [`Fighting the Tempoross. ${timeRemaining}.`];
 			case 'Wintertodt':
-				return [`Fighting the Wintertodt. ${timeRemaining}`];
+				return [`Fighting the Wintertodt. ${timeRemaining}.`];
 		}
 	}
 	return ['Idle'];

--- a/src/mahoji/commands/tames.ts
+++ b/src/mahoji/commands/tames.ts
@@ -596,10 +596,10 @@ export function getTameStatus(tameActivity: TameActivity | null) {
 				return [
 					`Killing ${activityData.quantity.toLocaleString()}x ${tameKillableMonsters
 						.find(m => m.id === activityData.monsterID)
-						?.name.toLowerCase()} ${timeRemaining}.`
+						?.name.toLowerCase()}. ${timeRemaining}.`
 				];
 			case TameType.Gatherer:
-				return [`Collecting ${itemNameFromID(activityData.itemID)?.toLowerCase()} ${timeRemaining}.`];
+				return [`Collecting ${itemNameFromID(activityData.itemID)?.toLowerCase()}. ${timeRemaining}.`];
 			case 'SpellCasting':
 				return [
 					`Casting ${seaMonkeySpells.find(i => i.id === activityData.spellID)!.name} ${


### PR DESCRIPTION
### Description:
- Fixes `/tames status` and `/tames list` from showing "The application did not respond" when tame is performing any of the four `/tames cast` spells.
### Changes:
- Changed the seaMonkeySpells and activityData comparision to properly check for spellID not itemID.
- Changed the `/tames status` format to be uniform for all five tame cases.
### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5320