### PR TITLE
Fix gear presets

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -824,6 +824,24 @@ GROUP BY data->>'clueID';`);
 	async validateEquippedGear() {
 		let itemsUnequippedAndRefunded = new Bank();
 		for (const [gearSetupName, gearSetup] of Object.entries(this.gear) as [GearSetupType, GearSetup][]) {
+			if (gearSetup['2h'] !== null) {
+				if (gearSetup.weapon?.item) {
+					const { refundBank } = await this.forceUnequip(
+						gearSetupName,
+						EquipmentSlot.Weapon,
+						'2h Already equipped'
+					);
+					itemsUnequippedAndRefunded.add(refundBank);
+				}
+				if (gearSetup.shield?.item) {
+					const { refundBank } = await this.forceUnequip(
+						gearSetupName,
+						EquipmentSlot.Shield,
+						'2h Already equipped'
+					);
+					itemsUnequippedAndRefunded.add(refundBank);
+				}
+			}
 			for (const slot of Object.values(EquipmentSlot)) {
 				const item = gearSetup[slot];
 				if (!item) continue;

--- a/src/mahoji/commands/gearpresets.ts
+++ b/src/mahoji/commands/gearpresets.ts
@@ -125,6 +125,11 @@ export async function createOrEditGearSetup(
 		pinned_setup: !pinned_setup || pinned_setup === 'reset' ? undefined : pinned_setup
 	};
 
+	if (gearData.two_handed !== null) {
+		gearData.shield = null;
+		gearData.weapon = null;
+	}
+
 	const preset = await prisma.gearPreset.upsert({
 		where: {
 			user_id_name: {

--- a/src/mahoji/lib/abstracted_commands/gearCommands.ts
+++ b/src/mahoji/lib/abstracted_commands/gearCommands.ts
@@ -39,6 +39,10 @@ export async function gearPresetEquipCommand(user: MUser, gearSetup: string, pre
 		return "You don't have a gear preset with that name.";
 	}
 	const preset = (userPreset ?? globalPreset) as GearPreset;
+	if (preset.two_handed !== null) {
+		preset.weapon = null;
+		preset.shield = null;
+	}
 
 	// Checks the preset to make sure the user has the required stats for every item in the preset
 	for (const gearItemId of Object.values(preset)) {

--- a/src/mahoji/lib/mahojiCommandOptions.ts
+++ b/src/mahoji/lib/mahojiCommandOptions.ts
@@ -141,9 +141,9 @@ export const gearPresetOption: CommandOption = {
 			}
 		});
 		return presets
-			.filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())))
 			.map(i => ({ name: i.name, value: i.name }))
-			.concat(globalPresets.map(i => ({ name: `${i.name} (Global)`, value: i.name })));
+			.concat(globalPresets.map(i => ({ name: `${i.name} (Global)`, value: i.name })))
+			.filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())));
 	}
 };
 

--- a/tests/integration/commands/gearPresets.test.ts
+++ b/tests/integration/commands/gearPresets.test.ts
@@ -1,0 +1,78 @@
+import { randInt } from 'e';
+import { describe, expect, test, vi } from 'vitest';
+
+import { prisma } from '../../../src/lib/settings/prisma';
+import itemID from '../../../src/lib/util/itemID';
+import { gearPresetsCommand } from '../../../src/mahoji/commands/gearpresets';
+import { createTestUser } from '../util';
+
+vi.mock('../../../src/lib/util', async () => {
+	const actual: any = await vi.importActual('../../../src/lib/util');
+	return {
+		...actual,
+		cryptoRand: (min: number, max: number) => randInt(min, max)
+	};
+});
+
+describe('Gear Presets Command', async () => {
+	const user = await createTestUser();
+
+	test('Create preset with 2h', async () => {
+		await user.runCommand(gearPresetsCommand, {
+			create: {
+				name: 'Test2h',
+				'2h': 'Bronze 2h sword',
+				weapon: 'Bronze dagger',
+				shield: 'Bronze kiteshield',
+				feet: 'Bronze boots',
+				head: 'Bronze full helm'
+			}
+		});
+
+		const gpResult = await prisma.gearPreset.findFirst({ where: { user_id: user.id, name: 'test2h' } });
+		// Verify row exists:
+		expect(gpResult).toBeTruthy();
+		if (!gpResult) return false;
+
+		// Make sure row is as expected:
+		expect(gpResult.head).toEqual(itemID('Bronze full helm'));
+		expect(gpResult.feet).toEqual(itemID('Bronze boots'));
+		expect(gpResult.weapon).toBeNull();
+		expect(gpResult.shield).toBeNull();
+		expect(gpResult.two_handed).toEqual(itemID('Bronze 2h sword'));
+	});
+
+	test('Test edit gearpreset', async () => {
+		// Generate gearPreset to edit:
+		await user.runCommand(gearPresetsCommand, {
+			create: {
+				name: 'TestEdit',
+				weapon: 'Bronze dagger',
+				shield: 'Bronze kiteshield',
+				feet: 'Bronze boots',
+				head: 'Bronze full helm'
+			}
+		});
+
+		const gpResult = await prisma.gearPreset.findFirst({ where: { user_id: user.id, name: 'testedit' } });
+		// Verify row exists:
+		expect(gpResult).toBeTruthy();
+		if (!gpResult) return false;
+
+		await user.runCommand(gearPresetsCommand, { edit: { gear_preset: 'TestEdit', weapon: 'Ghrazi rapier' } });
+
+		const gpEditResult = await prisma.gearPreset.findFirst({ where: { user_id: user.id, name: 'testedit' } });
+
+		// Verify row found:
+		expect(gpEditResult).toBeTruthy();
+		if (!gpEditResult) return false;
+
+		// Make sure row is as expected:
+		expect(gpEditResult.head).toEqual(itemID('Bronze full helm'));
+		expect(gpEditResult.feet).toEqual(itemID('Bronze boots'));
+		expect(gpEditResult.weapon).toEqual(itemID('Ghrazi rapier'));
+		expect(gpEditResult.shield).toEqual(itemID('Bronze kiteshield'));
+		expect(gpEditResult.hands).toBeNull();
+		expect(gpEditResult.ammo).toBeNull();
+	});
+});

--- a/tests/integration/commands/gearPresets.test.ts
+++ b/tests/integration/commands/gearPresets.test.ts
@@ -59,7 +59,9 @@ describe('Gear Presets Command', async () => {
 		expect(gpResult).toBeTruthy();
 		if (!gpResult) return false;
 
-		await user.runCommand(gearPresetsCommand, { edit: { gear_preset: 'TestEdit', weapon: 'Ghrazi rapier' } });
+		await user.runCommand(gearPresetsCommand, {
+			edit: { gear_preset: 'TestEdit', weapon: 'Ghrazi rapier', feet: 'None' }
+		});
 
 		const gpEditResult = await prisma.gearPreset.findFirst({ where: { user_id: user.id, name: 'testedit' } });
 
@@ -69,7 +71,7 @@ describe('Gear Presets Command', async () => {
 
 		// Make sure row is as expected:
 		expect(gpEditResult.head).toEqual(itemID('Bronze full helm'));
-		expect(gpEditResult.feet).toEqual(itemID('Bronze boots'));
+		expect(gpEditResult.feet).toBeNull();
 		expect(gpEditResult.weapon).toEqual(itemID('Ghrazi rapier'));
 		expect(gpEditResult.shield).toEqual(itemID('Bronze kiteshield'));
 		expect(gpEditResult.hands).toBeNull();

--- a/tests/integration/commands/gifts.test.ts
+++ b/tests/integration/commands/gifts.test.ts
@@ -2,7 +2,6 @@ import { Bank } from 'oldschooljs';
 import { beforeEach, describe, test } from 'vitest';
 
 import { giftCommand } from '../../../src/mahoji/commands/gift';
-import { minigamesCommand } from '../../../src/mahoji/commands/minigames';
 import { createTestUser, mockClient } from '../util';
 
 describe('Gift Command', async () => {

--- a/tests/integration/gearFixing.test.ts
+++ b/tests/integration/gearFixing.test.ts
@@ -1,40 +1,73 @@
 import deepEqual from 'deep-equal';
 import { Bank } from 'oldschooljs';
-import { test } from 'vitest';
+import { describe, test } from 'vitest';
 
 import { defaultGear, Gear } from '../../src/lib/structures/Gear';
 import { assert } from '../../src/lib/util';
 import itemID from '../../src/lib/util/itemID';
 import { createTestUser, mockClient } from './util';
 
-test('Gear Fixing', async () => {
-	await mockClient();
-	const user = await createTestUser();
+describe('Gear Fixing', async () => {
+	test('Basic tests', async () => {
+		await mockClient();
+		const user = await createTestUser();
 
-	const expectedRefund = new Bank().add('Twisted bow', 5).add('Dragon boots');
+		const expectedRefund = new Bank().add('Twisted bow', 5).add('Dragon boots');
 
-	const fixedGear = new Gear().raw();
-	fixedGear.shield = { item: itemID('Twisted bow'), quantity: 5 };
-	fixedGear.feet = { item: itemID('Dragon boots'), quantity: 1 };
-	fixedGear.body = { item: itemID('Bronze platebody'), quantity: 1 };
+		const fixedGear = new Gear().raw();
+		fixedGear.shield = { item: itemID('Twisted bow'), quantity: 5 };
+		fixedGear.feet = { item: itemID('Dragon boots'), quantity: 1 };
+		fixedGear.body = { item: itemID('Bronze platebody'), quantity: 1 };
 
-	await user.update({
-		gear_melee: fixedGear as any
+		await user.update({
+			gear_melee: fixedGear as any
+		});
+
+		const { itemsUnequippedAndRefunded } = await user.validateEquippedGear();
+
+		assert(
+			itemsUnequippedAndRefunded.equals(expectedRefund),
+			`Expected ${itemsUnequippedAndRefunded} to equal ${expectedRefund}`
+		);
+
+		assert(user.bank.equals(expectedRefund), `Expected ${user.bank} to equal ${expectedRefund}`);
+
+		assert(
+			deepEqual(user.gear.melee.raw(), {
+				...defaultGear,
+				body: { item: itemID('Bronze platebody'), quantity: 1 }
+			})
+		);
 	});
+	test('Multiple 2h + 1h equipped tests', async () => {
+		await mockClient();
+		const user = await createTestUser();
 
-	const { itemsUnequippedAndRefunded } = await user.validateEquippedGear();
+		const expectedRefund = new Bank().add('Bronze dagger').add('Bronze kiteshield');
 
-	assert(
-		itemsUnequippedAndRefunded.equals(expectedRefund),
-		`Expected ${itemsUnequippedAndRefunded} to equal ${expectedRefund}`
-	);
+		const fixedGear = new Gear().raw();
+		fixedGear['2h'] = { item: itemID('Bronze 2h sword'), quantity: 1 };
+		fixedGear.shield = { item: itemID('Bronze kiteshield'), quantity: 1 };
+		fixedGear.weapon = { item: itemID('Bronze dagger'), quantity: 1 };
 
-	assert(user.bank.equals(expectedRefund), `Expected ${user.bank} to equal ${expectedRefund}`);
+		await user.update({
+			gear_melee: fixedGear as any
+		});
 
-	assert(
-		deepEqual(user.gear.melee.raw(), {
-			...defaultGear,
-			body: { item: itemID('Bronze platebody'), quantity: 1 }
-		})
-	);
+		const { itemsUnequippedAndRefunded } = await user.validateEquippedGear();
+
+		assert(
+			itemsUnequippedAndRefunded.equals(expectedRefund),
+			`Expected ${itemsUnequippedAndRefunded} to equal ${expectedRefund}`
+		);
+
+		assert(user.bank.equals(expectedRefund), `Expected ${user.bank} to equal ${expectedRefund}`);
+
+		assert(
+			deepEqual(user.gear.melee.raw(), {
+				...defaultGear,
+				'2h': { item: itemID('Bronze 2h sword'), quantity: 1 }
+			})
+		);
+	});
 });


### PR DESCRIPTION
### Description:

- Fixes a bug that lets you equip weapon/shield + 2h at the same time
- Fixes/improves `/gearpresets edit` so that it actually edits the preset, and doesn't wipe unspecified values.
- Adds code to `validateEquippedGear()` function to check for 2h + shield/weapon equipped simultaneously and forces unequip if so.
- Adds & updates relevant tests.


### Other checks:

- [x] I have tested all my changes thoroughly.
