### PR TITLE
[TESTED]Display DG Buyables list by sending command without item flag

### DIFF
--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -178,7 +178,7 @@ async function startCommand(channelID: string, user: MUser, floor: string | unde
 
 async function buyCommand(user: MUser, name: string, quantity?: number) {
 	const buyable = dungBuyables.find(i => stringMatches(name, i.item.name));
-	if (!buyable) {
+	if (!options.item) {
 		return `${dungBuyables
 			.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`)
 			.join('\n')}.`;

--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -179,7 +179,7 @@ async function startCommand(channelID: string, user: MUser, floor: string | unde
 async function buyCommand(user: MUser, name: string, quantity?: number) {
 	const buyable = dungBuyables.find(i => stringMatches(name, i.item.name));
 	if (!buyable) {
-		return `That isn't a buyable item. Here are the items you can buy: \n\n${dungBuyables
+		return `${dungBuyables
 			.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`)
 			.join('\n')}.`;
 	}

--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -258,7 +258,7 @@ export const dgCommand: OSBMahojiCommand = {
 							.filter(i => (!value ? true : i.item.name.toLowerCase().includes(value.toLowerCase())))
 							.map(i => ({ name: i.item.name, value: i.item.name }));
 					},
-					required: true
+					required: false
 				},
 				{
 					type: ApplicationCommandOptionType.Integer,

--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -178,7 +178,7 @@ async function startCommand(channelID: string, user: MUser, floor: string | unde
 
 async function buyCommand(user: MUser, name?: string, quantity?: number) {
 	const buyable = dungBuyables.find(i => stringMatches(name, i.item.name));
-	if (!buyable || !name) {
+	if (!buyable) {
 		let msg = `${dungBuyables.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`).join('\n')}.`;
 		if (name !== undefined) msg = `**That isn't a buyable item**. Here are the items you can buy:\n\n${msg}`;
 		return msg;

--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -178,7 +178,7 @@ async function startCommand(channelID: string, user: MUser, floor: string | unde
 
 async function buyCommand(user: MUser, name: string, quantity?: number) {
 	const buyable = dungBuyables.find(i => stringMatches(name, i.item.name));
-	if (!options.item) {
+	if (!buyable) {
 		return `${dungBuyables.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`).join('\n')}.`;
 	}
 

--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -179,9 +179,7 @@ async function startCommand(channelID: string, user: MUser, floor: string | unde
 async function buyCommand(user: MUser, name: string, quantity?: number) {
 	const buyable = dungBuyables.find(i => stringMatches(name, i.item.name));
 	if (!options.item) {
-		return `${dungBuyables
-			.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`)
-			.join('\n')}.`;
+		return `${dungBuyables.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`).join('\n')}.`;
 	}
 
 	if (!quantity) {

--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -176,10 +176,12 @@ async function startCommand(channelID: string, user: MUser, floor: string | unde
 	return str;
 }
 
-async function buyCommand(user: MUser, name: string, quantity?: number) {
+async function buyCommand(user: MUser, name?: string, quantity?: number) {
 	const buyable = dungBuyables.find(i => stringMatches(name, i.item.name));
-	if (!buyable) {
-		return `${dungBuyables.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`).join('\n')}.`;
+	if (!buyable || !name) {
+		let msg = `${dungBuyables.map(i => `**${i.item.name}:** ${i.cost.toLocaleString()} tokens`).join('\n')}.`;
+		if (name !== undefined) msg = `**That isn't a buyable item**. Here are the items you can buy:\n\n${msg}`;
+		return msg;
 	}
 
 	if (!quantity) {
@@ -275,7 +277,7 @@ export const dgCommand: OSBMahojiCommand = {
 		interaction
 	}: CommandRunOptions<{
 		start?: { floor?: string; solo?: boolean };
-		buy?: { item: string; quantity?: number };
+		buy?: { item?: string; quantity?: number };
 		stats?: {};
 	}>) => {
 		if (interaction) await deferInteraction(interaction);


### PR DESCRIPTION
### Description:

to get the dg buyables list you had to type something random in the `item:` flag in order for the bot to tell you that's not a buyable item and display the items. this gets rid of the having to send a random command.
![SmartSelect_20240317_111539_Discord](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/fbc2a011-af09-4fbb-82d2-b98190bd0b91)


### Changes:

- made the `item` not required to send command
- removed the "that is not a buyable item" message


### Other checks:

- [x] I have tested all my changes thoroughly.
