### PR TITLE
Fix issue where LMS Sim wasn't cancelling on failure.

### DIFF
--- a/src/lib/minions/functions/lmsSimCommand.ts
+++ b/src/lib/minions/functions/lmsSimCommand.ts
@@ -118,22 +118,22 @@ export async function lmsSimCommand(channel: Channel | undefined, names?: string
 	} else {
 		filtered = new Set(splitContestants);
 		if (filtered.size !== splitContestants.length) {
-			channel.send('I am sorry, but a user cannot play twice.');
+			return channel.send('I am sorry, but a user cannot play twice.');
 		}
 
 		if (filtered.size < 4) {
-			channel.send(
+			return channel.send(
 				'Please specify atleast 4 players for Last Man Standing, like so: `+lms Alex, Kyra, Magna, Rick`, or type `+lms auto` to automatically pick people from the chat.'
 			);
 		}
 
 		if (filtered.size > 48) {
-			channel.send('I am sorry but the amount of players can be no greater than 48.');
+			return channel.send('I am sorry but the amount of players can be no greater than 48.');
 		}
 	}
 
 	if (playing.has(channel.guildId)) {
-		channel.send('There is a game in progress in this server already, try again when it finishes.');
+		return channel.send('There is a game in progress in this server already, try again when it finishes.');
 	}
 
 	playing.add(channel.guildId);


### PR DESCRIPTION
### Description:

- LMS Is supposed to only allow one instance per server.
- When an error occurs, the LMS command function isn't exited, causing it to fail to abort.

### Changes:

- Adds `return` statements before channel.send() calls to abort starting a new sim if one is in progress.

### Other checks:

- [ ] I have tested all my changes thoroughly.
