### PR TITLE
Fix Reverting Gatherer's cape

### DIFF
--- a/src/lib/bso/expertCapes.ts
+++ b/src/lib/bso/expertCapes.ts
@@ -23,7 +23,14 @@ export const expertCapesSource = [
 			'Woodcutting master cape',
 			'Divination master cape'
 		]),
-		skills: [SkillsEnum.Farming, SkillsEnum.Fishing, SkillsEnum.Hunter, SkillsEnum.Mining, SkillsEnum.Woodcutting]
+		skills: [
+			SkillsEnum.Farming,
+			SkillsEnum.Fishing,
+			SkillsEnum.Hunter,
+			SkillsEnum.Mining,
+			SkillsEnum.Woodcutting,
+			SkillsEnum.Divination
+		]
 	},
 	{
 		cape: getOSItem("Combatant's cape"),


### PR DESCRIPTION
### Description:
Reverting Gatherer's cape, even with 500m divination XP and divination master cape cl slot, doesn't return the Divination master cape.
### Changes:
- Update the skills under Gatherer's cape to include `SkillsEnum.Divination`. This fixes the issue stated above.
### Other checks:
- [X] I have tested all my changes thoroughly.
