### PR TITLE
Fix new King Goldemar boost, and an 'application did not respond' error.

### DIFF
--- a/src/lib/structures/Boss.ts
+++ b/src/lib/structures/Boss.ts
@@ -131,6 +131,8 @@ export interface BossOptions {
 	allowMoreThan1Group?: boolean;
 	quantity?: number;
 	allowedMentions?: BaseMessageOptions['allowedMentions'];
+	// Override for Max Boost if you have multiple conflicting boost items
+	boostMax?: number;
 	// Duration before mass is automatically send
 	automaticStartTime?: number;
 	// The total % reduction that perfect gear/kc/boosts nets:
@@ -185,6 +187,7 @@ export class BossInstance {
 	boosts: string[] = [];
 	automaticStartTime: number;
 	maxSize: number;
+	boostMax: number | null = null;
 	speedMaxReduction: number = 40;
 	speedGearWeight: number = 25;
 	speedKcWeight: number = 35;
@@ -210,6 +213,7 @@ export class BossInstance {
 		this.minSize = options.minSize;
 		this.solo = options.solo;
 		this.canDie = options.canDie;
+		this.boostMax = options.boostMax ?? null;
 		this.speedKcWeight = options.speedKcWeight ?? 35;
 		this.speedGearWeight = options.speedGearWeight ?? 25;
 		this.speedMaxReduction = options.speedMaxReduction ?? 40;
@@ -350,7 +354,7 @@ export class BossInstance {
 			speedKcWeight: speedReductionForKC
 		} = this;
 		// The total combined values for item boosts equal their relative contribution to the speed
-		const speedReductionForBoosts = sumArr(this.itemBoosts.map(i => i[1]));
+		const speedReductionForBoosts = this.boostMax ?? sumArr(this.itemBoosts.map(i => i[1]));
 		const totalSpeedReduction = speedReductionForGear + speedReductionForKC + speedReductionForBoosts;
 
 		const bossUsers: BossUser[] = [];

--- a/src/mahoji/commands/invention.ts
+++ b/src/mahoji/commands/invention.ts
@@ -244,8 +244,9 @@ export const inventionCommand: OSBMahojiCommand = {
 			};
 		}
 
+		// Defer Interaction for all DB-related functions:
+		await deferInteraction(interaction);
 		if (options.tools) {
-			await deferInteraction(interaction);
 			switch (options.tools.command) {
 				case 'items_disassembled': {
 					const a = await mahojiUsersSettingsFetch(user.id, {

--- a/src/mahoji/lib/abstracted_commands/kgCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/kgCommand.ts
@@ -29,6 +29,8 @@ export async function kgCommand(
 			strength: 105,
 			defence: 105
 		},
+		speedMaxReduction: 45,
+		boostMax: 40,
 		itemBoosts: [
 			['Axe of the high sungod', 20],
 			['Drygore longsword', 10],


### PR DESCRIPTION
### Description:

- Fixes an issue with the new KG boost. It's actually a hard nerf, and impossible to even kill it as fast as previously
- Adds deferInteraction to `invent`

### Changes:

- Adds a `boostMax` option to BossInstance to allow for overlapping boost items 
- **Example:**  
  - Set `boostMax` to the maximum possible equipped %, in this case, 40, (total = 55, subtract dual drygores (15) = 40)
  - You must also increase `speedMaxReduction` by a similar %, in this case, we added +5, otherwise there is no additional boost.
- Adds deferInteraction() before invention commands that work on the database.

### Other checks:

- [x] I have tested all my changes thoroughly.

Current **[Bugged]** with new Axe of the High Sun God Boost:
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/f2eab9ac-8739-4780-930f-ab90e2c54ee1)

Current **[Bugged]** with dual drygores (previous max):
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/fcd1cf50-38e3-43a0-a1f5-0d6cd0a025e7)

Previous max, pre-elder update: (dual drygores (max gear as of shown revision)
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/17ff6e04-4d4f-4e82-89c0-abd040a359d9)

This PR (fixed version) with Axe of the High Sungod:
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/f637eca1-6d57-4234-90a9-ef1484287904)
