### PR TITLE
Fix recently killed monster list

### DIFF
--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -40,11 +40,13 @@ export const autocompleteMonsters = [
 
 async function fetchUsersRecentlyKilledMonsters(userID: string) {
 	const res = await prisma.$queryRawUnsafe<{ mon_id: string }[]>(
-		`SELECT DISTINCT((data->>'monsterID')) AS mon_id
+		`SELECT DISTINCT((data->>'monsterID')) AS mon_id, MAX(start_date)
 FROM activity
 WHERE user_id = $1
 AND type = 'MonsterKilling'
 AND finish_date > now() - INTERVAL '31 days'
+GROUP BY 1
+ORDER BY 2 DESC
 LIMIT 10;`,
 		BigInt(userID)
 	);

--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -39,8 +39,8 @@ export const autocompleteMonsters = [
 ];
 
 async function fetchUsersRecentlyKilledMonsters(userID: string) {
-	const res = await prisma.$queryRawUnsafe<{ mon_id: string }[]>(
-		`SELECT DISTINCT((data->>'monsterID')) AS mon_id, MAX(start_date)
+	const res = await prisma.$queryRawUnsafe<{ mon_id: string; last_killed: Date }[]>(
+		`SELECT DISTINCT((data->>'monsterID')) AS mon_id, MAX(start_date) as last_killed
 FROM activity
 WHERE user_id = $1
 AND type = 'MonsterKilling'
@@ -50,7 +50,7 @@ ORDER BY 2 DESC
 LIMIT 10;`,
 		BigInt(userID)
 	);
-	return new Set(res.map(i => Number(i.mon_id)));
+	return res.map(i => Number(i.mon_id));
 }
 
 export const minionKCommand: OSBMahojiCommand = {
@@ -75,15 +75,17 @@ export const minionKCommand: OSBMahojiCommand = {
 							: [m.name.toLowerCase(), ...m.aliases].some(str => str.includes(value.toLowerCase()))
 					)
 					.sort((a, b) => {
-						const hasA = recentlyKilled.has(a.id);
-						const hasB = recentlyKilled.has(b.id);
-						if (hasA && hasB) return 0;
+						const hasA = recentlyKilled.includes(a.id);
+						const hasB = recentlyKilled.includes(b.id);
+						if (hasA && hasB) {
+							return recentlyKilled.indexOf(a.id) < recentlyKilled.indexOf(b.id) ? -1 : 1;
+						}
 						if (hasA) return -1;
 						if (hasB) return 1;
 						return 0;
 					})
 					.map(i => ({
-						name: `${i.name}${recentlyKilled.has(i.id) ? ' (Recently killed)' : ''}`,
+						name: `${i.name}${recentlyKilled.includes(i.id) ? ' (Recently killed)' : ''}`,
 						value: i.name
 					}));
 			}


### PR DESCRIPTION
### Description:

Currently, often the most recent monsters don't even show up in the recently killed list, because it takes a 31 day sample, and then limits the results to 10, without any consideration of the recency of the kills.

### Changes:

- Orders the Recently killed monsters by their most recent kill date

### Other checks:

- [x] I have tested all my changes thoroughly.
