### PR TITLE
Fix tradePlayerItems / stale bank overwrite bug.

### DIFF
--- a/src/lib/util/tradePlayerItems.ts
+++ b/src/lib/util/tradePlayerItems.ts
@@ -16,79 +16,76 @@ export async function tradePlayerItems(sender: MUser, recipient: MUser, _itemsTo
 	const itemsToReceive = _itemsToReceive ? _itemsToReceive.clone() : new Bank();
 
 	// Queue the primary trade function:
-	const processTradePromise = userQueueFn(sender.id, async () => {
-		try {
-			await Promise.all([sender.sync(), recipient.sync()]);
-			if (!sender.owns(itemsToSend)) {
-				return { success: false, message: `${sender.usernameOrMention} doesn't own all items.` };
-			}
-			if (!recipient.owns(itemsToReceive)) {
-				return { success: false, message: `${recipient.usernameOrMention} doesn't own all items.` };
-			}
-			const newSenderBank = sender.bank.clone();
-			const newRecipientBank = recipient.bank.clone();
-
-			let senderGP = sender.GP;
-			let recipientGP = recipient.GP;
-
-			if (itemsToSend.has('Coins')) {
-				const sentCoins = itemsToSend.amount('Coins');
-				senderGP -= sentCoins;
-				itemsToSend.remove('Coins', sentCoins);
-				recipientGP += sentCoins;
-			}
-			if (itemsToReceive.has('Coins')) {
-				const receivedCoins = itemsToReceive.amount('Coins');
-				recipientGP -= receivedCoins;
-				itemsToReceive.remove('Coins', receivedCoins);
-				senderGP += receivedCoins;
-			}
-
-			newSenderBank.remove(itemsToSend);
-			newRecipientBank.remove(itemsToReceive);
-			newSenderBank.add(itemsToReceive);
-			newRecipientBank.add(itemsToSend);
-
-			const updateSender = prisma.user.update({
-				data: {
-					GP: senderGP,
-					bank: newSenderBank.bank
-				},
-				where: {
-					id: sender.id
+	return userQueueFn(sender.id, async () => {
+		return userQueueFn(recipient.id, async () => {
+			try {
+				await Promise.all([sender.sync(), recipient.sync()]);
+				if (!sender.owns(itemsToSend)) {
+					return { success: false, message: `${sender.usernameOrMention} doesn't own all items.` };
 				}
-			});
-			const updateRecipient = prisma.user.update({
-				data: {
-					GP: recipientGP,
-					bank: newRecipientBank.bank
-				},
-				where: {
-					id: recipient.id
+				if (!recipient.owns(itemsToReceive)) {
+					return { success: false, message: `${recipient.usernameOrMention} doesn't own all items.` };
 				}
-			});
-			// Run both in a single transaction, so it all succeeds or all fails:
-			await prisma.$transaction([updateSender, updateRecipient]);
-			await Promise.all([sender.sync(), recipient.sync()]);
-			return { success: true, message: null };
-		} catch (e: any) {
-			// We should only get here if something bad happened... most likely prisma, but possibly command competition
-			logError(e, undefined, {
-				sender: sender.id,
-				recipient: recipient.id,
-				command: 'trade',
-				items_sent: itemsToSend.toString(),
-				items_received: itemsToReceive.toString()
-			});
-			return { success: false, message: 'Temporary error, please try again.' };
-		} finally {
-			modifyBusyCounter(sender.id, -1);
-			modifyBusyCounter(recipient.id, -1);
-		}
-	});
+				const newSenderBank = sender.bank.clone();
+				const newRecipientBank = recipient.bank.clone();
 
-	// Queue function for the recipient so no funny business / mistakes happen:
-	return userQueueFn(recipient.id, async () => {
-		return processTradePromise;
+				let senderGP = sender.GP;
+				let recipientGP = recipient.GP;
+
+				if (itemsToSend.has('Coins')) {
+					const sentCoins = itemsToSend.amount('Coins');
+					senderGP -= sentCoins;
+					itemsToSend.remove('Coins', sentCoins);
+					recipientGP += sentCoins;
+				}
+				if (itemsToReceive.has('Coins')) {
+					const receivedCoins = itemsToReceive.amount('Coins');
+					recipientGP -= receivedCoins;
+					itemsToReceive.remove('Coins', receivedCoins);
+					senderGP += receivedCoins;
+				}
+
+				newSenderBank.remove(itemsToSend);
+				newRecipientBank.remove(itemsToReceive);
+				newSenderBank.add(itemsToReceive);
+				newRecipientBank.add(itemsToSend);
+
+				const updateSender = prisma.user.update({
+					data: {
+						GP: senderGP,
+						bank: newSenderBank.bank
+					},
+					where: {
+						id: sender.id
+					}
+				});
+				const updateRecipient = prisma.user.update({
+					data: {
+						GP: recipientGP,
+						bank: newRecipientBank.bank
+					},
+					where: {
+						id: recipient.id
+					}
+				});
+				// Run both in a single transaction, so it all succeeds or all fails:
+				await prisma.$transaction([updateSender, updateRecipient]);
+				await Promise.all([sender.sync(), recipient.sync()]);
+				return { success: true, message: null };
+			} catch (e: any) {
+				// We should only get here if something bad happened... most likely prisma, but possibly command competition
+				logError(e, undefined, {
+					sender: sender.id,
+					recipient: recipient.id,
+					command: 'trade',
+					items_sent: itemsToSend.toString(),
+					items_received: itemsToReceive.toString()
+				});
+				return { success: false, message: 'Temporary error, please try again.' };
+			} finally {
+				modifyBusyCounter(sender.id, -1);
+				modifyBusyCounter(recipient.id, -1);
+			}
+		});
 	});
 }

--- a/tests/integration/paymentConflict.test.ts
+++ b/tests/integration/paymentConflict.test.ts
@@ -1,0 +1,140 @@
+import { randomSnowflake } from '@oldschoolgg/toolkit';
+import { randArrItem, randInt, roll, Time } from 'e';
+import { Bank } from 'oldschooljs';
+import { describe, expect, test } from 'vitest';
+
+import { payCommand } from '../../src/mahoji/commands/pay';
+import { createTestUser, mockClient, TestUser } from './util';
+
+describe('Payment conflicts', async () => {
+	const payerCount = 50;
+	const iterations = 100;
+	const addChance = 3;
+	const repeats = 5;
+
+	const bigBank = new Bank().add('Cannonball', 4).add('Bones', 10_000);
+
+	test(
+		'GE Simulation (Payee)',
+		async () => {
+			await mockClient();
+
+			// Payee is currently the primary target of the test.
+			const userPayee = await createTestUser(randomSnowflake(), new Bank(bigBank), { GP: 1_000_000_000 });
+
+			const payeeTarget = await globalClient.fetchUser(userPayee.id);
+
+			const startingBallCount = userPayee.bank.amount('Cannonball');
+
+			const payers: TestUser[] = [];
+			for (let i = 0; i < payerCount; i++) {
+				payers.push(await createTestUser(randomSnowflake(), new Bank(), { GP: 1_000_000_000 }));
+			}
+
+			const promisePay = async () => {
+				const payer = randArrItem(payers);
+				return new Promise<void>(async resolve => {
+					const amount = randInt(100_000, 1_000_000);
+					await payer.runCommand(payCommand, { user: { user: payeeTarget }, amount: amount.toString() });
+					resolve();
+				});
+			};
+			const promiseAdd = async () => {
+				return new Promise<void>(async resolve => {
+					await userPayee.addItemsToBank({ items: new Bank().add('Cannonball', 100) });
+					resolve();
+				});
+			};
+
+			const promises: Promise<void>[] = [];
+			let newBalls = 0;
+			for (let j = 0; j < iterations; j++) {
+				if (roll(addChance)) {
+					newBalls += 100;
+					promises.push(promiseAdd());
+				} else {
+					promises.push(promisePay());
+				}
+			}
+
+			await Promise.all(promises);
+
+			let totalGp = 0;
+			await userPayee.sync();
+			await Promise.all(payers.map(u => u.sync()));
+			totalGp += userPayee.GP;
+			for (const payer of payers) totalGp += payer.GP;
+			console.log(
+				`starting: ${startingBallCount} banked: ${userPayee.bank.amount('Cannonball')} - new: ${newBalls}`
+			);
+
+			expect(totalGp).toEqual(1_000_000_000 * (payerCount + 1));
+			expect(userPayee.bank.amount('Cannonball') - startingBallCount).toEqual(newBalls);
+		},
+		{
+			timeout: Time.Minute * 5,
+			repeats
+		}
+	);
+
+	test(
+		'GE Simulation (Payer)',
+		async () => {
+			await mockClient();
+			// May as well test for the Payer also, even though so far we're solid here.
+			const userPayer = await createTestUser(randomSnowflake(), new Bank(bigBank), { GP: 1_000_000_000 });
+
+			const startingBallCount = userPayer.bank.amount('Cannonball');
+
+			const payees: TestUser[] = [];
+			for (let i = 0; i < payerCount; i++) {
+				payees.push(await createTestUser(randomSnowflake(), new Bank(), { GP: 1_000_000_000 }));
+			}
+
+			const promisePay = async () => {
+				const payee = randArrItem(payees);
+				const payeeTarget = await globalClient.fetchUser(payee.id);
+				return new Promise<void>(async resolve => {
+					const amount = randInt(100_000, 1_000_000);
+					await userPayer.runCommand(payCommand, { user: { user: payeeTarget }, amount: amount.toString() });
+					resolve();
+				});
+			};
+			const promiseAdd = async () => {
+				return new Promise<void>(async resolve => {
+					await userPayer.addItemsToBank({ items: new Bank().add('Cannonball', 100) });
+					resolve();
+				});
+			};
+
+			const promises: Promise<void>[] = [];
+			let newBalls = 0;
+			for (let j = 0; j < iterations; j++) {
+				if (roll(addChance)) {
+					newBalls += 100;
+					promises.push(promiseAdd());
+				} else {
+					promises.push(promisePay());
+				}
+			}
+
+			await Promise.all(promises);
+
+			let totalGp = 0;
+			await userPayer.sync();
+			await Promise.all(payees.map(u => u.sync()));
+			totalGp += userPayer.GP;
+			for (const payee of payees) totalGp += payee.GP;
+			console.log(
+				`starting: ${startingBallCount} banked: ${userPayer.bank.amount('Cannonball')} - new: ${newBalls}`
+			);
+
+			expect(totalGp).toEqual(1_000_000_000 * (payerCount + 1));
+			expect(userPayer.bank.amount('Cannonball') - startingBallCount).toEqual(newBalls);
+		},
+		{
+			timeout: Time.Minute * 5,
+			repeats
+		}
+	);
+});

--- a/tests/integration/paymentConflict.test.ts
+++ b/tests/integration/paymentConflict.test.ts
@@ -64,9 +64,6 @@ describe('Payment conflicts', async () => {
 			await Promise.all(payers.map(u => u.sync()));
 			totalGp += userPayee.GP;
 			for (const payer of payers) totalGp += payer.GP;
-			console.log(
-				`starting: ${startingBallCount} banked: ${userPayee.bank.amount('Cannonball')} - new: ${newBalls}`
-			);
 
 			expect(totalGp).toEqual(1_000_000_000 * (payerCount + 1));
 			expect(userPayee.bank.amount('Cannonball') - startingBallCount).toEqual(newBalls);
@@ -125,9 +122,6 @@ describe('Payment conflicts', async () => {
 			await Promise.all(payees.map(u => u.sync()));
 			totalGp += userPayer.GP;
 			for (const payee of payees) totalGp += payee.GP;
-			console.log(
-				`starting: ${startingBallCount} banked: ${userPayer.bank.amount('Cannonball')} - new: ${newBalls}`
-			);
 
 			expect(totalGp).toEqual(1_000_000_000 * (payerCount + 1));
 			expect(userPayer.bank.amount('Cannonball') - startingBallCount).toEqual(newBalls);

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -19,6 +19,7 @@ vi.mock('../../src/lib/util/webhook', async () => {
 });
 
 // @ts-ignore mock
-globalClient.fetchUser = async () => ({
+globalClient.fetchUser = async (id: string | bigint) => ({
+	id: typeof id === 'string' ? id : String(id),
 	send: async () => {}
 });


### PR DESCRIPTION
### Description:

- This fixes a bug where a stale version of the bank can be inadvertently used causing item deletion in very rare cases.

### Changes:

- Fixes `tradePlayerItems()` by wrapping both user queues around the function instead of (attempting) to rely on await'ing the promise from the first.
- Adds test to verify problem is solved.
- Updates the mocked `fetchUser()` function to also include the `id` value as needed by the new test.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:
- The changes to "tradePlayerItems.ts" are actually fairly simple; the git diff is overcomplicating it. All that was done is the main body now has an additional function wrapped around it for inclusion of the promises.