### PR TITLE
Hellfire overrides attack requirements on wildy monsters

### DIFF
--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -5,6 +5,7 @@ import { Bank } from 'oldschooljs';
 
 import { globalConfig } from '../lib/constants';
 import { getSimilarItems } from '../lib/data/similarItems';
+import { GearStat } from '../lib/gear';
 import type { KillableMonster } from '../lib/minions/types';
 import type { SelectedUserStats } from '../lib/MUser';
 import { prisma } from '../lib/settings/prisma';
@@ -275,6 +276,19 @@ export function hasMonsterRequirements(user: MUser, monster: KillableMonster) {
 		for (const [setup, requirements] of objectEntries(monster.minimumGearRequirements)) {
 			const gear = user.gear[setup];
 			if (setup && requirements) {
+				if (setup === 'wildy' && user.gear.wildy.hasEquipped('Hellfire bow')) {
+					const attackOverrides = [
+						GearStat.AttackSlash,
+						GearStat.AttackCrush,
+						GearStat.AttackStab,
+						GearStat.MeleeStrength,
+						GearStat.AttackMagic,
+						GearStat.MagicDamage
+					];
+					for (const override of attackOverrides) {
+						delete requirements[override];
+					}
+				}
 				const [meetsRequirements, unmetKey, has] = gear.meetsStatRequirements(requirements);
 				if (!meetsRequirements) {
 					return [


### PR DESCRIPTION
### Description:

- Fixes Hellfire bow so it works on Wildy bosses again

### Changes:

- Overrides non-ranged attack requirements for Wildy slot when Hellfire bow is being used.

### Other checks:

- [x] I have tested all my changes thoroughly.
