### PR TITLE
Fix Pie Chart to show the data values.

### DIFF
--- a/src/lib/util/chart.ts
+++ b/src/lib/util/chart.ts
@@ -1,5 +1,6 @@
 import type { ChartConfiguration } from 'chart.js';
 import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 const width = 1000; // px
 const height = 500; // px
@@ -40,7 +41,8 @@ export async function pieChart(title: string, format: (value: any) => string, va
 					}
 				}
 			}
-		}
+		},
+		plugins: [ChartDataLabels]
 	};
 	return generateChart(options);
 }

--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -405,7 +405,7 @@ GROUP BY data->>'monsterID';`);
 			const { percent } = calcCLDetails(user);
 			const attachment: Buffer = await pieChart(
 				'Your Personal Collection Log Progress',
-				val => `${toKMB(val)}%`,
+				val => `${val.toFixed(2)}%`,
 				[
 					['Complete Collection Log Items', percent, '#9fdfb2'],
 					['Incomplete Collection Log Items', 100 - percent, '#df9f9f']


### PR DESCRIPTION
### Description:

- Currently you can't see the % of completion on the Pie Chart

### Changes:

- Updates the formatter function to show the % correctly, instead of trying to use toKMB
- Loads the plugin, because currently the plugin's settings were being used, but the plugin not loaded, so it was failing.

### Other checks:

- [x] I have tested all my changes thoroughly.

### Testing:
Current/old:
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/91d09c53-b3ae-40a2-8fe0-46d9301deca7)

Fixed/new:
![image](https://github.com/oldschoolgg/oldschoolbot/assets/10122432/d10508df-98ff-453c-b36f-316c7accf08c)
