### PR TITLE
Allow forestry pets to be equipped

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2238,7 +2238,9 @@ export const metamorphPets = resolveItems([
 	'Ziggy',
 	'Red',
 	'Great blue heron',
-	'Greatish guardian'
+	'Greatish guardian',
+	28_670, // use id to not get mixed up with the "Fox" quest item
+	'Pheasant'
 ]);
 
 export const allPetIDs = [


### PR DESCRIPTION
### Description:
Allow forestry pets to be equipped
### Changes:
- Add fox and pheasant to equippable pets
### Other checks:
- This doesn't need merged to BSO since https://github.com/oldschoolgg/oldschoolbot/pull/5794 will handle it
- [X] I have tested all my changes thoroughly.
