### PR TITLE
Fix broken slayer tasks

### DIFF
--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -290,6 +290,11 @@ export async function getUsersCurrentSlayerInfo(id: string) {
 			`Could not find task or slayer master for user ${id} task ${currentTask.monster_id} master ${currentTask.slayer_master_id}`,
 			{ userID: id }
 		);
+		// 'Skip' broken task:
+		await prisma.slayerTask.update({
+			data: { skipped: true, quantity_remaining: 0 },
+			where: { id: currentTask.id }
+		});
 		return {
 			currentTask: null,
 			assignedTask: null,

--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -424,7 +424,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.SpiritualMage,
+		monster: Monsters.SpiritualRanger,
 		amount: [110, 170],
 
 		weight: 12,
@@ -435,8 +435,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
-		unlocked: true,
-		dontAssign: true
+		unlocked: true
 	},
 	{
 		monster: Monsters.MountainTroll,

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -376,7 +376,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.SpiritualMage,
+		monster: Monsters.SpiritualRanger,
 		amount: [110, 170],
 
 		weight: 7,
@@ -389,8 +389,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
-		unlocked: true,
-		dontAssign: true
+		unlocked: true
 	},
 	{
 		monster: Monsters.SteelDragon,

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -355,9 +355,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.SpiritualMage,
-		amount: [110, 170],
-
+		monster: Monsters.SpiritualRanger,
+		amount: [120, 185],
 		weight: 6,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
 		levelRequirements: {
@@ -366,8 +365,7 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
-		unlocked: true,
-		dontAssign: true
+		unlocked: true
 	},
 	{
 		monster: Monsters.SteelDragon,

--- a/src/lib/slayer/tasks/vannakaTasks.ts
+++ b/src/lib/slayer/tasks/vannakaTasks.ts
@@ -478,7 +478,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.SpiritualMage,
+		monster: Monsters.SpiritualRanger,
 		amount: [110, 170],
 
 		weight: 8,
@@ -489,8 +489,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
-		unlocked: true,
-		dontAssign: true
+		unlocked: true
 	},
 	{
 		monster: Monsters.TerrorDog,


### PR DESCRIPTION
### Description:

- A previous PR broke slayer tasks for Spiritual creatures

### Changes:

- Enables spiritual creatures to be assigned again
- Fixes existing broken spiritual tasks
- Adds a fail-safe to 'skip' a task if it's broken.

### Other checks:

- [ ] I have tested all my changes thoroughly.
