### PR TITLE
Allow Inferno KC to impact Fightcaves

### DIFF
--- a/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
@@ -4,6 +4,7 @@ import { Bank, Monsters } from 'oldschooljs';
 import TzTokJad from 'oldschooljs/dist/simulation/monsters/special/TzTokJad';
 import { itemID } from 'oldschooljs/dist/util';
 
+import { getMinigameScore } from '../../../lib/settings/minigames';
 import { getUsersCurrentSlayerInfo } from '../../../lib/slayer/slayerUtil';
 import { FightCavesActivityTaskOptions } from '../../../lib/types/minions';
 import { formatDuration } from '../../../lib/util';
@@ -24,7 +25,9 @@ async function determineDuration(user: MUser): Promise<[number, string]> {
 
 	// Reduce time based on KC
 	const jadKC = await user.getKC(TzTokJad.id);
-	const percentIncreaseFromKC = Math.min(50, jadKC);
+	const zukKC = await getMinigameScore(user.id, 'inferno');
+	const experienceKC = jadKC + zukKC;
+	const percentIncreaseFromKC = Math.min(50, experienceKC);
 	baseTime = reduceNumByPercent(baseTime, percentIncreaseFromKC);
 	debugStr += `${percentIncreaseFromKC}% from KC`;
 
@@ -43,8 +46,11 @@ async function determineDuration(user: MUser): Promise<[number, string]> {
 	return [baseTime, debugStr];
 }
 
-function determineChanceOfDeathPreJad(user: MUser, attempts: number) {
+function determineChanceOfDeathPreJad(user: MUser, attempts: number, hasInfernoKC: boolean) {
 	let deathChance = Math.max(14 - attempts * 2, 5);
+
+	// If user has killed inferno, give them the lowest chance of death pre Jad.
+	if (hasInfernoKC) deathChance = 5;
 
 	// -4% Chance of dying before Jad if you have SGS.
 	if (user.hasEquipped(itemID('Saradomin godsword'))) {
@@ -54,8 +60,12 @@ function determineChanceOfDeathPreJad(user: MUser, attempts: number) {
 	return deathChance;
 }
 
-function determineChanceOfDeathInJad(attempts: number) {
-	const chance = Math.floor(100 - (Math.log(attempts) / Math.log(Math.sqrt(15))) * 50);
+function determineChanceOfDeathInJad(attempts: number, hasInfernoKC: boolean) {
+	let chance = Math.floor(100 - (Math.log(attempts) / Math.log(Math.sqrt(15))) * 50);
+
+	if (hasInfernoKC) {
+		chance /= 1.5;
+	}
 
 	// Chance of death cannot be 100% or <5%.
 	return Math.max(Math.min(chance, 99), 5);
@@ -98,11 +108,14 @@ export async function fightCavesCommand(user: MUser, channelID: string): Command
 
 	const { fight_caves_attempts: attempts } = await user.fetchStats({ fight_caves_attempts: true });
 
-	const jadDeathChance = determineChanceOfDeathInJad(attempts);
-	const preJadDeathChance = determineChanceOfDeathPreJad(user, attempts);
+	const jadKC = await user.getKC(TzTokJad.id);
+	const zukKC = await getMinigameScore(user.id, 'inferno');
+	const hasInfernoKC = zukKC > 0;
+
+	const jadDeathChance = determineChanceOfDeathInJad(attempts, hasInfernoKC);
+	const preJadDeathChance = determineChanceOfDeathPreJad(user, attempts, hasInfernoKC);
 
 	const usersRangeStats = user.gear.range.stats;
-	const jadKC = await user.getKC(TzTokJad.id);
 
 	duration += (randInt(1, 5) * duration) / 100;
 
@@ -148,6 +161,7 @@ export async function fightCavesCommand(user: MUser, channelID: string): Command
 **Boosts:** ${debugStr}
 **Range Attack Bonus:** ${usersRangeStats.attack_ranged}
 **Jad KC:** ${jadKC}
+**Zuk KC:** ${zukKC}
 **Attempts:** ${attempts}
 
 **Removed from your bank:** ${fightCavesCost}`,

--- a/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
@@ -26,7 +26,7 @@ async function determineDuration(user: MUser): Promise<[number, string]> {
 	// Reduce time based on KC
 	const jadKC = await user.getKC(TzTokJad.id);
 	const zukKC = await getMinigameScore(user.id, 'inferno');
-	const experienceKC = jadKC + (zukKC * 3);
+	const experienceKC = jadKC + zukKC * 3;
 	const percentIncreaseFromKC = Math.min(50, experienceKC);
 	baseTime = reduceNumByPercent(baseTime, percentIncreaseFromKC);
 	debugStr += `${percentIncreaseFromKC}% from KC`;

--- a/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fightCavesCommand.ts
@@ -26,7 +26,7 @@ async function determineDuration(user: MUser): Promise<[number, string]> {
 	// Reduce time based on KC
 	const jadKC = await user.getKC(TzTokJad.id);
 	const zukKC = await getMinigameScore(user.id, 'inferno');
-	const experienceKC = jadKC + zukKC;
+	const experienceKC = jadKC + (zukKC * 3);
 	const percentIncreaseFromKC = Math.min(50, experienceKC);
 	baseTime = reduceNumByPercent(baseTime, percentIncreaseFromKC);
 	debugStr += `${percentIncreaseFromKC}% from KC`;


### PR DESCRIPTION
Allows Inferno kc to increase speed along with jad kc

Gives the lowest chance of death pre Jad if the user has an inferno kc

Gives a reduction to chance of death by Jad if the user has inferno kc

Note: This PR doesn't increase any speeds or lower any death chances than what are already obtainable, it just helps the user get to the best speeds/death chances quicker.

- [x] I have tested all my changes thoroughly.
