### PR TITLE
Fix mysterious tree contracts

### DIFF
--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -41,7 +41,7 @@ async function farmingLootBoosts(user: MUser, plant: Plant, loot: Bank, messages
 		bonusPercentage += 100;
 		messages.push('100% for Farming master cape');
 	}
-	if (user.hasEquippedOrInBank(['Arcane harvester']) && !(plant.name === 'Mysterious tree')) {
+	if (user.hasEquippedOrInBank(['Arcane harvester']) && plant.name !== 'Mysterious tree') {
 		const boostRes = await inventionItemBoost({
 			user,
 			inventionID: InventionID.ArcaneHarvester,

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -44,18 +44,19 @@ async function farmingLootBoosts(user: MUser, plant: Plant, loot: Bank, messages
 		bonusPercentage += 100;
 		messages.push('100% for Farming master cape');
 	}
-	if (plantsNotUsedForArcaneHarvester.includes(plant)) return;
-	if (user.hasEquippedOrInBank(['Arcane harvester'])) {
-		const boostRes = await inventionItemBoost({
-			user,
-			inventionID: InventionID.ArcaneHarvester,
-			duration: plant.level * Time.Second * 30
-		});
-		if (boostRes.success) {
-			bonusPercentage += inventionBoosts.arcaneHarvester.harvestBoostPercent;
-			messages.push(
-				`${inventionBoosts.arcaneHarvester.harvestBoostPercent}% bonus yield from Arcane Harvester (${boostRes.messages})`
-			);
+	if (!plantsNotUsedForArcaneHarvester.includes(plant)) {
+		if (user.hasEquippedOrInBank(['Arcane harvester'])) {
+			const boostRes = await inventionItemBoost({
+				user,
+				inventionID: InventionID.ArcaneHarvester,
+				duration: plant.level * Time.Second * 30
+			});
+			if (boostRes.success) {
+				bonusPercentage += inventionBoosts.arcaneHarvester.harvestBoostPercent;
+				messages.push(
+					`${inventionBoosts.arcaneHarvester.harvestBoostPercent}% bonus yield from Arcane Harvester (${boostRes.messages})`
+				);
+			}
 		}
 	}
 	increaseBankQuantitesByPercent(loot, bonusPercentage);
@@ -644,13 +645,19 @@ export const farmingTask: MinionTask = {
 
 			if (hasPlopper) infoStr.push(`\nYou received ${plopperBoostPercent}% bonus loot from Plopper`);
 
-			handleTripFinish(
+			const seedPackCount = loot.amount('Seed pack');
+
+			return handleTripFinish(
 				user,
 				channelID,
 				infoStr.join('\n'),
 				janeMessage
 					? await chatHeadImage({
-							content: `You've completed your contract and I have rewarded you with 1 Seed pack. Please open this Seed pack before asking for a new contract!\nYou have completed ${
+							content: `You've completed your contract and I have rewarded you with ${seedPackCount} Seed pack${
+								seedPackCount > 1 ? 's' : ''
+							}. Please open ${
+								seedPackCount > 1 ? 'these Seed packs' : 'this Seed pack'
+							} before asking for a new contract!\nYou have completed ${
 								contractsCompleted + 1
 							} farming contracts.`,
 							head: 'jane'

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -28,9 +28,6 @@ import { updateBankSetting } from '../../lib/util/updateBankSetting';
 import { sendToChannelID } from '../../lib/util/webhook';
 import { userStatsBankUpdate } from '../../mahoji/mahojiSettings';
 
-const plantsNotUsedForArcaneHarvester = ['Mysterious tree'].map(i => Farming.Plants.find(p => p.name === i)!);
-assert(!(plantsNotUsedForArcaneHarvester as any[]).includes(undefined));
-
 const plopperBoostPercent = 100;
 
 async function farmingLootBoosts(user: MUser, plant: Plant, loot: Bank, messages: string[]) {
@@ -44,19 +41,17 @@ async function farmingLootBoosts(user: MUser, plant: Plant, loot: Bank, messages
 		bonusPercentage += 100;
 		messages.push('100% for Farming master cape');
 	}
-	if (!plantsNotUsedForArcaneHarvester.includes(plant)) {
-		if (user.hasEquippedOrInBank(['Arcane harvester'])) {
-			const boostRes = await inventionItemBoost({
-				user,
-				inventionID: InventionID.ArcaneHarvester,
-				duration: plant.level * Time.Second * 30
-			});
-			if (boostRes.success) {
-				bonusPercentage += inventionBoosts.arcaneHarvester.harvestBoostPercent;
-				messages.push(
-					`${inventionBoosts.arcaneHarvester.harvestBoostPercent}% bonus yield from Arcane Harvester (${boostRes.messages})`
-				);
-			}
+	if (user.hasEquippedOrInBank(['Arcane harvester'])) {
+		const boostRes = await inventionItemBoost({
+			user,
+			inventionID: InventionID.ArcaneHarvester,
+			duration: plant.level * Time.Second * 30
+		});
+		if (boostRes.success) {
+			bonusPercentage += inventionBoosts.arcaneHarvester.harvestBoostPercent;
+			messages.push(
+				`${inventionBoosts.arcaneHarvester.harvestBoostPercent}% bonus yield from Arcane Harvester (${boostRes.messages})`
+			);
 		}
 	}
 	increaseBankQuantitesByPercent(loot, bonusPercentage);

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -41,7 +41,7 @@ async function farmingLootBoosts(user: MUser, plant: Plant, loot: Bank, messages
 		bonusPercentage += 100;
 		messages.push('100% for Farming master cape');
 	}
-	if (user.hasEquippedOrInBank(['Arcane harvester'])) {
+	if (user.hasEquippedOrInBank(['Arcane harvester']) && !(plant.name === 'Mysterious tree')) {
 		const boostRes = await inventionItemBoost({
 			user,
 			inventionID: InventionID.ArcaneHarvester,
@@ -575,6 +575,13 @@ export const farmingTask: MinionTask = {
 			}
 
 			await farmingLootBoosts(user, plant, loot, infoStr);
+
+			if (plant.name === 'Mysterious tree') {
+				if (loot.has('Seed Pack')) {
+					loot.add('Seed Pack', 1);
+					infoStr.push('+1 Seed Pack for Mysterious tree farming contract');
+				}
+			}
 
 			if (loot.has('Plopper')) {
 				loot.bank[itemID('Plopper')] = 1;

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -248,8 +248,6 @@ export const farmingTask: MinionTask = {
 
 			str += `\n\n${user.minionName} tells you to come back after your plants have finished growing!`;
 
-			if (hasPlopper) str += `\nYou received ${plopperBoostPercent}% bonus loot from Plopper`;
-
 			handleTripFinish(user, channelID, str, undefined, data, null);
 		} else if (patchType.patchPlanted) {
 			// If they do have something planted here, harvest it and possibly replant.
@@ -644,8 +642,6 @@ export const farmingTask: MinionTask = {
 					}
 				});
 			}
-
-			if (hasPlopper) infoStr.push(`\nYou received ${plopperBoostPercent}% bonus loot from Plopper`);
 
 			const seedPackCount = loot.amount('Seed pack');
 


### PR DESCRIPTION
### Description:
Fixes an issue causing mysterious tree contracts to not properly multiple the seed packs & non mystery box loot. 
Fixes the wording in the Jane message

### Changes:
- remove plantsNotUsedForArcaneHarvester
- Make Mysterious tree contracts give an extra seed pack by default to make them give four total with max boosts to match other contracts.
- Add a return to the final handleTripFinish to remove the eslint warning
- Fix the Jane chatHeadImage() for farming contracts to show the correct amount of seed packs received. 
- Remove outdated plopper message "You recieved 100% bonus loot from Plopper" (seen below) since the "100% for Plopper" message is already shown

### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5523

![Discord_viM1SQmy4A](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/45e374e7-94f7-4688-bfbf-b0a10da124d1)

