### PR TITLE
Add 2% boost for ice spells per Virtus piece

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -75,6 +75,7 @@ import { generateChart } from '../../../lib/util/chart';
 import findMonster from '../../../lib/util/findMonster';
 import getOSItem from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
+import resolveItems from '../../../lib/util/resolveItems';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 import { hasMonsterRequirements, resolveAvailableItemBoosts } from '../../mahojiSettings';
 import { nexCommand } from './nexCommand';
@@ -247,6 +248,8 @@ export async function minionKillCommand(
 	let blackMaskBoostMsg = '';
 	let salveAmuletBoost = 0;
 	let salveAmuletBoostMsg = '';
+	let virtusBoost = 0;
+	let virtusBoostMsg = '';
 
 	const dragonBoost = 15; // Common boost percentage for dragon-related gear
 
@@ -322,6 +325,24 @@ export async function minionKillCommand(
 			}
 		}
 	}
+
+	function calculateVirtusBoost() {
+		let virtusPiecesEquipped = 0;
+		for (const item of resolveItems(['Virtus mask', 'Virtus robe top', 'Virtus robe bottom'])) {
+			if (user.gear.mage.hasEquipped(item)) {
+				virtusPiecesEquipped += blackMaskBoost !== 0 && itemNameFromID(item) === 'Virtus mask' ? 0 : 1;
+			}
+		}
+
+		virtusBoost = virtusPiecesEquipped * 2;
+		virtusBoostMsg =
+			virtusPiecesEquipped > 1
+				? ` with ${virtusPiecesEquipped} Virtus pieces`
+				: virtusPiecesEquipped > 0
+				? ` with ${virtusPiecesEquipped} Virtus piece`
+				: '';
+	}
+
 	if (isDragon && monster.name.toLowerCase() !== 'vorkath') {
 		applyDragonBoost();
 	}
@@ -386,13 +407,15 @@ export async function minionKillCommand(
 
 	if (boostChoice === 'barrage' && attackStyles.includes(SkillsEnum.Magic) && monster!.canBarrage) {
 		consumableCosts.push(iceBarrageConsumables);
-		timeToFinish = reduceNumByPercent(timeToFinish, boostIceBarrage);
-		boosts.push(`${boostIceBarrage}% for Ice Barrage`);
+		calculateVirtusBoost();
+		timeToFinish = reduceNumByPercent(timeToFinish, boostIceBarrage + virtusBoost);
+		boosts.push(`${boostIceBarrage + virtusBoost}% for Ice Barrage${virtusBoostMsg}`);
 		burstOrBarrage = SlayerActivityConstants.IceBarrage;
 	} else if (boostChoice === 'burst' && attackStyles.includes(SkillsEnum.Magic) && monster!.canBarrage) {
 		consumableCosts.push(iceBurstConsumables);
-		timeToFinish = reduceNumByPercent(timeToFinish, boostIceBurst);
-		boosts.push(`${boostIceBurst}% for Ice Burst`);
+		calculateVirtusBoost();
+		timeToFinish = reduceNumByPercent(timeToFinish, boostIceBurst + virtusBoost);
+		boosts.push(`${boostIceBurst + virtusBoost}% for Ice Burst${virtusBoostMsg}`);
 		burstOrBarrage = SlayerActivityConstants.IceBurst;
 	} else if (boostChoice === 'cannon' && hasCannon && monster!.cannonMulti) {
 		usingCannon = true;


### PR DESCRIPTION
### Description:

Added a 2% boost to ice spells per Virtus piece equipped. Virtus mask boost does _not_ stack with slayer helm boost. In osrs they give 4% damage boost per piece, but that pushed rates too high. 2% feels good. 

### Changes:

Added "virtusBoost" and "virtusBoostMsg" variables along with a function to calculate said variables.

The function checks mage gear for Virtus pieces, giving a 2% boost per. With an exception of skipping a boost for virtus mask if the player is already getting a slayer helm boost.

Then in the if checks for barrage/burst I added the Virtus boost and message. 

### Other checks:

- [ X] I have tested all my changes thoroughly.
