### PR TITLE
Add back big bonanaza to non repeatable trips

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -87,6 +87,7 @@ export const taskCanBeRepeated = (activity: Activity) => {
 			activity_type_enum.BossEvent,
 			activity_type_enum.Birdhouse,
 			activity_type_enum.HalloweenMiniMinigame,
+			activity_type_enum.BalthazarsBigBonanza,
 			activity_type_enum.GuthixianCache
 		] as activity_type_enum[]
 	).includes(activity.type);


### PR DESCRIPTION
### Description:
https://github.com/oldschoolgg/oldschoolbot/pull/5567 accidentally removed BalthazarsBigBonanza from non-repeatable trips
### Changes:
- Add BalthazarsBigBonanza to non repeatable trips
### Other checks:
- [X] I have tested all my changes thoroughly.
