### PR TITLE
Fixed only lowercase searches in CL issue 

### DIFF
--- a/src/mahoji/commands/cl.ts
+++ b/src/mahoji/commands/cl.ts
@@ -40,7 +40,7 @@ export const collectionLogCommand: OSBMahojiCommand = {
 							];
 						})
 						.flat(3)
-				].filter(i => (!value ? true : i.name.toLowerCase().includes(value)));
+				].filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase)));
 			}
 		},
 		{

--- a/src/mahoji/commands/cl.ts
+++ b/src/mahoji/commands/cl.ts
@@ -40,7 +40,7 @@ export const collectionLogCommand: OSBMahojiCommand = {
 							];
 						})
 						.flat(3)
-				].filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase)));
+				].filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())));
 			}
 		},
 		{


### PR DESCRIPTION
### Description:

right now searching any CL if you start your search using a capital letter for example `Halloween`.. no results show.   but when you type `halloween` all the halloween results show. this should fix that.

### Changes:

- changed `(value)` to `(value.toLowerCase)`

### Other checks:

- [ ] I have tested all my changes thoroughly.
