### PR TITLE
Clue bonus roll message

### DIFF
--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -155,7 +155,7 @@ for (const clueTier of ClueTiers) {
 			}
 			// Roll loot, and calculate how many bonus rolls were received:
 			loot.add(clueTier.table.open(includeBuggedRolls ? totalRolls + quantity : totalRolls, user));
-			const extraClueRolls = totalRolls - quantity;
+			const extraClueRolls = includeBuggedRolls ? totalRolls : totalRolls - quantity;
 
 			let mimicNumber = 0;
 			if (clueTier.mimicChance) {


### PR DESCRIPTION
### Description:
If we are assuming that the guaranteed +1 (from the revert) per casket is a bonus roll the message should reflect that.
If this isn't the case then we assume that every casket is +2 guaranteed and bonus rolls are randInt(1,3) -1 for message purposes.
### Changes:
Adjust extraClueRolls to check for includeBuggedRolls
### Other checks:
- [X] I have tested all my changes thoroughly.
