### PR TITLE
Flush economy log when bot is shutting down.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { join } from 'path';
 import { botToken, DEV_SERVER_ID, SENTRY_DSN, SupportServer } from './config';
 import { BLACKLISTED_GUILDS, BLACKLISTED_USERS } from './lib/blacklists';
 import { Channel, Events, globalConfig, META_CONSTANTS } from './lib/constants';
+import { economyLog } from './lib/economyLogs';
 import { onMessage } from './lib/events';
 import { makeServer } from './lib/http';
 import { modalInteractionHook } from './lib/modals';
@@ -30,7 +31,6 @@ import { interactionHook } from './lib/util/globalInteractions';
 import { handleInteractionError } from './lib/util/interactionReply';
 import { logError } from './lib/util/logError';
 import { sonicBoom } from './lib/util/logger';
-import { sendToChannelID } from './lib/util/webhook';
 import { onStartup } from './mahoji/lib/events';
 import { postCommand } from './mahoji/lib/postCommand';
 import { preCommand } from './mahoji/lib/preCommand';
@@ -179,17 +179,9 @@ client.on(Events.ServerNotification, (message: string) => {
 	const channel = globalClient.channels.cache.get(Channel.Notifications);
 	if (channel) (channel as TextChannel).send(message);
 });
-let economyLogBuffer: string[] = [];
 
 client.on(Events.EconomyLog, async (message: string) => {
-	economyLogBuffer.push(message);
-	if (economyLogBuffer.length === 10) {
-		await sendToChannelID(Channel.EconomyLogs, {
-			content: economyLogBuffer.join('\n---------------------------------\n'),
-			allowedMentions: { parse: [], users: [], roles: [] }
-		});
-		economyLogBuffer = [];
-	}
+	economyLog(message);
 });
 client.on('guildCreate', guild => {
 	if (!guild.available) return;

--- a/src/lib/economyLogs.ts
+++ b/src/lib/economyLogs.ts
@@ -5,7 +5,7 @@ let economyLogBuffer: string[] = [];
 
 export async function economyLog(message: string, flush: boolean = false) {
 	economyLogBuffer.push(message);
-	if (flush || economyLogBuffer.length === 10) {
+	if ((flush && economyLogBuffer.length !== 1) || economyLogBuffer.length === 10) {
 		await sendToChannelID(Channel.EconomyLogs, {
 			content: economyLogBuffer.join('\n---------------------------------\n'),
 			allowedMentions: { parse: [], users: [], roles: [] }

--- a/src/lib/economyLogs.ts
+++ b/src/lib/economyLogs.ts
@@ -1,0 +1,15 @@
+import { Channel } from './constants';
+import { sendToChannelID } from './util/webhook';
+
+let economyLogBuffer: string[] = [];
+
+export async function economyLog(message: string, flush: boolean = false) {
+	economyLogBuffer.push(message);
+	if (flush || economyLogBuffer.length === 10) {
+		await sendToChannelID(Channel.EconomyLogs, {
+			content: economyLogBuffer.join('\n---------------------------------\n'),
+			allowedMentions: { parse: [], users: [], roles: [] }
+		});
+		economyLogBuffer = [];
+	}
+}

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -28,7 +28,7 @@ import {
 	globalConfig,
 	META_CONSTANTS
 } from '../../lib/constants';
-import { economyLogPush } from '../../lib/economyLogs';
+import { economyLog } from '../../lib/economyLogs';
 import { generateGearImage } from '../../lib/gear/functions/generateGearImage';
 import { GearSetup } from '../../lib/gear/types';
 import { GrandExchange } from '../../lib/grandExchange';
@@ -1005,7 +1005,7 @@ export const adminCommand: OSBMahojiCommand = {
 		}
 		if (options.reboot) {
 			globalClient.isShuttingDown = true;
-			await economyLogPush('Flushing economy log due to reboot', true);
+			await economyLog('Flushing economy log due to reboot', true);
 			await interactionReply(interaction, {
 				content: 'https://media.discordapp.net/attachments/357422607982919680/1004657720722464880/freeze.gif'
 			});
@@ -1023,7 +1023,7 @@ ${META_CONSTANTS.RENDERED_STR}`
 			await interactionReply(interaction, {
 				content: `Shutting down in ${dateFm(new Date(Date.now() + timer))}.`
 			});
-			await economyLogPush('Flushing economy log due to shutdown', true);
+			await economyLog('Flushing economy log due to shutdown', true);
 			await Promise.all([sleep(timer), GrandExchange.queue.onEmpty()]);
 			await sendToChannelID(Channel.GeneralChannel, {
 				content: `I am shutting down! Goodbye :(

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -28,6 +28,7 @@ import {
 	globalConfig,
 	META_CONSTANTS
 } from '../../lib/constants';
+import { economyLogPush } from '../../lib/economyLogs';
 import { generateGearImage } from '../../lib/gear/functions/generateGearImage';
 import { GearSetup } from '../../lib/gear/types';
 import { GrandExchange } from '../../lib/grandExchange';
@@ -1004,10 +1005,11 @@ export const adminCommand: OSBMahojiCommand = {
 		}
 		if (options.reboot) {
 			globalClient.isShuttingDown = true;
-			await sleep(Time.Second * 20);
+			await economyLogPush('Flushing economy log due to reboot', true);
 			await interactionReply(interaction, {
 				content: 'https://media.discordapp.net/attachments/357422607982919680/1004657720722464880/freeze.gif'
 			});
+			await sleep(Time.Second * 20);
 			await sendToChannelID(Channel.GeneralChannel, {
 				content: `I am shutting down! Goodbye :(
 
@@ -1021,6 +1023,7 @@ ${META_CONSTANTS.RENDERED_STR}`
 			await interactionReply(interaction, {
 				content: `Shutting down in ${dateFm(new Date(Date.now() + timer))}.`
 			});
+			await economyLogPush('Flushing economy log due to shutdown', true);
 			await Promise.all([sleep(timer), GrandExchange.queue.onEmpty()]);
 			await sendToChannelID(Channel.GeneralChannel, {
 				content: `I am shutting down! Goodbye :(


### PR DESCRIPTION
### Description:

When the bot is shutting down, the pending economy log buffer is lost.

### Changes:

- Separates the economy log code into it's own file + function for isolation and ease of cross-referencing
- Alters the `.on(EconomyLog)` event handler to use the new function.
- Adds a call to the new function with the option `flush = true` on shutdown/reboot to force-flush the pending log buffer.
- Alters the reboot command to `sleep()` after sending the admin reply, rather than letting it spin for 20 seconds with no response.

### Other checks:

- [x] I have tested all my changes thoroughly.
