### PR TITLE
Wintertodt drygore axe

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -462,7 +462,8 @@ const source: [string, (string | number)[]][] = [
 	['Support cape', ['Completionist cape', 'Completionist cape (t)']],
 	["Artisan's cape", ['Completionist cape', 'Completionist cape (t)']],
 	['Log basket', ['Forestry basket']],
-	['Forestry kit', ['Forestry basket']]
+	['Forestry kit', ['Forestry basket']],
+	['Dwarven greataxe', ['Drygore axe']]
 ];
 
 // Make max cape count as all master capes

--- a/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
@@ -47,7 +47,7 @@ export async function wintertodtCommand(user: MUser, channelID: string) {
 
 	const boosts: string[] = [];
 
-	if (user.hasEquippedOrInBank(['Dwarven greataxe', 'Drygore Axe'], 'one')) {
+	if (user.hasEquippedOrInBank(['Dwarven greataxe', 'Drygore axe'], 'one')) {
 		durationPerTodt /= 2;
 		boosts.push('2x faster for Dwarven greataxe.');
 	}

--- a/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
@@ -47,7 +47,7 @@ export async function wintertodtCommand(user: MUser, channelID: string) {
 
 	const boosts: string[] = [];
 
-	if (user.hasEquippedOrInBank(['Dwarven greataxe', 'Drygore axe'], 'one')) {
+	if (user.hasEquippedOrInBank('Dwarven greataxe')) {
 		durationPerTodt /= 2;
 		boosts.push('2x faster for Dwarven greataxe.');
 	}

--- a/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
@@ -47,7 +47,7 @@ export async function wintertodtCommand(user: MUser, channelID: string) {
 
 	const boosts: string[] = [];
 
-	if (user.hasEquippedOrInBank('Dwarven greataxe')) {
+	if (user.hasEquippedOrInBank(['Dwarven greataxe', 'Drygore Axe'], 'one')) {
 		durationPerTodt /= 2;
 		boosts.push('2x faster for Dwarven greataxe.');
 	}


### PR DESCRIPTION
### Description:

Gives drygore axe the same boost at wintertodt as dwarven greataxe as it's an upgrade. Does not use materials. This is consistent with how the drygore axe functions with /chop.
Fixes https://github.com/oldschoolgg/oldschoolbot/issues/5850

### Changes:

Added drygore axe to hasEquippedOrInBank check. If you'd prefer similaritems let me know. Just not sure if this would be needed anywhere else.

It still shows "2x for Dwarven greataxe" regardless of which axe you have. But this is consistent with how /chop works when drygore axe is disabled. So don't think it's really an issue.

![Code_2024-04-29_16-13-27](https://github.com/oldschoolgg/oldschoolbot/assets/8431944/86f9ef50-895a-46f5-b298-701c6a759817)


### Other checks:

- [X] I have tested all my changes thoroughly.
