### PR TITLE
Boost 'Plated' materials rate from Metals class (primarily bars)

### DIFF
--- a/src/lib/invention/groups/Metals.ts
+++ b/src/lib/invention/groups/Metals.ts
@@ -24,5 +24,5 @@ export const Metals: DisassemblySourceGroup = {
 		{ item: i('Rune dart tip'), lvl: 9 },
 		{ item: i('Dragon dart tip'), lvl: 80, flags: new Set(['orikalkum']) }
 	],
-	parts: { strong: 10, plated: 10, heavy: 10, metallic: 70 }
+	parts: { strong: 10, plated: 20, heavy: 10, metallic: 60 }
 };


### PR DESCRIPTION
### Description:

- Increases rate of `Plated` materials from Metals class (mostly metal bars) from 10% to 20%
- Decreases rate of `Metallic` materials from 70% to 60%

### Other checks:

- [x] I have tested all my changes thoroughly.
