### PR TITLE
Fix Wildy death bug - causing no trip returns, and lost items

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -508,7 +508,7 @@ GROUP BY data->>'clueID';`);
 		};
 	}
 
-	async specialRemoveItems(bankToRemove: Bank, options?: { wildy?: boolean }) {
+	async specialRemoveItems(bankToRemove: Bank, options?: { wildy?: boolean; death?: boolean }) {
 		bankToRemove = determineRunes(this, bankToRemove);
 		const bankRemove = new Bank();
 		let dart: [Item, number] | null = null;
@@ -527,7 +527,7 @@ GROUP BY data->>'clueID';`);
 				continue;
 			}
 			const projectileCategory = Object.values(projectiles).find(i => i.items.includes(item.id));
-			if (projectileCategory) {
+			if (projectileCategory && !options?.death) {
 				if (ammoRemove !== null) {
 					bankRemove.add(item.id, quantity);
 					continue;
@@ -566,6 +566,7 @@ GROUP BY data->>'clueID';`);
 					} but you have only ${ammo}.`
 				);
 			newRangeGear.ammo!.quantity -= ammoRemove![1];
+			if (newRangeGear.ammo!.quantity <= 0) newRangeGear.ammo = null;
 			const updateKey = options?.wildy ? 'gear_wildy' : 'gear_range';
 			updates[updateKey] = newRangeGear as any as Prisma.InputJsonObject;
 		}

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -115,7 +115,7 @@ export const monsterTask: MinionTask = {
 						gear_wildy: calc.newGear as Prisma.InputJsonObject
 					});
 				} else {
-					await user.specialRemoveItems(calc.lostItems, { wildy: monster.wildy ? true : false });
+					await user.specialRemoveItems(calc.lostItems, { wildy: monster.wildy ? true : false, death: true });
 					reEquipedItems = true;
 				}
 


### PR DESCRIPTION
### Description:

- The death handling code is bugged, and tries to remove ammo from the gear instead of bank when you die.
- This leads to having 0x qty ammo, which causes subsequent trips to fail. (doesn't fail on the actual bugged trip)

### Changes:

- Updates the ammo removal function to remove the ammo if the qty is <= 0
- Updates deaths to remove ammo from bank on death.

### Other checks:

- [x] I have tested all my changes thoroughly.
