### PR TITLE
CL & Notification fixes

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -143,7 +143,7 @@ function kcProg(mon: Monster): FormatProgressFunction {
 }
 
 function mgProg(minigameName: MinigameName): FormatProgressFunction {
-	return ({ minigames }) => `${minigames[minigameName]} KC`;
+	return ({ minigames }) => `${minigames[minigameName]} Completions`;
 }
 
 function skillProg(skillName: SkillsEnum): FormatProgressFunction {
@@ -807,7 +807,7 @@ export const allCollectionLogs: ICollection = {
 			"Shades of Mort'ton": {
 				items: shadesOfMorttonCL,
 				isActivity: true,
-				fmtProg: () => '0 KC'
+				fmtProg: mgProg('shades_of_morton')
 			},
 			'Soul Wars': {
 				alias: ['soul wars', 'sw'],


### PR DESCRIPTION
### Description:
Shades notification doesn't work properly & minigame notifications use "KC" instead of "Completions" in OSB (merged into BSO here https://github.com/oldschoolgg/oldschoolbot/pull/5654)
### Changes:
- Change KC to Completions for minigame cl notifications
- Fix Shades of mor'ton notification
### Other checks:
- [X] I have tested all my changes thoroughly.
Before:
![firefox_TOSGjx6TXX](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/51bdadf2-0e35-4ec2-b4ff-2305632abfa9)
After:
![Discord_1JULkVg8jt](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/31006714-3883-49eb-88c1-dab35ad26f68)
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5687
