### PR TITLE
Combine add+remove calls into single transactions

### DIFF
--- a/src/lib/invention/inventions.ts
+++ b/src/lib/invention/inventions.ts
@@ -606,11 +606,12 @@ export async function inventCommand(user: MUser, inventionName: string): Command
 		addToGlobalInventionCostBank: true
 	});
 
+	const itemsToRemove = new Bank();
 	if (invention.itemCost) {
-		await user.removeItemsFromBank(invention.itemCost);
+		itemsToRemove.add(invention.itemCost);
 	}
 	const loot = new Bank().add(invention.item.id);
-	await user.addItemsToBank({ items: loot, collectionLog: true });
+	await user.transactItems({ itemsToRemove, itemsToAdd: loot, collectionLog: true });
 	return `${userMention(user.id)}, your minion created a ${invention.name}! (${
 		invention.description
 	}) Items removed: ${invention.itemCost ?? 'None'}. Materials used: ${cost}.`;

--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -25,6 +25,7 @@ import { interactionReply } from './interactionReply';
 import { logErrorForInteraction } from './logError';
 import { minionIsBusy } from './minionIsBusy';
 import { fetchRepeatTrips, repeatTrip } from './repeatStoredTrip';
+import { tradePlayerItems } from './tradePlayerItems';
 
 const globalInteractionActions = [
 	'DO_BEGINNER_CLUE',
@@ -305,8 +306,7 @@ async function donateICHandler(interaction: ButtonInteraction) {
 
 	try {
 		modifyBusyCounter(donator.id, 1);
-		await donator.removeItemsFromBank(cost);
-		await user.addItemsToBank({ items: cost, collectionLog: false, filterLoot: false });
+		await tradePlayerItems(donator, user, cost);
 		await userStatsBankUpdate(donator.id, 'ic_donations_given_bank', cost);
 		await userStatsBankUpdate(user.id, 'ic_donations_received_bank', cost);
 

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -235,8 +235,11 @@ const tripFinishEffects: TripFinishEffect[] = [
 						`Your Voidling couldn't do any alching because you don't own ${alchResult.bankToRemove}.`
 					);
 				}
-				await user.addItemsToBank({ items: alchResult.bankToAdd });
-				await user.removeItemsFromBank(alchResult.bankToRemove);
+				await user.transactItems({
+					itemsToRemove: alchResult.bankToRemove,
+					itemsToAdd: alchResult.bankToAdd,
+					collectionLog: true
+				});
 
 				updateBankSetting('magic_cost_bank', alchResult.bankToRemove);
 

--- a/src/mahoji/lib/abstracted_commands/useCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/useCommand.ts
@@ -614,8 +614,15 @@ for (const zygomite of resolveItems(['Herbal zygomite spores', 'Barky zygomite s
 	usables.push({
 		items: [getOSItem(zygomite), getOSItem('Deathly toxic potion')],
 		run: async (user: MUser) => {
-			await user.removeItemsFromBank(new Bank().add('Deathly toxic potion').add(zygomite));
-			await user.addItemsToBank({ items: new Bank().add('Toxic zygomite spores'), collectionLog: true });
+			const cost = new Bank().add('Deathly toxic potion').add(zygomite);
+			const loot = new Bank().add('Toxic zygomite spores');
+			await transactItems({
+				userID: user.id,
+				collectionLog: true,
+				filterLoot: false,
+				itemsToAdd: loot,
+				itemsToRemove: cost
+			});
 			return 'You poured the Deathly toxic potion on the zygomite spores, turning them into Toxic zygomite spores!';
 		}
 	});

--- a/src/mahoji/lib/abstracted_commands/useCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/useCommand.ts
@@ -616,8 +616,7 @@ for (const zygomite of resolveItems(['Herbal zygomite spores', 'Barky zygomite s
 		run: async (user: MUser) => {
 			const cost = new Bank().add('Deathly toxic potion').add(zygomite);
 			const loot = new Bank().add('Toxic zygomite spores');
-			await transactItems({
-				userID: user.id,
+			await user.transactItems({
 				collectionLog: true,
 				filterLoot: false,
 				itemsToAdd: loot,


### PR DESCRIPTION
### Description:

- Wherever an Add + Remove items fn calls can be merged, I have done so. (excluding instances shared in osb)

### Changes:

- Replaces two database calls, addItemsToBank + removeItemsFromBank, with a single call to transactItems()
- Updates donate ic code to use tradePlayerItems instead of separate transactions.

### Other checks:

- [x] I have tested all my changes thoroughly.
