### PR TITLE
Use input quantity on more tasks (when repeating trip)

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -125,6 +125,7 @@ export interface MonsterActivityTaskOptions extends ActivityTaskOptions {
 	type: 'MonsterKilling';
 	monsterID: number;
 	quantity: number;
+	iQty?: number;
 	usingCannon?: boolean;
 	cannonMulti?: boolean;
 	chinning?: boolean;
@@ -147,6 +148,7 @@ export interface FishingActivityTaskOptions extends ActivityTaskOptions {
 	type: 'Fishing';
 	fishID: number;
 	quantity: number;
+	iQty?: number;
 }
 
 export interface MiningActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -177,7 +177,7 @@ export const tripHandlers = {
 	[activity_type_enum.CamdozaalFishing]: {
 		commandName: 'activities',
 		args: (data: ActivityTaskOptionsWithQuantity) => ({
-			camdozaal: { action: 'fishing', quantity: data.quantity }
+			camdozaal: { action: 'fishing', quantity: data.iQty }
 		})
 	},
 	[activity_type_enum.BarbarianAssault]: {
@@ -295,7 +295,7 @@ export const tripHandlers = {
 	},
 	[activity_type_enum.Fishing]: {
 		commandName: 'fish',
-		args: (data: FishingActivityTaskOptions) => ({ name: data.fishID, quantity: data.quantity })
+		args: (data: FishingActivityTaskOptions) => ({ name: data.fishID, quantity: data.iQty })
 	},
 	[activity_type_enum.FishingTrawler]: {
 		commandName: 'minigames',
@@ -400,7 +400,7 @@ export const tripHandlers = {
 			else if (data.burstOrBarrage === SlayerActivityConstants.IceBurst) method = 'burst';
 			return {
 				name: autocompleteMonsters.find(i => i.id === data.monsterID)?.name ?? data.monsterID.toString(),
-				quantity: data.quantity,
+				quantity: data.iQty,
 				method
 			};
 		}

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -175,6 +175,7 @@ export const fishCommand: OSBMahojiCommand = {
 			userID: user.id,
 			channelID: channelID.toString(),
 			quantity,
+			iQty: options.quantity ? options.quantity : undefined,
 			duration,
 			type: 'Fishing'
 		});

--- a/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
@@ -156,7 +156,7 @@ async function fishingCommand(user: MUser, channelID: string, quantity: number |
 		userID: user.id,
 		channelID: channelID.toString(),
 		quantity,
-		iQty: inputQuantity ? inputQuantity : undefined,
+		iQty: inputQuantity,
 		duration,
 		type: 'CamdozaalFishing'
 	});

--- a/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
@@ -133,6 +133,7 @@ async function fishingCommand(user: MUser, channelID: string, quantity: number |
 	if (user.skillLevel(SkillsEnum.Fishing) < 7) {
 		return 'You need at least level 7 Fishing to fish in the Ruins of Camdozaal.';
 	}
+	const inputQuantity = quantity;
 
 	const maxTripLength = calcMaxTripLength(user, 'CamdozaalFishing');
 	const camdozaalfish = Fishing.camdozaalFishes.find(_fish => _fish.name === 'Raw guppy')!;
@@ -155,6 +156,7 @@ async function fishingCommand(user: MUser, channelID: string, quantity: number |
 		userID: user.id,
 		channelID: channelID.toString(),
 		quantity,
+		iQty: inputQuantity ? inputQuantity : undefined,
 		duration,
 		type: 'CamdozaalFishing'
 	});

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -137,6 +137,7 @@ export async function minionKillCommand(
 	if (user.minionIsBusy) {
 		return 'Your minion is busy.';
 	}
+	const inputQuantity = quantity;
 	const { minionName } = user;
 	const wildyGear = user.gear.wildy;
 	const style = convertAttackStylesToSetup(user.user.attack_style);
@@ -835,6 +836,7 @@ export async function minionKillCommand(
 		userID: user.id,
 		channelID: channelID.toString(),
 		quantity,
+		iQty: inputQuantity,
 		duration,
 		type: 'MonsterKilling',
 		usingCannon: !usingCannon ? undefined : usingCannon,


### PR DESCRIPTION
### Description:

Adds the new 'input quantity' value to a few more tasks that are affected by similar issues.

Simply put, if you repeat one of these trips, it will always use the 'final' quantity as the input value for the command, even if that wasn't how you ran the command initially. Repeating trip should use the same INPUT parameters, to ensure consistency.

### Changes:

- Adds `iQty` to monster kill activity, and fishing + camdozaal fishing

### Other checks:

- [x] I have tested all my changes thoroughly.
