### PR TITLE
Fix Invention Master Cape material cost discount display

### DIFF
--- a/src/lib/invention/inventions.ts
+++ b/src/lib/invention/inventions.ts
@@ -648,6 +648,8 @@ export async function inventionItemBoost({
 	let messages: string[] = [`Removed ${materialCost}`];
 	if (user.hasEquipped('Invention master cape')) {
 		materialCost.mutReduceAllValuesByPercent(inventionBoosts.inventionMasterCape.materialCostReductionPercent);
+		messages.shift();
+		messages.unshift(`Removed ${materialCost}`);
 		messages.push(
 			`${inventionBoosts.inventionMasterCape.materialCostReductionPercent}% less materials for mastery`
 		);


### PR DESCRIPTION
### Description:

- Currently the material cost isn't updated after removing 5% material cost

### Changes:

- Unshifts + re-shifts the "Removed"/cost message if the materials are mutated.

### Other checks:

- [x] I have tested all my changes thoroughly.
