### PR TITLE
Minor cl fixes

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -1157,7 +1157,7 @@ export const allCollectionLogs: ICollection = {
 			'Fist of Guthix': {
 				alias: ['fog', 'fist of guthix'],
 				items: fistOfGuthixCL,
-				fmtProg: mgProg('bax_baths')
+				fmtProg: mgProg('fist_of_guthix')
 			},
 			'Guthixian Caches': {
 				alias: ['guthixian caches'],

--- a/src/lib/settings/minigames.ts
+++ b/src/lib/settings/minigames.ts
@@ -247,8 +247,8 @@ export const Minigames: readonly BotMinigame[] = [
 		column: 'depths_of_atlantis_cm'
 	},
 	{
-		name: 'Guthixian Cache',
-		aliases: ['guthixian cache'],
+		name: 'Guthixian Caches',
+		aliases: ['guthixian caches', 'cache'],
 		column: 'guthixian_cache'
 	}
 ];


### PR DESCRIPTION
### Description:
2 minor cl fixes for bso
### Changes:
- Fix a bug causing guthixian cache completions to not show up on /cl image
- Fix Fist of Guthix from using bax_baths when formatting messages
### Other checks:
- [X] I have tested all my changes thoroughly.
