### PR TITLE
Balloon cat - Removed tradeable & tradeable on ge

### DIFF
--- a/src/lib/customItems/pets.ts
+++ b/src/lib/customItems/pets.ts
@@ -418,19 +418,6 @@ setCustomItem(
 	1_000_000
 );
 
-setCustomItem(
-	52_687,
-	'Balloon cat',
-	'Herbi',
-	{
-		customItemData: {
-			cantDropFromMysteryBoxes: true,
-			isSuperUntradeable: true
-		}
-	},
-	1_000_000
-);
-
 /**
  * Recolors
  */
@@ -600,6 +587,19 @@ setCustomItem(
 		tradeable: true,
 		customItemData: {
 			cantDropFromMysteryBoxes: true
+		}
+	},
+	1_000_000
+);
+
+setCustomItem(
+	52_687,
+	'Balloon cat',
+	'Herbi',
+	{
+		customItemData: {
+			cantDropFromMysteryBoxes: true,
+			isSuperUntradeable: true
 		}
 	},
 	1_000_000

--- a/src/lib/customItems/pets.ts
+++ b/src/lib/customItems/pets.ts
@@ -418,6 +418,20 @@ setCustomItem(
 	1_000_000
 );
 
+setCustomItem(
+	52_687,
+	'Balloon cat',
+	'Herbi',
+	{
+		customItemData: {
+			cantDropFromMysteryBoxes: true,
+			isSuperUntradeable: true
+		}
+	},
+	1_000_000
+);
+
+
 /**
  * Recolors
  */
@@ -587,21 +601,6 @@ setCustomItem(
 		tradeable: true,
 		customItemData: {
 			cantDropFromMysteryBoxes: true
-		}
-	},
-	1_000_000
-);
-
-setCustomItem(
-	52_687,
-	'Balloon cat',
-	'Herbi',
-	{
-		tradeable_on_ge: true,
-		tradeable: true,
-		customItemData: {
-			cantDropFromMysteryBoxes: true,
-			isSuperUntradeable: true
 		}
 	},
 	1_000_000

--- a/src/lib/customItems/pets.ts
+++ b/src/lib/customItems/pets.ts
@@ -431,7 +431,6 @@ setCustomItem(
 	1_000_000
 );
 
-
 /**
  * Recolors
  */


### PR DESCRIPTION
### Description:

fixed small things with Balloon cat code

### Changes:

- Removed `tradeable: true` & `tradeable_on_ge: true` from Balloon cat due to it is ment to be untradeable & has `isSuperUntradeable: true`

### Other checks:

- [x] I have tested all my changes thoroughly.
