### PR TITLE
Consistent trip repeat duration/qty when trips use 'until tired/satisfied' mechanic.

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -62,6 +62,8 @@ export interface ActivityTaskOptionsWithQuantity extends ActivityTaskOptions {
 		| 'CamdozaalMining'
 		| 'CamdozaalSmithing';
 	quantity: number;
+	// iQty is 'input quantity.' This is the number specified at command time, so we can accurately repeat such trips.
+	iQty?: number;
 }
 
 export interface ShootingStarsOptions extends ActivityTaskOptions {
@@ -154,6 +156,7 @@ export interface MiningActivityTaskOptions extends ActivityTaskOptions {
 	oreID: number;
 	quantity: number;
 	powermine: boolean;
+	iQty?: number;
 }
 
 export interface MotherlodeMiningActivityTaskOptions extends ActivityTaskOptions {
@@ -161,6 +164,7 @@ export interface MotherlodeMiningActivityTaskOptions extends ActivityTaskOptions
 	fakeDurationMax: number;
 	fakeDurationMin: number;
 	quantity: number;
+	iQty?: number;
 }
 
 export interface SmeltingActivityTaskOptions extends ActivityTaskOptions {
@@ -189,6 +193,7 @@ export interface WoodcuttingActivityTaskOptions extends ActivityTaskOptions {
 	powerchopping: boolean;
 	logID: number;
 	quantity: number;
+	iQty?: number;
 }
 
 export interface CraftingActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -165,7 +165,7 @@ export const tripHandlers = {
 	[activity_type_enum.CamdozaalMining]: {
 		commandName: 'activities',
 		args: (data: ActivityTaskOptionsWithQuantity) => ({
-			camdozaal: { action: 'mining', quantity: data.quantity }
+			camdozaal: { action: 'mining', quantity: data.iQty }
 		})
 	},
 	[activity_type_enum.CamdozaalSmithing]: {
@@ -379,7 +379,7 @@ export const tripHandlers = {
 		commandName: 'mine',
 		args: (data: MiningActivityTaskOptions) => ({
 			name: data.oreID,
-			quantity: data.quantity,
+			quantity: data.iQty,
 			powermine: data.powermine
 		})
 	},
@@ -387,7 +387,7 @@ export const tripHandlers = {
 		commandName: 'mine',
 		args: (data: MotherlodeMiningActivityTaskOptions) => ({
 			name: 'Motherlode mine',
-			quantity: data.quantity
+			quantity: data.iQty
 		})
 	},
 	[activity_type_enum.MonsterKilling]: {
@@ -549,7 +549,7 @@ export const tripHandlers = {
 		commandName: 'chop',
 		args: (data: WoodcuttingActivityTaskOptions) => ({
 			name: itemNameFromID(data.logID),
-			quantity: data.quantity,
+			quantity: data.iQty,
 			powerchop: data.powerchopping
 		})
 	},

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -189,6 +189,7 @@ export const chopCommand: OSBMahojiCommand = {
 			userID: user.id,
 			channelID: channelID.toString(),
 			quantity: newQuantity,
+			iQty: options.quantity ? options.quantity : undefined,
 			powerchopping: powerchop,
 			duration,
 			fakeDurationMin,

--- a/src/mahoji/commands/mine.ts
+++ b/src/mahoji/commands/mine.ts
@@ -188,6 +188,7 @@ export const mineCommand: OSBMahojiCommand = {
 			userID: userID.toString(),
 			channelID: channelID.toString(),
 			quantity: newQuantity,
+			iQty: options.quantity ? options.quantity : undefined,
 			powermine,
 			duration,
 			fakeDurationMax,

--- a/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
@@ -65,6 +65,7 @@ async function miningCommand(user: MUser, channelID: string, quantity: number | 
 		userID: user.id,
 		channelID: channelID.toString(),
 		quantity: newQuantity,
+		iQty: quantity ? quantity : undefined,
 		duration,
 		type: 'CamdozaalMining'
 	});

--- a/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
@@ -81,6 +81,7 @@ export async function motherlodeMineCommand({
 		userID: user.id,
 		channelID,
 		quantity: newQuantity,
+		iQty: quantity ? quantity : undefined,
 		duration,
 		fakeDurationMax,
 		fakeDurationMin,


### PR DESCRIPTION
### Description:

Currently, trips using the 'satisfied/tired' mechanic (mining, motherlode mine, comdozaal mining, woodcutting), all have the same fatal flaw:
- As you repeat the trip, it can only get smaller and smaller, since it always uses the previous FINAL quantity, and not the quantity specified when you run the command.
- This means, if you specify no quantity, the first trip takes ~30 minutes, and returns 400 ores.
- On repeat, it goes, 'until 400 ores or your minion gets tired.' and might only bring back 350 ores...
- Repeat until the trip length gets small enough that you can always get the previous quantity in your trip duration.

The problem is this leads to shorter (on average) trips than you're max length, which people often pay $$$ for.

And it greatly lessens the convenience of the repeat trip button, since it's usefulness is far degraded in these cases.

### Changes:

- Store the original `inputQuantity` (or undefined where none), and use this when repeating trips.

### Other checks:

- [x] I have tested all my changes thoroughly.
