### PR TITLE
Improve/fix Slepey tablet drop mechanic

### DIFF
--- a/src/tasks/minions/minigames/nightmareActivity.ts
+++ b/src/tasks/minions/minigames/nightmareActivity.ts
@@ -58,7 +58,9 @@ export const nightmareTask: MinionTask = {
 
 		const { newKC } = await user.incrementKC(monsterID, kc);
 
-		const ownsOrUsedTablet = user.bank.has('Slepey tablet') || user.bitfield.includes(BitField.HasSlepeyTablet);
+		const ownsOrUsedTablet =
+			user.bank.has('Slepey tablet') ||
+			(user.bitfield.includes(BitField.HasSlepeyTablet) && user.cl.has('Slepey Tablet'));
 		if (isPhosani) {
 			if (ownsOrUsedTablet) {
 				userLoot.remove('Slepey tablet', userLoot.amount('Slepey tablet'));


### PR DESCRIPTION
### Description:

Even though this is OSB, the same drop logic applies.

This patch updates Slepey tablet drops in the following way:

1. It's only considered 'owned' (unobtainable) if you have both unlocked/activated one, AND you have one on your collection log.

This should always be the case on OSB, however in BSO, it can be obtained by trading, previously making it unobtainable without UMBs.