### PR TITLE
Add price abuse check to packaged buyables.

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -994,8 +994,8 @@ const Buyables: Buyable[] = [
 	})),
 	{
 		name: 'Menaphite purple outfit',
-		gpCost: 5000,
-		ironmanPrice: 600,
+		gpCost: 25_000,
+		ironmanPrice: 10_000,
 		outputItems: new Bank({
 			'Menaphite purple hat': 1,
 			'Menaphite purple top': 1,
@@ -1005,8 +1005,8 @@ const Buyables: Buyable[] = [
 	},
 	{
 		name: 'Menaphite red outfit',
-		gpCost: 5000,
-		ironmanPrice: 600,
+		gpCost: 25_000,
+		ironmanPrice: 10_000,
 		outputItems: new Bank({
 			'Menaphite red hat': 1,
 			'Menaphite red top': 1,

--- a/tests/unit/priceAbuses.test.ts
+++ b/tests/unit/priceAbuses.test.ts
@@ -7,6 +7,63 @@ import { sacrificePriceOfItem } from '../../src/mahoji/commands/sacrifice';
 import { sellPriceOfItem, sellStorePriceOfItem } from '../../src/mahoji/commands/sell';
 
 describe('Price Abusing', () => {
+	const gpPackageBuyables = Buyables.filter(
+		i =>
+			i.gpCost !== undefined &&
+			i.itemCost === undefined &&
+			i.outputItems !== undefined &&
+			!isFunction(i.outputItems) &&
+			i.outputItems.length > 1
+	);
+
+	test('Package buyables', () => {
+		for (const b of gpPackageBuyables) {
+			// Check for packaged items
+			if (b.outputItems) {
+				if (isFunction(b.outputItems)) continue;
+				const outputItems = b.outputItems.items();
+
+				let totalPriceSoldFor = 0;
+				for (const [item, qty] of outputItems) {
+					totalPriceSoldFor += sellPriceOfItem(item, 0).price * qty;
+				}
+				const priceBoughtFor = b.gpCost;
+
+				if (totalPriceSoldFor > priceBoughtFor!) {
+					throw new Error(
+						`(Package) ${b.name} has an abusable price: buys for ${priceBoughtFor}, sells for ${totalPriceSoldFor}.`
+					);
+				}
+				if (b.ironmanPrice) {
+					let storePrice = 0;
+					for (const [item, qty] of outputItems) {
+						storePrice += sellStorePriceOfItem(item, qty).price;
+					}
+					if (storePrice > b.ironmanPrice) {
+						throw new Error(
+							`(Package) ${b.name} has an abusable price: buys for ${b.ironmanPrice}, sells for ${storePrice}.`
+						);
+					}
+				}
+
+				let sacPrice = 0;
+				for (const [item, qty] of outputItems) {
+					sacPrice += sacrificePriceOfItem(item, qty);
+				}
+				if (sacPrice > priceBoughtFor!) {
+					throw new Error(
+						`${b.name} has an abusable sacrifice price: buys for ${priceBoughtFor}, sacrifices for ${sacPrice}.`
+					);
+				}
+				if (b.ironmanPrice && sacPrice > b.ironmanPrice) {
+					throw new Error(
+						`${b.name} has an abusable ironman sacrifice price: buys for ${b.ironmanPrice}, sacrifices for ${sacPrice}.`
+					);
+				}
+			}
+		}
+	});
+
 	const gpBuyables = Buyables.filter(
 		i =>
 			i.gpCost !== undefined &&
@@ -31,7 +88,7 @@ describe('Price Abusing', () => {
 				const storePrice = sellStorePriceOfItem(item, 1);
 				if (storePrice.price > b.ironmanPrice) {
 					throw new Error(
-						`${item.name} has an abusable price: buys for ${storePrice.price}, sells for ${b.ironmanPrice}.`
+						`${item.name} has an abusable price: buys for ${b.ironmanPrice}, sells for ${storePrice.price}.`
 					);
 				}
 			}

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -761,8 +761,8 @@ exports[`OSB Buyables 1`] = `
     "qpRequired": 10,
   },
   {
-    "gpCost": 5000,
-    "ironmanPrice": 600,
+    "gpCost": 25000,
+    "ironmanPrice": 10000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -779,8 +779,8 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 5000,
-    "ironmanPrice": 600,
+    "gpCost": 25000,
+    "ironmanPrice": 10000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,


### PR DESCRIPTION
### Description:

- An exploit was recently found where the packaged buyables were not checked for Price abuses, this allowed a price difference in menaphite clothing to lead to a massive GP dupe.

### Changes:

- Updates priceAbuses.ts to catch abuses in packaged buyables.
- Updates buyable cost for menaphite package.
- One of the old ironman tests had the buy + sell prices swapped.

### Other checks:

- [x] I have tested all my changes thoroughly.
