### PR TITLE
Filter out completed quests

### DIFF
--- a/src/mahoji/commands/activities.ts
+++ b/src/mahoji/commands/activities.ts
@@ -1,3 +1,4 @@
+import { User } from 'discord.js';
 import { ApplicationCommandOptionType, CommandRunOptions } from 'mahoji';
 
 import {
@@ -173,7 +174,15 @@ export const activitiesCommand: OSBMahojiCommand = {
 					type: ApplicationCommandOptionType.String,
 					name: 'name',
 					description: 'The name of the quest (optional).',
-					choices: quests.map(i => ({ name: i.name, value: i.name })),
+					autocomplete: async (_value: string, user: User) => {
+						const mUser = await mUserFetch(user.id);
+						let list = quests
+							.filter(i => !mUser.user.finished_quest_ids.includes(i.id))
+							.map(i => ({ name: i.name, value: i.name }));
+						if (list.length === 0)
+							list = quests.map(i => ({ name: `${i.name} (completed)`, value: i.name }));
+						return list;
+					},
 					required: false
 				}
 			]


### PR DESCRIPTION
When doing activities quest and picking a quest, currently it just shows all the quests and it's hard to keep track of what's completed and what isn't.

Following the #bso-vote poll, this hides the quests you have completed from the list and only shows ones you haven't completed. Then when every quest is completed it shows (completed) at the end instead of providing an empty list.

![image](https://github.com/oldschoolgg/oldschoolbot/assets/79149170/8b64d0f4-00a1-435d-8512-3ef4fb4bcff5)

- [x] I have tested all my changes thoroughly.
