### PR TITLE
Defer interactions from Global buttons

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -325,6 +325,14 @@ export async function interactionHook(interaction: Interaction) {
 	const id = interaction.customId;
 	const userID = interaction.user.id;
 
+	const cd = Cooldowns.get(userID, 'button', Time.Second * 3);
+	if (cd !== null) {
+		return interactionReply(interaction, {
+			content: `You're on cooldown from clicking buttons, please wait: ${formatDuration(cd, true)}.`,
+			ephemeral: true
+		});
+	}
+
 	await deferInteraction(interaction);
 
 	const user = await mUserFetch(userID);
@@ -354,14 +362,6 @@ export async function interactionHook(interaction: Interaction) {
 		interaction,
 		continueDeltaMillis: null
 	};
-
-	const cd = Cooldowns.get(userID, 'button', Time.Second * 3);
-	if (cd !== null) {
-		return interactionReply(interaction, {
-			content: `You're on cooldown from clicking buttons, please wait: ${formatDuration(cd, true)}.`,
-			ephemeral: true
-		});
-	}
 
 	const timeSinceMessage = Date.now() - new Date(interaction.message.createdTimestamp).getTime();
 	const timeLimit = reactionTimeLimit(user.perkTier());

--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -15,7 +15,7 @@ import { toaHelpCommand } from '../simulation/toa';
 import { ItemBank } from '../types';
 import { formatDuration, stringMatches } from '../util';
 import { updateGiveawayMessage } from './giveaway';
-import { interactionReply } from './interactionReply';
+import { deferInteraction, interactionReply } from './interactionReply';
 import { minionIsBusy } from './minionIsBusy';
 import { fetchRepeatTrips, repeatTrip } from './repeatStoredTrip';
 
@@ -324,6 +324,8 @@ export async function interactionHook(interaction: Interaction) {
 	});
 	const id = interaction.customId;
 	const userID = interaction.user.id;
+
+	await deferInteraction(interaction);
 
 	const user = await mUserFetch(userID);
 	if (id.includes('GIVEAWAY_')) return giveawayButtonHandler(user, id, interaction);


### PR DESCRIPTION
### Description:

Currently, a lot of interactions (global button presses, like repeat trip, auto farm, etc) are not responding fast enough and are causing, 'application did not respond' errors which are causing data to be lost.

For example, auto farming contract often doesn't return in time, so you don't get to see what your seed pack loot was.

I put this before the call to mUserFetch, as I believe it's DB queries causing the delay, obviously I would love to solve the root issue, but this will help solve the problem for users while we look for a better solution.

### Changes:

- Adds `deferInteraction` to the top of the global button interaction hook to buy time to complete said tasks.

### Other checks:

- [x] I have tested all my changes thoroughly.
