### PR TITLE
Woodcutting Balancing & more priff checks

### DIFF
--- a/src/lib/implings.ts
+++ b/src/lib/implings.ts
@@ -130,7 +130,7 @@ export function handlePassiveImplings(user: MUser, data: ActivityTaskData) {
 	let bank = new Bank();
 	const missed = new Bank();
 
-	const impTable = implingTableByWorldLocation[activityInArea(data)];
+	const impTable = implingTableByWorldLocation[activityInArea(user, data)];
 
 	for (let i = 0; i < minutes; i++) {
 		const loot = impTable.roll();

--- a/src/lib/skilling/functions/determineWoodcuttingTime.ts
+++ b/src/lib/skilling/functions/determineWoodcuttingTime.ts
@@ -1,6 +1,7 @@
 import { percentChance, Time } from 'e';
 
 import { calcMaxTripLength } from '../../util/calcMaxTripLength';
+import resolveItems from '../../util/resolveItems';
 import { MUserClass } from './../../MUser';
 import { Log } from './../types';
 
@@ -10,6 +11,7 @@ interface WoodcuttingTimeOptions {
 	log: Log;
 	axeMultiplier: number;
 	powerchopping: boolean;
+	forestry: boolean;
 	woodcuttingLvl: number;
 }
 
@@ -19,17 +21,24 @@ export function determineWoodcuttingTime({
 	log,
 	axeMultiplier,
 	powerchopping,
+	forestry,
 	woodcuttingLvl
 }: WoodcuttingTimeOptions): [number, number] {
 	let timeElapsed = 0;
 
 	const bankTime = log.bankingTime;
+	const farmingLvl = user.skillsAsLevels.farming;
 	const chanceOfSuccess = (log.slope * woodcuttingLvl + log.intercept) * axeMultiplier;
 	const { findNewTreeTime } = log;
 
 	let teakTick = false;
-	if (user.skillsAsLevels.woodcutting >= 92 && (log.name === 'Teak Logs' || log.name === 'Mahogany Logs')) {
-		teakTick = true;
+	if (!forestry && woodcuttingLvl >= 92) {
+		if (resolveItems('Teak logs').includes(log.id) && farmingLvl >= 35) {
+			teakTick = true;
+		}
+		if (resolveItems('Mahogany logs').includes(log.id) && farmingLvl >= 55) {
+			teakTick = true;
+		}
 	}
 
 	let newQuantity = 0;

--- a/src/lib/skilling/skills/Woodcutting/forestry.ts
+++ b/src/lib/skilling/skills/Woodcutting/forestry.ts
@@ -1,0 +1,64 @@
+import { LootTable } from 'oldschooljs';
+import { SkillsEnum } from 'oldschooljs/dist/constants';
+
+export const LeafTable = new LootTable()
+	.add('Leaves', 20)
+	.add('Oak leaves', 20)
+	.add('Willow leaves', 20)
+	.add('Maple leaves', 20)
+	.add('Yew leaves', 20)
+	.add('Magic leaves', 20);
+
+export interface ForestryEvent {
+	id: number;
+	name: string;
+	uniqueXP: SkillsEnum;
+}
+
+export const ForestryEvents: ForestryEvent[] = [
+	{
+		id: 1,
+		name: 'Rising Roots',
+		uniqueXP: SkillsEnum.Woodcutting
+	},
+	{
+		id: 2,
+		name: 'Struggling Sapling',
+		uniqueXP: SkillsEnum.Farming
+	},
+	{
+		id: 3,
+		name: 'Flowering Bush',
+		uniqueXP: SkillsEnum.Woodcutting
+	},
+	{
+		id: 4,
+		name: 'Woodcutting Leprechaun',
+		uniqueXP: SkillsEnum.Woodcutting
+	},
+	{
+		id: 5,
+		name: 'Beehive',
+		uniqueXP: SkillsEnum.Construction
+	},
+	{
+		id: 6,
+		name: 'Friendly Ent',
+		uniqueXP: SkillsEnum.Fletching
+	},
+	{
+		id: 7,
+		name: 'Poachers',
+		uniqueXP: SkillsEnum.Hunter
+	},
+	{
+		id: 8,
+		name: 'Enchantment Ritual',
+		uniqueXP: SkillsEnum.Woodcutting
+	},
+	{
+		id: 9,
+		name: 'Pheasant Control',
+		uniqueXP: SkillsEnum.Thieving
+	}
+];

--- a/src/lib/skilling/skills/Woodcutting/woodcutting.ts
+++ b/src/lib/skilling/skills/Woodcutting/woodcutting.ts
@@ -1,8 +1,8 @@
 import { LootTable } from 'oldschooljs';
 
-import { Emoji } from '../../constants';
-import itemID from '../../util/itemID';
-import { Log, SkillsEnum } from '../types';
+import { Emoji } from '../../../constants';
+import itemID from '../../../util/itemID';
+import { Log, SkillsEnum } from '../../types';
 
 const sulliuscepTable = new LootTable()
 	.add('Numulite', [4, 8], 34)

--- a/src/lib/skilling/skills/index.ts
+++ b/src/lib/skilling/skills/index.ts
@@ -16,7 +16,7 @@ import Prayer from './prayer';
 import Runecraft from './runecraft';
 import Smithing from './smithing';
 import Thieving from './thieving';
-import Woodcutting from './woodcutting';
+import Woodcutting from './Woodcutting/woodcutting';
 
 export const Skills: Record<string, Skill> = {
 	Crafting,

--- a/src/lib/util/activityInArea.ts
+++ b/src/lib/util/activityInArea.ts
@@ -45,7 +45,8 @@ const WorldLocationsChecker = [
 					activity.type === 'Woodcutting' &&
 					resolveItems(['Teak logs', 'Mahogany logs']).includes(
 						(activity as WoodcuttingActivityTaskOptions).logID
-					)
+					) &&
+					(activity as WoodcuttingActivityTaskOptions).forestry === true
 				) {
 					return true;
 				}

--- a/src/lib/util/activityInArea.ts
+++ b/src/lib/util/activityInArea.ts
@@ -1,11 +1,14 @@
 import { Monsters } from 'oldschooljs';
 
+import { soteSkillRequirements } from '../skilling/functions/questRequirements';
 import {
 	ActivityTaskData,
 	AgilityActivityTaskOptions,
 	MonsterActivityTaskOptions,
-	PickpocketActivityTaskOptions
+	PickpocketActivityTaskOptions,
+	WoodcuttingActivityTaskOptions
 } from '../types/minions';
+import resolveItems from './resolveItems';
 
 export const enum WorldLocations {
 	Priffdinas,
@@ -15,27 +18,37 @@ export const enum WorldLocations {
 const WorldLocationsChecker = [
 	{
 		area: WorldLocations.Priffdinas,
-		checker: (activity: ActivityTaskData) => {
-			if (['Gauntlet', 'Zalcano'].includes(activity.type)) return true;
-			if (
-				activity.type === 'MonsterKilling' &&
-				[Monsters.DarkBeast.id, Monsters.PrifddinasElf.id].includes(
-					(activity as MonsterActivityTaskOptions).monsterID
-				)
-			) {
-				return true;
-			}
-			if (
-				activity.type === 'Pickpocket' &&
-				(activity as PickpocketActivityTaskOptions).monsterID === Monsters.PrifddinasElf.id
-			) {
-				return true;
-			}
-			if (
-				activity.type === 'Agility' &&
-				(activity as AgilityActivityTaskOptions).courseID === 'Prifddinas Rooftop Course'
-			) {
-				return true;
+		checker: (user: MUser, activity: ActivityTaskData) => {
+			if (user.hasSkillReqs(soteSkillRequirements) && user.QP >= 150) {
+				if (['Gauntlet', 'Zalcano'].includes(activity.type)) return true;
+				if (
+					activity.type === 'MonsterKilling' &&
+					[Monsters.DarkBeast.id, Monsters.PrifddinasElf.id].includes(
+						(activity as MonsterActivityTaskOptions).monsterID
+					)
+				) {
+					return true;
+				}
+				if (
+					activity.type === 'Pickpocket' &&
+					(activity as PickpocketActivityTaskOptions).monsterID === Monsters.PrifddinasElf.id
+				) {
+					return true;
+				}
+				if (
+					activity.type === 'Agility' &&
+					(activity as AgilityActivityTaskOptions).courseID === 'Prifddinas Rooftop Course'
+				) {
+					return true;
+				}
+				if (
+					activity.type === 'Woodcutting' &&
+					resolveItems(['Teak logs', 'Mahogany logs']).includes(
+						(activity as WoodcuttingActivityTaskOptions).logID
+					)
+				) {
+					return true;
+				}
 			}
 
 			return false;
@@ -43,9 +56,9 @@ const WorldLocationsChecker = [
 	}
 ];
 
-export default function activityInArea(activity: ActivityTaskData) {
+export default function activityInArea(user: MUser, activity: ActivityTaskData) {
 	for (const checkLocation of WorldLocationsChecker) {
-		if (checkLocation.checker(activity)) return checkLocation.area;
+		if (checkLocation.checker(user, activity)) return checkLocation.area;
 	}
 	return WorldLocations.World;
 }

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -26,7 +26,7 @@ import Prayer from '../skilling/skills/prayer';
 import Runecraft from '../skilling/skills/runecraft';
 import Smithing from '../skilling/skills/smithing';
 import { stealables } from '../skilling/skills/thieving/stealables';
-import Woodcutting from '../skilling/skills/woodcutting';
+import Woodcutting from '../skilling/skills/Woodcutting/woodcutting';
 import {
 	ActivityTaskOptionsWithQuantity,
 	AgilityActivityTaskOptions,

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -152,21 +152,27 @@ export const chopCommand: OSBMahojiCommand = {
 		const boosts = [];
 
 		let wcLvl = skills.woodcutting;
+		const farmingLvl = user.skillsAsLevels.farming;
 
-		// Invisible wc boost for woodcutting guild, forestry events don't happen in woodcutting guild
+		// Redwood logs, logs, sulliuscep, farming patches, woodcutting guild don't spawn forestry events
 		if (!forestry_events || resolveItems(['Redwood logs', 'Logs']).includes(log.id) || log.lootTable) {
 			forestry_events = false;
+			// Invisible wc boost for woodcutting guild
 			if (skills.woodcutting >= 60 && log.wcGuild) {
 				boosts.push('+7 invisible WC lvls at the Woodcutting guild');
 				wcLvl += 7;
 			}
+			// 1.5 tick hardwood at 92 wc, 1.5t is only possible at farming patches
+			if (skills.woodcutting >= 92) {
+				if (resolveItems('Teak logs').includes(log.id) && farmingLvl >= 35) {
+					boosts.push('1.5t woodcutting teak trees with 92+ wc & 35+ farming');
+				}
+				if (resolveItems('Mahogany logs').includes(log.id) && farmingLvl >= 55) {
+					boosts.push('1.5t woodcutting mahogany trees with 92+ wc & 55+ farming');
+				}
+			}
 		} else {
 			boosts.push('Participating in Forestry events');
-		}
-
-		// Enable 1.5 tick teaks half way to 99
-		if (skills.woodcutting >= 92 && (log.name === 'Teak Logs' || log.name === 'Mahogany Logs')) {
-			boosts.push('1.5t teak/mahogany chopping with 92+ wc');
 		}
 
 		// Default bronze axe, last in the array
@@ -209,6 +215,7 @@ export const chopCommand: OSBMahojiCommand = {
 			log,
 			axeMultiplier,
 			powerchopping: powerchop,
+			forestry: forestry_events,
 			woodcuttingLvl: wcLvl
 		});
 

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -3,7 +3,7 @@ import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
 import { TwitcherGloves, TWITCHERS_GLOVES } from '../../lib/constants';
 import { determineWoodcuttingTime } from '../../lib/skilling/functions/determineWoodcuttingTime';
-import Woodcutting from '../../lib/skilling/skills/woodcutting';
+import Woodcutting from '../../lib/skilling/skills/Woodcutting/woodcutting';
 import { WoodcuttingActivityTaskOptions } from '../../lib/types/minions';
 import { formatDuration, itemNameFromID, randomVariation, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';

--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -163,7 +163,8 @@ export const sellCommand: OSBMahojiCommand = {
 			bankToSell.has('Golden pheasant egg') ||
 			bankToSell.has('Fox whistle') ||
 			bankToSell.has('Petal garland') ||
-			bankToSell.has('Pheasant tail feathers')
+			bankToSell.has('Pheasant tail feathers') ||
+			bankToSell.has('Sturdy beehive parts')
 		) {
 			const forestryBank = new Bank();
 			const loot = new Bank();
@@ -182,6 +183,10 @@ export const sellCommand: OSBMahojiCommand = {
 			if (bankToSell.has('Pheasant tail feathers')) {
 				forestryBank.add('Pheasant tail feathers', bankToSell.amount('Pheasant tail feathers'));
 				loot.add('Anima-infused bark', bankToSell.amount('Pheasant tail feathers') * 5);
+			}
+			if (bankToSell.has('Sturdy beehive parts')) {
+				forestryBank.add('Sturdy beehive parts', bankToSell.amount('Sturdy beehive parts'));
+				loot.add('Anima-infused bark', bankToSell.amount('Sturdy beehive parts') * 25);
 			}
 
 			await handleMahojiConfirmation(

--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -19,6 +19,7 @@ import { getMinigameScore } from '../../../lib/settings/minigames';
 import { prisma } from '../../../lib/settings/prisma';
 import Agility from '../../../lib/skilling/skills/agility';
 import { Castables } from '../../../lib/skilling/skills/magic/castables';
+import { ForestryEvents } from '../../../lib/skilling/skills/Woodcutting/forestry';
 import { getSlayerTaskStats } from '../../../lib/slayer/slayerUtil';
 import { sorts } from '../../../lib/sorts';
 import { InfernoOptions } from '../../../lib/types/minions';
@@ -27,7 +28,6 @@ import { barChart, lineChart, pieChart } from '../../../lib/util/chart';
 import { getItem } from '../../../lib/util/getOSItem';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 import resolveItems from '../../../lib/util/resolveItems';
-import { ForestryEvents } from '../../../tasks/minions/woodcuttingActivity';
 import { Cooldowns } from '../Cooldowns';
 import { collectables } from './collectCommand';
 

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -243,7 +243,7 @@ export const woodcuttingTask: MinionTask = {
 	async run(data: WoodcuttingActivityTaskOptions) {
 		const { logID, quantity, userID, channelID, duration, powerchopping, forestry, twitchers } = data;
 		const user = await mUserFetch(userID);
-		let userWcLevel = user.skillLevel(SkillsEnum.Woodcutting);
+		const userWcLevel = user.skillLevel(SkillsEnum.Woodcutting);
 		const log = Woodcutting.Logs.find(i => i.id === logID)!;
 		const forestersRations = user.bank.amount("Forester's ration");
 		const wcCapeNestBoost =

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -371,6 +371,8 @@ export const woodcuttingTask: MinionTask = {
 			if (twitcherSetting !== undefined) {
 				str += `Your Twitcher's gloves increases the chance of receiving ${twitcherSetting} nests.\n`;
 			}
+		} else if (twitcherSetting === 'clue') {
+			str += `Your Twitcher's gloves increases the chance of receiving ${twitcherSetting} nests.\n`;
 		}
 
 		// Forestry events

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -5,11 +5,13 @@ import { Emoji, Events, TwitcherGloves } from '../../lib/constants';
 import { MediumSeedPackTable } from '../../lib/data/seedPackTables';
 import addSkillingClueToLoot from '../../lib/minions/functions/addSkillingClueToLoot';
 import { eggNest } from '../../lib/simulation/birdsNest';
+import { soteSkillRequirements } from '../../lib/skilling/functions/questRequirements';
 import Woodcutting from '../../lib/skilling/skills/woodcutting';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { WoodcuttingActivityTaskOptions } from '../../lib/types/minions';
 import { perTimeUnitChance, roll, skillingPetDropRate } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
+import resolveItems from '../../lib/util/resolveItems';
 import { userStatsBankUpdate } from '../../mahoji/mahojiSettings';
 
 export interface ForestryEvent {
@@ -259,6 +261,7 @@ export const woodcuttingTask: MinionTask = {
 		let lostLogs = 0;
 		let loot = new Bank();
 		let itemsToRemove = new Bank();
+		let priffUnlocked = user.hasSkillReqs(soteSkillRequirements) && user.QP >= 150;
 
 		// Felling axe +10% xp bonus & 20% logs lost
 		if (user.gear.skilling.hasEquipped('Bronze felling axe')) {
@@ -318,6 +321,12 @@ export const woodcuttingTask: MinionTask = {
 					loot.add(log.leaf, 1);
 				}
 			}
+		}
+
+		// Add crystal shards for chopping teaks/mahogany in priff
+		if (forestry && priffUnlocked && resolveItems(['Teak logs', 'Mahogany logs']).includes(log.id)) {
+			// 15 Shards per hour
+			loot.add('Crystal shard', Math.floor((duration / Time.Hour) * 15));
 		}
 
 		// Check for twitcher gloves

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -1,80 +1,19 @@
 import { percentChance, randInt, Time } from 'e';
-import { Bank, LootTable } from 'oldschooljs';
+import { Bank } from 'oldschooljs';
 
 import { Emoji, Events, TwitcherGloves } from '../../lib/constants';
 import { MediumSeedPackTable } from '../../lib/data/seedPackTables';
 import addSkillingClueToLoot from '../../lib/minions/functions/addSkillingClueToLoot';
 import { eggNest } from '../../lib/simulation/birdsNest';
 import { soteSkillRequirements } from '../../lib/skilling/functions/questRequirements';
-import Woodcutting from '../../lib/skilling/skills/woodcutting';
+import { ForestryEvents, LeafTable } from '../../lib/skilling/skills/Woodcutting/forestry';
+import Woodcutting from '../../lib/skilling/skills/Woodcutting/woodcutting';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { WoodcuttingActivityTaskOptions } from '../../lib/types/minions';
 import { perTimeUnitChance, roll, skillingPetDropRate } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import resolveItems from '../../lib/util/resolveItems';
 import { userStatsBankUpdate } from '../../mahoji/mahojiSettings';
-
-export interface ForestryEvent {
-	id: number;
-	name: string;
-	uniqueXP: SkillsEnum;
-}
-
-export const ForestryEvents: ForestryEvent[] = [
-	{
-		id: 1,
-		name: 'Rising Roots',
-		uniqueXP: SkillsEnum.Woodcutting
-	},
-	{
-		id: 2,
-		name: 'Struggling Sapling',
-		uniqueXP: SkillsEnum.Farming
-	},
-	{
-		id: 3,
-		name: 'Flowering Bush',
-		uniqueXP: SkillsEnum.Woodcutting
-	},
-	{
-		id: 4,
-		name: 'Woodcutting Leprechaun',
-		uniqueXP: SkillsEnum.Woodcutting
-	},
-	{
-		id: 5,
-		name: 'Beehive',
-		uniqueXP: SkillsEnum.Construction
-	},
-	{
-		id: 6,
-		name: 'Friendly Ent',
-		uniqueXP: SkillsEnum.Fletching
-	},
-	{
-		id: 7,
-		name: 'Poachers',
-		uniqueXP: SkillsEnum.Hunter
-	},
-	{
-		id: 8,
-		name: 'Enchantment Ritual',
-		uniqueXP: SkillsEnum.Woodcutting
-	},
-	{
-		id: 9,
-		name: 'Pheasant Control',
-		uniqueXP: SkillsEnum.Thieving
-	}
-];
-
-const LeafTable = new LootTable()
-	.add('Leaves', 20)
-	.add('Oak leaves', 20)
-	.add('Willow leaves', 20)
-	.add('Maple leaves', 20)
-	.add('Yew leaves', 20)
-	.add('Magic leaves', 20);
 
 async function handleForestry({ user, duration, loot }: { user: MUser; duration: number; loot: Bank }) {
 	let eventCounts: { [key: number]: number } = {};


### PR DESCRIPTION
### Description:
Balance woodcutting rates with forestry events and tick manipulation training & add more checks for priff content.
### Changes:
- Added Crystal implings/shards if doing forestry events and chopping teak/mahog
  - Requires 150 QP and SOTE stats (70 mining smithing farming woodcutting agility herblore con hunter)
- Only allow 1.5t teak/mahog if not doing forestry events and have 35/55 farming
  - 1.5t is only possible at farming patches & doesn't spawn events
  - Dynamic message for 1.5t teaks or mahogs 
- Ability to sell Sturdy beehive parts for 25 anima each
- fix twitchers message for clue only trees
- Added the same 150 QP and SOTE stats check to any and all activities that yield crystal imps
- Moved the forestry interface & leaf table, into their own file to prevent future circular issues
- moved forestry.ts and woodcutting.ts into a new folder called woodcutting
### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5786