### PR TITLE
Update osjs & quest/lamp fixes

### DIFF
--- a/src/lib/data/itemAliases.ts
+++ b/src/lib/data/itemAliases.ts
@@ -174,11 +174,14 @@ setItemAlias(2993, 'Chompy bird hat (dragon archer)');
 setItemAlias(2994, 'Chompy bird hat (expert ogre dragon archer)');
 setItemAlias(2995, 'Chompy bird hat (expert dragon archer)');
 
-// Item aliases
+// Achievement diary lamps
 setItemAlias(11_137, 'Antique lamp 1');
 setItemAlias(11_139, 'Antique lamp 2');
 setItemAlias(11_141, 'Antique lamp 3');
 setItemAlias(11_185, 'Antique lamp 4');
+
+// Defender of varrock quest lamp
+setItemAlias(28_820, 'Antique lamp (defender of varrock)');
 
 // Dragonfire shields
 setItemAlias(11_284, 'Uncharged dragonfire shield');

--- a/src/mahoji/commands/ge.ts
+++ b/src/mahoji/commands/ge.ts
@@ -17,7 +17,7 @@ import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmatio
 import { deferInteraction } from '../../lib/util/interactionReply';
 import itemIsTradeable from '../../lib/util/itemIsTradeable';
 import { cancelGEListingCommand } from '../lib/abstracted_commands/cancelGEListingCommand';
-import { itemOption, tradeableItemArr } from '../lib/mahojiCommandOptions';
+import { itemOption, ownedItemOption, tradeableItemArr } from '../lib/mahojiCommandOptions';
 import { OSBMahojiCommand } from '../lib/util';
 
 export type GEListingWithTransactions = GEListing & {
@@ -130,19 +130,10 @@ export const geCommand: OSBMahojiCommand = {
 			description: 'Sell something on the grand exchange.',
 			options: [
 				{
+					...ownedItemOption(item => Boolean(item.tradeable_on_ge)),
 					name: 'item',
-					type: ApplicationCommandOptionType.String,
 					description: 'The item you want to sell.',
-					required: true,
-					autocomplete: async (value, { id }) => {
-						const user = await mUserFetch(id);
-
-						return user.bank
-							.items()
-							.filter(i => i[0].tradeable_on_ge)
-							.filter(i => (!value ? true : i[0].name.toLowerCase().includes(value.toLowerCase())))
-							.map(i => ({ name: `${i[0].name} (${i[1]}x Owned)`, value: i[0].name }));
-					}
+					required: true
 				},
 				quantityOption,
 				priceOption

--- a/src/mahoji/commands/ge.ts
+++ b/src/mahoji/commands/ge.ts
@@ -17,7 +17,7 @@ import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmatio
 import { deferInteraction } from '../../lib/util/interactionReply';
 import itemIsTradeable from '../../lib/util/itemIsTradeable';
 import { cancelGEListingCommand } from '../lib/abstracted_commands/cancelGEListingCommand';
-import { itemOption, ownedItemOption, tradeableItemArr } from '../lib/mahojiCommandOptions';
+import { itemOption, tradeableItemArr } from '../lib/mahojiCommandOptions';
 import { OSBMahojiCommand } from '../lib/util';
 
 export type GEListingWithTransactions = GEListing & {
@@ -130,10 +130,19 @@ export const geCommand: OSBMahojiCommand = {
 			description: 'Sell something on the grand exchange.',
 			options: [
 				{
-					...ownedItemOption(item => Boolean(item.tradeable_on_ge)),
 					name: 'item',
+					type: ApplicationCommandOptionType.String,
 					description: 'The item you want to sell.',
-					required: true
+					required: true,
+					autocomplete: async (value, { id }) => {
+						const user = await mUserFetch(id);
+
+						return user.bank
+							.items()
+							.filter(i => i[0].tradeable_on_ge)
+							.filter(i => (!value ? true : i[0].name.toLowerCase().includes(value.toLowerCase())))
+							.map(i => ({ name: `${i[0].name} (${i[1]}x Owned)`, value: i[0].name }));
+					}
 				},
 				quantityOption,
 				priceOption

--- a/src/mahoji/lib/abstracted_commands/lampCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lampCommand.ts
@@ -84,13 +84,12 @@ export const XPLamps: IXPLamp[] = [
 		minimumLevel: 1,
 		allowedSkills: [SkillsEnum.Magic]
 	},
-	/*	Needs OSJS Update
 	{
 		itemID: 28_820,
 		amount: 5000,
 		name: 'Antique lamp (defender of varrock)',
 		minimumLevel: 1
-	},*/
+	},
 	{
 		itemID: itemID('Antique lamp (easy ca)'),
 		amount: 5000,
@@ -149,6 +148,13 @@ export const Lampables: IXPObject[] = [
 				skills[skill] =
 					data.user.skillLevel(skill) *
 					([
+						SkillsEnum.Attack,
+						SkillsEnum.Strength,
+						SkillsEnum.Defence,
+						SkillsEnum.Magic,
+						SkillsEnum.Ranged,
+						SkillsEnum.Hitpoints,
+						SkillsEnum.Prayer,
 						SkillsEnum.Mining,
 						SkillsEnum.Woodcutting,
 						SkillsEnum.Herblore,

--- a/src/mahoji/lib/abstracted_commands/questCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/questCommand.ts
@@ -91,7 +91,7 @@ export const quests: Quest[] = [
 		},
 		combatLevelReq: 50,
 		qpReq: 10,
-		rewards: new Bank().add(28_587).add(28_587).add(28_588).add(28_589).add(28_590).freeze(),
+		rewards: new Bank().add(28_587).add(28_588).add(28_589).add(28_590).freeze(),
 		calcTime: (user: MUser) => {
 			let duration = Time.Minute * 10;
 			if (user.combatLevel < 90) {
@@ -119,8 +119,7 @@ export const quests: Quest[] = [
 		},
 		combatLevelReq: 65,
 		qpReq: 20,
-		// Awaiting item update for the lamp to be added
-		// rewards: new Bank().add(28_820).freeze(),
+		rewards: new Bank().add(28_820).freeze(),
 		skillsRewards: {
 			smithing: 15_000,
 			hunter: 15_000

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -6313,7 +6313,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6327,7 +6327,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6341,7 +6341,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6355,7 +6355,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6369,7 +6369,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6383,7 +6383,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6397,7 +6397,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6411,7 +6411,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6425,7 +6425,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6439,7 +6439,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6453,7 +6453,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6467,7 +6467,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6481,7 +6481,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6495,7 +6495,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6509,7 +6509,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6523,7 +6523,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6537,7 +6537,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6551,7 +6551,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6565,7 +6565,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6579,7 +6579,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6593,7 +6593,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6607,7 +6607,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6621,7 +6621,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6635,7 +6635,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6649,7 +6649,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6663,7 +6663,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6677,7 +6677,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6691,7 +6691,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6705,7 +6705,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6719,7 +6719,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6733,7 +6733,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6747,7 +6747,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6761,7 +6761,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6775,7 +6775,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6789,7 +6789,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6803,7 +6803,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6817,7 +6817,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6831,7 +6831,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6845,7 +6845,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6859,7 +6859,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6873,7 +6873,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6887,7 +6887,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6901,7 +6901,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6915,7 +6915,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6929,7 +6929,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6943,7 +6943,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6957,7 +6957,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6971,7 +6971,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6985,7 +6985,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,
@@ -6999,7 +6999,7 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
-    "gpCost": 15000,
+    "gpCost": 20000,
     "itemCost": Bank {
       "bank": {},
       "frozen": false,


### PR DESCRIPTION
### Description:
Update osjs & restore/fix some quest & lamp rewards
### Changes:
- Update osjs to 2.5.4
- restore antique lamp to defender of varrock quest loot
- restore antique lamp to be used in /lamp
- add an item alias to properly identify the antique lamp with "Antique lamp (defender of varrock)"
- Update dark relic to include combat skills for the 150 multiplier
- remove a duplicate lamp quest reward from The Path of Glouphrie
- Add feather to no sacrifice value to prevent sacrifice manipulation (buys for 2 sacrifices for 3)
- Make team cape 20k each to prevent sell manipulation (Team cape-25 buys for 15k and sells for 20k)
- Update sacrifice test with new prices
### Other checks:
- [X] I have tested all my changes thoroughly.
