### PR TITLE
Group Masked kills by Monster group

### DIFF
--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -18,6 +18,7 @@ import resolveItems from '../util/resolveItems';
 import { autoslayModes } from './constants';
 import { slayerMasters } from './slayerMasters';
 import { SlayerRewardsShop, SlayerTaskUnlocksEnum } from './slayerUnlocks';
+import { allSlayerTasks } from './tasks';
 import { bossTasks } from './tasks/bossTasks';
 import { AssignableSlayerTask, SlayerMaster } from './types';
 
@@ -602,4 +603,13 @@ export async function isOnSlayerTask({
 		quantitySlayed,
 		...usersTask
 	};
+}
+
+export function getAllAlternateMonsters(options: { monster: Monster }): Monster[];
+export function getAllAlternateMonsters(options: { monsterId: number }): number[];
+export function getAllAlternateMonsters(options: { monster: Monster } | { monsterId: number }) {
+	const useMonster = 'monster' in options;
+	const monsterId = useMonster ? options.monster.id : options.monsterId;
+	const monsters = allSlayerTasks.map(task => (task.monsters.includes(monsterId) ? task.monsters : [])).flat(2);
+	return useMonster ? Monsters.filter(m => monsters.includes(m.id)).map(m => m) : monsters;
 }

--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -30,7 +30,7 @@ import { prisma } from '../../../lib/settings/prisma';
 import Agility from '../../../lib/skilling/skills/agility';
 import { Castables } from '../../../lib/skilling/skills/magic/castables';
 import { ForestryEvents } from '../../../lib/skilling/skills/woodcutting/forestry';
-import { getSlayerTaskStats } from '../../../lib/slayer/slayerUtil';
+import { getAllAlternateMonsters, getCommonTaskName, getSlayerTaskStats } from '../../../lib/slayer/slayerUtil';
 import { sorts } from '../../../lib/sorts';
 import { InfernoOptions } from '../../../lib/types/minions';
 import { formatDuration, getUsername, sanitizeBank, SQL_sumOfAllCLItems, stringMatches } from '../../../lib/util';
@@ -1365,14 +1365,32 @@ ${bank
 		}
 	},
 	{
-		name: 'Slayer Masks',
+		name: 'Slayer Masks - Progress',
+		perkTierNeeded: null,
+		run: async (_, userStats) => {
+			return slayerMaskHelms
+				.map(mask => {
+					const monster = Monsters.find(m => m.id === mask.monsters[0])!;
+					const className = getCommonTaskName(monster);
+					const compatibleMons = getAllAlternateMonsters({ monsterId: monster.id });
+					const totalKills = sumArr(
+						Object.entries(userStats.on_task_with_mask_monster_scores as ItemBank)
+							.filter(score => compatibleMons.includes(Number(score[0])))
+							.map(i => i[1])
+					);
+					return `${className}: ${totalKills} kills towards mask, ${mask.killsRequiredForUpgrade} needed`;
+				})
+				.join('\n');
+		}
+	},
+	{
+		name: 'Slayer Masks - All kills',
 		perkTierNeeded: null,
 		run: async (_, userStats) => {
 			return Object.entries(userStats.on_task_with_mask_monster_scores as ItemBank)
 				.map(i => {
 					const monster = Monsters.find(m => m.id === Number(i[0]))!;
-					const mask = slayerMaskHelms.find(m => m.monsters.includes(monster.id))!;
-					return `${monster.name}: ${i[1]} kills towards mask, ${mask.killsRequiredForUpgrade} needed`;
+					return `${monster.name}: ${i[1]} masked kills`;
 				})
 				.join('\n');
 		}
@@ -1494,7 +1512,7 @@ ${unluckiest
 			const result = await calculateXPSources(user);
 			return {
 				content: `You have gained....
-				
+
 ${Object.entries(result)
 	.map(i => `${i[0]}: ${i[1].toLocaleString()} XP`)
 	.join('\n')}`


### PR DESCRIPTION
### Description:

- Currently, the `/data name:Slayer Masks` command shows things like,
```
Dagannoth: 300 kills towards mask, 3400 needed
Dagannoth Rex: 555 kills towards mask, 3400 needed
Dagannoth Supreme: 33 kills towards mask, 3400 needed
```

### Changes:

- Splits the existing data point into 2 new data points:
- `Slayer Masks - Progress`: Groups the monsters by Task/"Monster Class", and shows combined total
- `Slayer Masks - All Kills`: Shows detailed breakdown of how many kills per-monster you have while masked.

### Other checks:

- [x] I have tested all my changes thoroughly.


### Examples:

Current:
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/06ad5620-78d8-4348-8e9d-0c2436d2ba21)

New:
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/bdd17077-b3b4-4099-a117-a39861c6136a)

