### PR TITLE
Shorten megaduck Cooldown and don't Cooldown if you fail to move duck.

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -42,6 +42,7 @@ import { convertLVLtoXP } from 'oldschooljs/dist/util/util';
 import { bool, integer, nodeCrypto, real } from 'random-js';
 
 import { ADMIN_IDS, OWNER_IDS, production, SupportServer } from '../config';
+import { Cooldowns } from '../mahoji/lib/Cooldowns';
 import { ClueTiers } from './clues/clueTiers';
 import {
 	badgesCache,
@@ -774,4 +775,8 @@ export function checkRangeGearWeapon(gear: Gear) {
 
 export function hasUnlockedAtlantis(user: MUser) {
 	return doaCL.some(itemID => user.cl.has(itemID));
+}
+
+export function resetCooldown(user: MUser, key?: string) {
+	return Cooldowns.delete(user.id, key);
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -42,7 +42,6 @@ import { convertLVLtoXP } from 'oldschooljs/dist/util/util';
 import { bool, integer, nodeCrypto, real } from 'random-js';
 
 import { ADMIN_IDS, OWNER_IDS, production, SupportServer } from '../config';
-import { Cooldowns } from '../mahoji/lib/Cooldowns';
 import { ClueTiers } from './clues/clueTiers';
 import {
 	badgesCache,
@@ -775,8 +774,4 @@ export function checkRangeGearWeapon(gear: Gear) {
 
 export function hasUnlockedAtlantis(user: MUser) {
 	return doaCL.some(itemID => user.cl.has(itemID));
-}
-
-export function resetCooldown(user: MUser, key?: string) {
-	return Cooldowns.delete(user.id, key);
 }

--- a/src/mahoji/commands/megaduck.ts
+++ b/src/mahoji/commands/megaduck.ts
@@ -8,11 +8,11 @@ import { Bank } from 'oldschooljs';
 import { Events } from '../../lib/constants';
 import { defaultMegaDuckLocation, MegaDuckLocation } from '../../lib/minions/types';
 import { prisma } from '../../lib/settings/prisma';
-import { getUsername, resetCooldown } from '../../lib/util';
+import { getUsername } from '../../lib/util';
 import { canvasImageFromBuffer } from '../../lib/util/canvasUtil';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
 import { mahojiGuildSettingsUpdate } from '../guildSettings';
-import { OSBMahojiCommand } from '../lib/util';
+import { OSBMahojiCommand, resetCooldown } from '../lib/util';
 
 const _mapImage = readFileSync('./src/lib/resources/images/megaduckmap.png');
 const noMoveImageBuf = readFileSync('./src/lib/resources/images/megaducknomovemap.png');

--- a/src/mahoji/lib/Cooldowns.ts
+++ b/src/mahoji/lib/Cooldowns.ts
@@ -22,8 +22,14 @@ class CooldownsSingleton {
 		return value - now;
 	}
 
-	delete(userID: string) {
-		this.cooldownMap.delete(userID);
+	delete(userID: string, key?: string) {
+		if (!key) {
+			this.cooldownMap.delete(userID);
+			return;
+		}
+		const map = this.cooldownMap.get(userID);
+		if (!map) return;
+		map.delete(key);
 	}
 }
 

--- a/src/mahoji/lib/util.ts
+++ b/src/mahoji/lib/util.ts
@@ -3,6 +3,7 @@ import { isObject } from 'e';
 import { ICommand, MahojiClient } from 'mahoji';
 import { CommandOptions, MahojiUserOption } from 'mahoji/dist/lib/types';
 
+import { Cooldowns } from './Cooldowns';
 import type { AbstractCommand, AbstractCommandAttributes } from './inhibitors';
 
 export interface OSBMahojiCommand extends ICommand {
@@ -71,4 +72,8 @@ export function getCommandArgs(
 
 export function allAbstractCommands(mahojiClient: MahojiClient): AbstractCommand[] {
 	return mahojiClient.commands.values.map(convertMahojiCommandToAbstractCommand);
+}
+
+export function resetCooldown(user: MUser, key?: string) {
+	return Cooldowns.delete(user.id, key);
 }


### PR DESCRIPTION
### Description:

Shortens cooldown to 30 seconds, and doesn't require a cooldown if you fail to move the duck.

### Changes:

- Changes megaduck CD to 30 seconds
- Adds a cooldown reset command to reset individual cooldowns, not just all cooldowns for a specific user.

### Other checks:

- [x] I have tested all my changes thoroughly.
