### PR TITLE
Fix Elder clue issues

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -138,18 +138,22 @@ for (const clueTier of ClueTiers) {
 		aliases: [clueTier.name.toLowerCase()],
 		output: async ({ quantity, user, self }) => {
 			const clueTier = ClueTiers.find(c => c.id === self.id)!;
-			let loot = new Bank(clueTier.table.open(quantity, user));
 
+			// BSO Clue roll code:
+			const loot = new Bank();
 			const hasCHEquipped = user.hasEquippedOrInBank(clueHunterOutfit, 'every');
-			let extraClueRolls = 0;
+			let totalRolls = 0;
 			for (let i = 0; i < quantity; i++) {
-				const roll = randInt(1, 3);
-				extraClueRolls += roll - 1;
-				loot.add(clueTier.table.open(roll, user));
+				// Calculate rolls, including bonus rolls (average 2 rolls total per casket):
+				const rolls = randInt(1, 3);
+				totalRolls += rolls;
 				if (clueTier.name === 'Master' && percentChance(hasCHEquipped ? 3.5 : 1.5)) {
 					loot.add('Clue scroll (grandmaster)');
 				}
 			}
+			// Roll loot, and calculate how many bonus rolls were received:
+			loot.add(clueTier.table.open(totalRolls, user));
+			const extraClueRolls = totalRolls - quantity;
 
 			let mimicNumber = 0;
 			if (clueTier.mimicChance) {

--- a/src/lib/simulation/elderClue.ts
+++ b/src/lib/simulation/elderClue.ts
@@ -86,8 +86,9 @@ export class ElderClue extends Clue {
 			}
 
 			const untradeableUniques = resolveItems(['Clue bag', 'Inventors tools', 'Elder knowledge']);
+			const currentCl = user.cl.clone();
 			if (roll(100)) {
-				const unowned = untradeableUniques.filter(id => !user.cl.has(id));
+				const unowned = untradeableUniques.filter(id => !currentCl.add(loot).has(id));
 				if (unowned.length > 0) {
 					loot.add(randArrItem(unowned));
 				} else {

--- a/src/lib/simulation/elderClue.ts
+++ b/src/lib/simulation/elderClue.ts
@@ -78,6 +78,8 @@ export class ElderClue extends Clue {
 	open(quantity: number, user: MUser) {
 		const loot = new Bank();
 
+		const currentCl = user.cl.clone();
+
 		for (let i = 0; i < quantity; i++) {
 			const numberOfRolls = randInt(4, 7);
 
@@ -86,7 +88,6 @@ export class ElderClue extends Clue {
 			}
 
 			const untradeableUniques = resolveItems(['Clue bag', 'Inventors tools', 'Elder knowledge']);
-			const currentCl = user.cl.clone();
 			if (roll(100)) {
 				const unowned = untradeableUniques.filter(id => !currentCl.add(loot).has(id));
 				if (unowned.length > 0) {

--- a/src/lib/simulation/elderClue.ts
+++ b/src/lib/simulation/elderClue.ts
@@ -78,8 +78,6 @@ export class ElderClue extends Clue {
 	open(quantity: number, user: MUser) {
 		const loot = new Bank();
 
-		const currentCl = user.cl.clone();
-
 		for (let i = 0; i < quantity; i++) {
 			const numberOfRolls = randInt(4, 7);
 
@@ -89,7 +87,7 @@ export class ElderClue extends Clue {
 
 			const untradeableUniques = resolveItems(['Clue bag', 'Inventors tools', 'Elder knowledge']);
 			if (roll(100)) {
-				const unowned = untradeableUniques.filter(id => !currentCl.add(loot).has(id));
+				const unowned = untradeableUniques.filter(id => !user.cl.has(id) && !loot.has(id));
 				if (unowned.length > 0) {
 					loot.add(randArrItem(unowned));
 				} else {

--- a/src/lib/util/elderClueRequirements.ts
+++ b/src/lib/util/elderClueRequirements.ts
@@ -15,7 +15,7 @@ import {
 } from '../data/CollectionsExport';
 import { getSimilarItems } from '../data/similarItems';
 import { slayerMaskHelms } from '../data/slayerMaskHelms';
-import resolveItems, { deepResolveItems } from './resolveItems';
+import { deepResolveItems } from './resolveItems';
 import { itemNameFromID } from './smallUtils';
 
 export const elderRequiredClueCLItems = uniqueArr([
@@ -34,7 +34,7 @@ export const elderSherlockItems = deepResolveItems([
 	'Axe of the high sungod',
 	'Hellfire bow',
 	'Ignis ring(i)',
-	'Infernal bulwark',
+	['Infernal bulwark', 'Superior inferno adze'],
 	'Royal crossbow',
 	'Spellbound ring(i)',
 	'Titan ballista',
@@ -43,10 +43,10 @@ export const elderSherlockItems = deepResolveItems([
 	'Dwarven warhammer',
 	'Tidal collector',
 	'Atlantean trident',
-	resolveItems(['Brackish blade', 'Ganodermic gloves', 'Ganodermic boots']),
+	['Brackish blade', 'Ganodermic gloves', 'Ganodermic boots'],
 	gods.map(g => ('pets' in g ? g.pets[g.pets.length - 1] : undefined)).filter(notEmpty),
 	slayerMaskHelms.map(h => h.helm.id),
-	resolveItems(['Elder rumble greegree', 'Gorilla rumble greegree'])
+	['Elder rumble greegree', 'Gorilla rumble greegree']
 ]);
 
 export async function checkElderClueRequirements(user: MUser) {

--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -78,7 +78,7 @@ export const clueCommand: OSBMahojiCommand = {
 				return ClueTiers.map(i => ({
 					name: `${i.name} (${bank.amount(i.scrollID)}x Owned)`,
 					value: i.name as string
-				})).concat([{ name: 'Elder', value: 'Elder' }]);
+				})).concat([{ name: 'Elder (Info)', value: 'Elder (Info)' }]);
 			}
 		},
 		{
@@ -91,7 +91,7 @@ export const clueCommand: OSBMahojiCommand = {
 	],
 	run: async ({ options, userID, channelID }: CommandRunOptions<{ tier: string; quantity?: number }>) => {
 		const user = await mUserFetch(userID);
-		if (options.tier === 'Elder') {
+		if (options.tier === 'Elder (Info)') {
 			const reqs = await checkElderClueRequirements(user);
 			if (reqs.unmetRequirements.length > 0) {
 				return `You do not have the requirements to do Elder clues.

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -1,10 +1,9 @@
 import { mentionCommand } from '@oldschoolgg/toolkit';
-import { Prisma, tame_growth, xp_gains_skill_enum } from '@prisma/client';
+import { activity_type_enum, Prisma, tame_growth, xp_gains_skill_enum } from '@prisma/client';
 import { User } from 'discord.js';
 import { noOp, Time, uniqueArr } from 'e';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 import { Bank, Items } from 'oldschooljs';
-import { SkillsEnum } from 'oldschooljs/dist/constants';
 import { convertLVLtoXP, itemID, toKMB } from 'oldschooljs/dist/util';
 
 import { production } from '../../config';
@@ -31,6 +30,7 @@ import { DisassemblySourceGroups } from '../../lib/invention/groups';
 import { Inventions, transactMaterialsFromUser } from '../../lib/invention/inventions';
 import { MaterialBank } from '../../lib/invention/MaterialBank';
 import killableMonsters, { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
+import { Celestara, Solis } from '../../lib/minions/data/killableMonsters/custom/SunMoon';
 import potions from '../../lib/minions/data/potions';
 import { mahojiUserSettingsUpdate } from '../../lib/MUser';
 import { allOpenables } from '../../lib/openables';
@@ -40,11 +40,12 @@ import { prisma } from '../../lib/settings/prisma';
 import { getFarmingInfo } from '../../lib/skilling/functions/getFarmingInfo';
 import Skills from '../../lib/skilling/skills';
 import Farming from '../../lib/skilling/skills/farming';
+import { SkillsEnum } from '../../lib/skilling/types';
 import { slayerMasterChoices } from '../../lib/slayer/constants';
 import { slayerMasters } from '../../lib/slayer/slayerMasters';
 import { getUsersCurrentSlayerInfo } from '../../lib/slayer/slayerUtil';
 import { allSlayerMonsters } from '../../lib/slayer/tasks';
-import { tameFeedableItems, tameSpecies } from '../../lib/tames';
+import { tameFeedableItems, tameSpecies, TameSpeciesID } from '../../lib/tames';
 import { stringMatches } from '../../lib/util';
 import { calcDropRatesFromBankWithoutUniques } from '../../lib/util/calcDropRatesFromBank';
 import { elderRequiredClueCLItems, elderSherlockItems } from '../../lib/util/elderClueRequirements';
@@ -959,16 +960,28 @@ ${droprates.join('\n')}`),
 						)) {
 							fedItems.add(food.item.id);
 						}
-						await generateNewTame(user, specie);
-
+						const tame = await generateNewTame(user, specie);
+						if (!tame) continue;
 						await prisma.tame.updateMany({
 							where: {
-								user_id: user.id
+								id: tame.id
 							},
 							data: {
-								growth_stage: tame_growth.adult
+								growth_stage: tame_growth.adult,
+								fed_items: fedItems.bank
 							}
 						});
+						if (tame.species_id === TameSpeciesID.Igne) {
+							await prisma.tame.update({
+								where: {
+									id: tame.id
+								},
+								data: {
+									equipped_primary: itemID('Gorajan igne claws'),
+									equipped_armor: itemID('Gorajan igne armor')
+								}
+							});
+						}
 					}
 					await getPOH(user.id);
 					await prisma.playerOwnedHouse.update({
@@ -1008,6 +1021,8 @@ ${droprates.join('\n')}`),
 						.add('Coins', 100_000_000)
 						.add('Shark', 100_000_000)
 						.add('Vial of blood', 100_000_000)
+						.add('Clue scroll (grandmaster)', 100)
+						.add('Reward casket (grandmaster)', 100)
 						.add('Rune pouch')
 						.add('Zamorakian spear')
 						.add('Dragon warhammer')
@@ -1030,6 +1045,25 @@ ${droprates.join('\n')}`),
 					for (const item of [...elderSherlockItems, ...elderRequiredClueCLItems]) {
 						loot.add(Array.isArray(item) ? item[0] : item);
 					}
+					await user.incrementKC(Celestara.id, 1);
+					await user.incrementKC(Solis.id, 1);
+
+					await prisma.activity.create({
+						data: {
+							user_id: BigInt(user.id),
+							completed: true,
+							start_date: new Date(),
+							finish_date: new Date(),
+							channel_id: BigInt(interaction.channelId),
+							group_activity: false,
+							type: activity_type_enum.ClueCompletion,
+							duration: 1,
+							data: {
+								clueID: itemID('Reward casket (grandmaster)'),
+								quantity: 100
+							}
+						}
+					});
 
 					let options = {
 						GP: 5_000_000_000,
@@ -1052,9 +1086,18 @@ ${droprates.join('\n')}`),
 							dartQuantity: 100_000,
 							dartID: itemID('Dragon dart')
 						},
-						bitfield: {
-							push: [BitField.HasUnlockedYeti, BitField.HasPlantedIvy]
-						}
+						bitfield: [
+							...user.bitfield,
+							BitField.HasScrollOfFarming,
+							BitField.HasScrollOfLongevity,
+							BitField.HasScrollOfTheHunt,
+							BitField.HasMoondashCharm,
+							BitField.HasUnlockedVenatrix,
+							BitField.HasDaemonheimAgilityPass,
+							BitField.HasGuthixEngram,
+							BitField.HasPlantedIvy,
+							BitField.HasArcaneScroll
+						]
 					};
 					for (const skill of Object.values(SkillsEnum)) {
 						// @ts-expect-error
@@ -1066,7 +1109,7 @@ ${droprates.join('\n')}`),
 						collectionLog: true
 					});
 					return `Fully maxed your account, stocked your bank, charged all chargeable items.
-					
+
 Spawned an adult of each tame, fed them all applicable items, and spawned ALL their equippable items into your bank (but not equipped).`;
 				}
 				if (options.patron) {


### PR DESCRIPTION
### Description:

- Fix some issues with Elder clues

### Changes:

- Changes the 'Elder' info option (extra `Elder` option in the `/clue` command) to 'Elder (Info)' to prevent conflicts with trying to run the clues.
- Add Superior Inferno Adze as an optional Sherlock item for Infernal core clue (Infernal Bulwark)
- Prevent duplicate untradeable items from being given during a single opening. (until the entire set is complete)
- Fixed bug in the rolling function, and optimized it so it only calls the Clue Openable `roll()` function once
- Remove extraneous call to `resolveItems()` inside a call to `deepResolve()`
- Improves `/testpotato max` command to make testing Elder clues MUCH easier.

### Other checks:

- [x] I have tested all my changes thoroughly.
