### PR TITLE
Fix 'permanent busy' bug that occurs after deleting a pending confirmation

### DIFF
--- a/src/lib/util/interactionHelpers.ts
+++ b/src/lib/util/interactionHelpers.ts
@@ -21,6 +21,7 @@ export async function interactionReplyGetDuration(
 
 	const response = await interactionReply(interaction, { content: prompt, components });
 
+	if (response === undefined) return false;
 	try {
 		const selection = await response.awaitMessageComponent({
 			filter: i => i.user.id === interaction.user.id,

--- a/src/lib/util/interactionReply.ts
+++ b/src/lib/util/interactionReply.ts
@@ -46,6 +46,11 @@ export async function handleInteractionError(err: unknown, interaction: Interact
 	// For silent errors, just return and do nothing. Users could see an error.
 	if (err instanceof Error && err.message === SILENT_ERROR) return;
 
+	// If DiscordAPIError #10008, that means someone deleted the message, we don't need to log this.
+	if (err instanceof DiscordAPIError && err.code === 10_008) {
+		return;
+	}
+
 	// If this isn't a UserError, its something we need to just log and know about to fix it.
 	// Or if its not repliable, we should never be erroring here.
 	if (!(err instanceof UserError) || !interaction.isRepliable()) {


### PR DESCRIPTION
### Description:

- If someone deletes a message / interaction that is still awaiting a response, the user who ran the command will be stuck in a permanent busy state.

- This is because trying to reply/edit an interaction that was deleted throws a Discord error, which prevents the postCommandHandler from running. 

### Changes:

- Updates the interactionReply() function to be async, so we can catch  the error there.
- Updates notification helper to check if interactionReply() result is undefined. 

- Also removes, `Tried to respond with '${err.message}' to this interaction, but it was already replied too.` since interactionReply() falls back to followUp's in that case.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:
We usually don't care about the result from interactionReply() since we can call it multiple times on the original interaction, and don't need the actual response handle. The only time we DO need the response handle is when the reply contains buttons who's input we need to capture. 