### PR TITLE
Irons can get Random Box Spawns again

### DIFF
--- a/src/lib/boxSpawns.ts
+++ b/src/lib/boxSpawns.ts
@@ -262,9 +262,7 @@ export async function boxSpawnHandler(msg: Message) {
 	);
 	let wonStr = `This is your ${formatOrdinal(newStats.main_server_challenges_won)} challenge win!`;
 	const loot = roll(20) ? LampTable.roll() : MysteryBoxes.roll();
-	if (!winnerUser.isIronman) {
-		await winnerUser.addItemsToBank({ items: loot, collectionLog: true });
-		return msg.channel.send(`Congratulations, ${winner}! You received: **${loot}**. ${wonStr}`);
-	}
-	return msg.channel.send(`Congratulations, ${winner}! You won! But you stand alone, no ${loot} for you. ${wonStr}`);
+
+	await winnerUser.addItemsToBank({ items: loot, collectionLog: true });
+	return msg.channel.send(`Congratulations, ${winner}! You received: **${loot}**. ${wonStr}`);
 }


### PR DESCRIPTION
### Description:

After polling successfully, Ironmen will be able to get the period box spawns again, if they win :)

### Changes:

- Removes ironman check

### Other checks:

- [x] I have tested all my changes thoroughly.
