### PR TITLE
Fixes and additions to /kill command

### DIFF
--- a/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
+++ b/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
@@ -136,7 +136,7 @@ const Treebeard: CustomMonster = {
 export const QueenBlackDragon: CustomMonster = {
 	id: 192_195,
 	name: 'Queen Black Dragon',
-	aliases: ['Queen Black Dragon', 'qbd', 'qdb'],
+	aliases: ['queen black dragon', 'qbd', 'qdb'],
 	timeToFinish: Time.Minute * 45,
 	table: new LootTable()
 		.every('Royal dragon bones')

--- a/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
+++ b/src/lib/minions/data/killableMonsters/custom/demiBosses.ts
@@ -136,7 +136,7 @@ const Treebeard: CustomMonster = {
 export const QueenBlackDragon: CustomMonster = {
 	id: 192_195,
 	name: 'Queen Black Dragon',
-	aliases: ['qbd', 'qdb'],
+	aliases: ['Queen Black Dragon', 'qbd', 'qdb'],
 	timeToFinish: Time.Minute * 45,
 	table: new LootTable()
 		.every('Royal dragon bones')

--- a/src/lib/simulation/simulatedKillables.ts
+++ b/src/lib/simulation/simulatedKillables.ts
@@ -1,19 +1,24 @@
-import { randInt } from 'e';
-import { Bank } from 'oldschooljs';
+import { randArrItem, randInt } from 'e';
+import { Bank, Misc } from 'oldschooljs';
 
 import { DOANonUniqueTable } from '../../tasks/minions/bso/doaActivity';
+import { nexUniqueDrops } from '../data/CollectionsExport';
 import { chanceOfDOAUnique, pickUniqueToGiveUser } from '../depthsOfAtlantis';
+import { MoktangLootTable } from '../minions/data/killableMonsters/custom/bosses/Moktang';
+import { NEX_UNIQUE_DROPRATE, nexLootTable } from '../nex';
 import { roll } from '../util';
 import { WintertodtCrate } from './wintertodt';
 
 interface SimulatedKillable {
 	name: string;
+	isCustom: Boolean;
 	loot: (quantity: number) => Bank;
 }
 
 export const simulatedKillables: SimulatedKillable[] = [
 	{
 		name: 'Wintertodt',
+		isCustom: false,
 		loot: (quantity: number) => {
 			const loot = new Bank();
 			for (let i = 0; i < quantity; i++) {
@@ -40,7 +45,30 @@ export const simulatedKillables: SimulatedKillable[] = [
 		}
 	},
 	{
+		name: 'The Nightmare',
+		isCustom: false,
+		loot: (quantity: number) => {
+			let bank = new Bank();
+			for (let i = 0; i < quantity; i++) {
+				bank.add(Misc.Nightmare.kill({ team: [{ damageDone: 2400, id: 'id' }], isPhosani: false }).id);
+			}
+			return bank;
+		}
+	},
+	{
+		name: "Phosani's Nightmare",
+		isCustom: false,
+		loot: (quantity: number) => {
+			let bank = new Bank();
+			for (let i = 0; i < quantity; i++) {
+				bank.add(Misc.Nightmare.kill({ team: [{ damageDone: 2400, id: 'id' }], isPhosani: true }).id);
+			}
+			return bank;
+		}
+	},
+	{
 		name: 'Depths of Atlantis (DOA) - Solo',
+		isCustom: true,
 		loot: (quantity: number) => {
 			const chanceOfUnique = chanceOfDOAUnique(1, false);
 			const loot = new Bank();
@@ -52,6 +80,27 @@ export const simulatedKillables: SimulatedKillable[] = [
 				}
 			}
 			return loot;
+		}
+	},
+	{
+		name: 'Nex',
+		isCustom: true,
+		loot: (quantity: number) => {
+			let loot = new Bank();
+			for (let i = 0; i < quantity; i++) {
+				if (roll(NEX_UNIQUE_DROPRATE(1))) {
+					loot.add(randArrItem(nexUniqueDrops), 1);
+				}
+				loot.add(nexLootTable.roll());
+			}
+			return loot;
+		}
+	},
+	{
+		name: 'Moktang',
+		isCustom: true,
+		loot: (quantity: number) => {
+			return MoktangLootTable.roll(quantity);
 		}
 	}
 ];

--- a/src/lib/workers/kill.worker.ts
+++ b/src/lib/workers/kill.worker.ts
@@ -2,11 +2,10 @@ import '../customItems/customItems';
 import '../data/itemAliases';
 
 import { stringMatches } from '@oldschoolgg/toolkit';
-import { Bank, Misc, Monsters } from 'oldschooljs';
+import { Bank, Monsters } from 'oldschooljs';
 
 import { production } from '../../config';
 import { YETI_ID } from '../constants';
-import { MoktangLootTable } from '../minions/data/killableMonsters/custom/bosses/Moktang';
 import killableMonsters from '../minions/data/killableMonsters/index';
 import { simulatedKillables } from '../simulation/simulatedKillables';
 import type { KillWorkerArgs, KillWorkerReturn } from '.';
@@ -62,21 +61,6 @@ export default async ({
 		}
 
 		return { bank: simulatedKillable.loot(quantity) };
-	}
-
-	if (['nightmare', 'the nightmare'].some(alias => stringMatches(alias, bossName))) {
-		let bank = new Bank();
-		if (quantity > 10_000) {
-			return { error: 'I can only kill a maximum of 10k nightmares a time!' };
-		}
-		for (let i = 0; i < quantity; i++) {
-			bank.add(Misc.Nightmare.kill({ team: [{ damageDone: 2400, id: 'id' }], isPhosani: false }).id);
-		}
-		return { bank };
-	}
-
-	if (stringMatches(bossName, 'moktang')) {
-		return { bank: MoktangLootTable.roll(quantity) };
 	}
 
 	return { error: "I don't have that monster!" };

--- a/src/mahoji/commands/kill.ts
+++ b/src/mahoji/commands/kill.ts
@@ -52,10 +52,7 @@ export const killCommand: OSBMahojiCommand = {
 			autocomplete: async (value: string) => {
 				return [
 					...Monsters.map(i => ({ name: i.name, aliases: i.aliases })),
-					...simulatedKillables.map(i => ({ name: i.name, aliases: [i.name] })),
-					{ name: 'nex', aliases: ['nex'] },
-					{ name: 'nightmare', aliases: ['nightmare'] },
-					{ name: 'Moktang', aliases: ['moktang'] }
+					...simulatedKillables.map(i => ({ name: i.name, aliases: [i.name] }))
 				]
 					.filter(i =>
 						!value ? true : i.aliases.some(alias => alias.toLowerCase().includes(value.toLowerCase()))
@@ -78,11 +75,19 @@ export const killCommand: OSBMahojiCommand = {
 		const user = await mUserFetch(userID);
 		deferInteraction(interaction);
 		const osjsMonster = Monsters.find(mon => mon.aliases.some(alias => stringMatches(alias, options.name)));
+		const simulatedKillable = simulatedKillables.find(i => stringMatches(i.name, options.name));
 
 		let limit = determineKillLimit(user);
 		if (osjsMonster?.isCustom) {
 			if (user.perkTier() < PerkTier.Four) {
 				return 'Simulating kills of custom monsters is a T3 perk!';
+			}
+			limit /= 4;
+		}
+
+		if (simulatedKillable?.isCustom) {
+			if (user.perkTier() < PerkTier.Four) {
+				return 'Simulating kills of custom monsters or raids is a T3 perk!';
 			}
 			limit /= 4;
 		}


### PR DESCRIPTION
### Description:
Various fixes and additions to `/kill` command
### Changes:
- Add Nex to simulatedKillables.ts to be able to simulate BSO nex with `/kill`
- Add Phosani Nightmare to simulatedKillables.ts to be able to simulate with `/kill`
- Add "queen black dragon" to QBD aliases to fix `/kill` erroring out when doing Queen Black Dragon
- Move Nightmare and Moktang from kill.worker.ts to simulatedKillables.ts to properly check for limits and patron status
- Add isCustom to SimulatedKillable interface to maintain custom bso killablables locked behind T3

### Other checks:
- [X] I have tested all my changes thoroughly.
- I will make a follow on PR for OSB to update it's `/kill` command aswell once this one is merged
Closes: https://github.com/oldschoolgg/oldschoolbot/issues/5082
Closes: https://github.com/oldschoolgg/oldschoolbot/issues/5556
Closes: https://github.com/oldschoolgg/oldschoolbot/issues/4694
Resolves: https://github.com/oldschoolgg/oldschoolbot/pull/5636
