### PR TITLE
Boost forestry uniques with Peky

### DIFF
--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -164,6 +164,7 @@ export const chopCommand: OSBMahojiCommand = {
 
 		let wcLvl = skills.woodcutting;
 		const farmingLvl = user.skillsAsLevels.farming;
+		const pekyBoost = user.usingPet('Peky');
 
 		// Ivy, Redwood logs, Logs, Sulliuscep, Farming patches, Woodcutting guild don't spawn forestry events
 		if (
@@ -188,7 +189,11 @@ export const chopCommand: OSBMahojiCommand = {
 				}
 			}
 		} else {
-			boosts.push('Participating in Forestry events');
+			boosts.push(
+				`Participating in Forestry events${
+					pekyBoost ? " (uniques are 5x as common thanks to Peky's help)" : ''
+				}`
+			);
 		}
 
 		// Default bronze axe, last in the array

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -27,8 +27,11 @@ async function handleForestry({ user, duration, loot }: { user: MUser; duration:
 	let strForestry = '';
 	const userWcLevel = user.skillLevel(SkillsEnum.Woodcutting);
 	const chanceWcLevel = Math.min(userWcLevel, 99);
-	const eggChance = Math.ceil(2700 - ((chanceWcLevel - 1) * (2700 - 1350)) / 98);
-	const whistleChance = Math.ceil(90 - ((chanceWcLevel - 1) * (90 - 45)) / 98);
+
+	const pekyBoost = user.usingPet('Peky') ? 5 : 1;
+	const eggChance = Math.ceil((2700 - ((chanceWcLevel - 1) * (2700 - 1350)) / 98) / pekyBoost);
+	const whistleChance = Math.ceil((90 - ((chanceWcLevel - 1) * (90 - 45)) / 98) / pekyBoost);
+	const garlandChance = Math.ceil(50 / pekyBoost);
 
 	perTimeUnitChance(duration, 20, Time.Minute, async () => {
 		const eventIndex = randInt(0, ForestryEvents.length - 1);
@@ -98,7 +101,7 @@ async function handleForestry({ user, duration, loot }: { user: MUser; duration:
 				break;
 			case 8: // Enchantment Ritual
 				eventInteraction = randInt(6, 8); // ritual circles
-				if (roll(50)) {
+				if (roll(garlandChance)) {
 					loot.add('Petal garland');
 				}
 				eventCounts[event.id]++;


### PR DESCRIPTION
### Description:
Assign a new perk to Peky to increase the chance of receiving the three rare forestry cl items.
bso-vote thread: https://discord.com/channels/342983479501389826/1032668754561224734/1233200327788859483
### Changes:
- add a 5x increased chance to receive Fox whistle, Golden pheasant egg, Petal garland when their respective events spawn and the user has peky equipped.
- add a pre-trip message to show that peky is boosting the unique items chance
### Other checks:
- [X] I have tested all my changes thoroughly.
