### PR TITLE
Add error to decant singular dose potions

### DIFF
--- a/src/lib/minions/functions/decantPotionFromBank.ts
+++ b/src/lib/minions/functions/decantPotionFromBank.ts
@@ -24,6 +24,7 @@ export default function decantPotionFromBank(
 		return { error: "That's not a valid potion that you can decant." };
 	}
 	if (potionToDecant.items.length === 2 && dose > 2) return { error: 'You can only decant mixes into 1 or 2 doses.' };
+	if (potionToDecant.items.length === 1) return { error: `You can't decant ${potionToDecant.name}.` };
 	const potionsToRemove = new Bank();
 	const potionsToAdd = new Bank();
 	let sumOfPots = 0;


### PR DESCRIPTION
Adds an error message for when a user tries to decant a singular dose potion.

Closes #5699

This only effects BSO currently, but might be worth adding to the master branch anyway?

- [x] I have tested all my changes thoroughly.
