### PR TITLE
Add functionality to Ghommal's lucky penny

### DIFF
--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -212,7 +212,7 @@ export const degradeableItems: DegradeableItem[] = [
 		setup: 'melee',
 		aliases: ['scythe of vitur'],
 		chargeInput: {
-			cost: new Bank().add('Blood rune', 300).add('Vial of blood').freeze(),
+			cost: new Bank().add('Blood rune', 200).add('Vial of blood').freeze(),
 			charges: 100
 		},
 		unchargedItem: getOSItem('Scythe of vitur (uncharged)'),

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -1,3 +1,4 @@
+import { roll } from 'e';
 import { Bank } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 import Monster from 'oldschooljs/dist/structures/Monster';
@@ -297,6 +298,17 @@ export async function degradeItem({
 	const degItem = degradeableItems.find(i => i.item === item);
 	if (!degItem) throw new Error('Invalid degradeable item');
 
+	// 5% chance to not consume a charge when Ghommal's lucky penny is equipped
+	let pennyReduction = 0;
+	if (user.hasEquipped("Ghommal's lucky penny")) {
+		for (let i = 0; i < chargesToDegrade; i++) {
+			if (roll(20)) {
+				pennyReduction++;
+			}
+		}
+	}
+	chargesToDegrade -= pennyReduction;
+
 	const currentCharges = user.user[degItem.settingsKey];
 	assert(typeof currentCharges === 'number');
 	const newCharges = Math.floor(currentCharges - chargesToDegrade);
@@ -353,7 +365,11 @@ export async function degradeItem({
 	const chargesAfter = user.user[degItem.settingsKey];
 	assert(typeof chargesAfter === 'number' && chargesAfter > 0);
 	return {
-		userMessage: `Your ${item.name} degraded by ${chargesToDegrade} charges, and now has ${chargesAfter} remaining.`
+		userMessage: `Your ${
+			item.name
+		} degraded by ${chargesToDegrade} charges, and now has ${chargesAfter} remaining.${
+			pennyReduction > 0 ? ` Your Ghommal's lucky penny saved ${pennyReduction} charges` : ''
+		}`
 	};
 }
 

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -1,4 +1,4 @@
-import { roll } from 'e';
+import { percentChance } from 'e';
 import { Bank } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 import Monster from 'oldschooljs/dist/structures/Monster';
@@ -302,7 +302,7 @@ export async function degradeItem({
 	let pennyReduction = 0;
 	if (user.hasEquipped("Ghommal's lucky penny")) {
 		for (let i = 0; i < chargesToDegrade; i++) {
-			if (roll(20)) {
+			if (percentChance(5)) {
 				pennyReduction++;
 			}
 		}


### PR DESCRIPTION
### Description:
"When equipped, it offers a 5% chance to not use a charge when using items that consume charges (such as jewellery and weapons)." https://oldschool.runescape.wiki/w/Ghommal%27s_lucky_penny
### Changes:
- Add a 5% chance to not use a charge when the user has Ghommal's lucky penny equipped.
- Reduce amount of blood runes to charge scythe from 300 to 200 (This was implemented in-game osrs 17Jan24)
### Other checks:
- [X] I have tested all my changes thoroughly.