### PR TITLE
Make Cooking boosts stack, also rebalance slightly.

### DIFF
--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -89,15 +89,23 @@ export const cookCommand: OSBMahojiCommand = {
 		if (cookable.id === itemID('Jug of wine') || cookable.id === itemID('Wine of zamorak')) {
 			timeToCookSingleCookable /= 1.6;
 			if (hasRemy) timeToCookSingleCookable /= 1.5;
-		} else if (user.hasEquippedOrInBank('Cooking master cape')) {
-			boosts.push('5x for Cooking master cape');
-			timeToCookSingleCookable /= 5;
-		} else if (user.hasEquippedOrInBank('Dwarven gauntlets')) {
-			boosts.push('3x for Dwarven gauntlets');
-			timeToCookSingleCookable /= 3;
-		} else if (hasRemy) {
-			boosts.push('2x for Remy');
-			timeToCookSingleCookable /= 2;
+		} else {
+			let cookingBoost = 1;
+			let cookingBoostItems: string[] = [];
+			if (user.hasEquippedOrInBank('Cooking master cape')) {
+				cookingBoostItems.push('Cooking master cape');
+				cookingBoost += 2.5;
+			}
+			if (user.hasEquippedOrInBank('Dwarven gauntlets')) {
+				cookingBoostItems.push('Dwarven gauntlets');
+				cookingBoost += 1.5;
+			}
+			if (hasRemy) {
+				cookingBoostItems.push('Remy');
+				cookingBoost += 1;
+			}
+			timeToCookSingleCookable /= cookingBoost;
+			boosts.push(`+${(cookingBoost - 1) * 100}% for ${cookingBoostItems.join(', ')}.`);
 		}
 
 		const userBank = user.bank;


### PR DESCRIPTION
### Description:

None of the BSO Custom Cooking item boosts stack.

If they stacked, then people would likely equip Remy while cooking, instead of Doug or something that brings more items into the game.

Obviously simply multiplying the boosts together would be insane, so I suggest doing it like fletching, where each adds to the total boost percentage.

 **Currently:  (none stack)**
- Cooking master cape - 5x 
- Dwarven gauntlets -  3x
- Remy - 2x  

So 5x is the current max boost.

 **Suggested: (individually)**
- Remy: +100%  (2x)
- Dwarven gauntlets: +150%  (2.5x)
- Cooking master cape: + 250%   (3.5x)

This would **nerf** each item individually (except Remy which is the same), but the total boost for all 3 combined would be a little better.

 **Resulting Combos:**
- Remy  + Dwarven : 3.5x   
- Remy + Cooking master: 4.5x
- Dwarven + Cooking master: 5x
- Remy + Dwarven + Cooking master cape: 6x

It totals to a 20% buff when using all 3 items, so it's a relatively small, and Remy **must** be equipped.  

- **But it's cooking, so it doesn't produce items, only converts**. 
- It would prevent things like Doug or Mr. E from being used, which do produce more items.

### Changes:

- Converts Cooking boosts to a boost percentage, allowing stacking
- Nerfs individual cooking boosts
- Max boost is now 6x instead of 5x, but requires all 3 items, and doesn't bring more items into the game.

### Other checks:

- [x] I have tested all my changes thoroughly.

### XP Rates  
*Includes full first age, Remy, dwarven gauntlets, and the Cooking master cape XP boost*
- Existing: 8.79m/Hr  
- Proposed:  10.55m/Hr