### PR TITLE
Fix /data stats: Personal Activity Durations + Weekly Gains

### DIFF
--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -101,7 +101,7 @@ Differences AS (
 
 SELECT
     user_id,
-    week_start,
+    week_start::text,
     diff_cl_global_rank,
     diff_cl_completion_percentage,
     diff_cl_completion_count,

--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -347,8 +347,8 @@ OR (data->>'users')::jsonb @> ${wrap(user.id)}::jsonb
 GROUP BY type;`);
 			const dataPoints: [string, number][] = result
 				.filter(i => i.hours >= 1)
-				.sort((a, b) => b.hours - a.hours)
-				.map(i => [i.type, i.hours]);
+				.sort((a, b) => Number(b.hours - a.hours))
+				.map(i => [i.type, Number(i.hours)]);
 			const buffer = await barChart('Your Activity Durations', val => `${val} Hrs`, dataPoints);
 			return makeResponseForBuffer(buffer);
 		}


### PR DESCRIPTION
### Description:

- Fix Personal Activity Duration `/data` stat
  - Chart + Sort (and Math.max, etc) do not support bigints
- Fix Weekly gains (query returns a Date not a string)
  - Fixes: Weekly GP / XP / CL slot / CL LB

### Changes:

- Convert to number's where appropriate
- Convert date to text where appropriate

### Other checks:

- [x] I have tested all my changes thoroughly.
