### PR TITLE
Add economy tracking for GE Bank + Big Alchables.

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,8 @@ model Analytic {
   ironMinionsCount   Int?
   totalSacrificed    BigInt?
   totalGP            BigInt?
+  totalGeGp          BigInt?
+  totalBigAlchGp     BigInt?
   dicingBank         BigInt?
   duelTaxBank        BigInt?
   dailiesAmount      BigInt?


### PR DESCRIPTION
### Description:

- Adds analytic stats for GE Bank + "Big Alchables" stored in banks; ie. Magical Artifact and Demon statuette



### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:
- Requires DB Push / sync
