### PR TITLE
Receive Guthix god favour from Guthixian cache

### DIFF
--- a/src/tasks/minions/bso/guthixianCacheActivity.ts
+++ b/src/tasks/minions/bso/guthixianCacheActivity.ts
@@ -69,6 +69,8 @@ export const guthixianCacheTask: MinionTask = {
 			str += `\n${loot.has('Doopy') ? `${Emoji.Purple} ` : ''}You received: ${loot}.`;
 		}
 
+		await user.addToGodFavour(['Guthix'], data.duration);
+
 		return handleTripFinish(user, channelID, str, undefined, data, loot);
 	}
 };


### PR DESCRIPTION
### Description:
Receive Guthix god favour for divine dominion from Guthixian cache. It gave +1.6% per trip in testing.
### Changes:
- Change guthixian caches to give guthix god favour
### Other checks:
- [X] I have tested all my changes thoroughly.
