### PR TITLE
Fix CA command being case sensitive

### DIFF
--- a/src/mahoji/commands/ca.ts
+++ b/src/mahoji/commands/ca.ts
@@ -140,7 +140,7 @@ export const caCommand: OSBMahojiCommand = {
 
 			if (selectedMonster) {
 				const tasksForSelectedMonster = allCombatAchievementTasks.filter(
-					task => task.monster === selectedMonster
+					task => task.monster.toLocaleLowerCase() === selectedMonster
 				);
 
 				if (tasksForSelectedMonster.length === 0)

--- a/src/mahoji/commands/ca.ts
+++ b/src/mahoji/commands/ca.ts
@@ -140,7 +140,7 @@ export const caCommand: OSBMahojiCommand = {
 
 			if (selectedMonster) {
 				const tasksForSelectedMonster = allCombatAchievementTasks.filter(
-					task => task.monster.toLocaleLowerCase() === selectedMonster
+					task => task.monster.toLowerCase() === selectedMonster!.toLowerCase()
 				);
 
 				if (tasksForSelectedMonster.length === 0)


### PR DESCRIPTION
### Description:
Fixes an issue with name field being case sensitive when using `/ca view name:`
### Changes:
- Change the comparison to check both strings as a lower case
### Other checks:
- [X] I have tested all my changes thoroughly.
![Discord_9l0FUKuhu8](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/6073c4d3-ab60-41da-a1aa-2eae70ad3df3)
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5670