### PR TITLE
Add guthixian cache stats

### DIFF
--- a/src/mahoji/commands/bsominigames.ts
+++ b/src/mahoji/commands/bsominigames.ts
@@ -265,6 +265,12 @@ export const minigamesCommand: OSBMahojiCommand = {
 					name: 'join',
 					description: 'Join the current guthixian cache, if one is open.',
 					options: []
+				},
+				{
+					type: ApplicationCommandOptionType.Subcommand,
+					name: 'stats',
+					description: 'View your guthixian cache stats and boosts.',
+					options: []
 				}
 			]
 		}
@@ -314,6 +320,7 @@ export const minigamesCommand: OSBMahojiCommand = {
 		};
 		guthixian_cache?: {
 			join?: {};
+			stats?: {};
 		};
 	}>) => {
 		const klasaUser = await mUserFetch(userID);
@@ -334,6 +341,11 @@ export const minigamesCommand: OSBMahojiCommand = {
 			}
 			return joinGuthixianCache(klasaUser, channelID);
 		}
+		if (options.guthixian_cache?.stats) {
+			const boost = klasaUser.user.guthixian_cache_boosts_available;
+			return `You have ${boost} Guthixian cache boost${boost === 1 ? '' : 's'} available.`;
+		}
+
 		if (divine_dominion?.check) {
 			return divineDominionCheck(klasaUser);
 		}


### PR DESCRIPTION
### Description:
Add a new command to show the user how many cache boosts they have available.
### Changes:
- add `/bsominigames guthixian_cache stats`
- add "cache" as an allias for Guthixian Caches cl
### Other checks:
- [X] I have tested all my changes thoroughly.
![Discord_9uA2DHf6Vq](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/e30fab79-83ba-4a81-8140-00fe8532f175)
