### PR TITLE
Don't process GE listings for blacklisted users + Add cancel GE Listings admin command.

### DIFF
--- a/src/lib/grandExchange.ts
+++ b/src/lib/grandExchange.ts
@@ -7,6 +7,7 @@ import { Item, ItemBank } from 'oldschooljs/dist/meta/types';
 import PQueue from 'p-queue';
 
 import { ADMIN_IDS, OWNER_IDS, production } from '../config';
+import { BLACKLISTED_USERS } from './blacklists';
 import { BitField, globalConfig, ONE_TRILLION, PerkTier } from './constants';
 import { marketPricemap } from './marketPrices';
 import { RobochimpUser, roboChimpUserFetch } from './roboChimp';
@@ -598,13 +599,15 @@ ${type} ${toKMB(quantity)} ${item.name} for ${toKMB(price)} each, for a total of
 			items: buyerLoot,
 			collectionLog: false,
 			dontAddToTempCL: true,
-			filterLoot: false
+			filterLoot: false,
+			neverUpdateHistory: true
 		});
 		await sellerUser.addItemsToBank({
 			items: sellerLoot,
 			collectionLog: false,
 			dontAddToTempCL: true,
-			filterLoot: false
+			filterLoot: false,
+			neverUpdateHistory: true
 		});
 
 		const itemName = itemNameFromID(buyerListing.item_id)!;
@@ -678,9 +681,8 @@ ${type} ${toKMB(quantity)} ${item.name} for ${toKMB(price)} each, for a total of
 					type: GEListingType.Buy,
 					fulfilled_at: null,
 					cancelled_at: null,
-					user_id: {
-						not: null
-					}
+					// Using NOT IN doesn't match null values.
+					user_id: { notIn: [...BLACKLISTED_USERS] }
 				},
 				orderBy: [
 					{
@@ -696,9 +698,8 @@ ${type} ${toKMB(quantity)} ${item.name} for ${toKMB(price)} each, for a total of
 					type: GEListingType.Sell,
 					fulfilled_at: null,
 					cancelled_at: null,
-					user_id: {
-						not: null
-					}
+					// Using NOT IN doesn't match null values.
+					user_id: { notIn: [...BLACKLISTED_USERS] }
 				},
 				orderBy: [
 					{

--- a/src/lib/grandExchange.ts
+++ b/src/lib/grandExchange.ts
@@ -681,8 +681,7 @@ ${type} ${toKMB(quantity)} ${item.name} for ${toKMB(price)} each, for a total of
 					type: GEListingType.Buy,
 					fulfilled_at: null,
 					cancelled_at: null,
-					// Using NOT IN doesn't match null values.
-					user_id: { notIn: [...BLACKLISTED_USERS] }
+					user_id: { not: null }
 				},
 				orderBy: [
 					{
@@ -698,8 +697,7 @@ ${type} ${toKMB(quantity)} ${item.name} for ${toKMB(price)} each, for a total of
 					type: GEListingType.Sell,
 					fulfilled_at: null,
 					cancelled_at: null,
-					// Using NOT IN doesn't match null values.
-					user_id: { notIn: [...BLACKLISTED_USERS] }
+					user_id: { not: null }
 				},
 				orderBy: [
 					{
@@ -829,7 +827,12 @@ Difference: ${shouldHave.difference(currentBank)}`);
 		if (this.locked) return;
 		const stopwatch = new Stopwatch();
 		stopwatch.start();
-		const { buyListings, sellListings } = await this.fetchActiveListings();
+		const { buyListings: _buyListings, sellListings: _sellListings } = await this.fetchActiveListings();
+
+		// Filter out listings from Blacklisted users:
+		const blacklist = [...BLACKLISTED_USERS];
+		const buyListings = _buyListings.filter(l => !blacklist.includes(l.user_id!));
+		const sellListings = _sellListings.filter(l => !blacklist.includes(l.user_id!));
 
 		for (const buyListing of buyListings) {
 			// These are all valid, matching sell listings we can match with this buy listing.

--- a/src/lib/grandExchange.ts
+++ b/src/lib/grandExchange.ts
@@ -830,9 +830,8 @@ Difference: ${shouldHave.difference(currentBank)}`);
 		const { buyListings: _buyListings, sellListings: _sellListings } = await this.fetchActiveListings();
 
 		// Filter out listings from Blacklisted users:
-		const blacklist = [...BLACKLISTED_USERS];
-		const buyListings = _buyListings.filter(l => !blacklist.includes(l.user_id!));
-		const sellListings = _sellListings.filter(l => !blacklist.includes(l.user_id!));
+		const buyListings = _buyListings.filter(l => !BLACKLISTED_USERS.has(l.user_id!));
+		const sellListings = _sellListings.filter(l => !BLACKLISTED_USERS.has(l.user_id!));
 
 		for (const buyListing of buyListings) {
 			// These are all valid, matching sell listings we can match with this buy listing.

--- a/src/mahoji/commands/rp.ts
+++ b/src/mahoji/commands/rp.ts
@@ -33,6 +33,7 @@ import { makeBankImage } from '../../lib/util/makeBankImage';
 import { migrateUser } from '../../lib/util/migrateUser';
 import { parseBank } from '../../lib/util/parseStringBank';
 import { sendToChannelID } from '../../lib/util/webhook';
+import { cancelUsersListings } from '../lib/abstracted_commands/cancelGEListingCommand';
 import { gearSetupOption } from '../lib/mahojiCommandOptions';
 import { OSBMahojiCommand } from '../lib/util';
 import { mahojiUsersSettingsFetch } from '../mahojiSettings';
@@ -303,6 +304,19 @@ export const rpCommand: OSBMahojiCommand = {
 							required: false
 						}
 					]
+				},
+				{
+					type: ApplicationCommandOptionType.Subcommand,
+					name: 'cancel_ge',
+					description: 'Cancel GE Listings',
+					options: [
+						{
+							type: ApplicationCommandOptionType.User,
+							name: 'user',
+							description: 'The user',
+							required: true
+						}
+					]
 				}
 			]
 		}
@@ -347,6 +361,7 @@ export const rpCommand: OSBMahojiCommand = {
 				partner?: MahojiUserOption;
 				guild_id?: string;
 			};
+			cancel_ge?: { user: MahojiUserOption };
 		};
 	}>) => {
 		await deferInteraction(interaction);
@@ -725,6 +740,12 @@ ORDER BY item_id ASC;`);
 			}
 
 			return { files: [{ attachment: Buffer.from(report), name: 'trade_report.txt' }] };
+		}
+
+		if (options.player?.cancel_ge) {
+			const targetUser = await mUserFetch(options.player.cancel_ge.user.user.id);
+			await cancelUsersListings(targetUser);
+			return `Cancelled listings for ${targetUser}`;
 		}
 
 		return 'Invalid command.';

--- a/src/mahoji/commands/rp.ts
+++ b/src/mahoji/commands/rp.ts
@@ -307,7 +307,7 @@ export const rpCommand: OSBMahojiCommand = {
 				},
 				{
 					type: ApplicationCommandOptionType.Subcommand,
-					name: 'cancel_ge',
+					name: 'ge_cancel',
 					description: 'Cancel GE Listings',
 					options: [
 						{
@@ -361,7 +361,7 @@ export const rpCommand: OSBMahojiCommand = {
 				partner?: MahojiUserOption;
 				guild_id?: string;
 			};
-			cancel_ge?: { user: MahojiUserOption };
+			ge_cancel?: { user: MahojiUserOption };
 		};
 	}>) => {
 		await deferInteraction(interaction);
@@ -742,8 +742,8 @@ ORDER BY item_id ASC;`);
 			return { files: [{ attachment: Buffer.from(report), name: 'trade_report.txt' }] };
 		}
 
-		if (options.player?.cancel_ge) {
-			const targetUser = await mUserFetch(options.player.cancel_ge.user.user.id);
+		if (options.player?.ge_cancel) {
+			const targetUser = await mUserFetch(options.player.ge_cancel.user.user.id);
 			await cancelUsersListings(targetUser);
 			return `Cancelled listings for ${targetUser}`;
 		}

--- a/src/mahoji/lib/abstracted_commands/cancelGEListingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/cancelGEListingCommand.ts
@@ -7,6 +7,7 @@ import { makeTransactFromTableBankQueries } from '../../../lib/tableBank';
 import { logError } from '../../../lib/util/logError';
 
 export async function cancelUsersListings(user: MUser) {
+	await user.sync();
 	const activeListings = await prisma.gEListing.findMany({
 		where: {
 			user_id: user.id,

--- a/tests/integration/grandExchange.test.ts
+++ b/tests/integration/grandExchange.test.ts
@@ -198,13 +198,17 @@ Based on G.E data, we should have received ${data.totalTax} tax`;
 		await GrandExchange.tick();
 		await GrandExchange.tick();
 
+		// The user object isn't updated by the GE tick, since that uses completely separate user objects.
+		await wes.sync();
+		await magnaboy.sync();
+
 		const amountSold = 50;
 		const priceSoldAt = 100;
 		const totalGPBeforeTax = amountSold * priceSoldAt;
 		const taxPerItem = calcPercentOfNum(1, priceSoldAt);
 		expect(taxPerItem).toEqual(1);
 		const totalTax = taxPerItem * amountSold;
-		expect(taxPerItem).toEqual(1);
+		expect(totalTax).toEqual(50);
 		const gpShouldBeReceivedAfterTax = totalGPBeforeTax - totalTax;
 		expect(gpShouldBeReceivedAfterTax).toEqual(4950);
 


### PR DESCRIPTION
### Description:

Does what it says on the tin.

### Changes:

- Adds `notIn: [ ...BLACKLISTED_USERS ]` to the select query.
- Adds `/rp player ge_cancel` command
- Updates grandExchange.test.ts to use `cancelUsersListings()` function

### Other checks:

- [x] I have tested all my changes thoroughly.
