### PR TITLE
Clean up BSO wintertodt messages

### DIFF
--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -18,6 +18,7 @@ export const wintertodtTask: MinionTask = {
 	async run(data: ActivityTaskOptionsWithQuantity) {
 		const { userID, channelID, quantity, duration } = data;
 		const user = await mUserFetch(userID);
+		const hasMasterCape = user.hasEquippedOrInBank('Firemaking master cape');
 
 		let loot = new Bank();
 
@@ -105,7 +106,7 @@ export const wintertodtTask: MinionTask = {
 		if (flappyRes.shouldGiveBoost) {
 			loot.multiply(2);
 		}
-		if (user.hasEquippedOrInBank('Firemaking master cape')) {
+		if (hasMasterCape) {
 			loot.multiply(2);
 		}
 
@@ -114,7 +115,7 @@ export const wintertodtTask: MinionTask = {
 			collectionLog: true,
 			itemsToAdd: loot
 		});
-		incrementMinigameScore(user.id, 'wintertodt', quantity);
+		await incrementMinigameScore(user.id, 'wintertodt', quantity);
 
 		const image = await makeBankImage({
 			bank: itemsAdded,
@@ -122,7 +123,11 @@ export const wintertodtTask: MinionTask = {
 			previousCL
 		});
 
-		let output = `${user}, ${user.minionName} finished subduing Wintertodt ${quantity}x times. ${xpStr}, you cut ${numberOfRoots}x Bruma roots.`;
+		let output = `${user}, ${
+			user.minionName
+		} finished subduing Wintertodt ${quantity}x times. ${xpStr}, you cut ${numberOfRoots}x Bruma roots${
+			hasMasterCape ? ', 2x loot for Firemaking master cape.' : '.'
+		}`;
 
 		if (fmBonusXP > 0) {
 			output += `\n\n**Firemaking Bonus XP:** ${fmBonusXP.toLocaleString()}`;
@@ -149,6 +154,6 @@ export const wintertodtTask: MinionTask = {
 			]
 		});
 
-		handleTripFinish(user, channelID, output, image.file.attachment, data, itemsAdded);
+		return handleTripFinish(user, channelID, output, image.file.attachment, data, itemsAdded);
 	}
 };


### PR DESCRIPTION
### Description:
Clean up BSO wintertodt messages
### Changes:
- put all boosts on the same line after "Boosts:"
- put all food related messages on the same line after "Food:"
- remove redundant warm clothing message from showing twice
- add "2x loot for Firemaking master cape" to the return trip message when the user has their loot doubled by the firemaking master cape.
- add an await to incrementMinigameScore and return to handleTripFinish to remove two warnings.
### Other checks:
before:
![Discord_v4ACRIHRo5](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/a4a0e4bf-e711-49bf-b481-adf5bfa80d03)
after:
![Discord_yMfRzqveF9](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/983ee36d-b14b-4d17-bb06-4cf5045a830d)
- [X] I have tested all my changes thoroughly.
