### PR TITLE
First wave of "Works from Bank" poll results

### DIFF
--- a/src/lib/addXP.ts
+++ b/src/lib/addXP.ts
@@ -190,7 +190,7 @@ export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 	const boosts = staticXPBoosts.get(params.skillName);
 	if (boosts && !params.artificial) {
 		for (const booster of boosts) {
-			if (user.hasEquipped(booster.item.id)) {
+			if (user.hasEquippedOrInBank(booster.item.id)) {
 				params.amount = increaseNumByPercent(params.amount, booster.boostPercent);
 			}
 		}
@@ -198,9 +198,9 @@ export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 
 	const skillOutfit = skillingOutfitBoosts.find(i => i.skill === params.skillName);
 	if (!params.artificial && skillOutfit) {
-		const amountBoost = user.hasEquipped(skillOutfit.outfit, true)
+		const amountBoost = user.hasEquippedOrInBank(skillOutfit.outfit, 'every')
 			? skillOutfit.totalBoost
-			: skillOutfit.outfit.filter(i => user.hasEquipped(i)).length * skillOutfit.individualBoost;
+			: skillOutfit.outfit.filter(i => user.hasEquippedOrInBank(i)).length * skillOutfit.individualBoost;
 		params.amount = increaseNumByPercent(params.amount, amountBoost);
 	}
 

--- a/src/lib/implings.ts
+++ b/src/lib/implings.ts
@@ -47,7 +47,7 @@ export const implings: Record<number, { level: number; customRequirements?: (use
 			return false;
 		}
 	},
-	[EternalImpling.id]: { level: 99, customRequirements: async user => user.hasEquipped('Vasa cloak') },
+	[EternalImpling.id]: { level: 99, customRequirements: async user => user.hasEquippedOrInBank('Vasa cloak') },
 	[MysteryImpling.id]: { level: 105 }
 };
 

--- a/src/lib/implings.ts
+++ b/src/lib/implings.ts
@@ -176,7 +176,7 @@ export async function handlePassiveImplings(user: MUser, data: ActivityTaskData)
 	let baseChance = IMPLING_CHANCE_PER_MINUTE;
 	const hasScrollOfTheHunt = user.bitfield.includes(BitField.HasScrollOfTheHunt);
 	if (hasScrollOfTheHunt) baseChance = Math.floor(baseChance / 2);
-	if (user.hasEquipped('Hunter master cape')) baseChance = Math.floor(baseChance / 2);
+	if (user.hasEquippedOrInBank('Hunter master cape')) baseChance = Math.floor(baseChance / 2);
 
 	const impTable = implingTableByWorldLocation[activityInArea(data)](baseChance, user.usingPet('Mr. E'));
 

--- a/src/lib/invention/disassemble.ts
+++ b/src/lib/invention/disassemble.ts
@@ -202,7 +202,7 @@ export async function handleDisassembly({
 			);
 		}
 	}
-	if (user.hasEquipped('Invention master cape')) {
+	if (user.hasEquippedOrInBank('Invention master cape')) {
 		timePer = reduceNumByPercent(timePer, inventionBoosts.inventionMasterCape.disassemblySpeedBoostPercent);
 		messages.push(
 			`${inventionBoosts.inventionMasterCape.disassemblySpeedBoostPercent}% faster disassembly for mastery`

--- a/src/lib/invention/inventions.ts
+++ b/src/lib/invention/inventions.ts
@@ -646,7 +646,7 @@ export async function inventionItemBoost({
 	}
 
 	let messages: string[] = [`Removed ${materialCost}`];
-	if (user.hasEquipped('Invention master cape')) {
+	if (user.hasEquippedOrInBank('Invention master cape')) {
 		materialCost.mutReduceAllValuesByPercent(inventionBoosts.inventionMasterCape.materialCostReductionPercent);
 		messages.shift();
 		messages.unshift(`Removed ${materialCost}`);

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -137,7 +137,7 @@ for (const clueTier of ClueTiers) {
 			const clueTier = ClueTiers.find(c => c.id === self.id)!;
 			let loot = new Bank(clueTier.table.open(quantity));
 
-			const hasCHEquipped = user.hasEquipped(clueHunterOutfit, true);
+			const hasCHEquipped = user.hasEquippedOrInBank(clueHunterOutfit, 'every');
 			let extraClueRolls = 0;
 			for (let i = 0; i < quantity; i++) {
 				const roll = randInt(1, 3);

--- a/src/lib/skilling/functions/calcsRunecrafting.ts
+++ b/src/lib/skilling/functions/calcsRunecrafting.ts
@@ -29,9 +29,9 @@ export async function bloodEssence(user: MUser, quantity: number): Promise<numbe
 export function raimentBonus(user: MUser, quantity: number): number {
 	let bonusQuantity = 0;
 	if (
-		user.gear.skilling.hasEquipped(
+		user.hasEquippedOrInBank(
 			Object.keys(Runecraft.raimentsOfTheEyeItems).map(i => parseInt(i)),
-			true
+			'every'
 		)
 	) {
 		const amountToAdd = Math.floor(quantity * (60 / 100));
@@ -39,7 +39,7 @@ export function raimentBonus(user: MUser, quantity: number): number {
 	} else {
 		// For each Raiments of the Eye item, check if they have it, give its' quantity boost if so (NO bonus XP).
 		for (const [itemID, bonus] of Object.entries(Runecraft.raimentsOfTheEyeItems)) {
-			if (user.gear.skilling.hasEquipped([parseInt(itemID)], false)) {
+			if (user.hasEquippedOrInBank(parseInt(itemID))) {
 				const amountToAdd = Math.floor(quantity * (bonus / 100));
 				bonusQuantity += amountToAdd;
 			}

--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -89,7 +89,7 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 		}
 	}
 
-	if (user.hasEquipped('Zak')) {
+	if (user.usingPet('Zak')) {
 		max *= 1.4;
 	}
 

--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -65,7 +65,7 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 		case 'TinkeringWorkshop':
 		case 'Disassembling':
 		case 'Research': {
-			if (user.hasEquipped('Materials bag') || user.owns('Materials bag')) {
+			if (user.hasEquippedOrInBank('Materials bag')) {
 				max += Time.Minute * 7;
 			}
 			break;

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -253,7 +253,7 @@ const tripFinishEffects: TripFinishEffect[] = [
 	{
 		name: 'Invention Effects',
 		fn: async ({ data, messages, user }) => {
-			if (user.hasEquipped('Silverhawk boots') && data.duration > Time.Minute) {
+			if (user.hasEquippedOrInBank('Silverhawk boots') && data.duration > Time.Minute) {
 				const costRes = await inventionItemBoost({
 					user,
 					inventionID: InventionID.SilverHawkBoots,

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -166,7 +166,7 @@ export const chopCommand: OSBMahojiCommand = {
 		// Default bronze axe, last in the array
 		let axeMultiplier = 1;
 
-		if (user.hasEquipped(['Drygore axe'])) {
+		if (user.hasEquippedOrInBank(['Drygore axe'])) {
 			let [predeterminedTotalTime] = determineWoodcuttingTime({
 				quantity,
 				user,

--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -135,7 +135,7 @@ export const clueCommand: OSBMahojiCommand = {
 				durationMultiplier: 0.5
 			},
 			{
-				condition: () => user.hasEquipped(clueHunterOutfit, true),
+				condition: () => user.hasEquippedOrInBank(clueHunterOutfit, 'every'),
 				boost: '2x Boost for Clue hunter outfit',
 				durationMultiplier: 0.5
 			},

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -82,7 +82,7 @@ export const cookCommand: OSBMahojiCommand = {
 		const [hasFavour] = gotFavour(user, Favours.Hosidius, 100);
 		if (hasFavour) boosts.push('Using Hosidius Range');
 		if (hasFavour && hasEliteDiary) boosts.push('Kourend Elite Diary');
-		const hasGaunts = user.hasEquipped('Cooking gauntlets');
+		const hasGaunts = user.hasEquippedOrInBank('Cooking gauntlets');
 		if (hasGaunts) boosts.push('Cooking gauntlets equipped');
 
 		let timeToCookSingleCookable = Time.Second * 2.4 + Time.Second * 0.45;
@@ -90,9 +90,9 @@ export const cookCommand: OSBMahojiCommand = {
 		if (cookable.id === itemID('Jug of wine') || cookable.id === itemID('Wine of zamorak')) {
 			timeToCookSingleCookable /= 1.6;
 			if (hasRemy) timeToCookSingleCookable /= 1.5;
-		} else if (user.hasEquipped('Cooking master cape')) {
+		} else if (user.hasEquippedOrInBank('Cooking master cape')) {
 			timeToCookSingleCookable /= 5;
-		} else if (user.hasEquipped('Dwarven gauntlets')) {
+		} else if (user.hasEquippedOrInBank('Dwarven gauntlets')) {
 			timeToCookSingleCookable /= 3;
 		} else if (hasRemy) {
 			timeToCookSingleCookable /= 2;

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -83,7 +83,7 @@ export const cookCommand: OSBMahojiCommand = {
 		if (hasFavour) boosts.push('Using Hosidius Range');
 		if (hasFavour && hasEliteDiary) boosts.push('Kourend Elite Diary');
 		const hasGaunts = user.hasEquippedOrInBank('Cooking gauntlets');
-		if (hasGaunts) boosts.push('Cooking gauntlets equipped');
+		if (hasGaunts) boosts.push('Cooking gauntlets available');
 
 		let timeToCookSingleCookable = Time.Second * 2.4 + Time.Second * 0.45;
 
@@ -91,10 +91,13 @@ export const cookCommand: OSBMahojiCommand = {
 			timeToCookSingleCookable /= 1.6;
 			if (hasRemy) timeToCookSingleCookable /= 1.5;
 		} else if (user.hasEquippedOrInBank('Cooking master cape')) {
+			boosts.push('5x for Cooking master cape');
 			timeToCookSingleCookable /= 5;
 		} else if (user.hasEquippedOrInBank('Dwarven gauntlets')) {
+			boosts.push('3x for Dwarven gauntlets');
 			timeToCookSingleCookable /= 3;
 		} else if (hasRemy) {
+			boosts.push('2x for Remy');
 			timeToCookSingleCookable /= 2;
 		}
 

--- a/src/mahoji/commands/craft.ts
+++ b/src/mahoji/commands/craft.ts
@@ -94,7 +94,7 @@ export const craftCommand: OSBMahojiCommand = {
 			boosts.push('3x faster for Klik helping Tan');
 		}
 		if (!isTannable) {
-			if (user.hasEquipped('Dwarven greathammer')) {
+			if (user.hasEquippedOrInBank('Dwarven greathammer')) {
 				timeToCraftSingleItem /= 2;
 				boosts.push('2x faster for Dwarven greathammer');
 			}

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -138,7 +138,7 @@ export const fishCommand: OSBMahojiCommand = {
 				break;
 		}
 
-		if (user.hasEquipped('Shark tooth necklace')) {
+		if (user.hasEquippedOrInBank('Shark tooth necklace')) {
 			scaledTimePerFish = reduceNumByPercent(scaledTimePerFish, 5);
 			boosts.push('5% for Shark tooth necklace');
 		}

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -116,22 +116,22 @@ export const fishCommand: OSBMahojiCommand = {
 			case itemID('Fishing bait'):
 				if (fish.name === 'Infernal eel') {
 					scaledTimePerFish *= 1;
-				} else if (user.hasEquipped('Pearl fishing rod') && fish.name !== 'Infernal eel') {
+				} else if (user.hasEquippedOrInBank('Pearl fishing rod') && fish.name !== 'Infernal eel') {
 					scaledTimePerFish *= 0.95;
 					boosts.push('5% for Pearl fishing rod');
 				}
 				break;
 			case itemID('Feather'):
-				if (fish.name === 'Barbarian fishing' && user.hasEquipped('Pearl barbarian rod')) {
+				if (fish.name === 'Barbarian fishing' && user.hasEquippedOrInBank('Pearl barbarian rod')) {
 					scaledTimePerFish *= 0.95;
 					boosts.push('5% for Pearl barbarian rod');
-				} else if (user.hasEquipped('Pearl fly fishing rod') && fish.name !== 'Barbarian fishing') {
+				} else if (user.hasEquippedOrInBank('Pearl fly fishing rod') && fish.name !== 'Barbarian fishing') {
 					scaledTimePerFish *= 0.95;
 					boosts.push('5% for Pearl fly fishing rod');
 				}
 				break;
 			default:
-				if (user.hasEquipped('Crystal harpoon')) {
+				if (user.hasEquippedOrInBank('Crystal harpoon')) {
 					scaledTimePerFish *= 0.95;
 					boosts.push('5% for Crystal harpoon');
 				}

--- a/src/mahoji/commands/fletch.ts
+++ b/src/mahoji/commands/fletch.ts
@@ -85,7 +85,7 @@ export const fletchCommand: OSBMahojiCommand = {
 				'<:scruffy:749945071146762301> To help out, Scruffy is fetching items from the bank for you - making your training much faster! Good boy! (+100% for Scruffy)'
 			);
 		}
-		if (user.hasEquipped('Dwarven knife')) {
+		if (user.hasEquippedOrInBank('Dwarven knife')) {
 			boostMsg.push('+100% for Dwarven knife');
 			boost += 1;
 		}

--- a/src/mahoji/commands/rates.ts
+++ b/src/mahoji/commands/rates.ts
@@ -286,7 +286,6 @@ export const ratesCommand: OSBMahojiCommand = {
 									if (shouldTryUseSpirits && !spiritOre) continue;
 									const { totalMiningXPToAdd, smithingXPFromAdze, loot, totalCost } =
 										calculateMiningResult({
-											user,
 											duration,
 											isPowermining: result.isPowermining,
 											isUsingObsidianPickaxe: hasOffhandVolcPick,

--- a/src/mahoji/commands/rates.ts
+++ b/src/mahoji/commands/rates.ts
@@ -286,6 +286,7 @@ export const ratesCommand: OSBMahojiCommand = {
 									if (shouldTryUseSpirits && !spiritOre) continue;
 									const { totalMiningXPToAdd, smithingXPFromAdze, loot, totalCost } =
 										calculateMiningResult({
+											user,
 											duration,
 											isPowermining: result.isPowermining,
 											isUsingObsidianPickaxe: hasOffhandVolcPick,

--- a/src/mahoji/commands/smelt.ts
+++ b/src/mahoji/commands/smelt.ts
@@ -111,18 +111,18 @@ export const smeltingCommand: OSBMahojiCommand = {
 				timeToSmithSingleBar *= 1.075;
 				boosts.push('-7.5% penalty for not having graceful equipped');
 			}
-			if (user.hasEquipped('Smithing master cape')) {
+			if (user.hasEquippedOrInBank('Smithing master cape')) {
 				timeToSmithSingleBar /= 2;
 				boosts.push('2x boost for Smithing master cape');
 			}
-			if (user.hasEquipped('Dwarven gauntlets') && bar.id !== itemID('Gold bar')) {
+			if (user.hasEquippedOrInBank('Dwarven gauntlets') && bar.id !== itemID('Gold bar')) {
 				boosts.push('2x boost for having Dwarven gauntlets equipped');
 				timeToSmithSingleBar /= 2;
 			}
 		}
 
 		if (!blast_furnace) {
-			if (user.hasEquipped('Dwarven gauntlets')) {
+			if (user.hasEquippedOrInBank('Dwarven gauntlets')) {
 				boosts.push('2x boost for having a Dwarven gauntlets equipped');
 				timeToSmithSingleBar /= 2;
 			}

--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -75,16 +75,16 @@ export const smithCommand: OSBMahojiCommand = {
 		// If they have the entire Smiths' Uniform, give 100% chance save 1 tick each item
 		let setBonus = 0;
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Smithing.smithsUniformItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			setBonus += 100;
 		} else {
 			// For each Smiths' Uniform item, check if they have it, give % chance to save 1 tick each item
 			for (const [itemID, bonus] of Object.entries(Smithing.smithsUniformItems)) {
-				if (user.gear.skilling.hasEquipped([parseInt(itemID)], false)) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					setBonus += bonus;
 				}
 			}

--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -110,7 +110,7 @@ export const smithCommand: OSBMahojiCommand = {
 		let timeToSmithSingleBar = timeToUse + Time.Second / 4 - (Time.Second * 0.6 * setBonus) / 100;
 		if (user.usingPet('Takon')) {
 			timeToSmithSingleBar /= 4;
-		} else if (user.hasEquipped('Dwarven greathammer')) {
+		} else if (user.hasEquippedOrInBank('Dwarven greathammer')) {
 			timeToSmithSingleBar /= 2;
 		}
 
@@ -196,7 +196,7 @@ export const smithCommand: OSBMahojiCommand = {
 
 		if (user.usingPet('Takon')) {
 			str += ' Takon is Smithing for you, at incredible speeds and skill.';
-		} else if (user.hasEquipped('Dwarven greathammer')) {
+		} else if (user.hasEquippedOrInBank('Dwarven greathammer')) {
 			str += ' 2x faster for Dwarven greathammer.';
 		}
 		if (hasScroll) {

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -38,7 +38,6 @@ import { prisma } from '../../lib/settings/prisma';
 import { getFarmingInfo } from '../../lib/skilling/functions/getFarmingInfo';
 import Skills from '../../lib/skilling/skills';
 import Farming from '../../lib/skilling/skills/farming';
-import { SkillsEnum } from '../../lib/skilling/types';
 import { getUsersTame, tameSpecies } from '../../lib/tames';
 import { stringMatches } from '../../lib/util';
 import { calcDropRatesFromBankWithoutUniques } from '../../lib/util/calcDropRatesFromBank';
@@ -405,9 +404,11 @@ export const testPotatoCommand: OSBMahojiCommand | null = production
 							name: 'skill',
 							description: 'The skill.',
 							required: true,
-							choices: Object.values(Skills)
-								.map(s => ({ name: s.name, value: s.id }))
-								.filter(i => i.value !== SkillsEnum.Woodcutting)
+							autocomplete: async value => {
+								return Object.values(Skills)
+									.map(s => ({ name: s.name, value: s.id }))
+									.filter(s => (!value ? true : s.name.toLowerCase().includes(value.toLowerCase())));
+							}
 						},
 						{
 							type: ApplicationCommandOptionType.Integer,

--- a/src/mahoji/lib/abstracted_commands/giantsFoundryCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/giantsFoundryCommand.ts
@@ -178,16 +178,16 @@ export async function giantsFoundryStartCommand(
 	// If they have the entire Smiths' Uniform, give an extra 15% speed bonus
 	let setBonus = 0;
 	if (
-		user.gear.skilling.hasEquipped(
+		user.hasEquippedOrInBank(
 			Object.keys(Smithing.smithsUniformItems).map(i => parseInt(i)),
-			true
+			'every'
 		)
 	) {
 		setBonus += 15;
 	} else {
 		// For each Smiths' Uniform item, check if they have it, give its' set boost and covert to 15% speed bonus later.
 		for (const [itemID] of Object.entries(Smithing.smithsUniformItems)) {
-			if (user.gear.skilling.hasEquipped([parseInt(itemID)], false)) {
+			if (user.hasEquippedOrInBank(parseInt(itemID))) {
 				setBonus += 3;
 			}
 		}

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -539,7 +539,7 @@ export async function minionKillCommand(
 	}
 
 	const hasBlessing = user.hasEquipped('Dwarven blessing');
-	const hasZealotsAmulet = user.hasEquipped('Amulet of zealots');
+	const hasZealotsAmulet = user.hasEquippedOrInBank('Amulet of zealots');
 	if (hasZealotsAmulet && hasBlessing) {
 		timeToFinish *= 0.75;
 		boosts.push('25% for Dwarven blessing & Amulet of zealots');

--- a/src/mahoji/lib/abstracted_commands/monkeyRumbleCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/monkeyRumbleCommand.ts
@@ -78,11 +78,11 @@ export async function monkeyRumbleCommand(user: MUser, channelID: string): Comma
 	let duration = quantity * fightDuration;
 
 	let chanceOfSpecial = Math.floor(125 * (6 - monkeyTierOfUser(user) / 2));
-	if (user.hasEquipped('Big banana')) {
+	if (user.hasEquippedOrInBank('Big banana')) {
 		chanceOfSpecial = reduceNumByPercent(chanceOfSpecial, 12);
 		boosts.push('12% higher chance of purple monkeys from Big banana');
 	}
-	if (user.hasEquipped('Ring of luck')) {
+	if (user.hasEquippedOrInBank('Ring of luck')) {
 		chanceOfSpecial = reduceNumByPercent(chanceOfSpecial, 4);
 		boosts.push('4% higher chance of purple monkeys from ring of luck');
 	}
@@ -92,7 +92,7 @@ export async function monkeyRumbleCommand(user: MUser, channelID: string): Comma
 	}
 	monkeysToFight.sort((a, b) => (a.special === b.special ? 0 : a.special ? -1 : 1));
 	let foodRequired = Math.floor(duration / (Time.Minute * 1.34));
-	if (user.hasEquipped('Big banana')) {
+	if (user.hasEquippedOrInBank('Big banana')) {
 		foodRequired = reduceNumByPercent(foodRequired, 25);
 		foodRequired = Math.floor(foodRequired);
 		boosts.push('25% less food from Big banana');

--- a/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
@@ -73,7 +73,7 @@ export async function motherlodeMineCommand({
 		goldSilverBoost,
 		miningLvl: miningLevel,
 		maxTripLength: calcMaxTripLength(user, 'Mining'),
-		hasGlory: user.hasEquipped('Amulet of glory')
+		hasGlory: user.hasEquippedOrInBank('Amulet of glory')
 	});
 
 	const fakeDurationMin = quantity ? randomVariation(reduceNumByPercent(duration, 25), 20) : duration;

--- a/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
@@ -47,7 +47,7 @@ export async function wintertodtCommand(user: MUser, channelID: string) {
 
 	const boosts: string[] = [];
 
-	if (user.hasEquipped('Dwarven greataxe')) {
+	if (user.hasEquippedOrInBank('Dwarven greataxe')) {
 		durationPerTodt /= 2;
 		boosts.push('2x faster for Dwarven greataxe.');
 	}

--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -213,11 +213,10 @@ export function userHasGracefulEquipped(user: MUser) {
 }
 
 export function anglerBoostPercent(user: MUser) {
-	const skillingSetup = user.gear.skilling;
 	let amountEquipped = 0;
 	let boostPercent = 0;
 	for (const [id, percent] of anglerBoosts) {
-		if (skillingSetup.hasEquipped([id])) {
+		if (user.hasEquippedOrInBank(id)) {
 			boostPercent += percent;
 			amountEquipped++;
 		}

--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -230,10 +230,9 @@ export function anglerBoostPercent(user: MUser) {
 const rogueOutfit = resolveItems(['Rogue mask', 'Rogue top', 'Rogue trousers', 'Rogue gloves', 'Rogue boots']);
 
 export function rogueOutfitPercentBonus(user: MUser): number {
-	const skillingSetup = user.gear.skilling;
 	let amountEquipped = 0;
 	for (const id of rogueOutfit) {
-		if (skillingSetup.hasEquipped([id])) {
+		if (user.hasEquippedOrInBank(id)) {
 			amountEquipped++;
 		}
 	}

--- a/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
+++ b/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
@@ -82,9 +82,9 @@ export const aerialFishingTask: MinionTask = {
 
 		// If they have the entire angler outfit, give an extra 2.5% xp bonus
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Fishing.anglerItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			const amountToAdd = Math.floor(fishXpReceived * (2.5 / 100));
@@ -93,7 +93,7 @@ export const aerialFishingTask: MinionTask = {
 		} else {
 			// For each angler item, check if they have it, give its' XP boost if so.
 			for (const [itemID, bonus] of Object.entries(Fishing.anglerItems)) {
-				if (user.hasEquipped(parseInt(itemID))) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					const amountToAdd = Math.floor(fishXpReceived * (bonus / 100));
 					fishXpReceived += amountToAdd;
 					bonusXP += amountToAdd;

--- a/src/tasks/minions/HunterActivity/hunterActivity.ts
+++ b/src/tasks/minions/HunterActivity/hunterActivity.ts
@@ -304,7 +304,7 @@ export const hunterTask: MinionTask = {
 				creatureScores: (await user.fetchStats({ creature_scores: true })).creature_scores as ItemBank,
 				allGear: user.gear,
 				collectionLog: user.cl,
-				hasHunterMasterCape: user.hasEquipped('Hunter master cape'),
+				hasHunterMasterCape: user.hasEquippedOrInBank('Hunter master cape'),
 				equippedPet: user.user.minion_equippedPet,
 				wildyPeakTier: wildyPeak?.peakTier,
 				isUsingArcaneHarvester: boostRes?.success ?? false,

--- a/src/tasks/minions/PrayerActivity/offeringActivity.ts
+++ b/src/tasks/minions/PrayerActivity/offeringActivity.ts
@@ -10,7 +10,7 @@ import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 export function zealOutfitBoost(user: MUser) {
 	let zealOutfitAmount = 0;
 	for (const piece of zealOutfit) {
-		if (user.gear.skilling.hasEquipped([piece])) {
+		if (user.hasEquippedOrInBank(piece)) {
 			zealOutfitAmount++;
 		}
 	}

--- a/src/tasks/minions/bso/disassemblingActivity.ts
+++ b/src/tasks/minions/bso/disassemblingActivity.ts
@@ -20,7 +20,7 @@ export async function disassemblyTask(data: DisassembleTaskOptions) {
 	const messages: string[] = [];
 	const cost = new Bank().add(item.id, qty);
 	const materialLoot = new MaterialBank(data.mats);
-	if (user.hasEquipped('Invention master cape')) {
+	if (user.hasEquippedOrInBank('Invention master cape')) {
 		materialLoot.mutIncreaseAllValuesByPercent(inventionBoosts.inventionMasterCape.extraMaterialsPercent);
 		messages.push(`${inventionBoosts.inventionMasterCape.extraMaterialsPercent}% bonus materials for mastery`);
 	}

--- a/src/tasks/minions/bso/guthixianCacheActivity.ts
+++ b/src/tasks/minions/bso/guthixianCacheActivity.ts
@@ -35,7 +35,7 @@ export const guthixianCacheTask: MinionTask = {
 		let str = `${user}, ${user.minionName} finished completing the Guthixian Cache. ${xpRes}`;
 
 		let amountOfBoostsReceived = 1;
-		if (user.hasEquipped('Divination master cape') && roll(4)) {
+		if (user.hasEquippedOrInBank('Divination master cape') && roll(4)) {
 			amountOfBoostsReceived++;
 			str += ' You received an extra boost from your Divination master cape.';
 		}

--- a/src/tasks/minions/bso/memoryHarvestActivity.ts
+++ b/src/tasks/minions/bso/memoryHarvestActivity.ts
@@ -210,7 +210,7 @@ export const memoryHarvestTask: MinionTask = {
 				hasGuthixianBoost: didGetGuthixianBoost,
 				hasDivineHand,
 				isUsingDivinationPotion,
-				hasMasterCape: user.hasEquipped('Divination master cape'),
+				hasMasterCape: user.hasEquippedOrInBank('Divination master cape'),
 				rounds
 			});
 
@@ -240,7 +240,7 @@ export const memoryHarvestTask: MinionTask = {
 		} memories, and turning them into ${
 			harvestMethodIndex === MemoryHarvestType.ConvertToEnergy ? 'energies' : 'XP'
 		}. ${xpRes}.
-		
+
 Pet chance 1 in ${petChancePerMemory.toLocaleString()}, ${formatDuration(avgPetTime)} on average to get pet`;
 
 		if (loot.length > 0) {

--- a/src/tasks/minions/cookingActivity.ts
+++ b/src/tasks/minions/cookingActivity.ts
@@ -24,7 +24,7 @@ export const cookingTask: MinionTask = {
 
 		const [hasEliteDiary] = await userhasDiaryTier(user, KourendKebosDiary.elite);
 		const [hasFavour] = gotFavour(user, Favours.Hosidius, 100);
-		const hasGaunts = user.hasEquipped('Cooking gauntlets');
+		const hasGaunts = user.hasEquippedOrInBank('Cooking gauntlets');
 
 		if (hasFavour && cookable.burnKourendBonus) {
 			stopBurningLvl = cookable.burnKourendBonus[(hasEliteDiary ? 1 : 0) * 2 + (hasGaunts ? 1 : 0)];

--- a/src/tasks/minions/firemakingActivity.ts
+++ b/src/tasks/minions/firemakingActivity.ts
@@ -16,9 +16,9 @@ export const firemakingTask: MinionTask = {
 
 		// If they have the entire pyromancer outfit, give an extra 0.5% xp bonus
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Firemaking.pyromancerItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			const amountToAdd = Math.floor(xpReceived * (2.5 / 100));

--- a/src/tasks/minions/firemakingActivity.ts
+++ b/src/tasks/minions/firemakingActivity.ts
@@ -27,7 +27,7 @@ export const firemakingTask: MinionTask = {
 		} else {
 			// For each pyromancer item, check if they have it, give its' XP boost if so.
 			for (const [itemID, bonus] of Object.entries(Firemaking.pyromancerItems)) {
-				if (user.hasEquipped(parseInt(itemID))) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					const amountToAdd = Math.floor(xpReceived * (bonus / 100));
 					xpReceived += amountToAdd;
 					bonusXP += amountToAdd;

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -23,7 +23,7 @@ function radasBlessing(user: MUser) {
 	];
 
 	for (const [itemName, boostPercent] of blessingBoosts) {
-		if (user.hasEquipped(itemName)) {
+		if (user.hasEquippedOrInBank(itemName)) {
 			return { blessingEquipped: true, blessingChance: boostPercent as number };
 		}
 	}
@@ -97,9 +97,9 @@ export const fishingTask: MinionTask = {
 
 		// If they have the entire angler outfit, give an extra 0.5% xp bonus
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Fishing.anglerItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			const amountToAdd = Math.floor(xpReceived * (2.5 / 100));
@@ -108,7 +108,7 @@ export const fishingTask: MinionTask = {
 		} else {
 			// For each angler item, check if they have it, give its' XP boost if so.
 			for (const [itemID, bonus] of Object.entries(Fishing.anglerItems)) {
-				if (user.hasEquipped(parseInt(itemID))) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					const amountToAdd = Math.floor(xpReceived * (bonus / 100));
 					xpReceived += amountToAdd;
 					bonusXP += amountToAdd;

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -93,28 +93,6 @@ export const fishingTask: MinionTask = {
 		} else {
 			xpReceived = quantity * fish.xp;
 		}
-		let bonusXP = 0;
-
-		// If they have the entire angler outfit, give an extra 0.5% xp bonus
-		if (
-			user.hasEquippedOrInBank(
-				Object.keys(Fishing.anglerItems).map(i => parseInt(i)),
-				'every'
-			)
-		) {
-			const amountToAdd = Math.floor(xpReceived * (2.5 / 100));
-			xpReceived += amountToAdd;
-			bonusXP += amountToAdd;
-		} else {
-			// For each angler item, check if they have it, give its' XP boost if so.
-			for (const [itemID, bonus] of Object.entries(Fishing.anglerItems)) {
-				if (user.hasEquippedOrInBank(parseInt(itemID))) {
-					const amountToAdd = Math.floor(xpReceived * (bonus / 100));
-					xpReceived += amountToAdd;
-					bonusXP += amountToAdd;
-				}
-			}
-		}
 
 		let xpRes = await user.addXP({
 			skillName: SkillsEnum.Fishing,
@@ -190,6 +168,7 @@ export const fishingTask: MinionTask = {
 			loot.add('Leaping trout', leapingTrout);
 		}
 
+		let bonusXP = 0;
 		const xpBonusPercent = anglerBoostPercent(user);
 		if (xpBonusPercent > 0) {
 			bonusXP += Math.ceil(calcPercentOfNum(xpBonusPercent, xpReceived));

--- a/src/tasks/minions/herbloreActivity.ts
+++ b/src/tasks/minions/herbloreActivity.ts
@@ -12,7 +12,7 @@ import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
 function BSOApplyExtraQuantity(user: MUser, quantity: number, mixableItem: Mixable, messages: string[]) {
 	const isMixingPotion = mixableItem.xp !== 0 && !mixableItem.wesley && !mixableItem.zahur;
-	const hasHerbMasterCape = user.hasEquipped('Herblore master cape');
+	const hasHerbMasterCape = user.hasEquippedOrInBank('Herblore master cape');
 	const herbCapePerk = isMixingPotion && hasHerbMasterCape;
 	let bonus = 0;
 	if (herbCapePerk) {

--- a/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
+++ b/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
@@ -88,16 +88,16 @@ export const guardiansOfTheRiftTask: MinionTask = {
 		// If they have the entire Raiments of the Eye outfit, give an extra 20% quantity bonus (NO bonus XP)
 		let setBonus = 1;
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Runecraft.raimentsOfTheEyeItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			setBonus += 60 / 100;
 		} else {
 			// For each Raiments of the Eye item, check if they have it, give its' quantity boost if so (NO bonus XP).
 			for (const [itemID, bonus] of Object.entries(Runecraft.raimentsOfTheEyeItems)) {
-				if (user.gear.skilling.hasEquipped([parseInt(itemID)], false)) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					setBonus += bonus / 100;
 				}
 			}

--- a/src/tasks/minions/minigames/temporossActivity.ts
+++ b/src/tasks/minions/minigames/temporossActivity.ts
@@ -42,9 +42,9 @@ export const temporossTask: MinionTask = {
 
 		// If they have the entire angler outfit, give an extra 0.5% xp bonus
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Fishing.anglerItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			const amountToAdd = Math.floor(fXPtoGive * (2.5 / 100));
@@ -53,7 +53,7 @@ export const temporossTask: MinionTask = {
 		} else {
 			// For each angler item, check if they have it, give its' XP boost if so.
 			for (const [itemID, bonus] of Object.entries(Fishing.anglerItems)) {
-				if (user.hasEquipped(parseInt(itemID))) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					const amountToAdd = Math.floor(fXPtoGive * (bonus / 100));
 					fXPtoGive += amountToAdd;
 					fBonusXP += amountToAdd;

--- a/src/tasks/minions/minigames/trawlerActivity.ts
+++ b/src/tasks/minions/minigames/trawlerActivity.ts
@@ -55,7 +55,7 @@ export const trawlerTask: MinionTask = {
 
 		if (hasEliteArdy) str += '\n\n50% Extra fish for Ardougne Elite diary';
 
-		if (user.hasEquipped('Fishing master cape')) {
+		if (user.hasEquippedOrInBank('Fishing master cape')) {
 			loot.multiply(4);
 			for (let i = 0; i < quantity; i++) {
 				if (roll(2)) loot.add(MysteryBoxes.roll());

--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -82,9 +82,9 @@ export const wintertodtTask: MinionTask = {
 
 		// If they have the entire pyromancer outfit, give an extra 0.5% xp bonus
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Firemaking.pyromancerItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			const amountToAdd = Math.floor(fmXpToGive * (2.5 / 100));
@@ -93,7 +93,7 @@ export const wintertodtTask: MinionTask = {
 		} else {
 			// For each pyromancer item, check if they have it, give its' XP boost if so.
 			for (const [itemID, bonus] of Object.entries(Firemaking.pyromancerItems)) {
-				if (user.hasEquipped(parseInt(itemID))) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					const amountToAdd = Math.floor(fmXpToGive * (bonus / 100));
 					fmXpToGive += amountToAdd;
 					fmBonusXP += amountToAdd;

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -19,7 +19,6 @@ import resolveItems from '../../lib/util/resolveItems';
 import { mahojiUsersSettingsFetch, userStatsBankUpdate, userStatsUpdate } from '../../mahoji/mahojiSettings';
 
 export function calculateMiningResult({
-	user,
 	ore,
 	allGear,
 	duration,
@@ -36,7 +35,6 @@ export function calculateMiningResult({
 	collectionLog,
 	miningXP
 }: {
-	user: MUser;
 	ore: Ore;
 	allGear: UserFullGearSetup;
 	duration: number;
@@ -66,9 +64,9 @@ export function calculateMiningResult({
 
 	// Prospector outfit
 	if (
-		user.hasEquippedOrInBank(
+		allGear.skilling.hasEquipped(
 			Object.keys(Mining.prospectorItems).map(i => parseInt(i)),
-			'every'
+			true
 		)
 	) {
 		const amountToAdd = Math.floor(totalMiningXPToAdd * (2.5 / 100));
@@ -278,7 +276,6 @@ export const miningTask: MinionTask = {
 			barsFromAdzeBank,
 			oresFromSpiritsBank
 		} = calculateMiningResult({
-			user,
 			duration,
 			isPowermining: powermine ?? false,
 			isUsingObsidianPickaxe: user.hasEquipped(['Offhand volcanic pickaxe'], false),

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -19,6 +19,7 @@ import resolveItems from '../../lib/util/resolveItems';
 import { mahojiUsersSettingsFetch, userStatsBankUpdate, userStatsUpdate } from '../../mahoji/mahojiSettings';
 
 export function calculateMiningResult({
+	user,
 	ore,
 	allGear,
 	duration,
@@ -35,6 +36,7 @@ export function calculateMiningResult({
 	collectionLog,
 	miningXP
 }: {
+	user: MUser;
 	ore: Ore;
 	allGear: UserFullGearSetup;
 	duration: number;
@@ -64,9 +66,9 @@ export function calculateMiningResult({
 
 	// Prospector outfit
 	if (
-		allGear.skilling.hasEquipped(
+		user.hasEquippedOrInBank(
 			Object.keys(Mining.prospectorItems).map(i => parseInt(i)),
-			true
+			'every'
 		)
 	) {
 		const amountToAdd = Math.floor(totalMiningXPToAdd * (2.5 / 100));
@@ -276,6 +278,7 @@ export const miningTask: MinionTask = {
 			barsFromAdzeBank,
 			oresFromSpiritsBank
 		} = calculateMiningResult({
+			user,
 			duration,
 			isPowermining: powermine ?? false,
 			isUsingObsidianPickaxe: user.hasEquipped(['Offhand volcanic pickaxe'], false),

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -387,7 +387,7 @@ export const monsterTask: MinionTask = {
 			}
 		}
 
-		let masterCapeRolls = user.hasEquipped('Slayer master cape') ? newSuperiorCount : 0;
+		let masterCapeRolls = user.hasEquippedOrInBank('Slayer master cape') ? newSuperiorCount : 0;
 		newSuperiorCount += masterCapeRolls;
 
 		// Regular loot

--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -33,14 +33,14 @@ export const runecraftTask: MinionTask = {
 
 		let xpReceived = essenceQuantity * runeXP;
 
-		const hasMaster = user.hasEquipped(
+		const hasMaster = user.hasEquippedOrInBank(
 			[
 				'Master runecrafter hat',
 				'Master runecrafter robe',
 				'Master runecrafter skirt',
 				'Master runecrafter boots'
 			],
-			true
+			'every'
 		);
 		if (hasMaster) {
 			xpReceived = increaseNumByPercent(xpReceived, 10);

--- a/src/tasks/minions/smeltingActivity.ts
+++ b/src/tasks/minions/smeltingActivity.ts
@@ -20,7 +20,7 @@ export const smeltingTask: MinionTask = {
 		const bar = Smithing.Bars.find(bar => bar.id === barID)!;
 
 		// If this bar has a chance of failing to smelt, calculate that here.
-		const masterCapeInEffect = bar.chanceOfFail > 0 && user.hasEquipped('Smithing master cape');
+		const masterCapeInEffect = bar.chanceOfFail > 0 && user.hasEquippedOrInBank('Smithing master cape');
 		const hasBS = user.hasEquippedOrInBank(BlacksmithOutfit, 'every');
 		const oldQuantity = quantity;
 		if ((bar.chanceOfFail > 0 && bar.name !== 'Iron bar') || (!blastf && bar.name === 'Iron bar')) {
@@ -36,7 +36,7 @@ export const smeltingTask: MinionTask = {
 
 		let xpReceived = quantity * bar.xp;
 
-		if (bar.id === itemID('Gold bar') && user.hasEquipped('Goldsmith gauntlets')) {
+		if (bar.id === itemID('Gold bar') && user.hasEquippedOrInBank('Goldsmith gauntlets')) {
 			xpReceived = quantity * 56.2;
 		}
 

--- a/src/tasks/minions/volcanicMineActivity.ts
+++ b/src/tasks/minions/volcanicMineActivity.ts
@@ -23,21 +23,20 @@ export const vmTask: MinionTask = {
 	async run(data: ActivityTaskOptionsWithQuantity) {
 		const { quantity, userID, channelID, duration } = data;
 		const user = await mUserFetch(userID);
-		const userSkillingGear = user.gear.skilling;
 		const userMiningLevel = user.skillLevel(SkillsEnum.Mining);
 		let boost = 1;
 		// Activity boosts
-		if (userMiningLevel >= 99 && userSkillingGear.hasEquipped('Dwarven pickaxe')) {
+		if (userMiningLevel >= 99 && user.hasEquippedOrInBank('Dwarven pickaxe')) {
 			boost += 2;
-		} else if (userMiningLevel >= 71 && userSkillingGear.hasEquipped('Crystal pickaxe')) {
+		} else if (userMiningLevel >= 71 && user.hasEquippedOrInBank('Crystal pickaxe')) {
 			boost += 0.5;
-		} else if (userMiningLevel >= 61 && userSkillingGear.hasEquipped('Dragon pickaxe')) {
+		} else if (userMiningLevel >= 61 && user.hasEquippedOrInBank('Dragon pickaxe')) {
 			boost += 0.3;
 		}
 		if (
-			userSkillingGear.hasEquipped(
+			user.hasEquippedOrInBank(
 				['Prospector helmet', 'Prospector jacket', 'Prospector legs', 'Prospector boots'],
-				true
+				'every'
 			)
 		) {
 			boost += 0.025;

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -40,9 +40,9 @@ export const woodcuttingTask: MinionTask = {
 
 		// If they have the entire lumberjack outfit, give an extra 0.5% xp bonus
 		if (
-			user.gear.skilling.hasEquipped(
+			user.hasEquippedOrInBank(
 				Object.keys(Woodcutting.lumberjackItems).map(i => parseInt(i)),
-				true
+				'every'
 			)
 		) {
 			const amountToAdd = Math.floor(xpReceived * (2.5 / 100));
@@ -51,7 +51,7 @@ export const woodcuttingTask: MinionTask = {
 		} else {
 			// For each lumberjack item, check if they have it, give its XP boost if so.
 			for (const [itemID, bonus] of Object.entries(Woodcutting.lumberjackItems)) {
-				if (user.gear.skilling.hasEquipped([parseInt(itemID)], false)) {
+				if (user.hasEquippedOrInBank(parseInt(itemID))) {
 					const amountToAdd = Math.floor(xpReceived * (bonus / 100));
 					xpReceived += amountToAdd;
 					bonusXP += amountToAdd;

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -88,7 +88,7 @@ export const woodcuttingTask: MinionTask = {
 			}
 		}
 
-		if (user.hasEquipped('Woodcutting master cape')) {
+		if (user.hasEquippedOrInBank('Woodcutting master cape')) {
 			loot.multiply(2);
 		}
 


### PR DESCRIPTION
### Description:

Added "works-from-bank" to several things based on poll results:

- Skilling Master Capes
- Skilling outfits
- Skilling items

Notable exception:
- No combat Master capes were changed (still must be equipped)  (Can be done in 2nd wave if we agree)
- Items with a downside still must be equipped (ie. Offhand Volcanic Pickaxe, Strung rabbits foot, Thieves' armband, etc)
- Graceful still must be equipped.
- Mining is mostly unchanged since, will be done in second wave.
- Inventions unchanged, (will be done in second wave, according to poll results)

### Changes:

- Makes skilling outfits work in addXp.ts
- Updates various skilling outfits that aren't centralized in addXp.ts, often because they have varying % which isn't supported there
- Makes global XP boosts  (ring of fire / flame gloves) work from bank
- Makes Skilling Master capes work from the bank, specifically: Invention, Divination, Hunter (was already half working from bank), Fishing, Woodcutting, Firemaking, Slayer
- Barbarian / fishing rods work from bank
- Clue hunter outfit works from bank
- Shark tooth necklace works from bank for fishing
- Dwarven greataxe works from bank for wintertodt
- Dwarven knife + greathammer work from bank
- Radas blessing, cooking gauntlets, amulet of glory work from bank

### Other checks:

- [ ] I have tested all my changes thoroughly.
