### PR TITLE
Fix issue with CL notifications

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,7 +24,8 @@ export const BOT_TYPE: 'BSO' | 'OSB' = 'OSB' as 'BSO' | 'OSB';
 
 export const Channel = {
 	General: DISCORD_SETTINGS.Channels?.General ?? '342983479501389826',
-	Notifications: production ? '469523207691436042' : '1042760447830536212',
+	Notifications:
+		DISCORD_SETTINGS.Channels?.Notifications ?? (production ? '469523207691436042' : '1042760447830536212'),
 	GrandExchange: DISCORD_SETTINGS.Channels?.GrandExchange ?? '682996313209831435',
 	Developers: DISCORD_SETTINGS.Channels?.Developers ?? '648196527294251020',
 	BlacklistLogs: DISCORD_SETTINGS.Channels?.BlacklistLogs ?? '782459317218967602',

--- a/src/lib/handleNewCLItems.ts
+++ b/src/lib/handleNewCLItems.ts
@@ -128,7 +128,7 @@ export async function handleNewCLItems({
 				resultLimit: 100_000,
 				method: 'raw_cl'
 			})
-		).length;
+		).filter(u => u.qty === finishedCL.items.length).length;
 
 		const placeStr = nthUser > 100 ? '' : ` They are the ${formatOrdinal(nthUser)} user to finish this CL.`;
 


### PR DESCRIPTION
### Description:

- Currently, the notification saying, 'the user is Nth to finish this CL' is incorrect. It's counting all users on the leaderboard, not just users who have completed the CL.

### Changes:

- Filters the leaderboard to only count completions
- Adds support for a local Notifications channel override for testing notifications

### Other checks:

- [x] I have tested all my changes thoroughly.

![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/43655364-da54-4915-9971-4e933e7455cf)
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/80631d1b-4978-43a0-9770-ca8dfb5bf049)
