### PR TITLE
Change how invention materials command is displayed

### DIFF
--- a/src/lib/invention/MaterialBank.ts
+++ b/src/lib/invention/MaterialBank.ts
@@ -87,11 +87,11 @@ export class MaterialBank {
 			return 'No materials';
 		}
 		const res = [];
-		for (const [type, qty] of entries.sort((a, b) => b[1] - a[1])) {
-			res.push(`${qty.toLocaleString()}x ${toTitleCase(type)}`);
+		for (const [type, qty] of entries.sort((a, b) => a[0].localeCompare(b[0]))) {
+			res.push(`${toTitleCase(type)}: ${qty.toLocaleString()}`);
 		}
 
-		return res.join(', ');
+		return `${res.join('\n')}`;
 	}
 
 	public values() {

--- a/src/mahoji/commands/invention.ts
+++ b/src/mahoji/commands/invention.ts
@@ -215,7 +215,7 @@ export const inventionCommand: OSBMahojiCommand = {
 			return str;
 		}
 		if (options.materials) {
-			return `You own: ${user.materialsOwned()}`;
+			return { content: `You own:\n${user.materialsOwned()}`, ephemeral: true };
 		}
 
 		if (options.group) {


### PR DESCRIPTION
### Description:
Change how invention materials command is displayed.
Discord poll: https://discord.com/channels/342983479501389826/1032668754561224734/1216090520065937499
### Changes:
- change `/invention materials`
  - alphabetical
  - ascending
  - ephemeral (to reduce spam since this can be a long list)
### Other checks:
- [X] I have tested all my changes thoroughly.
Example picture:
![Discord_2cY7is6xeY](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/c8b01170-93ca-415c-92a6-c7d009c45eab)

