### PR TITLE
Make Divine hand work from bank when Converting to Energy

### DIFF
--- a/src/lib/invention/inventions.ts
+++ b/src/lib/invention/inventions.ts
@@ -441,7 +441,7 @@ export const Inventions: readonly Invention[] = [
 			strong: 1
 		}),
 		itemCost: null,
-		flags: ['equipped'],
+		flags: ['bank'],
 		inventionLevelNeeded: 100,
 		usageCostMultiplier: 1
 	},


### PR DESCRIPTION
### Description:

- The code for Divination was changed recently to try using Divine hand from the bank if converting to energy.

However, the invention was not updated to allow bank access, so this fails to work.

Wisp buster still must be equipped to work, and takes priority over the DH.

### Changes:

- Changed 'equipped' to 'bank' flag.

### Other checks:

- [x] I have tested all my changes thoroughly.
