### PR TITLE
Fix for dt tablets

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/dt.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dt.ts
@@ -78,7 +78,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Frozen tablet')) return;
+			if (user.bank.has('Frozen tablet') && user.cl.has('Frozen tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -162,7 +162,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Frozen tablet')) return;
+			if (user.bank.has('Frozen tablet') && user.cl.has('Frozen tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -264,7 +264,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackRanged,
 		attackStylesUsed: [GearStat.AttackRanged],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Scarred tablet')) return;
+			if (user.bank.has('Scarred tablet') && user.cl.has('Scarred tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -353,7 +353,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackRanged,
 		attackStylesUsed: [GearStat.AttackRanged],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Scarred tablet')) return;
+			if (user.bank.has('Scarred tablet') && user.cl.has('Scarred tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -443,7 +443,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackMagic,
 		attackStylesUsed: [GearStat.AttackMagic],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Sirenic tablet')) return;
+			if (user.bank.has('Sirenic tablet') && user.cl.has('Sirenic tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -548,7 +548,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackMagic,
 		attackStylesUsed: [GearStat.AttackMagic],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Sirenic tablet')) return;
+			if (user.bank.has('Sirenic tablet') && user.cl.has('Sirenic tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -641,7 +641,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Strangled tablet')) return;
+			if (user.bank.has('Strangled tablet') && user.cl.has('Strangled tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {
@@ -725,7 +725,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
 		effect: async ({ quantity, user, loot, messages }) => {
-			if (user.bank.has('Strangled tablet')) return;
+			if (user.bank.has('Strangled tablet') && user.cl.has('Strangled tablet')) return;
 			let gotTab = false;
 			for (let i = 0; i < quantity; i++) {
 				if (roll(25)) {


### PR DESCRIPTION
### Description:
Correct an issue preventing users from being able to collect the dt2 tablet cl slot
### Changes:
- Added a second check to dt2 tabs to prevent making the cl inaccessible if the user has one in bank (obtained through trading or tame killing)
### Other checks:
- [X] I have tested all my changes thoroughly.

Separated from: https://github.com/oldschoolgg/oldschoolbot/pull/5578