### PR TITLE
[QoL] Add + Fix Mining aliases

### DIFF
--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -167,7 +167,7 @@ const ores: Ore[] = [
 		intercept: 10.04,
 		petChance: 211_886,
 		clueScrollChance: 211_886,
-		aliases: ['gems', 'gem']
+		aliases: ['gems', 'gem', 'gem rocks']
 	},
 	{
 		level: 40,

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -54,7 +54,8 @@ const ores: Ore[] = [
 		slope: 1.06,
 		intercept: 49.33,
 		petChance: 741_600,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		aliases: ['copper']
 	},
 	{
 		level: 1,
@@ -66,7 +67,8 @@ const ores: Ore[] = [
 		slope: 1.06,
 		intercept: 49.33,
 		petChance: 741_600,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		aliases: ['tin']
 	},
 	{
 		level: 1,
@@ -89,7 +91,8 @@ const ores: Ore[] = [
 		intercept: 42.5,
 		petChance: 741_600,
 		minerals: 100,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		aliases: ['iron']
 	},
 	{
 		level: 20,
@@ -101,7 +104,8 @@ const ores: Ore[] = [
 		slope: 0.7,
 		intercept: 9,
 		petChance: 741_600,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		aliases: ['silver']
 	},
 	{
 		level: 22,
@@ -112,7 +116,8 @@ const ores: Ore[] = [
 		bankingTime: 0,
 		slope: 1.06,
 		intercept: 49.33,
-		petChance: 741_600
+		petChance: 741_600,
+		aliases: ['ash', 'volcanic']
 	},
 	{
 		level: 30,
@@ -122,7 +127,8 @@ const ores: Ore[] = [
 		respawnTime: 2.75,
 		bankingTime: 33,
 		slope: 0,
-		intercept: 100
+		intercept: 100,
+		aliases: ['pess', 'pure', 'essence', 'ess']
 	},
 	{
 		level: 30,
@@ -147,7 +153,8 @@ const ores: Ore[] = [
 		slope: 0.8,
 		intercept: 10.01,
 		petChance: 741_600,
-		clueScrollChance: 741_600
+		clueScrollChance: 741_600,
+		aliases: ['sand']
 	},
 	{
 		level: 40,
@@ -159,7 +166,8 @@ const ores: Ore[] = [
 		slope: 0.18,
 		intercept: 10.04,
 		petChance: 211_886,
-		clueScrollChance: 211_886
+		clueScrollChance: 211_886,
+		aliases: ['gems', 'gem']
 	},
 	{
 		level: 40,
@@ -171,7 +179,8 @@ const ores: Ore[] = [
 		slope: 0.28,
 		intercept: 2.15,
 		petChance: 296_640,
-		clueScrollChance: 296_640
+		clueScrollChance: 296_640,
+		aliases: ['gold']
 	},
 	{
 		level: 45,
@@ -195,7 +204,8 @@ const ores: Ore[] = [
 		slope: 0.2,
 		intercept: 0.59,
 		petChance: 148_320,
-		clueScrollChance: 148_320
+		clueScrollChance: 148_320,
+		aliases: ['mith', 'mith ore', 'mithril']
 	},
 	{
 		level: 60,
@@ -205,7 +215,8 @@ const ores: Ore[] = [
 		respawnTime: 3,
 		bankingTime: 0,
 		slope: 0,
-		intercept: 100
+		intercept: 100,
+		aliases: ['dae', 'daey', 'daeyalt', 'daeyalt essence']
 	},
 	{
 		level: 70,
@@ -217,7 +228,8 @@ const ores: Ore[] = [
 		slope: 0.11,
 		intercept: -0.53,
 		petChance: 59_328,
-		clueScrollChance: 59_328
+		clueScrollChance: 59_328,
+		aliases: ['addy', 'adamant', 'adamant ore', 'adamantite']
 	},
 	{
 		level: 85,
@@ -229,7 +241,8 @@ const ores: Ore[] = [
 		slope: 0.08,
 		intercept: -0.85,
 		petChance: 42_377,
-		clueScrollChance: 42_377
+		clueScrollChance: 42_377,
+		aliases: ['rune', 'rune ore', 'runite']
 	},
 	{
 		level: 92,
@@ -242,7 +255,8 @@ const ores: Ore[] = [
 		intercept: -1.35,
 		petChance: 46_350,
 		minerals: 20,
-		clueScrollChance: 46_350
+		clueScrollChance: 46_350,
+		aliases: ['amy', 'ame']
 	}
 ];
 
@@ -252,6 +266,7 @@ const MotherlodeMine: Ore = {
 	xp: 60,
 	id: -1,
 	name: 'Motherlode mine',
+	aliases: ['mlm', 'ml', 'motherlode'],
 	respawnTime: 5.5,
 	bankingTime: 60,
 	slope: 0.181,

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -45,6 +45,7 @@ export interface Ore {
 	petChance?: number;
 	minerals?: number;
 	clueScrollChance?: number;
+	aliases?: string[];
 }
 
 export interface Log {

--- a/src/mahoji/commands/mine.ts
+++ b/src/mahoji/commands/mine.ts
@@ -59,7 +59,9 @@ export const mineCommand: OSBMahojiCommand = {
 		const user = await mUserFetch(userID);
 		let { quantity, powermine } = options;
 
-		const motherlodeMine = Mining.MotherlodeMine.name === options.name;
+		const motherlodeMine =
+			stringMatches(Mining.MotherlodeMine.name, options.name) ||
+			Mining.MotherlodeMine.aliases!.some(a => stringMatches(a, options.name));
 
 		if (motherlodeMine) {
 			return motherlodeMineCommand({ user, channelID, quantity });
@@ -69,7 +71,7 @@ export const mineCommand: OSBMahojiCommand = {
 			ore =>
 				stringMatches(ore.id, options.name) ||
 				stringMatches(ore.name, options.name) ||
-				stringMatches(ore.name.split(' ')[0], options.name)
+				(ore.aliases && ore.aliases.some(a => stringMatches(a, options.name)))
 		);
 		if (!ore) {
 			return `Thats not a valid ore to mine. Valid ores are ${Mining.Ores.map(ore => ore.name).join(', ')}, or ${


### PR DESCRIPTION
### Description:

This PR adds the ability to use aliases with the mining command.

We all know you can use the autocomplete, however, that is usually slower than just typing in a few keystrokes without waiting for Discord + the bot to respond with the matching list.


### Changes:

- `/mine name:rune` will now mine runite ore, instead of rune essence (nobody mines rune essence).
- Added the following aliases:
  - ml / mlm / motherlode: Motherlode mine
  - ame / amy: Amethyst
  - rune / rune ore: Runite ore
  - addy / adamant / adamant ore: Adamantite ore
  - dae / daey /daeyalt / daeyalt essence - Daeyalt esesnce rock
  - mith / mith ore: Mithril ore
  - gems / gem / gem rocks: Gem rock
  - sand: Sandstone
  - pess / essence / ess - Pure esssence
  - ash: Volcanic ash

### Other checks:

- [x] I have tested all my changes thoroughly.
