### PR TITLE
Added subtext to bank for spirit weed

### DIFF
--- a/src/lib/bankImage.ts
+++ b/src/lib/bankImage.ts
@@ -168,6 +168,7 @@ const forcedShortNameMap = new Map<number, string>([
 	[i('Dwarf weed'), 'dwarf'],
 	[i('Torstol'), 'torstol'],
 	[i('Korulsi'), 'korulsi'],
+	[i('Spirit weed'), 'spiritw'],
 
 	[i('Grimy guam leaf'), 'guam'],
 	[i('Grimy marrentill'), 'marren'],


### PR DESCRIPTION
### Description:

- spirit weed was missing the subtext.

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [x] I have tested all my changes thoroughly.
