### PR TITLE
Add quantity to Wintertodt

### DIFF
--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -322,7 +322,8 @@ export function minionStatus(user: MUser) {
 			}. ${formattedDuration} Your ${Emoji.Cooking} Cooking level is ${user.skillLevel(SkillsEnum.Cooking)}`;
 		}
 		case 'Wintertodt': {
-			return `${name} is currently fighting the Wintertodt. ${formattedDuration}`;
+			const data = currentTask as ActivityTaskOptionsWithQuantity;
+			return `${name} is currently fighting Wintertodt  ${data.quantity}x times. ${formattedDuration}`;
 		}
 		case 'Tempoross': {
 			return `${name} is currently fighting Tempoross. ${formattedDuration}`;

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -323,7 +323,7 @@ export function minionStatus(user: MUser) {
 		}
 		case 'Wintertodt': {
 			const data = currentTask as ActivityTaskOptionsWithQuantity;
-			return `${name} is currently fighting Wintertodt  ${data.quantity}x times. ${formattedDuration}`;
+			return `${name} is currently fighting Wintertodt ${data.quantity}x times. ${formattedDuration}`;
 		}
 		case 'Tempoross': {
 			return `${name} is currently fighting Tempoross. ${formattedDuration}`;

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -436,8 +436,9 @@ export const tripHandlers = {
 	},
 	[activity_type_enum.Wintertodt]: {
 		commandName: 'k',
-		args: () => ({
-			name: 'wintertodt'
+		args: (data: ActivityTaskOptionsWithQuantity) => ({
+			name: 'wintertodt',
+			quantity: data.quantity
 		})
 	},
 	[activity_type_enum.Nightmare]: {

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -160,7 +160,7 @@ export async function minionKillCommand(
 	if (stringMatches(name, 'zalcano')) return zalcanoCommand(user, channelID);
 	if (stringMatches(name, 'tempoross')) return temporossCommand(user, channelID, quantity);
 	if (name.toLowerCase().includes('nightmare')) return nightmareCommand(user, channelID, name, quantity);
-	if (name.toLowerCase().includes('wintertodt')) return wintertodtCommand(user, channelID);
+	if (name.toLowerCase().includes('wintertodt')) return wintertodtCommand(user, channelID, quantity);
 
 	let monster = findMonster(name);
 	let revenants = false;

--- a/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
@@ -2,7 +2,6 @@ import { Time, calcWhatPercent, reduceNumByPercent } from 'e';
 import { Bank } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
-import { floor } from 'lodash';
 import { Eatables } from '../../../lib/data/eatables';
 import { warmGear } from '../../../lib/data/filterables';
 import { trackLoot } from '../../../lib/lootTrack';
@@ -47,14 +46,14 @@ export async function wintertodtCommand(user: MUser, channelID: string, quantity
 	durationPerTodt = reduceNumByPercent(durationPerTodt, 5 * warmGearAmount);
 
 	const maxTripLength = calcMaxTripLength(user, 'Wintertodt');
-	if (!quantity) quantity = floor(maxTripLength / durationPerTodt);
+	if (!quantity) quantity = Math.floor(maxTripLength / durationPerTodt);
 	quantity = Math.max(1, quantity);
 	const duration = durationPerTodt * quantity;
 
 	if (quantity > 1 && duration > maxTripLength) {
 		return `${user.minionName} can't go on PvM trips longer than ${formatDuration(
 			maxTripLength
-		)}, try a lower quantity. The highest amount you can do for Wintertodt is ${floor(
+		)}, try a lower quantity. The highest amount you can do for Wintertodt is ${Math.floor(
 			maxTripLength / durationPerTodt
 		)}.`;
 	}

--- a/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/wintertodtCommand.ts
@@ -2,6 +2,7 @@ import { Time, calcWhatPercent, reduceNumByPercent } from 'e';
 import { Bank } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
+import { floor } from 'lodash';
 import { Eatables } from '../../../lib/data/eatables';
 import { warmGear } from '../../../lib/data/filterables';
 import { trackLoot } from '../../../lib/lootTrack';
@@ -11,7 +12,7 @@ import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 
-export async function wintertodtCommand(user: MUser, channelID: string) {
+export async function wintertodtCommand(user: MUser, channelID: string, quantity?: number) {
 	const fmLevel = user.skillLevel(SkillsEnum.Firemaking);
 	const wcLevel = user.skillLevel(SkillsEnum.Woodcutting);
 	if (fmLevel < 50) {
@@ -45,7 +46,18 @@ export async function wintertodtCommand(user: MUser, channelID: string) {
 	healAmountNeeded -= warmGearAmount * 15;
 	durationPerTodt = reduceNumByPercent(durationPerTodt, 5 * warmGearAmount);
 
-	const quantity = Math.floor(calcMaxTripLength(user, 'Wintertodt') / durationPerTodt);
+	const maxTripLength = calcMaxTripLength(user, 'Wintertodt');
+	if (!quantity) quantity = floor(maxTripLength / durationPerTodt);
+	quantity = Math.max(1, quantity);
+	const duration = durationPerTodt * quantity;
+
+	if (quantity > 1 && duration > maxTripLength) {
+		return `${user.minionName} can't go on PvM trips longer than ${formatDuration(
+			maxTripLength
+		)}, try a lower quantity. The highest amount you can do for Wintertodt is ${floor(
+			maxTripLength / durationPerTodt
+		)}.`;
+	}
 
 	for (const food of Eatables) {
 		const healAmount = typeof food.healAmount === 'number' ? food.healAmount : food.healAmount(user);
@@ -97,8 +109,6 @@ export async function wintertodtCommand(user: MUser, channelID: string) {
 
 		break;
 	}
-
-	const duration = durationPerTodt * quantity;
 
 	await addSubTaskToActivityTask<MinigameActivityTaskOptionsWithNoChanges>({
 		minigameID: 'wintertodt',

--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -113,6 +113,7 @@ export const wintertodtTask: MinionTask = {
 		incrementMinigameScore(user.id, 'wintertodt', quantity);
 
 		const image = await makeBankImage({
+			title: `Loot From ${quantity}x Wintertodt`,
 			bank: itemsAdded,
 			user,
 			previousCL


### PR DESCRIPTION
Allows users to specify the quantity of Wintertodt. If no quantity is provided do a max trip as always. Also adds "Loot from x Wintertodt" into the loot image.

- [x] I have tested all my changes thoroughly.
