### PR TITLE
Slayer Task Weightings

### DIFF
--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -439,20 +439,6 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		dontAssign: true
 	},
 	{
-		monster: Monsters.SpiritualRanger,
-		amount: [110, 170],
-
-		weight: 12,
-		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		levelRequirements: {
-			slayer: 60
-		},
-		combatLevel: 60,
-		slayerLevel: 63,
-		questPoints: 3,
-		unlocked: true
-	},
-	{
 		monster: Monsters.MountainTroll,
 		amount: [110, 170],
 		weight: 11,

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -379,7 +379,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		monster: Monsters.SpiritualMage,
 		amount: [110, 170],
 
-		weight: 12,
+		weight: 7,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
 		extendedAmount: [180, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.SpiritualFervour,
@@ -391,21 +391,6 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		questPoints: 3,
 		unlocked: true,
 		dontAssign: true
-	},
-	{
-		monster: Monsters.SpiritualRanger,
-		amount: [130, 200],
-		weight: 7,
-		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		extendedAmount: [180, 250],
-		extendedUnlockId: SlayerTaskUnlocksEnum.SpiritualFervour,
-		levelRequirements: {
-			slayer: 60
-		},
-		combatLevel: 60,
-		slayerLevel: 63,
-		questPoints: 3,
-		unlocked: true
 	},
 	{
 		monster: Monsters.SteelDragon,

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -105,7 +105,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.BlueDragon,
 		amount: [120, 170],
-		weight: 8,
+		weight: 4,
 		monsters: [Monsters.BlueDragon.id, Monsters.BabyBlueDragon.id, Monsters.BrutalBlueDragon.id],
 		combatLevel: 65,
 		questPoints: 34,
@@ -204,7 +204,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		monster: Monsters.FossilIslandWyvernSpitting,
 		amount: [15, 30],
 
-		weight: 9,
+		weight: 5,
 		monsters: [
 			Monsters.FossilIslandWyvernAncient.id,
 			Monsters.FossilIslandWyvernLongTailed.id,
@@ -381,7 +381,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.SteelDragon,
 		amount: [30, 50],
-		weight: 7,
+		weight: 5,
 		monsters: [Monsters.SteelDragon.id],
 		levelRequirements: killableMonsters.find(k => k.id === Monsters.SteelDragon.id)!.levelRequirements,
 		extendedAmount: [40, 60],

--- a/src/lib/slayer/tasks/mazchnaTasks.ts
+++ b/src/lib/slayer/tasks/mazchnaTasks.ts
@@ -89,14 +89,6 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.Lizard,
-		amount: [40, 70],
-		weight: 8,
-		monsters: [Monsters.Lizard.id, Monsters.SmallLizard.id, Monsters.DesertLizard.id, Monsters.SulphurLizard.id],
-		slayerLevel: 22,
-		unlocked: true
-	},
-	{
 		monster: Monsters.GuardDog,
 		amount: [40, 70],
 		weight: 7,
@@ -183,6 +175,14 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 		combatLevel: 50,
 		slayerLevel: 37,
 		questPoints: 4,
+		unlocked: true
+	},
+	{
+		monster: Monsters.Lizard,
+		amount: [40, 70],
+		weight: 8,
+		monsters: [Monsters.Lizard.id, Monsters.SmallLizard.id, Monsters.DesertLizard.id, Monsters.SulphurLizard.id],
+		slayerLevel: 22,
 		unlocked: true
 	},
 	{

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -358,7 +358,7 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		monster: Monsters.SpiritualMage,
 		amount: [110, 170],
 
-		weight: 12,
+		weight: 6,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
 		levelRequirements: {
 			slayer: 60
@@ -368,19 +368,6 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		questPoints: 3,
 		unlocked: true,
 		dontAssign: true
-	},
-	{
-		monster: Monsters.SpiritualRanger,
-		amount: [120, 185],
-		weight: 6,
-		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		levelRequirements: {
-			slayer: 60
-		},
-		combatLevel: 60,
-		slayerLevel: 63,
-		questPoints: 3,
-		unlocked: true
 	},
 	{
 		monster: Monsters.SteelDragon,

--- a/src/lib/slayer/tasks/turaelTasks.ts
+++ b/src/lib/slayer/tasks/turaelTasks.ts
@@ -22,6 +22,20 @@ export const turaelTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
+		monster: Monsters.BlackBear,
+		amount: [15, 50],
+		weight: 7,
+		monsters: [
+			Monsters.BlackBear.id,
+			Monsters.GrizzlyBearCub.id,
+			Monsters.BearCub.id,
+			Monsters.GrizzlyBear.id,
+			Monsters.Callisto.id
+		],
+		combatLevel: 13,
+		unlocked: true
+	},
+	{
 		monster: Monsters.Bird,
 		amount: [15, 50],
 		weight: 6,
@@ -36,20 +50,6 @@ export const turaelTasks: AssignableSlayerTask[] = [
 			Monsters.Duckling.id,
 			Monsters.Bird.id
 		],
-		unlocked: true
-	},
-	{
-		monster: Monsters.BlackBear,
-		amount: [15, 50],
-		weight: 7,
-		monsters: [
-			Monsters.BlackBear.id,
-			Monsters.GrizzlyBearCub.id,
-			Monsters.BearCub.id,
-			Monsters.GrizzlyBear.id,
-			Monsters.Callisto.id
-		],
-		combatLevel: 13,
 		unlocked: true
 	},
 	{

--- a/src/lib/slayer/tasks/vannakaTasks.ts
+++ b/src/lib/slayer/tasks/vannakaTasks.ts
@@ -481,7 +481,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		monster: Monsters.SpiritualMage,
 		amount: [110, 170],
 
-		weight: 12,
+		weight: 8,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
 		levelRequirements: {
 			slayer: 60
@@ -491,19 +491,6 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		questPoints: 3,
 		unlocked: true,
 		dontAssign: true
-	},
-	{
-		monster: Monsters.SpiritualRanger,
-		amount: [60, 120],
-		weight: 8,
-		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		levelRequirements: {
-			slayer: 60
-		},
-		combatLevel: 60,
-		slayerLevel: 63,
-		questPoints: 3,
-		unlocked: true
 	},
 	{
 		monster: Monsters.TerrorDog,


### PR DESCRIPTION
Reviewed all the slayer task weightings and matched them to the wiki, removed duplicated spiritualranger tasks when spiritualmager tasks are there.

Closes #5674 

- [x] I have tested all my changes thoroughly.
