### PR TITLE
Arcane harvester fixes / tweaks

### DIFF
--- a/src/lib/skilling/skills/farming/trees.ts
+++ b/src/lib/skilling/skills/farming/trees.ts
@@ -233,7 +233,8 @@ const trees: Plant[] = [
 		additionalPatchesByFarmLvl: [],
 		timePerPatchTravel: 20,
 		timePerHarvest: 10,
-		additionalPatchesByFarmGuildAndLvl: []
+		additionalPatchesByFarmGuildAndLvl: [],
+		noArcaneHarvester: true
 	}
 ];
 

--- a/src/lib/skilling/skills/farming/zygomites.ts
+++ b/src/lib/skilling/skills/farming/zygomites.ts
@@ -87,6 +87,7 @@ export const zygomitePlants: Plant[] = zygomiteFarmingSource.map(src => ({
 	additionalPatchesByFarmGuildAndLvl: [],
 	timePerPatchTravel: 10,
 	timePerHarvest: 5,
+	noArcaneHarvester: src.name === 'Toxic zygomite' ? true : undefined,
 	onHarvest: async ({ loot, user, quantity, messages }) => {
 		const dropRate = clAdjustedDroprate(
 			user,

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -280,6 +280,7 @@ export interface Plant {
 	timePerPatchTravel: number;
 	timePerHarvest: number;
 	onHarvest?: (options: { user: MUser; loot: Bank; quantity: number; messages: string[] }) => Promise<unknown>;
+	noArcaneHarvester?: boolean;
 }
 
 export enum HunterTechniqueEnum {

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -34,6 +34,7 @@ async function farmingLootBoosts(
 	user: MUser,
 	method: 'harvest' | 'plant',
 	plant: Plant,
+	quantity: number,
 	loot: Bank,
 	messages: string[]
 ) {
@@ -47,11 +48,11 @@ async function farmingLootBoosts(
 		bonusPercentage += 100;
 		messages.push('100% for Farming master cape');
 	}
-	if (method === 'harvest' && user.hasEquippedOrInBank(['Arcane harvester']) && plant.name !== 'Mysterious tree') {
+	if (method === 'harvest' && user.hasEquippedOrInBank(['Arcane harvester']) && !plant.noArcaneHarvester) {
 		const boostRes = await inventionItemBoost({
 			user,
 			inventionID: InventionID.ArcaneHarvester,
-			duration: plant.level * Time.Second * 30
+			duration: plant.level * Time.Second * quantity
 		});
 		if (boostRes.success) {
 			bonusPercentage += inventionBoosts.arcaneHarvester.harvestBoostPercent;
@@ -217,7 +218,7 @@ export const farmingTask: MinionTask = {
 				duration: data.duration
 			})}`;
 
-			await farmingLootBoosts(user, 'plant', plant, loot, infoStr);
+			await farmingLootBoosts(user, 'plant', plant, quantity, loot, infoStr);
 
 			if (loot.has('Plopper')) {
 				loot.bank[itemID('Plopper')] = 1;
@@ -564,7 +565,7 @@ export const farmingTask: MinionTask = {
 				infoStr.push(`\n${user.minionName} tells you to come back after your plants have finished growing!`);
 			}
 
-			await farmingLootBoosts(user, 'harvest', plantToHarvest, loot, infoStr);
+			await farmingLootBoosts(user, 'harvest', plantToHarvest, patchType.lastQuantity, loot, infoStr);
 			if ('onHarvest' in plantToHarvest && plantToHarvest.onHarvest) {
 				await plantToHarvest.onHarvest({ user, loot, quantity: patchType.lastQuantity, messages: infoStr });
 			}


### PR DESCRIPTION
### Description:

- Arcane harvester still charges full price for Toxic zygomite, even though there is no loot/benefit.
- Arcane harvester charges the same regardless of the quantity, this balances it based on quantity.

### Changes:

- Adds flag to determine if harvester should run, and sets for Mysterious tree + Toxic Zygomite
- Alters Invention cost to use quantity to determine cost instead of always max cost.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:

- Polled successfully