### PR TITLE
Allow users to exclude ironmen from MostDrops Command

### DIFF
--- a/src/mahoji/commands/tools.ts
+++ b/src/mahoji/commands/tools.ts
@@ -644,9 +644,14 @@ async function dryStreakCommand(monsterName: string, itemName: string, ironmanOn
 		.join('\n')}`;
 }
 
-async function mostDrops(user: MUser, itemName: string, ironmanOnly: boolean) {
+async function mostDrops(user: MUser, itemName: string, filter: string) {
 	const item = getItem(itemName);
-	const ironmanPart = ironmanOnly ? 'AND "minion.ironman" = true' : '';
+	const ironmanPart =
+		filter === 'Both'
+			? ''
+			: filter === 'Irons Only'
+			? 'AND "minion.ironman" = true'
+			: 'AND "minion.ironman" = false';
 	if (!item) return "That's not a valid item.";
 	if (!allDroppedItems.includes(item.id) && !user.bitfield.includes(BitField.isModerator)) {
 		return "You can't check this item, because it's not on any collection log.";
@@ -842,10 +847,11 @@ export const toolsCommand: OSBMahojiCommand = {
 							required: true
 						},
 						{
-							type: ApplicationCommandOptionType.Boolean,
-							name: 'ironman',
-							description: 'Only check ironmen accounts.',
-							required: false
+							type: ApplicationCommandOptionType.String,
+							name: 'filter',
+							description: 'Filter by account type.',
+							required: false,
+							choices: ['Both', 'Irons Only', 'Mains Only'].map(i => ({ name: i, value: i }))
 						}
 					]
 				},
@@ -1005,7 +1011,7 @@ export const toolsCommand: OSBMahojiCommand = {
 			};
 			mostdrops?: {
 				item: string;
-				ironman?: boolean;
+				filter?: string;
 			};
 			sacrificed_bank?: {};
 			cl_bank?: {
@@ -1050,7 +1056,7 @@ export const toolsCommand: OSBMahojiCommand = {
 			}
 			if (patron.mostdrops) {
 				if (mahojiUser.perkTier() < PerkTier.Four) return patronMsg(PerkTier.Four);
-				return mostDrops(mahojiUser, patron.mostdrops.item, Boolean(patron.mostdrops.ironman));
+				return mostDrops(mahojiUser, patron.mostdrops.item, String(patron.mostdrops.filter));
 			}
 			if (patron.sacrificed_bank) {
 				if (mahojiUser.perkTier() < PerkTier.Two) return patronMsg(PerkTier.Two);

--- a/src/mahoji/commands/tools.ts
+++ b/src/mahoji/commands/tools.ts
@@ -832,7 +832,7 @@ export const toolsCommand: OSBMahojiCommand = {
 							type: ApplicationCommandOptionType.Boolean,
 							name: 'ironman',
 							description: 'Only check ironmen accounts.',
-							required: false							
+							required: false
 						}
 					]
 				},

--- a/src/mahoji/commands/tools.ts
+++ b/src/mahoji/commands/tools.ts
@@ -647,11 +647,11 @@ async function dryStreakCommand(monsterName: string, itemName: string, ironmanOn
 async function mostDrops(user: MUser, itemName: string, filter: string) {
 	const item = getItem(itemName);
 	const ironmanPart =
-		filter === 'Both'
-			? ''
-			: filter === 'Irons Only'
+		filter === 'Irons Only'
 			? 'AND "minion.ironman" = true'
-			: 'AND "minion.ironman" = false';
+			: filter === 'Mains Only'
+			? 'AND "minion.ironman" = false'
+			: '';
 	if (!item) return "That's not a valid item.";
 	if (!allDroppedItems.includes(item.id) && !user.bitfield.includes(BitField.isModerator)) {
 		return "You can't check this item, because it's not on any collection log.";


### PR DESCRIPTION
### Description:
This has been requested for a long time, since irons were giving enhanced rates for crates.
This only updated the mostdrops command for now.
![image](https://github.com/oldschoolgg/oldschoolbot/assets/8431944/6cd7e1b6-75c4-4c8a-bb56-7e2e6476f014)

the format of the ironmanPart is what eslint wants, assuming it's ok.
also my first pull request, lemme know if I'm doing something stupid or missed something. I did web dev for 5 years but did more backend, so my javascript skills aren't great and never worked with typescript.
### Changes:

Changed the ironmanOnly flag from bool to string
Changed param from 'ironman' to "filter"
Added "Both" (doesn't actually do anything, just defaults to ''), "Irons Only", and "Main Only" choices.

### Other checks:

- [x ] I have tested all my changes thoroughly.