### PR TITLE
[TESTED] added minigame score tracking for Turaels Trials

### DIFF
--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -54,7 +54,9 @@ export const turaelsTrialsTask: MinionTask = {
 		return handleTripFinish(
 			user,
 			channelID,
-			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. **Your new total is __${newScore}__**. ${xpResults.join(', ')}`,
+			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. **Your new total is __${newScore}__**. ${xpResults.join(
+				', '
+			)}`,
 			undefined,
 			data,
 			result.loot

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -54,7 +54,7 @@ export const turaelsTrialsTask: MinionTask = {
 		return handleTripFinish(
 			user,
 			channelID,
-			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. Your new total is ${newScore}. ${xpResults.join(', ')}`,
+			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. **Your new total is __${newScore}__**. ${xpResults.join(', ')}`,
 			undefined,
 			data,
 			result.loot

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -38,7 +38,7 @@ export const turaelsTrialsTask: MinionTask = {
 
 		const result = calculateTuraelsTrialsResult({ quantity, method });
 
-		const { newScore } = await incrementMinigameScore(userID, 'TuraelsTrials', quantity);
+		const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
 
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);
@@ -54,7 +54,7 @@ export const turaelsTrialsTask: MinionTask = {
 		return handleTripFinish(
 			user,
 			channelID,
-			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. ${xpResults.join(', ')}`,
+			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. Your new total is ${newScore}. ${xpResults.join(', ')}`,
 			undefined,
 			data,
 			result.loot

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -55,7 +55,7 @@ export const turaelsTrialsTask: MinionTask = {
 			user.id,
 			{
 				turaels_trials: {
-					increment: quantity
+					increment: number
 				}
 			},
 			{}

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -38,7 +38,7 @@ export const turaelsTrialsTask: MinionTask = {
 
 		const result = calculateTuraelsTrialsResult({ quantity, method });
 
-const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
+		const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
 
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -37,7 +37,7 @@ export const turaelsTrialsTask: MinionTask = {
 		const user = await mUserFetch(userID);
 
 		const result = calculateTuraelsTrialsResult({ quantity, method });
-		
+
 		await incrementMinigameScore(user.id, 'turaels_trials', quantity);
 
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -54,7 +54,7 @@ export const turaelsTrialsTask: MinionTask = {
 		await userStatsUpdate(
 			user.id,
 			{
-				superiors_slain: {
+				turaels_trials: {
 					increment: quantity
 				}
 			},

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -54,8 +54,8 @@ export const turaelsTrialsTask: MinionTask = {
 		await userStatsUpdate(
 			user.id,
 			{
-				turaels_trials: {
-					increment: number
+				TuraelsTrials: {
+					increment: quantity
 				}
 			},
 			{}

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -38,11 +38,7 @@ export const turaelsTrialsTask: MinionTask = {
 
 		const result = calculateTuraelsTrialsResult({ quantity, method });
 
-<<<<<<< HEAD
-		const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
-=======
 		const { newScore } = await incrementMinigameScore(userID, 'TuraelsTrials', quantity);
->>>>>>> b63059a02 (fixed mistake)
 
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -38,7 +38,7 @@ export const turaelsTrialsTask: MinionTask = {
 
 		const result = calculateTuraelsTrialsResult({ quantity, method });
 
-		await incrementMinigameScore(user.id, 'turaels_trials', quantity);
+const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
 
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);
@@ -50,16 +50,6 @@ export const turaelsTrialsTask: MinionTask = {
 			minimal: true,
 			source: 'TuraelsTrials'
 		});
-
-		await userStatsUpdate(
-			user.id,
-			{
-				TuraelsTrials: {
-					increment: quantity
-				}
-			},
-			{}
-		);
 
 		return handleTripFinish(
 			user,

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -1,8 +1,8 @@
 import { Bank } from 'oldschooljs';
 
 import { TuraelsTrialsMethod } from '../../../lib/bso/turaelsTrials';
-import { XPBank } from '../../../lib/structures/Banks';
 import { incrementMinigameScore } from '../../../lib/settings/settings';
+import { XPBank } from '../../../lib/structures/Banks';
 import { TuraelsTrialsOptions } from '../../../lib/types/minions';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { trackClientBankStats, userStatsBankUpdate } from '../../../mahoji/mahojiSettings';

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -54,7 +54,7 @@ export const turaelsTrialsTask: MinionTask = {
 		return handleTripFinish(
 			user,
 			channelID,
-			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. **Your new total is __${newScore}__**. ${xpResults.join(
+			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. **Your KC is: __${newScore}__**. ${xpResults.join(
 				', '
 			)}`,
 			undefined,

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -5,7 +5,7 @@ import { incrementMinigameScore } from '../../../lib/settings/settings';
 import { XPBank } from '../../../lib/structures/Banks';
 import { TuraelsTrialsOptions } from '../../../lib/types/minions';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
-import { trackClientBankStats, userStatsBankUpdate, userStatsUpdate } from '../../../mahoji/mahojiSettings';
+import { trackClientBankStats, userStatsBankUpdate } from '../../../mahoji/mahojiSettings';
 
 export function calculateTuraelsTrialsResult({ quantity, method }: { quantity: number; method: TuraelsTrialsMethod }) {
 	const loot = new Bank();
@@ -38,7 +38,11 @@ export const turaelsTrialsTask: MinionTask = {
 
 		const result = calculateTuraelsTrialsResult({ quantity, method });
 
+<<<<<<< HEAD
 		const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
+=======
+		const { newScore } = await incrementMinigameScore(userID, 'TuraelsTrials', quantity);
+>>>>>>> b63059a02 (fixed mistake)
 
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -2,6 +2,7 @@ import { Bank } from 'oldschooljs';
 
 import { TuraelsTrialsMethod } from '../../../lib/bso/turaelsTrials';
 import { XPBank } from '../../../lib/structures/Banks';
+import { incrementMinigameScore } from '../../../lib/settings/settings';
 import { TuraelsTrialsOptions } from '../../../lib/types/minions';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { trackClientBankStats, userStatsBankUpdate } from '../../../mahoji/mahojiSettings';
@@ -39,6 +40,7 @@ export const turaelsTrialsTask: MinionTask = {
 
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);
+		await incrementMinigameScore(user.id, 'turaels_trials', quantity);
 		await userStatsBankUpdate(user.id, 'turaels_trials_loot_bank', result.loot);
 
 		const xpResults: string[] = await user.addXPBank({


### PR DESCRIPTION
### Description:

`/minion kc`, `/lb minigames minigame:turaels trials` & return message now track score.

### Changes:

- added incrementMinigameScore.
- added score total to return message and made it bold

### Other checks:

- [x] I have tested all my changes thoroughly.
![SmartSelect_20240519_073016_Discord](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/3b5c02b5-07d7-4b2e-840b-178348bff794) 
![SmartSelect_20240519_080230_Discord](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/e265b01e-44c6-4522-baec-4f4abc68a414)
