### PR TITLE
Fix first age XP bonus

### DIFF
--- a/src/lib/addXP.ts
+++ b/src/lib/addXP.ts
@@ -200,7 +200,7 @@ export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 		totalFirstAgeBonus += 1;
 	}
 
-	params.amount = increaseNumByPercent(params.amount, totalFirstAgeBonus);
+	if (totalFirstAgeBonus > 0) params.amount = increaseNumByPercent(params.amount, totalFirstAgeBonus);
 
 	const boosts = staticXPBoosts.get(params.skillName);
 	if (boosts && !params.artificial) {

--- a/src/lib/addXP.ts
+++ b/src/lib/addXP.ts
@@ -200,6 +200,8 @@ export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 		totalFirstAgeBonus += 1;
 	}
 
+	params.amount = increaseNumByPercent(params.amount, totalFirstAgeBonus);
+
 	const boosts = staticXPBoosts.get(params.skillName);
 	if (boosts && !params.artificial) {
 		for (const booster of boosts) {


### PR DESCRIPTION
### Description:

- First Age XP wasn't actually being awarded, since Elder clue update

### Changes:

- Adds code to increase XP accordingly 

### Other checks:

- [x] I have tested all my changes thoroughly.
