### PR TITLE
Carapace fixes

### DIFF
--- a/src/lib/skilling/skills/crafting/craftables/carapace.ts
+++ b/src/lib/skilling/skills/crafting/craftables/carapace.ts
@@ -5,50 +5,50 @@ import { Craftable } from '../../../types';
 
 export const carapaceCraftables: Craftable[] = [
 	{
-		name: 'Carapace gloves',
-		id: itemID('Carapace gloves'),
-		level: 11,
-		xp: 23.8,
-		inputItems: new Bank({ Carapace: 1 }),
-		tickRate: 3
-	},
-	{
-		name: 'Carapace boots',
-		id: itemID('Carapace boots'),
-		level: 15,
-		xp: 26.2,
-		inputItems: new Bank({ Carapace: 1 }),
-		tickRate: 3
-	},
-	{
 		name: 'Carapace helm',
 		id: itemID('Carapace helm'),
-		level: 22,
-		xp: 28.5,
-		inputItems: new Bank({ Carapace: 1 }),
-		tickRate: 3
-	},
-	{
-		name: 'Carapace gloves',
-		id: itemID('Carapace gloves'),
-		level: 32,
-		xp: 32,
-		inputItems: new Bank({ Carapace: 1 }),
+		level: 33,
+		xp: 24,
+		inputItems: new Bank({ Carapace: 2 }),
 		tickRate: 3
 	},
 	{
 		name: 'Carapace torso',
 		id: itemID('Carapace torso'),
 		level: 35,
-		xp: 35,
+		xp: 36,
 		inputItems: new Bank({ Carapace: 3 }),
 		tickRate: 3
 	},
 	{
 		name: 'Carapace legs',
 		id: itemID('Carapace legs'),
-		level: 44,
-		xp: 37,
+		level: 34,
+		xp: 24,
+		inputItems: new Bank({ Carapace: 2 }),
+		tickRate: 3
+	},
+	{
+		name: 'Carapace boots',
+		id: itemID('Carapace boots'),
+		level: 31,
+		xp: 12,
+		inputItems: new Bank({ Carapace: 1 }),
+		tickRate: 3
+	},
+	{
+		name: 'Carapace gloves',
+		id: itemID('Carapace gloves'),
+		level: 30,
+		xp: 12,
+		inputItems: new Bank({ Carapace: 1 }),
+		tickRate: 3
+	},
+	{
+		name: 'Carapace shield',
+		id: itemID('Carapace shield'),
+		level: 36,
+		xp: 36,
 		inputItems: new Bank({ Carapace: 3 }),
 		tickRate: 3
 	}


### PR DESCRIPTION
### Description:
Adjustments and fixes to Carapace craftable gear
### Changes:
- Remove the duplicate Carapace gloves and replace it with the Carapace shield
- Update level requirement and xp based off https://runescape.wiki/w/Carapace
- Change the order so it has a neater appearance on cl
### Other checks:
- [X] I have tested all my changes thoroughly.
