### PR TITLE
Fix materials used formatting on trip return

### DIFF
--- a/src/lib/invention/MaterialBank.ts
+++ b/src/lib/invention/MaterialBank.ts
@@ -91,7 +91,7 @@ export class MaterialBank {
 			res.push(`${toTitleCase(type)}: ${qty.toLocaleString()}`);
 		}
 
-		return `${res.join('\n')}`;
+		return res.join(', ');
 	}
 
 	public values() {

--- a/src/mahoji/commands/invention.ts
+++ b/src/mahoji/commands/invention.ts
@@ -215,7 +215,8 @@ export const inventionCommand: OSBMahojiCommand = {
 			return str;
 		}
 		if (options.materials) {
-			return { content: `You own:\n${user.materialsOwned()}`, ephemeral: true };
+			const materialsOwned = user.materialsOwned().toString().split(', ').join('\n');
+			return { content: `You own:\n${materialsOwned}`, ephemeral: true };
 		}
 
 		if (options.group) {

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -84,12 +84,12 @@ async function bonecrusherEffect(user: MUser, loot: Bank, duration: number, mess
 		multiplier: false
 	});
 	messages.push(
-		`${xpStr} Prayer XP${
+		`${xpStr} Prayer XP ${
 			hasSuperior
-				? `(${inventionBoosts.superiorBonecrusher.xpBoostPercent}% more from Superior bonecrusher, ${
-						boostMsg ? `, ${boostMsg}` : ''
-				  })`
-				: ''
+				? `+${inventionBoosts.superiorBonecrusher.xpBoostPercent}% more from Superior bonecrusher${
+						boostMsg ? ` (${boostMsg})` : ''
+				  }`
+				: ' from Gorajan bonecrusher'
 		}`
 	);
 }


### PR DESCRIPTION
### Description:
#5769 introduced an issue with formatting materials used on return trips. This PR aims to fix it.
### Changes:
- Add the `.join('\n')` under the invention command options instead of MaterialBank
- Fix some formatting with bonecrusherEffect()
### Other checks:
- [X] I have tested all my changes thoroughly.
Example:
![Discord_jc3Nd47dgW](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/674651d5-3508-4951-96d6-c5b559c6bfd5)
