### PR TITLE
Fix dye swap creatables

### DIFF
--- a/src/lib/data/creatables/guardiansOfTheRiftCreatables.ts
+++ b/src/lib/data/creatables/guardiansOfTheRiftCreatables.ts
@@ -108,38 +108,38 @@ export const guardiansOfTheRiftCreatables: Createable[] = [
 	// Dye swaps
 	{
 		name: 'Abyssal green dye (using Abyssal blue dye)',
-		inputItems: new Bank({ 'Abyssal green dye': 1 }),
-		outputItems: new Bank({ 'Abyssal blue dye': 1 }),
+		inputItems: new Bank({ 'Abyssal blue dye': 1 }),
+		outputItems: new Bank({ 'Abyssal green dye': 1 }),
 		noCl: true
 	},
 	{
 		name: 'Abyssal green dye (using Abyssal red dye)',
+		inputItems: new Bank({ 'Abyssal red dye': 1 }),
+		outputItems: new Bank({ 'Abyssal green dye': 1 }),
+		noCl: true
+	},
+	{
+		name: 'Abyssal blue dye (using Abyssal green dye)',
+		inputItems: new Bank({ 'Abyssal green dye': 1 }),
+		outputItems: new Bank({ 'Abyssal blue dye': 1 }),
+		noCl: true
+	},
+	{
+		name: 'Abyssal blue dye (using Abyssal red dye)',
+		inputItems: new Bank({ 'Abyssal red dye': 1 }),
+		outputItems: new Bank({ 'Abyssal blue dye': 1 }),
+		noCl: true
+	},
+	{
+		name: 'Abyssal red dye (using Abyssal green dye)',
 		inputItems: new Bank({ 'Abyssal green dye': 1 }),
 		outputItems: new Bank({ 'Abyssal red dye': 1 }),
 		noCl: true
 	},
 	{
-		name: 'Abyssal blue dye (using Abyssal green dye)',
-		inputItems: new Bank({ 'Abyssal blue dye': 1 }),
-		outputItems: new Bank({ 'Abyssal green dye': 1 }),
-		noCl: true
-	},
-	{
-		name: 'Abyssal blue dye (using Abyssal red dye)',
+		name: 'Abyssal red dye (using Abyssal blue dye)',
 		inputItems: new Bank({ 'Abyssal blue dye': 1 }),
 		outputItems: new Bank({ 'Abyssal red dye': 1 }),
-		noCl: true
-	},
-	{
-		name: 'Abyssal red dye (using Abyssal green dye)',
-		inputItems: new Bank({ 'Abyssal red dye': 1 }),
-		outputItems: new Bank({ 'Abyssal green dye': 1 }),
-		noCl: true
-	},
-	{
-		name: 'Abyssal red dye (using Abyssal blue dye)',
-		inputItems: new Bank({ 'Abyssal red dye': 1 }),
-		outputItems: new Bank({ 'Abyssal blue dye': 1 }),
 		noCl: true
 	}
 ];

--- a/src/lib/data/creatables/leagueCreatables.ts
+++ b/src/lib/data/creatables/leagueCreatables.ts
@@ -271,7 +271,7 @@ const voidOrnaments: Createable[] = [
 		outputItems: new Bank().add('Elite void robe (or)')
 	},
 	{
-		name: 'Revert Elite void robe (or))',
+		name: 'Revert Elite void robe (or)',
 		inputItems: new Bank({
 			'Elite void robe (or)': 1
 		}),

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -21474,7 +21474,7 @@ exports[`OSB Creatables 1`] = `
       },
       "frozen": false,
     },
-    "name": "Revert Elite void robe (or))",
+    "name": "Revert Elite void robe (or)",
     "noCl": true,
     "outputItems": Bank {
       "bank": {
@@ -22744,7 +22744,7 @@ exports[`OSB Creatables 1`] = `
     "cantHaveItems": undefined,
     "inputItems": Bank {
       "bank": {
-        "26807": 1,
+        "26809": 1,
       },
       "frozen": false,
     },
@@ -22752,7 +22752,7 @@ exports[`OSB Creatables 1`] = `
     "noCl": true,
     "outputItems": Bank {
       "bank": {
-        "26809": 1,
+        "26807": 1,
       },
       "frozen": false,
     },
@@ -22761,7 +22761,7 @@ exports[`OSB Creatables 1`] = `
     "cantHaveItems": undefined,
     "inputItems": Bank {
       "bank": {
-        "26807": 1,
+        "26811": 1,
       },
       "frozen": false,
     },
@@ -22769,7 +22769,7 @@ exports[`OSB Creatables 1`] = `
     "noCl": true,
     "outputItems": Bank {
       "bank": {
-        "26811": 1,
+        "26807": 1,
       },
       "frozen": false,
     },
@@ -22778,7 +22778,7 @@ exports[`OSB Creatables 1`] = `
     "cantHaveItems": undefined,
     "inputItems": Bank {
       "bank": {
-        "26809": 1,
+        "26807": 1,
       },
       "frozen": false,
     },
@@ -22786,7 +22786,7 @@ exports[`OSB Creatables 1`] = `
     "noCl": true,
     "outputItems": Bank {
       "bank": {
-        "26807": 1,
+        "26809": 1,
       },
       "frozen": false,
     },
@@ -22795,7 +22795,7 @@ exports[`OSB Creatables 1`] = `
     "cantHaveItems": undefined,
     "inputItems": Bank {
       "bank": {
-        "26809": 1,
+        "26811": 1,
       },
       "frozen": false,
     },
@@ -22803,7 +22803,7 @@ exports[`OSB Creatables 1`] = `
     "noCl": true,
     "outputItems": Bank {
       "bank": {
-        "26811": 1,
+        "26809": 1,
       },
       "frozen": false,
     },
@@ -22812,7 +22812,7 @@ exports[`OSB Creatables 1`] = `
     "cantHaveItems": undefined,
     "inputItems": Bank {
       "bank": {
-        "26811": 1,
+        "26807": 1,
       },
       "frozen": false,
     },
@@ -22820,7 +22820,7 @@ exports[`OSB Creatables 1`] = `
     "noCl": true,
     "outputItems": Bank {
       "bank": {
-        "26807": 1,
+        "26811": 1,
       },
       "frozen": false,
     },
@@ -22829,7 +22829,7 @@ exports[`OSB Creatables 1`] = `
     "cantHaveItems": undefined,
     "inputItems": Bank {
       "bank": {
-        "26811": 1,
+        "26809": 1,
       },
       "frozen": false,
     },
@@ -22837,7 +22837,7 @@ exports[`OSB Creatables 1`] = `
     "noCl": true,
     "outputItems": Bank {
       "bank": {
-        "26809": 1,
+        "26811": 1,
       },
       "frozen": false,
     },


### PR DESCRIPTION
### Description:
Fixes dye swap creatables having their input and output items swapped.
### Changes:
- Fix dye swap input/output items
- remove a duplicate bracket for Revert Elite void robe (or)
### Other checks:
- [X] I have tested all my changes thoroughly.
