### PR TITLE
Fix BSO Inferno cl

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -372,15 +372,16 @@ export const grotesqueGuardiansCL = resolveItems([
 	'Granite dust'
 ]);
 export const hesporiCL = resolveItems(['Bottomless compost bucket', 'Iasor seed', 'Kronos seed', 'Attas seed']);
-export const theInfernoCL = resolveItems([
-	'Jal-nib-rek',
-	'Infernal cape',
-	'Tokkul',
-	'Infernal core',
-	"TzKal-Zuk's skin",
+
+export const theInfernoCL = resolveItems(['Jal-nib-rek', 'Infernal cape']);
+
+export const emergedZukInfernoCL = resolveItems([
+	'Jal-MejJak',
 	'Head of TzKal Zuk',
-	'Jal-MejJak'
+	"TzKal-Zuk's skin",
+	'Infernal core'
 ]);
+
 export const kalphiteQueenCL = resolveItems([
 	'Kalphite princess',
 	'Kq head',
@@ -3054,8 +3055,6 @@ export const odsCL = resolveItems([
 ]);
 
 export const tinkeringWorshopCL = resolveItems([...inventorOutfit, 'Materials bag']);
-
-export const emergedZukInfernoCL = resolveItems(['Head of TzKal Zuk', 'Infernal core', 'Tokkul']);
 
 export const polyporeDungeonCL = resolveItems([
 	'Mycelium leggings web',

--- a/tests/unit/snapshots/clsnapshots.test.ts.snap
+++ b/tests/unit/snapshots/clsnapshots.test.ts.snap
@@ -61,7 +61,7 @@ Easter 2023 (13)
 Easy Treasure Trails (131)
 Elite Treasure Trail Rewards (Rare) (39)
 Elite Treasure Trails (59)
-Emerged Zuk Inferno (3)
+Emerged Zuk Inferno (4)
 Expert Capes (4)
 Farming (173)
 Festive crate (s4) (27)
@@ -160,7 +160,7 @@ Thanksgiving 2021 (5)
 The Fight Caves (2)
 The Forgotten Four (29)
 The Gauntlet (5)
-The Inferno (7)
+The Inferno (2)
 The Leviathan (7)
 The Nightmare (12)
 The Whisperer (7)
@@ -1925,7 +1925,6 @@ Thread of elidinis
 Tin stone spirit
 Tiny lamp
 Tiny tempor
-Tokkul
 Toktz-ket-xil
 Toktz-mej-tal
 Toktz-xil-ak


### PR DESCRIPTION
### Description:
Fix both BSO Inferno collection logs
### Changes:
- Remove tokkul (This isn't on the cl ingame)
- Make `/cl name:The Inferno` match ingame osrs (OSB pet, infernal cape)
- Make `/cl name:Emerged Zuk Inferno` have the 4 custom items (BSO pet, zuk head, zuk skin, infernal core)
### Other checks:
- [X] I have tested all my changes thoroughly.
