### PR TITLE
Fix broken Lamp command from missing item

### DIFF
--- a/src/mahoji/lib/abstracted_commands/lampCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lampCommand.ts
@@ -84,12 +84,13 @@ export const XPLamps: IXPLamp[] = [
 		minimumLevel: 1,
 		allowedSkills: [SkillsEnum.Magic]
 	},
+	/*	Needs OSJS Update
 	{
 		itemID: 28_820,
 		amount: 5000,
 		name: 'Antique lamp (defender of varrock)',
 		minimumLevel: 1
-	},
+	},*/
 	{
 		itemID: itemID('Antique lamp (easy ca)'),
 		amount: 5000,


### PR DESCRIPTION
### Description:

`/minion lamp` command is broken in OSB + BSO because of a missing item...

### Changes:

- comments out the code dependent on the missing item until the next OSJS udpate

### Other checks:

- [x] I have tested all my changes thoroughly.
