### PR TITLE
Return all items when reverting Completionist cape

### DIFF
--- a/src/lib/data/creatables/bsoItems.ts
+++ b/src/lib/data/creatables/bsoItems.ts
@@ -1350,6 +1350,9 @@ export const BsoCreateables: Createable[] = [
 					refundBank.add(masterCape);
 				}
 			}
+			refundBank.add('Master quest cape');
+			refundBank.add('Achievement diary cape(t)');
+			refundBank.add('Music cape (t)');
 			return refundBank;
 		},
 		inputItems: new Bank().add('Completionist cape').add('Completionist hood'),


### PR DESCRIPTION
### Description:
Reverting the Completionist cape doesn't return master quest cape, achievement diary cape, or music cape
### Changes:
- change `/create item:Revert completionist cape` to give back the three missing capes
### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5614