### PR TITLE
Update Larren's & Brimstone openable

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -172,7 +172,7 @@ const osjsOpenables: UnifiedOpenable[] = [
 		}> => {
 			const chest = new BrimstoneChestOpenable(BrimstoneChest);
 			const fishLvl = args.user.skillLevel(SkillsEnum.Fishing);
-			const brimstoneOptions: any = {
+			const brimstoneOptions = {
 				fishLvl
 			};
 			const openLoot: Bank = chest.open(args.quantity, brimstoneOptions);

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -172,7 +172,7 @@ const osjsOpenables: UnifiedOpenable[] = [
 		}> => {
 			const chest = new BrimstoneChestOpenable(BrimstoneChest);
 			const fishLvl = args.user.skillLevel(SkillsEnum.Fishing);
-			const brimstoneOptions = {
+			const brimstoneOptions: OpenableOpenOptions = {
 				fishLvl
 			};
 			const openLoot: Bank = chest.open(args.quantity, brimstoneOptions);

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -1,7 +1,7 @@
 import { formatOrdinal } from '@oldschoolgg/toolkit';
 import { Bank, LootTable, Openables } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
-import { Item } from 'oldschooljs/dist/meta/types';
+import { Item, OpenableOpenOptions } from 'oldschooljs/dist/meta/types';
 import { Mimic } from 'oldschooljs/dist/simulation/misc';
 import BrimstoneChest, { BrimstoneChestOpenable } from 'oldschooljs/dist/simulation/openables/BrimstoneChest';
 import { HallowedSackTable } from 'oldschooljs/dist/simulation/openables/HallowedSack';
@@ -257,7 +257,7 @@ const osjsOpenables: UnifiedOpenable[] = [
 		}> => {
 			const chest = new LarransChestOpenable(LarransChest);
 			const fishLvl = args.user.skillLevel(SkillsEnum.Fishing);
-			const larransOptions: any = {
+			const larransOptions: OpenableOpenOptions = {
 				fishLvl,
 				chestSize: 'big'
 			};

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -1,9 +1,12 @@
 import { formatOrdinal } from '@oldschoolgg/toolkit';
 import { Bank, LootTable, Openables } from 'oldschooljs';
+import { SkillsEnum } from 'oldschooljs/dist/constants';
 import { Item } from 'oldschooljs/dist/meta/types';
 import { Mimic } from 'oldschooljs/dist/simulation/misc';
+import BrimstoneChest, { BrimstoneChestOpenable } from 'oldschooljs/dist/simulation/openables/BrimstoneChest';
 import { HallowedSackTable } from 'oldschooljs/dist/simulation/openables/HallowedSack';
 import { Implings } from 'oldschooljs/dist/simulation/openables/Implings';
+import LarransChest, { LarransChestOpenable } from 'oldschooljs/dist/simulation/openables/LarransChest';
 
 import { ClueTiers } from './clues/clueTiers';
 import { Emoji, Events, MIMIC_MONSTER_ID } from './constants';
@@ -162,7 +165,20 @@ const osjsOpenables: UnifiedOpenable[] = [
 		id: 23_083,
 		openedItem: getOSItem(23_083),
 		aliases: ['brimstone chest', 'brimstone'],
-		output: Openables.BrimstoneChest.table,
+		output: async (
+			args: OpenArgs
+		): Promise<{
+			bank: Bank;
+		}> => {
+			const chest = new BrimstoneChestOpenable(BrimstoneChest);
+			const fishLvl = args.user.skillLevel(SkillsEnum.Fishing);
+			const brimstoneOptions: any = {
+				fishLvl
+			};
+			const openLoot: Bank = chest.open(args.quantity, brimstoneOptions);
+
+			return { bank: openLoot };
+		},
 		allItems: Openables.BrimstoneChest.table.allItems
 	},
 	{
@@ -234,7 +250,21 @@ const osjsOpenables: UnifiedOpenable[] = [
 			'larrans small chest',
 			"larran's small chest"
 		],
-		output: Openables.LarransChest.table,
+		output: async (
+			args: OpenArgs
+		): Promise<{
+			bank: Bank;
+		}> => {
+			const chest = new LarransChestOpenable(LarransChest);
+			const fishLvl = args.user.skillLevel(SkillsEnum.Fishing);
+			const larransOptions: any = {
+				fishLvl,
+				chestSize: 'big'
+			};
+			const openLoot: Bank = chest.open(args.quantity, larransOptions);
+
+			return { bank: openLoot };
+		},
 		allItems: Openables.LarransChest.table.allItems
 	},
 	{

--- a/src/mahoji/commands/cl.ts
+++ b/src/mahoji/commands/cl.ts
@@ -39,7 +39,7 @@ export const collectionLogCommand: OSBMahojiCommand = {
 							];
 						})
 						.flat(3)
-				].filter(i => (!value ? true : i.name.toLowerCase().includes(value)));
+				].filter(i => (!value ? true : i.name.toLowerCase().includes(value.toLowerCase())));
 			}
 		},
 		{


### PR DESCRIPTION
### Description:
Update Larren's & Brimstone openable to allow for fish rolls.
### Changes:
- Update Larran's openable
- Update Brimstone openable
### Other checks:
- [X] I have tested all my changes thoroughly.
- Supports: https://github.com/oldschoolgg/oldschoolbot/pull/5426
- This PR will still work without merging: https://github.com/oldschoolgg/oldschooljs/pull/357 but it will only roll one type of fish. Once https://github.com/oldschoolgg/oldschooljs/pull/357 is merged it will work similar to ingame.
