### PR TITLE
`/drop` improvement - Double check drop message fix

### DIFF
--- a/src/lib/util/smallUtils.ts
+++ b/src/lib/util/smallUtils.ts
@@ -332,3 +332,10 @@ export function containsBlacklistedWord(str: string): boolean {
 	}
 	return false;
 }
+
+export function ellipsize(str: string, maxLen: number = 2000) {
+	if (str.length > maxLen) {
+		return `${str.substring(0, maxLen - 3)}...`;
+	}
+	return str;
+}

--- a/src/mahoji/commands/drop.ts
+++ b/src/mahoji/commands/drop.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
 import { ClueTiers } from '../../lib/clues/clueTiers';
-import { ellipsize, itemNameFromID } from '../../lib/util';
+import { ellipsize, itemNameFromID, returnStringOrFile } from '../../lib/util';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
 import { parseBank } from '../../lib/util/parseStringBank';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -85,6 +85,6 @@ export const dropCommand: OSBMahojiCommand = {
 		await user.removeItemsFromBank(bank);
 		updateBankSetting('dropped_items', bank);
 
-		return `Dropped ${bank}.`;
+		return returnStringOrFile(`Dropped ${bank}.`);
 	}
 };

--- a/src/mahoji/commands/drop.ts
+++ b/src/mahoji/commands/drop.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
 import { ClueTiers } from '../../lib/clues/clueTiers';
-import { itemNameFromID } from '../../lib/util';
+import { ellipsize, itemNameFromID } from '../../lib/util';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
 import { parseBank } from '../../lib/util/parseStringBank';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -68,14 +68,17 @@ export const dropCommand: OSBMahojiCommand = {
 
 		await handleMahojiConfirmation(
 			interaction,
-			`${user}, are you sure you want to drop ${bank}? This is irreversible, and you will lose the items permanently.`
+			`${user}, are you sure you want to drop ${ellipsize(
+				bank.toString(),
+				1800
+			)}? This is irreversible, and you will lose the items permanently.`
 		);
 		if (doubleCheckItems.length > 0) {
 			await handleMahojiConfirmation(
 				interaction,
-				`${user}, some of the items you are dropping are on your **favorites** or look valuable, are you *really* sure you want to drop them? **${doubleCheckItems
+				`${user}, some of the items you are dropping are on your **favorites** or look valuable, are you *really* sure you want to drop them?\n**${doubleCheckItems
 					.map(itemNameFromID)
-					.join(', ')}**\n\nDropping: ${bank}`
+					.join(', ')}**\n\nDropping: ${ellipsize(bank.toString(), 1000)}`
 			);
 		}
 

--- a/src/mahoji/commands/drop.ts
+++ b/src/mahoji/commands/drop.ts
@@ -66,17 +66,16 @@ export const dropCommand: OSBMahojiCommand = {
 		].flat(1);
 		const doubleCheckItems = itemsToDoubleCheck.filter(f => bank.has(f));
 
+		await handleMahojiConfirmation(
+			interaction,
+			`${user}, are you sure you want to drop ${bank}? This is irreversible, and you will lose the items permanently.`
+		);
 		if (doubleCheckItems.length > 0) {
 			await handleMahojiConfirmation(
 				interaction,
-				`${user}, some of the items you are dropping look valuable, are you *really* sure you want to drop them? **${doubleCheckItems
+				`${user}, some of the items you are dropping are on your **favorites** or look valuable, are you *really* sure you want to drop them? **${doubleCheckItems
 					.map(itemNameFromID)
-					.join(', ')}**`
-			);
-		} else {
-			await handleMahojiConfirmation(
-				interaction,
-				`${user}, are you sure you want to drop ${bank}? This is irreversible, and you will lose the items permanently.`
+					.join(', ')}**\n\nDropping: ${bank}`
 			);
 		}
 

--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -7,7 +7,7 @@ import { Item, ItemBank } from 'oldschooljs/dist/meta/types';
 import { MAX_INT_JAVA } from '../../lib/constants';
 import { prisma } from '../../lib/settings/prisma';
 import { NestBoxesTable } from '../../lib/simulation/misc';
-import { itemID, toKMB } from '../../lib/util';
+import { itemID, returnStringOrFile, toKMB } from '../../lib/util';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
 import { parseBank } from '../../lib/util/parseStringBank';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -234,8 +234,10 @@ export const sellCommand: OSBMahojiCommand = {
 			prisma.botItemSell.createMany({ data: botItemSellData })
 		]);
 
-		return `Sold ${bankToSell} for **${totalPrice.toLocaleString()}gp (${toKMB(totalPrice)})**${
-			user.isIronman ? ' (General store price)' : ` (${taxRatePercent}% below market price)`
-		}.`;
+		return returnStringOrFile(
+			`Sold ${bankToSell} for **${totalPrice.toLocaleString()}gp (${toKMB(totalPrice)})**${
+				user.isIronman ? ' (General store price)' : ` (${taxRatePercent}% below market price)`
+			}.`
+		);
 	}
 };


### PR DESCRIPTION
### Description:

- Currently /drop is quite broken. If you try to drop something on your favorites, or something considered valuable, it hides everything else that is about to be dropped, and it looks like you're only dropping the listed items.

### Changes:

- First asks the normal drop confirmation.
- Then confirms with the 'double check' items if they exist.
- Truncates bank string if it's too long, returns file if the total dropped exceeds 2k chars, just in case.

### Other checks:

- [x] I have tested all my changes thoroughly.
