### PR TITLE
Forestry accurate xp & data commands

### DIFF
--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -27,6 +27,7 @@ import { barChart, lineChart, pieChart } from '../../../lib/util/chart';
 import { getItem } from '../../../lib/util/getOSItem';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 import resolveItems from '../../../lib/util/resolveItems';
+import { ForestryEvents } from '../../../tasks/minions/woodcuttingActivity';
 import { Cooldowns } from '../Cooldowns';
 import { collectables } from './collectCommand';
 
@@ -972,6 +973,43 @@ GROUP BY "bankBackground";`);
 						`${skillEmoji[i.skill as keyof typeof skillEmoji] as keyof SkillsScore} ${toKMB(i.total_xp)}`
 				)
 				.join('\n')}`;
+		}
+	},
+	{
+		name: 'Personal XP gained from Forestry events',
+		perkTierNeeded: PerkTier.Four,
+		run: async (user: MUser) => {
+			const result = await prisma.$queryRawUnsafe<any>(
+				`SELECT skill,
+					SUM(xp)::int AS total_xp
+				 FROM xp_gains
+				 WHERE source = 'ForestryEvents'
+				 AND user_id = ${BigInt(user.id)}
+				 GROUP BY skill
+				 ORDER BY CASE 
+					 WHEN skill = 'woodcutting' THEN 0
+					 ELSE 1
+				 END`
+			);
+
+			return `**Personal XP gained from Forestry events**\n${result
+				.map(
+					(i: any) =>
+						`${skillEmoji[i.skill as keyof typeof skillEmoji] as keyof SkillsScore} ${toKMB(i.total_xp)}`
+				)
+				.join('\n')}`;
+		}
+	},
+	{
+		name: 'Forestry events completed',
+		perkTierNeeded: PerkTier.Four,
+		run: async (_, userStats) => {
+			let str = 'You have completed...\n\n';
+			for (const event of ForestryEvents) {
+				const qty = (userStats.forestry_event_completions_bank as ItemBank)[event.id] ?? 0;
+				str += `${event.name}: ${qty}\n`;
+			}
+			return str;
 		}
 	},
 	{


### PR DESCRIPTION
### Description:
Update forestry event XP
Add 2 data commands for forestry

### Changes:
- Data commands for forestry
  - `/data name:Personal XP gained from Forestry events`
  - `/data name:Forestry events completed`
- update forestry event xp based on my own ingame testing & any verified xp rates from osrs wiki
- remove generic default xp calcualtions
- two new variables `eventRounds` & `eventInteraction` with comments next to each use to better explain what is happening
- update anima infused bark amount per event to closer reflect ingame rates. 


### Other checks:
- [X] I have tested all my changes thoroughly.
testing, updated XP, and data commands can be seen here: https://discord.com/channels/940758552425955348/1213966198262468618/1216139230619631646 