### PR TITLE
Fix guthixian cache activity - increment minigame score.

### DIFF
--- a/src/tasks/minions/bso/guthixianCacheActivity.ts
+++ b/src/tasks/minions/bso/guthixianCacheActivity.ts
@@ -4,6 +4,7 @@ import { Bank } from 'oldschooljs';
 import { chargePortentIfHasCharges, PortentID } from '../../../lib/bso/divination';
 import { Emoji } from '../../../lib/constants';
 import { divinersOutfit } from '../../../lib/data/CollectionsExport';
+import { incrementMinigameScore } from '../../../lib/settings/minigames';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
 import { percentChance } from '../../../lib/util';
@@ -69,6 +70,7 @@ export const guthixianCacheTask: MinionTask = {
 			str += `\n${loot.has('Doopy') ? `${Emoji.Purple} ` : ''}You received: ${loot}.`;
 		}
 
+		await incrementMinigameScore(user.id, 'guthixian_cache');
 		await user.addToGodFavour(['Guthix'], data.duration);
 
 		return handleTripFinish(user, channelID, str, undefined, data, loot);


### PR DESCRIPTION
### Description:

Guthixian cache isn't incrementing minigame score



### Other checks:

- [x] I have tested all my changes thoroughly.


I'll see if i can retroactively update the DB when deploying this