### PR TITLE
Reworded Turaels Trials KC return trip message

### DIFF
--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -58,7 +58,7 @@ export const turaelsTrialsTask: MinionTask = {
 			channelID,
 			`${user}, your minion finished slaying ${quantity}x superiors in ${name}.\n**Your ${name} KC is now ${newScore}**.\n\n${xpResults.join(
 				', '
-			)}`,
+			)}\n`,
 			undefined,
 			data,
 			result.loot

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -40,8 +40,6 @@ export const turaelsTrialsTask: MinionTask = {
 
 		const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
 
-		const name = 'Turaels Trials';
-
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);
 		await userStatsBankUpdate(user.id, 'turaels_trials_loot_bank', result.loot);
@@ -56,7 +54,7 @@ export const turaelsTrialsTask: MinionTask = {
 		return handleTripFinish(
 			user,
 			channelID,
-			`${user}, your minion finished slaying ${quantity}x superiors in ${name}.\n**Your ${name} KC is now ${newScore}**.\n\n${xpResults.join(
+			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials.\n**Your Turaels Trials KC is now ${newScore}**.\n\n${xpResults.join(
 				', '
 			)}\n`,
 			undefined,

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -56,7 +56,7 @@ export const turaelsTrialsTask: MinionTask = {
 			channelID,
 			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials.\n**Your Turaels Trials KC is now ${newScore}**.\n\n${xpResults.join(
 				', '
-			)}\n`,
+			)}`,
 			undefined,
 			data,
 			result.loot

--- a/src/tasks/minions/bso/turaelsTrialsActivity.ts
+++ b/src/tasks/minions/bso/turaelsTrialsActivity.ts
@@ -40,6 +40,8 @@ export const turaelsTrialsTask: MinionTask = {
 
 		const { newScore } = await incrementMinigameScore(userID, 'turaels_trials', quantity);
 
+		const name = 'Turaels Trials';
+
 		await user.addItemsToBank({ items: result.loot, collectionLog: true });
 		await trackClientBankStats('turaels_trials_loot_bank', result.loot);
 		await userStatsBankUpdate(user.id, 'turaels_trials_loot_bank', result.loot);
@@ -54,7 +56,7 @@ export const turaelsTrialsTask: MinionTask = {
 		return handleTripFinish(
 			user,
 			channelID,
-			`${user}, your minion finished slaying ${quantity}x superiors in Turaels Trials. **Your KC is: __${newScore}__**. ${xpResults.join(
+			`${user}, your minion finished slaying ${quantity}x superiors in ${name}.\n**Your ${name} KC is now ${newScore}**.\n\n${xpResults.join(
 				', '
 			)}`,
 			undefined,


### PR DESCRIPTION
### Description:

this is a resubmit of #5886
reformatted the way the trip return says the users total kc.

### Changes:

- added line breaks between the return message and xp, and also between xp and messages below


### Other checks:
<details>
<summary></summary>

- [x] I have tested all my changes
![SmartSelect_20240521_235624_Discord](https://github.com/oldschoolgg/oldschoolbot/assets/133211494/8afe7497-9218-4835-b80c-897f1680c409)
</details>


<!--
ELLIPSIS_HIDDEN
-->


----
<details>
<summary>Ellipsis</summary>
| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fcc6af8dc776c064071e9f48144da413b00d1664  | 
|--------|

### Summary:
This PR improves the return message format in 'turaelsTrialsActivity.ts' for better readability and clarity after completing a Turaels Trials task.

**Key points**:
- Modified `turaelsTrialsActivity.ts`.
- Reformatted return message for clarity.
- Added line breaks in return message for better readability.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
</details>


<!--
ELLIPSIS_HIDDEN
-->
