### PR TITLE
Add quantity owned to /ge sell

### DIFF
--- a/src/mahoji/commands/ge.ts
+++ b/src/mahoji/commands/ge.ts
@@ -17,7 +17,7 @@ import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmatio
 import { deferInteraction } from '../../lib/util/interactionReply';
 import itemIsTradeable from '../../lib/util/itemIsTradeable';
 import { cancelGEListingCommand } from '../lib/abstracted_commands/cancelGEListingCommand';
-import { itemOption, ownedItemOption, tradeableItemArr } from '../lib/mahojiCommandOptions';
+import { itemOption, tradeableItemArr } from '../lib/mahojiCommandOptions';
 import { OSBMahojiCommand } from '../lib/util';
 
 export type GEListingWithTransactions = GEListing & {
@@ -130,10 +130,19 @@ export const geCommand: OSBMahojiCommand = {
 			description: 'Sell something on the grand exchange.',
 			options: [
 				{
-					...ownedItemOption(item => Boolean(item.tradeable_on_ge)),
 					name: 'item',
+					type: ApplicationCommandOptionType.String,
 					description: 'The item you want to sell.',
-					required: true
+					required: true,
+					autocomplete: async (value, { id }) => {
+						const user = await mUserFetch(id);
+
+						return user.bank
+							.items()
+							.filter(i => i[0].tradeable_on_ge)
+							.filter(i => (!value ? true : i[0].name.toLowerCase().includes(value.toLowerCase())))
+							.map(i => ({ name: `${i[0].name} (${i[1]}x Owned)`, value: i[0].name }));
+					}
 				},
 				quantityOption,
 				priceOption


### PR DESCRIPTION
### Description:
Add quantity owned next to the item list above `/ge sell` command, similar to how disassembling works in bso.

Community poll: https://discord.com/channels/342983479501389826/1032668754561224734/1249490793039921163
<!-- What did you change? Describe it here. -->

### Changes:
- update the sell subcommand under ge to show amount owned (very similar to disassemble code in bso).
### Other checks:
- [X] I have tested all my changes thoroughly.
Example:
![Discord_Ir8sMf0xRR](https://github.com/oldschoolgg/oldschoolbot/assets/69014816/630c1247-6525-4a40-a055-78df53f84ae2)
