### PR TITLE
data command fix

### DIFF
--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -970,7 +970,9 @@ GROUP BY "bankBackground";`);
 			return `**Personal XP gained from Tears of Guthix**\n${result
 				.map(
 					(i: any) =>
-						`${skillEmoji[i.skill as keyof typeof skillEmoji] as keyof SkillsScore} ${toKMB(i.total_xp)}`
+						`${skillEmoji[i.skill as keyof typeof skillEmoji] as keyof SkillsScore} ${toKMB(
+							Number(i.total_xp)
+						)}`
 				)
 				.join('\n')}`;
 		}
@@ -995,7 +997,9 @@ GROUP BY "bankBackground";`);
 			return `**Personal XP gained from Forestry events**\n${result
 				.map(
 					(i: any) =>
-						`${skillEmoji[i.skill as keyof typeof skillEmoji] as keyof SkillsScore} ${toKMB(i.total_xp)}`
+						`${skillEmoji[i.skill as keyof typeof skillEmoji] as keyof SkillsScore} ${toKMB(
+							Number(i.total_xp)
+						)}`
 				)
 				.join('\n')}`;
 		}


### PR DESCRIPTION
### Description:
Fix 'Personal XP gained from Tears of Guthix' & 'Personal XP gained from Forestry events' data commands from causing errors.
### Changes:
Added `Number()` cast inside `toKMB()` to fix the error: "TypeError: Cannot mix BigInt and other types, use explicit conversions"
### Other checks:
- [X] I have tested all my changes thoroughly.
