### PR TITLE
Fix crystal imp lb and status

### DIFF
--- a/src/lib/skilling/skills/hunter/creatures/butterflyNetting.ts
+++ b/src/lib/skilling/skills/hunter/creatures/butterflyNetting.ts
@@ -58,7 +58,7 @@ const butterflyNettingCreatures: Creature[] = [
 	},
 	{
 		name: 'Crystal impling',
-		id: 37,
+		id: 42,
 		aliases: ['cimp', 'crystal imp', 'c imp', 'crystal impling'],
 		level: 80,
 		hunterXP: 280,

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -432,7 +432,10 @@ export function minionStatus(user: MUser) {
 						stringMatches(alias, data.creatureName) || stringMatches(alias.split(' ')[0], data.creatureName)
 				)
 			);
-			return `${name} is currently hunting ${data.quantity}x ${creature!.name}. ${formattedDuration}`;
+			let crystalImpling = creature?.name === 'Crystal impling';
+			return `${name} is currently hunting ${
+				crystalImpling ? creature!.name : `${data.quantity}x ${creature!.name}`
+			}. ${formattedDuration}`;
 		}
 
 		case 'Birdhouse': {


### PR DESCRIPTION
Changes the ID of crystal impling so it doesn't conflict with bluegill of aerial fishing.

Also updates the minion status message to remove the quantity.

- [x] I have tested all my changes thoroughly.
