### PR TITLE
Add Shayzien Combat Ring

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -938,6 +938,7 @@ enum activity_type_enum {
   TombsOfAmascut
   UnderwaterAgilityThieving
   StrongholdOfSecurity
+  CombatRing
   SpecificQuest
   CamdozaalFishing
   CamdozaalMining

--- a/src/lib/Task.ts
+++ b/src/lib/Task.ts
@@ -11,6 +11,7 @@ import { camdozaalSmithingTask } from '../tasks/minions/camdozaalActivity/camdoz
 import { castingTask } from '../tasks/minions/castingActivity';
 import { clueTask } from '../tasks/minions/clueActivity';
 import { collectingTask } from '../tasks/minions/collectingActivity';
+import { combatRingTask } from '../tasks/minions/combatRingActivity';
 import { constructionTask } from '../tasks/minions/constructionActivity';
 import { cookingTask } from '../tasks/minions/cookingActivity';
 import { craftingTask } from '../tasks/minions/craftingActivity';
@@ -178,6 +179,7 @@ export const tasks: MinionTask[] = [
 	toaTask,
 	underwaterAgilityThievingTask,
 	strongholdTask,
+	combatRingTask,
 	specificQuestTask,
 	camdozaalMiningTask,
 	camdozaalSmithingTask,

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -45,7 +45,8 @@ export interface ActivityTaskOptionsWithNoChanges extends ActivityTaskOptions {
 		| 'Easter'
 		| 'ShootingStars'
 		| 'HalloweenEvent'
-		| 'StrongholdOfSecurity';
+		| 'StrongholdOfSecurity'
+		| 'CombatRing';
 }
 
 export interface ActivityTaskOptionsWithQuantity extends ActivityTaskOptions {

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -667,6 +667,11 @@ export function minionStatus(user: MUser) {
 				durationRemaining
 			)}.`;
 		}
+		case 'CombatRing': {
+			return `${name} is currently fighting in the Combat Ring! The trip should take ${formatDuration(
+				durationRemaining
+			)}.`;
+		}
 		case 'SpecificQuest': {
 			const data = currentTask as SpecificQuestOptions;
 			return `${name} is currently doing the ${

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -76,7 +76,8 @@ export const taskCanBeRepeated = (activity: Activity) => {
 			activity_type_enum.Easter,
 			activity_type_enum.TokkulShop,
 			activity_type_enum.Birdhouse,
-			activity_type_enum.StrongholdOfSecurity
+			activity_type_enum.StrongholdOfSecurity,
+			activity_type_enum.CombatRing
 		] as activity_type_enum[]
 	).includes(activity.type);
 };
@@ -99,6 +100,10 @@ export const tripHandlers = {
 		args: () => ({})
 	},
 	[activity_type_enum.StrongholdOfSecurity]: {
+		commandName: 'm',
+		args: () => ({})
+	},
+	[activity_type_enum.CombatRing]: {
 		commandName: 'm',
 		args: () => ({})
 	},

--- a/src/mahoji/lib/abstracted_commands/combatRingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/combatRingCommand.ts
@@ -1,0 +1,20 @@
+import { Time } from 'e';
+
+import type { ActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
+import { randomVariation } from '../../../lib/util';
+import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
+
+export async function combatRingCommand(user: MUser, channelID: string) {
+	if (user.minionIsBusy) {
+		return 'Your minion is busy.';
+	}
+
+	await addSubTaskToActivityTask<ActivityTaskOptionsWithNoChanges>({
+		userID: user.id,
+		channelID: channelID.toString(),
+		duration: randomVariation(Time.Minute * 5, 5),
+		type: 'CombatRing'
+	});
+
+	return `${user.minionName} is now fighting in the Shayzien Combat Ring!`;
+}

--- a/src/mahoji/lib/abstracted_commands/otherActivitiesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/otherActivitiesCommand.ts
@@ -1,6 +1,7 @@
 import { activity_type_enum } from '@prisma/client';
 
 import { championsChallengeCommand } from './championsChallenge';
+import { combatRingCommand } from './combatRingCommand';
 import { strongHoldOfSecurityCommand } from './strongHoldOfSecurityCommand';
 
 export const otherActivities = [
@@ -13,6 +14,11 @@ export const otherActivities = [
 		name: 'Stronghold of Security',
 		command: championsChallengeCommand,
 		type: activity_type_enum.StrongholdOfSecurity
+	},
+	{
+		name: 'Combat Ring (Shayzien)',
+		command: combatRingCommand,
+		type: activity_type_enum.CombatRing
 	}
 ];
 
@@ -22,6 +28,9 @@ export function otherActivitiesCommand(type: string, user: MUser, channelID: str
 	}
 	if (type === 'StrongholdOfSecurity') {
 		return strongHoldOfSecurityCommand(user, channelID);
+	}
+	if (type === 'CombatRing') {
+		return combatRingCommand(user, channelID);
 	}
 	return 'Invalid activity type.';
 }

--- a/src/tasks/minions/combatRingActivity.ts
+++ b/src/tasks/minions/combatRingActivity.ts
@@ -1,0 +1,55 @@
+import { Bank } from 'oldschooljs';
+
+import { ActivityTaskOptionsWithNoChanges } from '../../lib/types/minions';
+import { handleTripFinish } from '../../lib/util/handleTripFinish';
+
+export const combatRingTask: MinionTask = {
+	type: 'CombatRing',
+	async run(data: ActivityTaskOptionsWithNoChanges) {
+		const { channelID, userID } = data;
+		const user = await mUserFetch(userID);
+
+		const loot = new Bank({
+			'Shayzien boots (1)': 1,
+			'Shayzien gloves (1)': 1,
+			'Shayzien greaves (1)': 1,
+			'Shayzien helm (1)': 1,
+			'Shayzien platebody (1)': 1,
+			'Shayzien boots (2)': 1,
+			'Shayzien gloves (2)': 1,
+			'Shayzien greaves (2)': 1,
+			'Shayzien helm (2)': 1,
+			'Shayzien platebody (2)': 1,
+			'Shayzien boots (3)': 1,
+			'Shayzien gloves (3)': 1,
+			'Shayzien greaves (3)': 1,
+			'Shayzien helm (3)': 1,
+			'Shayzien platebody (3)': 1,
+			'Shayzien boots (4)': 1,
+			'Shayzien gloves (4)': 1,
+			'Shayzien greaves (4)': 1,
+			'Shayzien helm (4)': 1,
+			'Shayzien platebody (4)': 1,
+			'Shayzien boots (5)': 1,
+			'Shayzien gloves (5)': 1,
+			'Shayzien greaves (5)': 1,
+			'Shayzien helm (5)': 1,
+			'Shayzien body (5)': 1
+		});
+
+		await transactItems({
+			userID: user.id,
+			collectionLog: true,
+			itemsToAdd: loot
+		});
+
+		handleTripFinish(
+			user,
+			channelID,
+			`${user}, ${user.minionName} finished the Combat Ring, and received ${loot}.`,
+			undefined,
+			data,
+			loot
+		);
+	}
+};


### PR DESCRIPTION
Since the removal of favour, users are unable to get the Shayzien armour that gives a boost to Lizardman Shamans.

This pr copies how stronghold of security has been setup and adds the shayzien minigame to unlock the armour.

- [x] I have tested all my changes thoroughly.
