### PR TITLE
Fix Avas / `specialRemoveItems()` test code

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -1,7 +1,7 @@
 import { userMention } from '@discordjs/builders';
 import { UserError } from '@oldschoolgg/toolkit/dist/lib/UserError';
 import { GearSetupType, Prisma, User, UserStats, xp_gains_skill_enum } from '@prisma/client';
-import { calcWhatPercent, objectEntries, sumArr, uniqueArr } from 'e';
+import { calcWhatPercent, objectEntries, percentChance, sumArr, uniqueArr } from 'e';
 import { Bank } from 'oldschooljs';
 import { EquipmentSlot, Item } from 'oldschooljs/dist/meta/types';
 
@@ -35,7 +35,7 @@ import { SkillsEnum } from './skilling/types';
 import { BankSortMethod } from './sorts';
 import { defaultGear, Gear } from './structures/Gear';
 import { ItemBank, Skills } from './types';
-import { addItemToBank, convertXPtoLVL, itemNameFromID, percentChance } from './util';
+import { addItemToBank, convertXPtoLVL, itemNameFromID } from './util';
 import { determineRunes } from './util/determineRunes';
 import { getKCByName } from './util/getKCByName';
 import getOSItem, { getItem } from './util/getOSItem';

--- a/tests/integration/specialRemoveItems.test.ts
+++ b/tests/integration/specialRemoveItems.test.ts
@@ -30,6 +30,7 @@ describe('specialRemoveItems', () => {
 		expect(user.gear.range.ammo!.quantity).toBe(1000);
 		await user.specialRemoveItems(new Bank().add('Rune arrow', 1000));
 		expect(user.gear.range.ammo!.quantity).toBeLessThan(850);
+		expect(user.gear.range.ammo!.quantity).toBeGreaterThan(650);
 	});
 
 	test("should not deduct for ava's and javelin", async () => {


### PR DESCRIPTION
### Description:

- Ava's test code doesn't actually check to ensure ava's is working, it is bugged and only tests if you have less than X ammo left, which will always pass if ava's isn't working.

### Changes:

- Adds a range, so it must fall within a reasonable range for Avas' effect to trigger.
- Changes MUser to use the (e) version of percentChance() to match BSO. (It is only used for Avas calculation; cryptoRand is unnecessary here)

### Other checks:

- [x] I have tested all my changes thoroughly.
