### PR TITLE
Fix Invention Filters

### DIFF
--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -7,7 +7,7 @@ import { MediumClueTable } from 'oldschooljs/dist/simulation/clues/Medium';
 
 import { tmbTable, umbTable } from '../bsoOpenables';
 import { customItems } from '../customItems/util';
-import { materialTypes } from '../invention';
+import { DisassembleFlag, disassembleFlagMaterials, materialTypes } from '../invention';
 import { DisassemblySourceGroups } from '../invention/groups';
 import Potions from '../minions/data/potions';
 import { monkeyEatables } from '../monkeyRumble';
@@ -1044,10 +1044,21 @@ for (const clGroup of Object.values(allCollectionLogs).map(c => c.activities)) {
 }
 
 for (const type of materialTypes) {
-	const items = DisassemblySourceGroups.filter(i => Boolean(i.parts[type]))
-		.map(i => i.items.map(i => (Array.isArray(i.item) ? i.item : [i.item])))
-		.flat(5)
-		.map(i => i.id);
+	let items: number[] = [];
+	if (disassembleFlagMaterials.includes(type as DisassembleFlag)) {
+		items = DisassemblySourceGroups.flatMap(group =>
+			group.items
+				.filter(item => item.flags && item.flags.has(type as DisassembleFlag))
+				.flatMap(item => (Array.isArray(item.item) ? item.item.map(i => i.id) : [item.item.id]))
+		);
+	} else {
+		items = DisassemblySourceGroups.filter(group => Boolean(group.parts[type]))
+			.map(group =>
+				group.items.flatMap(item => (Array.isArray(item.item) ? item.item.map(i => i.id) : [item.item.id]))
+			)
+			.flat(5);
+	}
+
 	filterableTypes.push({
 		name: `${type}-material`,
 		aliases: [type],

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -1052,13 +1052,10 @@ for (const type of materialTypes) {
 				.flatMap(item => (Array.isArray(item.item) ? item.item.map(i => i.id) : [item.item.id]))
 		);
 	} else {
-		items = DisassemblySourceGroups.filter(group => Boolean(group.parts[type]))
-			.map(group =>
-				group.items.flatMap(item => (Array.isArray(item.item) ? item.item.map(i => i.id) : [item.item.id]))
-			)
-			.flat(5);
+		items = DisassemblySourceGroups.filter(group => Boolean(group.parts[type])).flatMap(group =>
+			group.items.flatMap(item => (Array.isArray(item.item) ? item.item.map(i => i.id) : [item.item.id]))
+		);
 	}
-
 	filterableTypes.push({
 		name: `${type}-material`,
 		aliases: [type],

--- a/src/lib/invention/index.ts
+++ b/src/lib/invention/index.ts
@@ -48,17 +48,20 @@ export interface SingleMaterial {
 	quantity: number;
 }
 
-export type DisassembleFlag =
-	| 'third_age'
-	| 'dyed'
-	| 'dwarven'
-	| 'barrows'
-	| 'abyssal'
-	| 'corporeal'
-	| 'treasure_trails'
-	| 'mystery_box'
-	| 'orikalkum'
-	| 'justiciar';
+export const disassembleFlagMaterials = [
+	'third_age',
+	'dyed',
+	'dwarven',
+	'barrows',
+	'abyssal',
+	'corporeal',
+	'treasure_trails',
+	'mystery_box',
+	'orikalkum',
+	'justiciar'
+] as const;
+
+export type DisassembleFlag = (typeof disassembleFlagMaterials)[number];
 
 interface IDisassembleFlag {
 	name: string;


### PR DESCRIPTION
### Description:
Fixes invention filters that don't work properly, such as orikalkum and justiciar.
### Changes:
- Rework DisassembleFlag so it can be used as a constant
- Change how the materials filter works to check for flags on items.
### Other checks:
- [X] I have tested all my changes thoroughly.
![Discord_nhtO5LHubn](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/7246c682-6a13-4c39-940c-1082f6bd22eb)
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5093
