### PR TITLE
Updated fishing contest button to check for the items of both locations

### DIFF
--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -44,8 +44,9 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 			if (user.bank.amount(location.bait.id) >= quantity) {
 				loc = location.name;
 			}
-		}
-		if (!loc) loc = validLocs[0].name;
+	}
+	if (!loc) loc = validLocs[0].name;
+		const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
 	}
 	if (!fishingLocation) {
 		return `That's not a valid location to fish at, you can fish at these locations: ${fishingLocations

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -41,7 +41,7 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 
 	if (!loc) {
 		for (const location of validLocs) {
-			if (user.bank.amount(location.bait.id) >= quanity) {
+			if (user.bank.amount(location.bait.id) >= quantity) {
 				loc = location.name;
 			}
 		}

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -36,8 +36,6 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 		quantity++;
 		quantityBoosts.push('1 for Crystal fishing rod');
 	}
-	if (true) {
-	}
 
 	if (!loc) {
 		for (const location of validLocs) {

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -35,7 +35,8 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 	if (user.hasEquippedOrInBank('Crystal fishing rod')) {
 		quantity++;
 		quantityBoosts.push('1 for Crystal fishing rod');
-	}
+	}if (!loc) loc = validLocs[0].name;
+	const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
 
 	if (!loc) {
 		for (const location of validLocs) {
@@ -44,7 +45,7 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 			}
 	}
 	if (!loc) loc = validLocs[0].name;
-		const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
+	const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
 	}
 	if (!fishingLocation) {
 		return `That's not a valid location to fish at, you can fish at these locations: ${fishingLocations

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -18,26 +18,6 @@ import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 export async function fishingContestStartCommand(user: MUser, channelID: string, loc: string | undefined) {
 	const currentFishType = getCurrentFishType();
 	const validLocs = getValidLocationsForFishType(currentFishType);
-	if (!loc) loc = validLocs[0].name;
-	const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
-	if (!fishingLocation) {
-		return `That's not a valid location to fish at, you can fish at these locations: ${fishingLocations
-			.map(i => `${i.name}(${i.temperature} ${i.water})`)
-			.join(', ')}.`;
-	}
-
-	if (!validLocs.includes(fishingLocation)) {
-		return `This Fishing Location isn't valid for todays catch! These ones are: ${validLocs
-			.map(i => i.name)
-			.join(', ')}`;
-	}
-
-	if (!['Contest rod', "Beginner's tackle box"].every(i => user.hasEquippedOrInBank(i))) {
-		return 'You need to buy a Contest rod and a tackle box to compete in the Fishing contest.';
-	}
-	if (user.minionIsBusy) {
-		return 'Your minion is busy.';
-	}
 	let quantity = 1;
 	let duration = Math.floor(quantity * Time.Minute * 1.69);
 	let quantityBoosts = [];
@@ -55,6 +35,35 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 	if (user.hasEquippedOrInBank('Crystal fishing rod')) {
 		quantity++;
 		quantityBoosts.push('1 for Crystal fishing rod');
+	} if (true) {
+		
+	}
+
+	if (!loc) {
+    for (const location of validLocs) {
+        if (user.bank.amount(location.bait.id) >= quanity) {
+            loc = location.name;
+        }
+    }
+    if (!loc) loc = validLocs[0].name;
+	}
+	if (!fishingLocation) {
+		return `That's not a valid location to fish at, you can fish at these locations: ${fishingLocations
+			.map(i => `${i.name}(${i.temperature} ${i.water})`)
+			.join(', ')}.`;
+	}
+
+	if (!validLocs.includes(fishingLocation)) {
+		return `This Fishing Location isn't valid for todays catch! These ones are: ${validLocs
+			.map(i => i.name)
+			.join(', ')}`;
+	}
+
+	if (!['Contest rod', "Beginner's tackle box"].every(i => user.hasEquippedOrInBank(i))) {
+		return 'You need to buy a Contest rod and a tackle box to compete in the Fishing contest.';
+	}
+	if (user.minionIsBusy) {
+		return 'Your minion is busy.';
 	}
 
 	const result = await getUsersFishingContestDetails(user);

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -35,17 +35,17 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 	if (user.hasEquippedOrInBank('Crystal fishing rod')) {
 		quantity++;
 		quantityBoosts.push('1 for Crystal fishing rod');
-	} if (true) {
-		
+	}
+	if (true) {
 	}
 
 	if (!loc) {
-    for (const location of validLocs) {
-        if (user.bank.amount(location.bait.id) >= quanity) {
-            loc = location.name;
-        }
-    }
-    if (!loc) loc = validLocs[0].name;
+		for (const location of validLocs) {
+			if (user.bank.amount(location.bait.id) >= quanity) {
+				loc = location.name;
+			}
+		}
+		if (!loc) loc = validLocs[0].name;
 	}
 	if (!fishingLocation) {
 		return `That's not a valid location to fish at, you can fish at these locations: ${fishingLocations

--- a/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingContestCommand.ts
@@ -35,7 +35,8 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 	if (user.hasEquippedOrInBank('Crystal fishing rod')) {
 		quantity++;
 		quantityBoosts.push('1 for Crystal fishing rod');
-	}if (!loc) loc = validLocs[0].name;
+	}
+	if (!loc) loc = validLocs[0].name;
 	const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
 
 	if (!loc) {
@@ -43,9 +44,9 @@ export async function fishingContestStartCommand(user: MUser, channelID: string,
 			if (user.bank.amount(location.bait.id) >= quantity) {
 				loc = location.name;
 			}
-	}
-	if (!loc) loc = validLocs[0].name;
-	const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
+		}
+		if (!loc) loc = validLocs[0].name;
+		const fishingLocation = fishingLocations.find(i => stringMatches(i.name, loc!));
 	}
 	if (!fishingLocation) {
 		return `That's not a valid location to fish at, you can fish at these locations: ${fishingLocations


### PR DESCRIPTION
…items of both locations

### Description:

The button just calls the normal fishing contest command with no location option causing the bot to to respond you need so many of bait to fish at location instead of checking if you have items for the other location

i updated the `fishingContestStartCommand()` function to check for the items of both locations

all-in-all this will get rid of having to manually send the command for the location you do have items for.

mad thanks to @themrrobert for this.

### Changes:

- changed `if (!loc)...` to iterate over all validLoc items putting current value in `location`
- changed (user.bank.has(location.fishing_location)) to (user.bank.amount(location.bait.id)

### Other checks:

- [ ] I have tested all my changes thoroughly.
