### PR TITLE
Add option to hide/unhide tame

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -748,6 +748,7 @@ model Tame {
   max_total_loot     Json        @default("{}") @db.Json
   fed_items          Json        @default("{}") @db.Json
   species_variant    Int         @default(1)
+  hidden             Boolean     @default(false)
 
   equipped_primary Int?
   equipped_armor   Int?


### PR DESCRIPTION
### Description:

- Adds option to hide/unhide your tame. (from /tames list)
- This is because you can easily acquire a large-ish number of tames trying to hatch several for good stats and/or shiny tames.

### Changes:

- Adds `hidden` column on Tame table
- Adds `/tames hide` command to toggle/set the `hidden` value
- Adds `hidden` option to `/tames list` command to include the hidden tames in case you do want to see the big graphic :)

### Other checks:

- [x] I have tested all my changes thoroughly.

![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/18a84483-ea9b-4b3c-9c53-779338518a6b)
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/169e72c0-3b5e-41de-be9e-e1c542b779a4)
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/6bc75c53-1212-45cb-bdd4-7c28551365a9)
