### PR TITLE
League task fix & smithables

### DIFF
--- a/src/lib/skilling/skills/smithing/smithables/dwarven.ts
+++ b/src/lib/skilling/skills/smithing/smithables/dwarven.ts
@@ -124,25 +124,6 @@ const Dwarven: SmithedItem[] = [
 		outputMultiple: 1,
 		requiresBlacksmith: true,
 		cantBeDoubled: true
-	},
-	{
-		name: 'Silver stake',
-		level: 95,
-		xp: 77,
-		id: itemID('Silver stake'),
-		inputBars: { [itemID('Silver bar')]: 3, [itemID('Elder logs')]: 1 },
-		timeToUse: Time.Second * 3,
-		outputMultiple: 1,
-		cantBeDoubled: true
-	},
-	{
-		name: 'Silver bolts (unf)',
-		level: 21,
-		xp: 50.0,
-		id: itemID('Silver bolts (unf)'),
-		inputBars: { [itemID('Silver bar')]: 1 },
-		timeToUse: Time.Second * 3.4,
-		outputMultiple: 10
 	}
 ];
 

--- a/src/lib/skilling/skills/smithing/smithables/index.ts
+++ b/src/lib/skilling/skills/smithing/smithables/index.ts
@@ -6,9 +6,21 @@ import Gorajan from './gorajan';
 import Iron from './iron';
 import Mithril from './mithril';
 import Rune from './rune';
+import Silver from './silver';
 import Steel from './steel';
 
-const smithables = [...Adamant, ...Bronze, ...Iron, ...Mithril, ...Rune, ...Steel, ...Dwarven, ...Gorajan, ...Gold];
+const smithables = [
+	...Bronze,
+	...Iron,
+	...Silver,
+	...Steel,
+	...Gold,
+	...Mithril,
+	...Adamant,
+	...Rune,
+	...Dwarven,
+	...Gorajan
+];
 
 export default smithables;
 export const smithingCL = smithables.map(i => i.id);

--- a/src/lib/skilling/skills/smithing/smithables/silver.ts
+++ b/src/lib/skilling/skills/smithing/smithables/silver.ts
@@ -1,0 +1,28 @@
+import { Time } from 'e';
+
+import itemID from '../../../../util/itemID';
+import { SmithedItem } from '../../../types';
+
+const Silver: SmithedItem[] = [
+	{
+		name: 'Silver stake',
+		level: 95,
+		xp: 77,
+		id: itemID('Silver stake'),
+		inputBars: { [itemID('Silver bar')]: 3, [itemID('Elder logs')]: 1 },
+		timeToUse: Time.Second * 3,
+		outputMultiple: 1,
+		cantBeDoubled: true
+	},
+	{
+		name: 'Silver bolts (unf)',
+		level: 21,
+		xp: 50.0,
+		id: itemID('Silver bolts (unf)'),
+		inputBars: { [itemID('Silver bar')]: 1 },
+		timeToUse: Time.Second * 3.4,
+		outputMultiple: 10
+	}
+];
+
+export default Silver;


### PR DESCRIPTION
### Description:
The leagues task `Create every Dwarven item from scratch` currently checks for silver items aswell as dwarven items
### Changes:
- Move all silver smithables into silver.ts to prevent the above issue
- Change the order of smithables to have `/cl name: Smithing` go from bronze to gora
### Other checks:
- [X] I have tested all my changes thoroughly.
