### PR TITLE
Add a way to negate stamina cost for Crystal Implings

### DIFF
--- a/src/mahoji/commands/hunt.ts
+++ b/src/mahoji/commands/hunt.ts
@@ -224,7 +224,7 @@ export const huntCommand: OSBMahojiCommand = {
 			if (poh.pool === getPOHObject(poolName).id) {
 				if (user.hasEquippedOrInBank('Max cape') || user.hasEquippedOrInBank('Construct. cape')) {
 					staminaPool = true;
-					break; 
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
Adds checks for a stamina pool, construction cape, eternal teleport crystal and ring of endurance to remove the stamina potions cost for hunting crystal implings but still get the relevant boost.

- [ ] I have tested all my changes thoroughly.
