### PR TITLE
Update fail rate of Wines of Zamorak

### DIFF
--- a/src/lib/skilling/skills/cooking/cooking.ts
+++ b/src/lib/skilling/skills/cooking/cooking.ts
@@ -226,7 +226,7 @@ export const Cookables: Cookable[] = [
 		name: 'Wine of zamorak',
 		alias: ['zammy wine'],
 		inputCookables: { [itemID("Zamorak's grapes")]: 1, [itemID('Jug of water')]: 1 },
-		stopBurnAt: 125,
+		stopBurnAt: 98,
 		burntCookable: itemID('Jug of bad wine')
 	},
 	{


### PR DESCRIPTION
Following the 1st March 2023 update, updates the Wines of Zamorak to the correct stop burning level.

Closes #5751 
