### PR TITLE
Fix exploit with Supply crates

### DIFF
--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -130,6 +130,7 @@ async function finalizeOpening({
 
 	if (hasSmokey) {
 		let bonuses = [];
+		const totalLeaguesPoints = (await roboChimpUserFetch(user.id)).leagues_points_total;
 		for (const openable of openables) {
 			if (!openable.smokeyApplies) continue;
 			let smokeyBonus = 0;
@@ -145,7 +146,7 @@ async function finalizeOpening({
 						user,
 						openable,
 						quantity: smokeyBonus,
-						totalLeaguesPoints: (await roboChimpUserFetch(user.id)).leagues_points_total
+						totalLeaguesPoints
 					})
 				).bank
 			);
@@ -275,6 +276,8 @@ export async function abstractedOpenCommand(
 	const loot = new Bank();
 	const messages: string[] = [];
 
+	const totalLeaguesPoints = (await roboChimpUserFetch(user.id)).leagues_points_total;
+
 	for (const openable of openables) {
 		const { openedItem } = openable;
 		const quantity = typeof _quantity === 'string' ? user.bank.amount(openedItem.id) : _quantity;
@@ -289,7 +292,7 @@ export async function abstractedOpenCommand(
 			openable,
 			quantity,
 			user,
-			totalLeaguesPoints: process.env.TEST ? 0 : (await roboChimpUserFetch(user.id)).leagues_points_total
+			totalLeaguesPoints
 		});
 		loot.add(thisLoot.bank);
 		if (thisLoot.message) messages.push(thisLoot.message);


### PR DESCRIPTION
### Description:

- This fixes an issue with Supply crates that allows you to find a chase item with a limited number of attempts.
- Also fixes an issue where a database query was inside a for loop that should have been outside the for loop.

### Changes:

- Limits the amount of rolled crates to the number of keys you have
- Moves DB query outside for loop.

### Other checks:

- [x] I have tested all my changes thoroughly.
