### PR TITLE
Update divineDominion.ts

### DIFF
--- a/src/lib/bso/divineDominion.ts
+++ b/src/lib/bso/divineDominion.ts
@@ -175,7 +175,7 @@ export const gods = [
 		name: 'Armadyl',
 		warpriestSet: getOSItem('Warpriest of Armadyl set'),
 		godItems: resolveItems([
-			'Zamorak platebody',
+			'Armadyl platebody',
 			'Armadyl platelegs',
 			'Armadyl full helm',
 			'Armadyl kiteshield',

--- a/src/lib/bso/divineDominion.ts
+++ b/src/lib/bso/divineDominion.ts
@@ -35,7 +35,6 @@ export const gods = [
 			"Zamorak d'hide boots",
 			"Zamorak d'hide shield",
 			'Zamorak godsword',
-			'Zamorak bracers',
 			'Zamorakian spear',
 			'Zamorakian hasta',
 			'Unholy blessing',
@@ -124,7 +123,6 @@ export const gods = [
 			'Saradomin godsword',
 			'Saradomin sword',
 			'Staff of light',
-			'Saradomin bracers',
 			'Holy blessing'
 		]),
 		friendlyMonsters: [Monsters.Barrows.id, Monsters.Paladin.id, Monsters.CommanderZilyana.id, Monsters.Unicorn.id]
@@ -155,7 +153,6 @@ export const gods = [
 			"Bandos d'hide boots",
 			"Bandos d'hide shield",
 			'Bandos godsword',
-			'Bandos bracers',
 			'Bandos boots',
 			'Bandos tassets',
 			'Bandos chestplate',
@@ -184,7 +181,6 @@ export const gods = [
 			'Armadyl page 2',
 			'Armadyl page 3',
 			'Armadyl page 4',
-			'Armadyl bracers',
 			"Armadyl d'hide body",
 			'Armadyl chaps',
 			'Armadyl coif',


### PR DESCRIPTION
Typo under Armadyl had "Zamorak platebody', updated to Armadyl

### Description:
Under Armadyl section, updated Zamorak Platebody to Armadyl platebody.
Removed duplicate bracer items in each list.
<!-- What did you change? Describe it here. -->

### Changes:
Same as description 
<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [ ] I have tested all my changes thoroughly.
