### PR TITLE
Cleanup Scatter activity & show accurate XP results.

### DIFF
--- a/src/lib/addXP.ts
+++ b/src/lib/addXP.ts
@@ -158,7 +158,7 @@ export async function addXP(user: MUser, params: AddXpParams): Promise<string> {
 	if (preMax !== -1) {
 		str += params.minimal
 			? `+${Math.ceil(preMax).toLocaleString()} ${skillEmoji[params.skillName]}`
-			: `You received ${Math.ceil(preMax).toLocaleString()} ${skillEmoji[params.skillName]} XP`;
+			: `You received ${Math.ceil(preMax).toLocaleString()} ${skillEmoji[params.skillName]} XP.`;
 		if (params.duration) {
 			let rawXPHr = (params.amount / (params.duration / Time.Minute)) * 60;
 			rawXPHr = Math.floor(rawXPHr / 1000) * 1000;

--- a/tests/integration/MUser.test.ts
+++ b/tests/integration/MUser.test.ts
@@ -94,7 +94,7 @@ describe('MUser', () => {
 		expect(user.skillsAsLevels.agility).toEqual(1);
 		const result = await user.addXP({ skillName: SkillsEnum.Agility, amount: 1000 });
 		expect(user.skillsAsLevels.agility).toEqual(9);
-		expect(result).toEqual(`You received 1,000 <:agility:630911040355565568> XP
+		expect(result).toEqual(`You received 1,000 <:agility:630911040355565568> XP.
 **Congratulations! Your Agility level is now 9** 🎉`);
 		const xpAdded = await global.prisma!.xPGain.findMany({
 			where: {


### PR DESCRIPTION
### Description:

- Adds missing period to `addXp()` results
- Reworks scatterActivity to properly use the addXp result, and not try to calculate everything all over again.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes
- There is no BSO-specific code in scatterActivity, but for some reason, there are conflicts. Just accept all changes from master when merging.
