### PR TITLE
[TESTED]corrected farming check patches & harvest reminder dm 

### DIFF
--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -267,7 +267,7 @@ WHERE bitfield && '{2,3,4,5,6,7,8,12,21,24}'::int[] AND user_stats."last_daily_t
 					if (!user) continue;
 					const message = await user
 						.send({
-							content: `The ${planted.name} planted in your ${patchType} patches is ready to be harvested!`,
+							content: `The ${planted.name} planted in your ${patchType} patches are ready to be harvested!`,
 							components: [farmingReminderButtons]
 						})
 						.catch(noOp);

--- a/src/lib/util/farmingHelpers.ts
+++ b/src/lib/util/farmingHelpers.ts
@@ -51,7 +51,7 @@ export function findPlant(lastPlanted: IPatchData['lastPlanted']) {
 export function userGrowingProgressStr(patchesDetailed: IPatchDataDetailed[]): BaseMessageOptions {
 	let str = '';
 	for (const patch of patchesDetailed.filter(i => i.ready === true)) {
-		str += `${Emoji.Tick} **${patch.friendlyName}**: ${patch.lastQuantity} ${patch.lastPlanted} is ready to be harvested!\n`;
+		str += `${Emoji.Tick} **${patch.friendlyName}**: ${patch.lastQuantity} ${patch.lastPlanted} are ready to be harvested!\n`;
 	}
 	for (const patch of patchesDetailed.filter(i => i.ready === false)) {
 		str += `${Emoji.Stopwatch} **${patch.friendlyName}**: ${patch.lastQuantity} ${


### PR DESCRIPTION
### Description:

made the wording grammatically correct because the patches are plural.

example:
### current: 
12 mysterious tree `is` ready to be harvested
### my fix: 
12 mysterious tree `are` ready to be harvested

### Changes:

- changed `is` to `are`

### Other checks:

- [x] I have tested all my changes thoroughly.
![Screenshot_20240425_060403_Discord.jpg](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/a174c45c-42fa-4338-9209-ed2ded95b651)

