### PR TITLE
Pluralise function & minor fixes

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -157,7 +157,8 @@ function clueProg(tiers: ClueTier['name'][]): FormatProgressFunction {
 				const tier = ClueTiers.find(_tier => _tier.name === i)!;
 				return `${stats.openableScores.amount(tier.id)} ${tier.name} Opens`;
 			})
-			.filter(notEmpty);
+			.filter(notEmpty)
+			.join(', ');
 	};
 }
 

--- a/src/lib/minions/data/killableMonsters/bosses/dt.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dt.ts
@@ -116,10 +116,6 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		qpRequired: 100,
 		equippedItemBoosts: [
 			{
-				items: [{ boostPercent: 3, itemID: itemID('Avernic defender') }],
-				gearSetup: 'melee'
-			},
-			{
 				items: [{ boostPercent: 3, itemID: itemID('Ferocious gloves') }],
 				gearSetup: 'melee'
 			},
@@ -682,10 +678,6 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		notifyDrops: resolveItems(['Virtus robe top', 'Butch', 'Virtus robe bottom', 'Virtus mask']),
 		qpRequired: 100,
 		equippedItemBoosts: [
-			{
-				items: [{ boostPercent: 3, itemID: itemID('Avernic defender') }],
-				gearSetup: 'melee'
-			},
 			{
 				items: [{ boostPercent: 3, itemID: itemID('Ferocious gloves') }],
 				gearSetup: 'melee'

--- a/src/lib/simulation/toa.ts
+++ b/src/lib/simulation/toa.ts
@@ -1036,7 +1036,7 @@ export async function checkTOAUser(
 	if (unmetReqs.length > 0) {
 		return [
 			true,
-			`${user.usernameOrMention} doesn't meet the requirements: ${unmetReqs.map(i => i.result).join(', ')}`
+			`${user.usernameOrMention} doesn't meet the requirements: ${unmetReqs.map(i => i.result).join(', ')}.`
 		];
 	}
 

--- a/src/lib/util/smallUtils.ts
+++ b/src/lib/util/smallUtils.ts
@@ -92,6 +92,10 @@ export function hasSkillReqs(user: MUser, reqs: Skills): [boolean, string | null
 	return [true, null];
 }
 
+export function pluraliseItemName(name: string): string {
+	return name + (name.endsWith('s') ? '' : 's');
+}
+
 /**
  * Scale percentage exponentially
  *

--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -10,6 +10,7 @@ import { SmithingActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
+import { pluraliseItemName } from '../../lib/util/smallUtils';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
 import { OSBMahojiCommand } from '../lib/util';
 
@@ -54,13 +55,15 @@ export const smithCommand: OSBMahojiCommand = {
 		if (!smithedItem) return 'That is not a valid item to smith.';
 
 		if (user.skillLevel(SkillsEnum.Smithing) < smithedItem.level) {
-			return `${user.minionName} needs ${smithedItem.level} Smithing to smith ${smithedItem.name}s.`;
+			return `${user.minionName} needs ${smithedItem.level} Smithing to smith ${pluraliseItemName(
+				smithedItem.name
+			)}.`;
 		}
 
 		const userQP = user.QP;
 
 		if (smithedItem.qpRequired && userQP < smithedItem.qpRequired) {
-			return `${user.minionName} needs ${smithedItem.qpRequired} QP to smith ${smithedItem.name}`;
+			return `${user.minionName} needs ${smithedItem.qpRequired} QP to smith ${smithedItem.name}.`;
 		}
 		// If they have the entire Smiths' Uniform, give 100% chance save 1 tick each item
 		let setBonus = 0;

--- a/src/mahoji/lib/abstracted_commands/minionBuyCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/minionBuyCommand.ts
@@ -25,7 +25,7 @@ export async function minionBuyCommand(user: MUser, ironman: boolean): CommandRe
 
 <:patreonLogo:679334888792391703> **Patreon:** If you're able too, please consider supporting my work on Patreon, it's highly appreciated and helps me hugely <https://www.patreon.com/oldschoolbot> ❤️
 
-<:BSO:863823820435619890> **BSO:** I run a 2nd bot called BSO (Bot School Old), which you can also play, it has lots of fun and unique changes, like 5x XP and infinitely stacking clues. Type \`+bso\` for more information.
+<:BSO:863823820435619890> **BSO:** I run a 2nd bot called BSO (Bot School Old), which you can also play, it has lots of fun and unique changes, like 5x XP and infinitely stacking clues. Type \`/help\` for more information.
 
 Please click the buttons below for important links.`,
 		components: [

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -1060,7 +1060,7 @@ export async function monsterInfo(user: MUser, name: string): Promise<string | I
 	str.push(
 		`Due to the random variation of an added 1-20% duration, ${maxCanKill}x kills can take between (${formatDuration(
 			min
-		)} and (${formatDuration(max)})\nIf the Weekend boost is active, it takes: (${formatDuration(
+		)}) and (${formatDuration(max)})\nIf the Weekend boost is active, it takes: (${formatDuration(
 			min * 0.9
 		)}) to (${formatDuration(max * 0.9)}) to finish.\n`
 	);

--- a/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
@@ -86,7 +86,7 @@ async function checkReqs(user: MUser, monster: KillableMonster, isPhosani: boole
 			hitpoints: 90
 		});
 		if (!requirements[0]) {
-			return `${user.usernameOrMention} doesn't meet the requirements: ${requirements[1]}`;
+			return `${user.usernameOrMention} doesn't meet the requirements: ${requirements[1]}.`;
 		}
 		if ((await user.getKC(NightmareMonster.id)) < 50) {
 			return "You need to have killed The Nightmare atleast 50 times before you can face the Phosani's Nightmare.";
@@ -319,7 +319,7 @@ ${soloBoosts.length > 0 ? `**Boosts:** ${soloBoosts.join(', ')}` : ''}`
 					NightmareMonster.timeToFinish
 			  )} - the total trip will take ${formatDuration(duration)}.`;
 
-	str += `\n\nRemoved ${soloFoodUsage} from your bank.${
+	str += `\nRemoved ${soloFoodUsage} from your bank.${
 		isPhosani
 			? hasShadow
 				? ` Your minion is using ${shadowChargesPerKc * quantity} Tumeken's shadow charges. `

--- a/src/mahoji/lib/abstracted_commands/slayerTaskCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/slayerTaskCommand.ts
@@ -422,8 +422,8 @@ export async function slayerSkipTaskCommand({
 		interactionReply(
 			interaction,
 			`You cannot have more than ${maxBlocks} slayer blocks!\n\nUse:\n` +
-				'`st --unblock kalphite`\n to remove a block.\n' +
-				'`st --list` for list of blocked monsters and their IDs.'
+				'`/slayer rewards unblock assignment:kalphite`\n to remove a blocked monster.\n' +
+				'`/slayer manage command:list_blocks` for your list of blocked monsters.'
 		);
 		return;
 	}

--- a/src/tasks/minions/minigames/nightmareActivity.ts
+++ b/src/tasks/minions/minigames/nightmareActivity.ts
@@ -59,11 +59,13 @@ export const nightmareTask: MinionTask = {
 		const { newKC } = await user.incrementKC(monsterID, kc);
 
 		const ownsOrUsedTablet = user.bank.has('Slepey tablet') || user.bitfield.includes(BitField.HasSlepeyTablet);
-		if (ownsOrUsedTablet) {
-			userLoot.remove('Slepey tablet', userLoot.amount('Slepey tablet'));
-		}
-		if (!ownsOrUsedTablet && kc > 0 && newKC >= 100 && !userLoot.has('Slepey tablet')) {
-			userLoot.add('Slepey tablet');
+		if (isPhosani) {
+			if (ownsOrUsedTablet) {
+				userLoot.remove('Slepey tablet', userLoot.amount('Slepey tablet'));
+			}
+			if (!ownsOrUsedTablet && kc > 0 && newKC >= 100 && !userLoot.has('Slepey tablet')) {
+				userLoot.add('Slepey tablet');
+			}
 		}
 
 		// Fix purple items on solo kills

--- a/src/tasks/minions/minigames/tobActivity.ts
+++ b/src/tasks/minions/minigames/tobActivity.ts
@@ -92,7 +92,7 @@ export const tobTask: MinionTask = {
 				team: tobUsers
 			});
 
-			resultMessage += `\n **Raid ${raidId} results: **`;
+			resultMessage += `\n **Raid${quantity < 2 ? '' : ` ${raidId}`} results:**`;
 
 			// Give them all +1 attempts
 			const diedToMaiden = wipedRoom !== null && wipedRoom === 0;
@@ -221,7 +221,8 @@ export const tobTask: MinionTask = {
 				duration
 			}))
 		});
-		const shouldShowImage = allUsers.length <= 3 && teamsLoot.entries().every(i => i[1].length <= 6);
+		const shouldShowImage =
+			allUsers.length <= 3 && teamsLoot.entries().every(i => i[1].length <= 6 && i[1].length > 0);
 
 		if (users.length === 1) {
 			return handleTripFinish(

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -8,7 +8,7 @@ import { baseModifyBusyCounter } from '../../src/lib/busyCounterCache';
 import { deduplicateClueScrolls } from '../../src/lib/clues/clueUtils';
 import getUserFoodFromBank from '../../src/lib/minions/functions/getUserFoodFromBank';
 import { SkillsEnum } from '../../src/lib/skilling/types';
-import { sanitizeBank, skillingPetDropRate, stripEmojis } from '../../src/lib/util';
+import { pluraliseItemName, sanitizeBank, skillingPetDropRate, stripEmojis } from '../../src/lib/util';
 import getOSItem from '../../src/lib/util/getOSItem';
 import { sellPriceOfItem, sellStorePriceOfItem } from '../../src/mahoji/commands/sell';
 import { mockMUser } from './utils';
@@ -135,5 +135,11 @@ describe('util', () => {
 		expect(baseModifyBusyCounter(cache, id, -1)).toEqual(0);
 		expect(cache.get(id)).toEqual(0);
 		// expect(() => baseModifyBusyCounter(cache, id, -1)).toThrow();
+	});
+
+	test('pluraliseItemName correctly pluralises items', async () => {
+		expect(pluraliseItemName('Steel Axe')).toEqual('Steel Axes');
+		expect(pluraliseItemName('Steel Arrowtips')).toEqual('Steel Arrowtips');
+		expect(pluraliseItemName('Adamantite nails')).toEqual('Adamantite nails');
 	});
 });


### PR DESCRIPTION
### Description:
- Add pluraliseItemName function 
- Various minor fixes
### Changes:
- Add pluraliseItemName() from @osrsjobbo on https://github.com/oldschoolgg/oldschoolbot/pull/4895
- Fix grammar for smithing with pluraliseItemName 
- Remove avernic hilt boost from awakened vard and duke due scythe being a mandatory requirment
- If only one tob raid is done in a trip return "Raid Results" instead of "Raid 1 Results:"
- Fix a return error for slayer blocks that used the old "=st --unblock" methods 
- Add a .join() to function clueProg to properly space out clue opens when shown in various places (i.e. notifications)
- Remove an extra /n in the trip message when killing nightmare solo
- Add a check to Slepey tablet to ensure its only rewarded for phosani kc
- Add a missing ")" to `/k name:X show_info:True`
- Add a check for tob chest image to prevent showing an empty picture on wipe
- Add a period to Nightmare and TOA missing required items message
- Replace `+bso` with `/help` in the minion buy command

### Other checks:
- [X] I have tested all my changes thoroughly.

closes: https://github.com/oldschoolgg/oldschoolbot/issues/4879
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5340
