### PR TITLE
Zygomites update!

### DIFF
--- a/src/lib/skilling/skills/farming/zygomites.ts
+++ b/src/lib/skilling/skills/farming/zygomites.ts
@@ -1,21 +1,99 @@
+import { SimpleTable } from '@oldschoolgg/toolkit';
 import { roll } from 'e';
 import { Bank, LootTable } from 'oldschooljs';
+import { Item } from 'oldschooljs/dist/meta/types';
 
 import { MysteryBoxes } from '../../../bsoOpenables';
 import { BitField } from '../../../constants';
 import { globalDroprates } from '../../../data/globalDroprates';
 import { clAdjustedDroprate } from '../../../util';
 import getOSItem from '../../../util/getOSItem';
-import resolveItems from '../../../util/resolveItems';
 import { Plant } from '../../types';
 
 export const zygomiteSeedMutChance = 10;
-export const zygomiteMutSurvivalChance = 19;
+
+interface MutatedSourceItem {
+	item: Item;
+	zygomite: 'Herbal zygomite' | 'Barky zygomite' | 'Fruity zygomite';
+	weight: number;
+	mutationChance: number;
+}
+
+export const mutatedSourceItems: MutatedSourceItem[] = [
+	{
+		item: getOSItem('Torstol seed'),
+		zygomite: 'Herbal zygomite',
+		weight: 10,
+		mutationChance: 15
+	},
+	{
+		item: getOSItem('Dwarf weed seed'),
+		zygomite: 'Herbal zygomite',
+		weight: 1,
+		mutationChance: 2
+	},
+	{
+		item: getOSItem('Lantadyme seed'),
+		zygomite: 'Herbal zygomite',
+		weight: 10,
+		mutationChance: 15
+	},
+	{
+		item: getOSItem('Magic seed'),
+		zygomite: 'Barky zygomite',
+		weight: 20,
+		mutationChance: 10
+	},
+	{
+		item: getOSItem('Redwood tree seed'),
+		zygomite: 'Barky zygomite',
+		weight: 1,
+		mutationChance: 2
+	},
+	{
+		item: getOSItem('Yew seed'),
+		zygomite: 'Barky zygomite',
+		weight: 25,
+		mutationChance: 12
+	},
+	{
+		item: getOSItem('Dragonfruit tree seed'),
+		zygomite: 'Fruity zygomite',
+		weight: 1,
+		mutationChance: 2
+	},
+	{
+		item: getOSItem('Papaya tree seed'),
+		zygomite: 'Fruity zygomite',
+		weight: 6,
+		mutationChance: 15
+	},
+	{
+		item: getOSItem('Palm tree seed'),
+		zygomite: 'Fruity zygomite',
+		weight: 5,
+		mutationChance: 14
+	},
+	{
+		item: getOSItem('Blood orange seed'),
+		zygomite: 'Fruity zygomite',
+		weight: 3,
+		mutationChance: 5
+	}
+];
+
+function sourceItemsToTable(items: MutatedSourceItem[]) {
+	const table = new SimpleTable<MutatedSourceItem>();
+	for (const item of items) {
+		table.add(item, item.weight);
+	}
+	return table;
+}
 
 export const zygomiteFarmingSource = [
 	{
 		name: 'Herbal zygomite',
-		mutatedFromItems: resolveItems(['Torstol seed', 'Dwarf weed seed', 'Lantadyme seed']),
+		mutatedFromItems: sourceItemsToTable(mutatedSourceItems.filter(m => m.zygomite === 'Herbal zygomite')),
 		seedItem: getOSItem('Herbal zygomite spores'),
 		lootTable: new LootTable()
 			.every(
@@ -23,11 +101,11 @@ export const zygomiteFarmingSource = [
 				5
 			)
 			.every(new LootTable().add('Torstol').add('Dwarf weed').add('Cadantine').add('Kwuarm'), [40, 100])
-			.every(MysteryBoxes)
+			.oneIn(3, MysteryBoxes)
 	},
 	{
 		name: 'Barky zygomite',
-		mutatedFromItems: resolveItems(['Magic seed', 'Redwood tree seed']),
+		mutatedFromItems: sourceItemsToTable(mutatedSourceItems.filter(m => m.zygomite === 'Barky zygomite')),
 		seedItem: getOSItem('Barky zygomite spores'),
 		lootTable: new LootTable()
 			.every(
@@ -35,11 +113,11 @@ export const zygomiteFarmingSource = [
 				5
 			)
 			.every(new LootTable().add('Elder logs').add('Mahogany logs'), [50, 100])
-			.every(MysteryBoxes)
+			.oneIn(3, MysteryBoxes)
 	},
 	{
 		name: 'Fruity zygomite',
-		mutatedFromItems: resolveItems(['Dragonfruit tree seed', 'Palm tree seed', 'Papaya tree seed']),
+		mutatedFromItems: sourceItemsToTable(mutatedSourceItems.filter(m => m.zygomite === 'Fruity zygomite')),
 		seedItem: getOSItem('Fruity zygomite spores'),
 		lootTable: new LootTable()
 			.every(
@@ -47,7 +125,7 @@ export const zygomiteFarmingSource = [
 				5
 			)
 			.every(new LootTable().add('Avocado').add('Mango').add('Papaya fruit').add('Lychee'), [50, 150])
-			.every(MysteryBoxes)
+			.oneIn(3, MysteryBoxes)
 	},
 	{
 		name: 'Toxic zygomite',

--- a/src/lib/skilling/skills/farming/zygomites.ts
+++ b/src/lib/skilling/skills/farming/zygomites.ts
@@ -10,75 +10,75 @@ import { clAdjustedDroprate } from '../../../util';
 import getOSItem from '../../../util/getOSItem';
 import { Plant } from '../../types';
 
-export const zygomiteSeedMutChance = 10;
+export const zygomiteSeedMutChance = 12;
 
 interface MutatedSourceItem {
 	item: Item;
 	zygomite: 'Herbal zygomite' | 'Barky zygomite' | 'Fruity zygomite';
 	weight: number;
-	mutationChance: number;
+	surivalChance: number;
 }
 
 export const mutatedSourceItems: MutatedSourceItem[] = [
 	{
-		item: getOSItem('Torstol seed'),
-		zygomite: 'Herbal zygomite',
-		weight: 10,
-		mutationChance: 15
-	},
-	{
-		item: getOSItem('Dwarf weed seed'),
-		zygomite: 'Herbal zygomite',
-		weight: 1,
-		mutationChance: 2
-	},
-	{
-		item: getOSItem('Lantadyme seed'),
-		zygomite: 'Herbal zygomite',
-		weight: 10,
-		mutationChance: 15
-	},
-	{
-		item: getOSItem('Magic seed'),
-		zygomite: 'Barky zygomite',
-		weight: 20,
-		mutationChance: 10
-	},
-	{
-		item: getOSItem('Redwood tree seed'),
-		zygomite: 'Barky zygomite',
-		weight: 1,
-		mutationChance: 2
-	},
-	{
-		item: getOSItem('Yew seed'),
-		zygomite: 'Barky zygomite',
-		weight: 25,
-		mutationChance: 12
-	},
-	{
-		item: getOSItem('Dragonfruit tree seed'),
-		zygomite: 'Fruity zygomite',
-		weight: 1,
-		mutationChance: 2
-	},
-	{
 		item: getOSItem('Papaya tree seed'),
 		zygomite: 'Fruity zygomite',
 		weight: 6,
-		mutationChance: 15
+		surivalChance: 19
 	},
 	{
 		item: getOSItem('Palm tree seed'),
 		zygomite: 'Fruity zygomite',
 		weight: 5,
-		mutationChance: 14
+		surivalChance: 15
 	},
 	{
 		item: getOSItem('Blood orange seed'),
 		zygomite: 'Fruity zygomite',
 		weight: 3,
-		mutationChance: 5
+		surivalChance: 9
+	},
+	{
+		item: getOSItem('Dragonfruit tree seed'),
+		zygomite: 'Fruity zygomite',
+		weight: 1,
+		surivalChance: 3
+	},
+	{
+		item: getOSItem('Torstol seed'),
+		zygomite: 'Herbal zygomite',
+		weight: 10,
+		surivalChance: 15
+	},
+	{
+		item: getOSItem('Dwarf weed seed'),
+		zygomite: 'Herbal zygomite',
+		weight: 1,
+		surivalChance: 3
+	},
+	{
+		item: getOSItem('Lantadyme seed'),
+		zygomite: 'Herbal zygomite',
+		weight: 10,
+		surivalChance: 17
+	},
+	{
+		item: getOSItem('Yew seed'),
+		zygomite: 'Barky zygomite',
+		weight: 25,
+		surivalChance: 14
+	},
+	{
+		item: getOSItem('Magic seed'),
+		zygomite: 'Barky zygomite',
+		weight: 20,
+		surivalChance: 12
+	},
+	{
+		item: getOSItem('Redwood tree seed'),
+		zygomite: 'Barky zygomite',
+		weight: 1,
+		surivalChance: 2
 	}
 ];
 
@@ -101,7 +101,7 @@ export const zygomiteFarmingSource = [
 				5
 			)
 			.every(new LootTable().add('Torstol').add('Dwarf weed').add('Cadantine').add('Kwuarm'), [40, 100])
-			.oneIn(3, MysteryBoxes)
+			.every(MysteryBoxes)
 	},
 	{
 		name: 'Barky zygomite',
@@ -113,7 +113,7 @@ export const zygomiteFarmingSource = [
 				5
 			)
 			.every(new LootTable().add('Elder logs').add('Mahogany logs'), [50, 100])
-			.oneIn(3, MysteryBoxes)
+			.every(MysteryBoxes)
 	},
 	{
 		name: 'Fruity zygomite',
@@ -125,7 +125,7 @@ export const zygomiteFarmingSource = [
 				5
 			)
 			.every(new LootTable().add('Avocado').add('Mango').add('Papaya fruit').add('Lychee'), [50, 150])
-			.oneIn(3, MysteryBoxes)
+			.every(MysteryBoxes)
 	},
 	{
 		name: 'Toxic zygomite',

--- a/src/lib/skilling/skills/farming/zygomites.ts
+++ b/src/lib/skilling/skills/farming/zygomites.ts
@@ -1,5 +1,5 @@
 import { SimpleTable } from '@oldschoolgg/toolkit';
-import { roll } from 'e';
+import { randArrItem, roll } from 'e';
 import { Bank, LootTable } from 'oldschooljs';
 import { Item } from 'oldschooljs/dist/meta/types';
 
@@ -10,7 +10,7 @@ import { clAdjustedDroprate } from '../../../util';
 import getOSItem from '../../../util/getOSItem';
 import { Plant } from '../../types';
 
-export const zygomiteSeedMutChance = 12;
+export const zygomiteSeedMutChance = 15;
 
 interface MutatedSourceItem {
 	item: Item;
@@ -36,7 +36,7 @@ export const mutatedSourceItems: MutatedSourceItem[] = [
 		item: getOSItem('Blood orange seed'),
 		zygomite: 'Fruity zygomite',
 		weight: 3,
-		surivalChance: 9
+		surivalChance: 10
 	},
 	{
 		item: getOSItem('Dragonfruit tree seed'),
@@ -45,34 +45,34 @@ export const mutatedSourceItems: MutatedSourceItem[] = [
 		surivalChance: 3
 	},
 	{
+		item: getOSItem('Lantadyme seed'),
+		zygomite: 'Herbal zygomite',
+		weight: 14,
+		surivalChance: 16
+	},
+	{
 		item: getOSItem('Torstol seed'),
 		zygomite: 'Herbal zygomite',
-		weight: 10,
-		surivalChance: 15
+		weight: 13,
+		surivalChance: 14
 	},
 	{
 		item: getOSItem('Dwarf weed seed'),
 		zygomite: 'Herbal zygomite',
-		weight: 1,
+		weight: 2,
 		surivalChance: 3
-	},
-	{
-		item: getOSItem('Lantadyme seed'),
-		zygomite: 'Herbal zygomite',
-		weight: 10,
-		surivalChance: 17
 	},
 	{
 		item: getOSItem('Yew seed'),
 		zygomite: 'Barky zygomite',
-		weight: 25,
-		surivalChance: 14
+		weight: 17,
+		surivalChance: 15
 	},
 	{
 		item: getOSItem('Magic seed'),
 		zygomite: 'Barky zygomite',
-		weight: 20,
-		surivalChance: 12
+		weight: 11,
+		surivalChance: 13
 	},
 	{
 		item: getOSItem('Redwood tree seed'),
@@ -193,3 +193,24 @@ export const zygomitePlants: Plant[] = zygomiteFarmingSource.map(src => ({
 		}
 	}
 }));
+
+export function calculateZygomiteLoot(minutes: number, userBank: Bank) {
+	const cost = new Bank();
+	const loot = new Bank();
+
+	for (let i = 0; i < minutes; i++) {
+		if (roll(zygomiteSeedMutChance)) {
+			const randomZyg = randArrItem(zygomiteFarmingSource.filter(z => z.lootTable !== null));
+			const sourceSeed = randomZyg.mutatedFromItems?.roll();
+			if (!sourceSeed) continue;
+			if (userBank.amount(sourceSeed.item.id) < cost.amount(sourceSeed.item.id) + 1) continue;
+
+			cost.add(sourceSeed.item.id);
+
+			if (roll(sourceSeed.surivalChance)) {
+				loot.add(randomZyg.seedItem);
+			}
+		}
+	}
+	return { cost, loot };
+}

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -23,7 +23,7 @@ import { mysteriousStepData } from '../mysteryTrail';
 import { triggerRandomEvent } from '../randomEvents';
 import { RuneTable, WilvusTable, WoodTable } from '../simulation/seedTable';
 import { DougTable, PekyTable } from '../simulation/sharedTables';
-import { zygomiteFarmingSource, zygomiteSeedMutChance } from '../skilling/skills/farming/zygomites';
+import { calculateZygomiteLoot } from '../skilling/skills/farming/zygomites';
 import { SkillsEnum } from '../skilling/types';
 import { getUsersCurrentSlayerInfo } from '../slayer/slayerUtil';
 import { ActivityTaskData } from '../types/minions';
@@ -421,23 +421,9 @@ const tripFinishEffects: TripFinishEffect[] = [
 			if (!user.bank.has('Moonlight mutator')) return;
 			if (user.user.disabled_inventions.includes(InventionID.MoonlightMutator)) return;
 
-			const loot = new Bank();
-			const cost = new Bank();
-
 			const minutes = Math.floor(data.duration / Time.Minute);
 			if (minutes < 1) return;
-			for (let i = 0; i < minutes; i++) {
-				if (roll(zygomiteSeedMutChance)) {
-					const randomZyg = randArrItem(zygomiteFarmingSource.filter(z => z.lootTable !== null));
-					const sourceSeed = randomZyg.mutatedFromItems?.roll();
-					if (!sourceSeed || !user.bank.has(sourceSeed.item.id)) continue;
-					cost.add(sourceSeed.item.id);
-
-					if (roll(sourceSeed.surivalChance)) {
-						loot.add(randomZyg.seedItem);
-					}
-				}
-			}
+			const { loot, cost } = calculateZygomiteLoot(minutes, user.bank);
 
 			if (cost.length > 0 || loot.length > 0) {
 				if (cost.length > 0 && !user.bank.has(cost)) {

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -432,7 +432,7 @@ const tripFinishEffects: TripFinishEffect[] = [
 					if (!sourceSeed || !user.bank.has(sourceSeed.item.id)) continue;
 					cost.add(sourceSeed.item.id);
 
-					if (roll(sourceSeed.mutationChance)) {
+					if (roll(sourceSeed.surivalChance)) {
 						loot.add(randomZyg.seedItem);
 					}
 				}

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -1,7 +1,7 @@
 import { mentionCommand } from '@oldschoolgg/toolkit';
 import { activity_type_enum } from '@prisma/client';
 import { AttachmentBuilder, bold, ButtonBuilder, MessageCollector, MessageCreateOptions } from 'discord.js';
-import { notEmpty, randArrItem, randInt, roll, shuffleArr, Time } from 'e';
+import { notEmpty, randArrItem, randInt, roll, Time } from 'e';
 import { Bank } from 'oldschooljs';
 
 import { alching } from '../../mahoji/commands/laps';
@@ -23,11 +23,7 @@ import { mysteriousStepData } from '../mysteryTrail';
 import { triggerRandomEvent } from '../randomEvents';
 import { RuneTable, WilvusTable, WoodTable } from '../simulation/seedTable';
 import { DougTable, PekyTable } from '../simulation/sharedTables';
-import {
-	zygomiteFarmingSource,
-	zygomiteMutSurvivalChance,
-	zygomiteSeedMutChance
-} from '../skilling/skills/farming/zygomites';
+import { zygomiteFarmingSource, zygomiteSeedMutChance } from '../skilling/skills/farming/zygomites';
 import { SkillsEnum } from '../skilling/types';
 import { getUsersCurrentSlayerInfo } from '../slayer/slayerUtil';
 import { ActivityTaskData } from '../types/minions';
@@ -432,11 +428,11 @@ const tripFinishEffects: TripFinishEffect[] = [
 			if (minutes < 1) return;
 			for (let i = 0; i < minutes; i++) {
 				if (roll(zygomiteSeedMutChance)) {
-					const ownedSeed = shuffleArr(randomZyg.mutatedFromItems!).find(seed => user.bank.has(seed));
-					if (!ownedSeed) continue;
-					cost.add(ownedSeed);
+					const sourceSeed = randomZyg.mutatedFromItems?.roll();
+					if (!sourceSeed || !user.bank.has(sourceSeed.item.id)) continue;
+					cost.add(sourceSeed.item.id);
 
-					if (roll(zygomiteMutSurvivalChance)) {
+					if (roll(sourceSeed.mutationChance)) {
 						loot.add(randomZyg.seedItem);
 					}
 				}

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -420,7 +420,7 @@ const tripFinishEffects: TripFinishEffect[] = [
 		fn: async ({ data, user, messages }) => {
 			if (!user.bank.has('Moonlight mutator')) return;
 			if (user.user.disabled_inventions.includes(InventionID.MoonlightMutator)) return;
-			const randomZyg = randArrItem(zygomiteFarmingSource.filter(z => z.lootTable !== null));
+
 			const loot = new Bank();
 			const cost = new Bank();
 
@@ -428,6 +428,7 @@ const tripFinishEffects: TripFinishEffect[] = [
 			if (minutes < 1) return;
 			for (let i = 0; i < minutes; i++) {
 				if (roll(zygomiteSeedMutChance)) {
+					const randomZyg = randArrItem(zygomiteFarmingSource.filter(z => z.lootTable !== null));
 					const sourceSeed = randomZyg.mutatedFromItems?.roll();
 					if (!sourceSeed || !user.bank.has(sourceSeed.item.id)) continue;
 					cost.add(sourceSeed.item.id);
@@ -450,9 +451,9 @@ const tripFinishEffects: TripFinishEffect[] = [
 				});
 
 				if (cost.length > 0 && loot.length === 0) {
-					messages.push(`<:moonlightMutator:1220590471613513780> Mutated ${cost} seeds, but all died`);
+					messages.push(`<:moonlightMutator:1220590471613513780> Mutated ${cost}, but all died`);
 				} else if (loot.length > 0) {
-					messages.push(`<:moonlightMutator:1220590471613513780> Mutated ${cost} seeds, ${loot} survived`);
+					messages.push(`<:moonlightMutator:1220590471613513780> Mutated ${cost}; ${loot} survived`);
 				}
 			}
 		}

--- a/tests/unit/zygomite.test.ts
+++ b/tests/unit/zygomite.test.ts
@@ -1,0 +1,29 @@
+import { Bank } from 'oldschooljs';
+import { describe, expect, test } from 'vitest';
+
+import { calculateZygomiteLoot, mutatedSourceItems } from '../../src/lib/skilling/skills/farming/zygomites';
+
+describe('Zygomites', () => {
+	const userBank = new Bank();
+	for (const seed of mutatedSourceItems) {
+		userBank.add(seed.item, 1_000_000);
+	}
+
+	test('Zygomite rates', () => {
+		const minutes = 10_000_000;
+		const { cost, loot } = calculateZygomiteLoot(minutes, userBank);
+		let totalZygSeeds = 0;
+		for (const [, qty] of loot.items()) {
+			totalZygSeeds += qty;
+		}
+		let totalCostSeeds = 0;
+		for (const [, qty] of cost.items()) {
+			totalCostSeeds += qty;
+		}
+
+		const successOdds = 1 / (totalZygSeeds / totalCostSeeds);
+		// Rate should be ~11.71
+		expect(successOdds).toBeGreaterThan(11);
+		expect(successOdds).toBeLessThan(12.5);
+	});
+});


### PR DESCRIPTION
### Description:

- Reworked Zygomites significantly, while keeping the overall rates as close as possible.
- I am very proud of this PR, I worked very hard to maintain the existing balance, while still improving the experience for everyone!

### Changes:

- The seeds chosen to be mutated now scale based on their rarity.
- The survival chance of mutated seeds also scales based on rarity (keeping overall rate roughly the same)
- Updates the rates command to calculate the weighted average and use that to display info.
- Improved some text to make it clearer and more readable.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:

- Now the seed to be mutated is chosen before the mutation. -- This critically prevents exploitation to acquire Zygomite seeds faster by stashing lower-level seeds away, because it will not 'force' the higher seeds to be used.
- If you don't have the seed it's chosen to mutate, you've lost your chance for that roll. This keeps the balance
