### PR TITLE
Add quantity to Zalcano

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -56,7 +56,8 @@ import type {
 	TempleTrekkingActivityTaskOptions,
 	TheatreOfBloodTaskOptions,
 	TiaraRunecraftActivityTaskOptions,
-	WoodcuttingActivityTaskOptions
+	WoodcuttingActivityTaskOptions,
+	ZalcanoActivityTaskOptions
 } from '../types/minions';
 import { itemNameFromID } from '../util';
 import { giantsFoundryAlloys } from './../../mahoji/lib/abstracted_commands/giantsFoundryCommand';
@@ -424,8 +425,9 @@ export const tripHandlers = {
 	},
 	[activity_type_enum.Zalcano]: {
 		commandName: 'k',
-		args: () => ({
-			name: 'zalcano'
+		args: (data: ZalcanoActivityTaskOptions) => ({
+			name: 'zalcano',
+			quantity: data.quantity
 		})
 	},
 	[activity_type_enum.Tempoross]: {

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -157,7 +157,7 @@ export async function minionKillCommand(
 
 	if (stringMatches(name, 'colosseum')) return colosseumCommand(user, channelID);
 	if (stringMatches(name, 'nex')) return nexCommand(interaction, user, channelID, solo);
-	if (stringMatches(name, 'zalcano')) return zalcanoCommand(user, channelID);
+	if (stringMatches(name, 'zalcano')) return zalcanoCommand(user, channelID, quantity);
 	if (stringMatches(name, 'tempoross')) return temporossCommand(user, channelID, quantity);
 	if (name.toLowerCase().includes('nightmare')) return nightmareCommand(user, channelID, name, quantity);
 	if (name.toLowerCase().includes('wintertodt')) return wintertodtCommand(user, channelID);

--- a/src/mahoji/lib/abstracted_commands/zalcanoCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/zalcanoCommand.ts
@@ -62,7 +62,7 @@ export async function zalcanoCommand(user: MUser, channelID: string, quantity?: 
 	if (quantity > 1 && duration > maxTripLength) {
 		return `${user.minionName} can't go on PvM trips longer than ${formatDuration(
 			maxTripLength
-		)}, try a lower quantity. The highest amount you can do for Wintertodt is ${Math.floor(
+		)}, try a lower quantity. The highest amount you can do for Zalcano is ${Math.floor(
 			maxTripLength / baseTime
 		)}.`;
 	}

--- a/src/mahoji/lib/abstracted_commands/zalcanoCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/zalcanoCommand.ts
@@ -21,7 +21,7 @@ function calcPerformance(kcLearned: number, skillPercentage: number) {
 	return Math.min(100, basePerformance);
 }
 
-export async function zalcanoCommand(user: MUser, channelID: string) {
+export async function zalcanoCommand(user: MUser, channelID: string, quantity?: number) {
 	const [hasReqs, reason] = hasSkillReqs(user, soteSkillRequirements);
 	if (!hasReqs) {
 		return `To fight Zalcano, you need: ${reason}.`;
@@ -54,8 +54,18 @@ export async function zalcanoCommand(user: MUser, channelID: string) {
 	else if (kc > 50) healAmountNeeded = 3 * 12;
 	else if (kc > 20) healAmountNeeded = 5 * 12;
 
-	const quantity = Math.floor(calcMaxTripLength(user, 'Zalcano') / baseTime);
+	const maxTripLength = calcMaxTripLength(user, 'Zalcano');
+	if (!quantity) quantity = Math.floor(maxTripLength / baseTime);
+	quantity = Math.max(1, quantity);
 	const duration = quantity * baseTime;
+
+	if (quantity > 1 && duration > maxTripLength) {
+		return `${user.minionName} can't go on PvM trips longer than ${formatDuration(
+			maxTripLength
+		)}, try a lower quantity. The highest amount you can do for Wintertodt is ${Math.floor(
+			maxTripLength / baseTime
+		)}.`;
+	}
 
 	const { foodRemoved } = await removeFoodFromUser({
 		user,


### PR DESCRIPTION
Allows users to specify the quantity of Zalcano. If no quantity is provided do a max trip as before.

- [x] I have tested all my changes thoroughly.
