### PR TITLE
Fix Black Mask cl issues

### DIFF
--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -364,7 +364,6 @@ export function hasSlayerUnlock(
 }
 
 const filterLootItems = resolveItems([
-	'Black mask (10)',
 	"Hydra's eye",
 	"Hydra's fang",
 	"Hydra's heart",
@@ -379,26 +378,18 @@ const bludgeonPieces = resolveItems(['Bludgeon claw', 'Bludgeon spine', 'Bludgeo
 
 export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 	// Order: Fang, eye, heart.
-	const numBlackMask = myLoot.amount('Black mask (10)');
 	let numHydraEyes = myLoot.amount("Hydra's eye");
 	numHydraEyes += myLoot.amount("Hydra's fang");
 	numHydraEyes += myLoot.amount("Hydra's heart");
 	const numDarkTotemBases = myLoot.amount('Dark totem base');
 	const numBludgeonPieces = myLoot.amount('Bludgeon claw');
-	if (!numBludgeonPieces && !numDarkTotemBases && !numHydraEyes && !numBlackMask) {
+	if (!numBludgeonPieces && !numDarkTotemBases && !numHydraEyes) {
 		return { bankLoot: myLoot, clLoot: myLoot };
 	}
 
 	myLoot.filter(i => !filterLootItems.includes(i.id), true);
 
 	const myClLoot = new Bank(myLoot.bank);
-
-	if (numBlackMask) {
-		for (let x = 0; x < numBlackMask; x++) {
-			myLoot.add('Black mask');
-			myClLoot.add('Black mask (10)');
-		}
-	}
 
 	const combinedBank = new Bank(myBank).add(myLoot);
 	if (numBludgeonPieces) {


### PR DESCRIPTION
### Description:
Black mask (10) is auto converted into black mask when received from cave horrors. This has caused various cl issues over the years and still is an issue with the cl slot under creatables. This PR removes the auto conversion and treats black mask the same as in-game. Cave horror drops black mask (10), then the user can either use it for its perks or uncharged it, with `/create item:Uncharged black mask`, for use in making a slayer helm. This will fix all the issues surrounding black mask and hopefully put this issue to rest permanently. 
### Changes:
- Remove the auto conversion of black mask(10)
### Other checks:
- [X] I have tested all my changes thoroughly.
