### PR TITLE
Fix Music cape requirments for random events

### DIFF
--- a/src/lib/musicCape.ts
+++ b/src/lib/musicCape.ts
@@ -205,19 +205,16 @@ AND data->>'runeID' IS NOT NULL;`;
 		}
 	})
 	.add({
-		name: 'One of Every Random Event',
-		has: async ({ stats, user }) => {
+		name: 'One Random Event with a unique music track',
+		has: async ({ stats }) => {
 			const results: RequirementFailure[] = [];
 			const eventBank = stats.randomEventCompletionsBank();
+			const uniqueTracks = RandomEvents.filter(i => i.uniqueMusic);
 
-			const notDoneRandomEvents = RandomEvents.filter(i => {
-				if (i.outfit && i.outfit.every(id => user.cl.has(id))) return false;
-				return !eventBank[i.id];
-			}).map(i => i.name);
-
-			if (notDoneRandomEvents.length > 0) {
+			if (!uniqueTracks.some(i => eventBank[i.id])) {
+				const tracksNeeded = RandomEvents.filter(i => i.uniqueMusic).map(i => i.name);
 				results.push({
-					reason: `You need to do these random events at least once: ${notDoneRandomEvents.join(', ')}.`
+					reason: `You need to do one of these random events: ${tracksNeeded.join(', ')}.`
 				});
 			}
 			return results;

--- a/src/lib/musicCape.ts
+++ b/src/lib/musicCape.ts
@@ -26,7 +26,7 @@ export const musicCapeRequirements = new Requirements()
 			}
 			return [
 				{
-					reason: 'You need to complete 20 slayer tasks'
+					reason: 'You need to complete 20 slayer tasks.'
 				}
 			];
 		}
@@ -230,7 +230,7 @@ AND data->>'runeID' IS NOT NULL;`;
 					return [];
 				}
 			}
-			return [{ reason: 'You need to build something in your POH' }];
+			return [{ reason: 'You need to build something in your POH.' }];
 		}
 	})
 	.add({
@@ -239,6 +239,6 @@ AND data->>'runeID' IS NOT NULL;`;
 			for (const scroll of championScrolls) {
 				if (user.cl.has(scroll)) return [];
 			}
-			return [{ reason: 'You need to have a Champion Scroll in your CL' }];
+			return [{ reason: 'You need to have a Champion Scroll in your CL.' }];
 		}
 	});

--- a/src/lib/randomEvents.ts
+++ b/src/lib/randomEvents.ts
@@ -12,6 +12,7 @@ export interface RandomEvent {
 	id: number;
 	name: string;
 	outfit?: number[];
+	uniqueMusic?: boolean;
 	loot: LootTable;
 }
 
@@ -56,18 +57,20 @@ const randomEventTable = new LootTable()
 	.add('Tooth half of key', 1, 1);
 
 // https://oldschool.runescape.wiki/w/Random_events#List_of_random_events
-// Missing: Evil Bob, Jekyll and Hyde, Maze, Prison Pete
+// Missing: Evil Bob, Jekyll and Hyde, Maze (uniqueMusic: true), Prison Pete (uniqueMusic: true)
 export const RandomEvents: RandomEvent[] = [
 	{
 		id: 1,
 		name: 'Bee keeper',
 		outfit: beekeeperOutfit,
+		uniqueMusic: true,
 		loot: new LootTable().add('Coins', [16, 36]).add('Flax', [1, 27])
 	},
 	{
 		id: 2,
 		name: 'Drill Demon',
 		outfit: camoOutfit,
+		uniqueMusic: true,
 		loot: new LootTable().every('Genie lamp')
 	},
 	{
@@ -79,6 +82,7 @@ export const RandomEvents: RandomEvent[] = [
 		id: 4,
 		name: 'Freaky Forester',
 		outfit: lederhosenOutfit,
+		uniqueMusic: true,
 		loot: new LootTable().every('Genie lamp')
 	},
 	{
@@ -101,11 +105,13 @@ export const RandomEvents: RandomEvent[] = [
 		id: 8,
 		name: 'Mime',
 		outfit: mimeOutfit,
+		uniqueMusic: true,
 		loot: new LootTable().every('Genie lamp')
 	},
 	{
 		id: 9,
 		name: 'Quiz master',
+		uniqueMusic: true,
 		loot: new LootTable().every('Mystery box')
 	},
 	{
@@ -123,6 +129,7 @@ export const RandomEvents: RandomEvent[] = [
 	{
 		id: 11,
 		name: 'Surprise Exam',
+		uniqueMusic: true,
 		loot: new LootTable().every('Book of knowledge')
 	},
 	{
@@ -156,6 +163,7 @@ export const RandomEvents: RandomEvent[] = [
 	{
 		id: 15,
 		name: 'Evil twin',
+		uniqueMusic: true,
 		loot: new LootTable()
 			.add('Uncut sapphire', [2, 4])
 			.add('Uncut emerald', [2, 4])
@@ -175,6 +183,7 @@ export const RandomEvents: RandomEvent[] = [
 	{
 		id: 18,
 		name: 'Pinball',
+		uniqueMusic: true,
 		loot: new LootTable().add('Sapphire', 5, 3).add('Emerald', 5, 3).add('Ruby', 5, 3).add('Diamond', 2, 1)
 	},
 	{


### PR DESCRIPTION
### Description:
Currently music cape requires 1 of each random event, only a handful of random events provide a unique track. A previous update changed how these tracks are unlocked: "All unique random event music tracks are unlocked the first time you enter a random event that has its own unique music track."
### Changes:
- Add `uniqueMusic?: boolean;` to random events with unique music tracks
- Update music cape requirement for random events
- A few punctuation corrections
### Other checks:
- [X] I have tested all my changes thoroughly.
source:  https://oldschool.runescape.wiki/w/Music#Track_list
