### PR TITLE
Wildy Slayer fixes

### DIFF
--- a/src/lib/minions/data/killableMonsters/krystiliaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/krystiliaMonsters.ts
@@ -15,6 +15,7 @@ export const krystiliaMonsters: KillableMonster[] = [
 
 		difficultyRating: 5,
 		qpRequired: 0,
+		canCannon: true,
 		pkActivityRating: 1,
 		pkBaseDeathChance: 1,
 		revsWeaponBoost: true,
@@ -32,7 +33,7 @@ export const krystiliaMonsters: KillableMonster[] = [
 		difficultyRating: 2,
 		qpRequired: 0,
 		canCannon: true,
-		cannonMulti: true,
+		cannonMulti: false,
 		canBarrage: false,
 		pkActivityRating: 1,
 		pkBaseDeathChance: 1,

--- a/src/lib/minions/data/killableMonsters/krystiliaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/krystiliaMonsters.ts
@@ -17,7 +17,8 @@ export const krystiliaMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 1,
 		pkBaseDeathChance: 1,
-		revsWeaponBoost: true
+		revsWeaponBoost: true,
+		wildyMulti: true
 	},
 	{
 		id: Monsters.ChaosDruid.id,
@@ -53,7 +54,8 @@ export const krystiliaMonsters: KillableMonster[] = [
 		canBarrage: false,
 		pkActivityRating: 1,
 		pkBaseDeathChance: 1,
-		revsWeaponBoost: true
+		revsWeaponBoost: true,
+		wildyMulti: true
 	},
 	{
 		id: Monsters.DeadlyRedSpider.id,
@@ -87,7 +89,8 @@ export const krystiliaMonsters: KillableMonster[] = [
 		canBarrage: false,
 		pkActivityRating: 2,
 		pkBaseDeathChance: 7,
-		revsWeaponBoost: true
+		revsWeaponBoost: true,
+		wildyMulti: true
 	},
 	{
 		id: Monsters.Ent.id,
@@ -125,7 +128,8 @@ export const krystiliaMonsters: KillableMonster[] = [
 		pkActivityRating: 1,
 		pkBaseDeathChance: 1,
 		revsWeaponBoost: true,
-		canBePked: true
+		canBePked: true,
+		wildyMulti: true
 	},
 	{
 		id: Monsters.LavaDragon.id,
@@ -143,7 +147,8 @@ export const krystiliaMonsters: KillableMonster[] = [
 		pkActivityRating: 3,
 		pkBaseDeathChance: 4,
 		revsWeaponBoost: true,
-		canBePked: true
+		canBePked: true,
+		wildyMulti: true
 	},
 	{
 		id: Monsters.MagicAxe.id,
@@ -162,7 +167,8 @@ export const krystiliaMonsters: KillableMonster[] = [
 		},
 		pkActivityRating: 1,
 		pkBaseDeathChance: 1,
-		revsWeaponBoost: true
+		revsWeaponBoost: true,
+		canCannon: true
 	},
 	{
 		id: Monsters.Mammoth.id,
@@ -181,7 +187,8 @@ export const krystiliaMonsters: KillableMonster[] = [
 		pkActivityRating: 1,
 		pkBaseDeathChance: 1,
 		revsWeaponBoost: true,
-		canBePked: true
+		canBePked: true,
+		wildyMulti: true
 	},
 	{
 		id: Monsters.Pirate.id,

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -677,7 +677,9 @@ export const vannakaMonsters: KillableMonster[] = [
 		attackStylesUsed: [GearStat.AttackSlash],
 		canCannon: true,
 		revsWeaponBoost: true,
-		wildySlayerCave: true
+		wildySlayerCave: true,
+		pkActivityRating: 2,
+		pkBaseDeathChance: 4
 	},
 	{
 		id: Monsters.HarpieBugSwarm.id,

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -37,7 +37,7 @@ export interface DetermineBoostParams {
 	monster: KillableMonster;
 	method?: PvMMethod | null;
 	isOnTask?: boolean;
-	wildyJelly?: boolean;
+	wildyBurst?: boolean;
 }
 export function determineBoostChoice(params: DetermineBoostParams) {
 	let boostChoice = 'none';
@@ -55,12 +55,12 @@ export function determineBoostChoice(params: DetermineBoostParams) {
 		boostChoice = 'cannon';
 	} else if (
 		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
-		(params.monster?.canBarrage || params.wildyJelly)
+		(params.monster?.canBarrage || params.wildyBurst)
 	) {
 		boostChoice = 'barrage';
 	} else if (
 		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
-		(params.monster?.canBarrage || params.wildyJelly)
+		(params.monster?.canBarrage || params.wildyBurst)
 	) {
 		boostChoice = 'burst';
 	} else if (params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)) {

--- a/src/lib/slayer/tasks/index.ts
+++ b/src/lib/slayer/tasks/index.ts
@@ -3,6 +3,7 @@ import { bossTasks } from './bossTasks';
 import { chaeldarTasks } from './chaeldarTasks';
 import { duradelTasks } from './duradelTasks';
 import { konarTasks } from './konarTasks';
+import { krystiliaTasks } from './krystiliaTasks';
 import { mazchnaTasks } from './mazchnaTasks';
 import { nieveTasks } from './nieveTasks';
 import { turaelTasks } from './turaelTasks';
@@ -16,7 +17,8 @@ export const allSlayerTasks: AssignableSlayerTask[] = [
 	...nieveTasks,
 	...turaelTasks,
 	...vannakaTasks,
-	...duradelTasks
+	...duradelTasks,
+	...krystiliaTasks
 ];
 
 export const allSlayerMonsters = allSlayerTasks.map(m => m.monster);

--- a/src/lib/util/calcWildyPkChance.ts
+++ b/src/lib/util/calcWildyPkChance.ts
@@ -46,7 +46,8 @@ export async function calcWildyPKChance(
 	peak: Peak,
 	monster: KillableMonster,
 	duration: number,
-	supplies: boolean
+	supplies: boolean,
+	cannonMulti: boolean
 ): Promise<[number, boolean, string]> {
 	// Chance per minute, Difficulty from 1 to 10, and factor a million difference, High peak 5x as likley encounter, Medium peak 1x, Low peak 5x as unlikley
 	const peakInfluence = peakFactor.find(_peaktier => _peaktier.peakTier === peak?.peakTier)?.factor ?? 1;
@@ -72,7 +73,7 @@ export async function calcWildyPKChance(
 	deathChance += deathChanceFromLevels;
 
 	// Multi does make it riskier, but only if there's actually a team on you
-	const wildyMultiMultiplier = monster.wildyMulti === true ? 2 : 1;
+	const wildyMultiMultiplier = monster.wildyMulti || cannonMulti ? 2 : 1;
 	const hasSupplies = supplies ? 0.5 : 1;
 	const hasOverheads = user.skillLevel(SkillsEnum.Prayer) >= 43 ? 0.25 : 1;
 

--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -211,6 +211,164 @@ const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 	}
 ];
 
+const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
+	{
+		monsterID: Monsters.AbyssalDemon.id,
+		efficientName: Monsters.AbyssalDemon.name,
+		efficientMonster: Monsters.AbyssalDemon.id,
+		efficientMethod: 'barrage'
+	},
+	{
+		monsterID: Monsters.Ankou.id,
+		efficientName: Monsters.Ankou.name,
+		efficientMonster: Monsters.Ankou.id,
+		efficientMethod: 'barrage'
+	},
+	{
+		monsterID: Monsters.BlackDemon.id,
+		efficientName: Monsters.BlackDemon.name,
+		efficientMonster: Monsters.BlackDemon.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.BlackKnight.id,
+		efficientName: Monsters.BlackKnight.name,
+		efficientMonster: Monsters.BlackKnight.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.Bloodveld.id,
+		efficientName: Monsters.Bloodveld.name,
+		efficientMonster: Monsters.Bloodveld.id,
+		efficientMethod: 'barrage'
+	},
+	{
+		monsterID: Monsters.ChaosDruid.id,
+		efficientName: Monsters.ChaosDruid.name,
+		efficientMonster: Monsters.ChaosDruid.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.DarkWarrior.id,
+		efficientName: Monsters.DarkWarrior.name,
+		efficientMonster: Monsters.DarkWarrior.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.DeadlyRedSpider.id,
+		efficientName: Monsters.DeadlyRedSpider.name,
+		efficientMonster: Monsters.DeadlyRedSpider.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.DustDevil.id,
+		efficientName: Monsters.DustDevil.name,
+		efficientMonster: Monsters.DustDevil.id,
+		efficientMethod: 'barrage'
+	},
+	{
+		monsterID: Monsters.ElderChaosDruid.id,
+		efficientName: Monsters.ElderChaosDruid.name,
+		efficientMonster: Monsters.ElderChaosDruid.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.Ent.id,
+		efficientName: Monsters.Ent.name,
+		efficientMonster: Monsters.Ent.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.GreaterDemon.id,
+		efficientName: Monsters.GreaterDemon.name,
+		efficientMonster: Monsters.GreaterDemon.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.GreenDragon.id,
+		efficientName: Monsters.GreenDragon.name,
+		efficientMonster: Monsters.GreenDragon.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.GuardBandit.id,
+		efficientName: Monsters.GuardBandit.name,
+		efficientMonster: Monsters.GuardBandit.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.Hellhound.id,
+		efficientName: Monsters.Hellhound.name,
+		efficientMonster: Monsters.Hellhound.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.IceGiant.id,
+		efficientName: Monsters.IceGiant.name,
+		efficientMonster: Monsters.IceGiant.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.IceWarrior.id,
+		efficientName: Monsters.IceWarrior.name,
+		efficientMonster: Monsters.IceWarrior.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.Jelly.id,
+		efficientName: Monsters.Jelly.name,
+		efficientMonster: Monsters.Jelly.id,
+		efficientMethod: 'barrage'
+	},
+	{
+		monsterID: Monsters.LesserDemon.id,
+		efficientName: Monsters.LesserDemon.name,
+		efficientMonster: Monsters.LesserDemon.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.MagicAxe.id,
+		efficientName: Monsters.MagicAxe.name,
+		efficientMonster: Monsters.MagicAxe.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.Mammoth.id,
+		efficientName: Monsters.Mammoth.name,
+		efficientMonster: Monsters.Mammoth.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.MossGiant.id,
+		efficientName: Monsters.MossGiant.name,
+		efficientMonster: Monsters.MossGiant.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.Nechryael.id,
+		efficientName: Monsters.Nechryael.name,
+		efficientMonster: Monsters.Nechryael.id,
+		efficientMethod: 'barrage'
+	},
+	{
+		monsterID: Monsters.RevenantImp.id,
+		efficientName: Monsters.RevenantDemon.name,
+		efficientMonster: Monsters.RevenantDemon.id,
+		efficientMethod: 'none'
+	},
+	{
+		monsterID: Monsters.Scorpion.id,
+		efficientName: Monsters.Scorpion.name,
+		efficientMonster: Monsters.Scorpion.id,
+		efficientMethod: 'cannon'
+	},
+	{
+		monsterID: Monsters.Spider.id,
+		efficientName: Monsters.Spider.name,
+		efficientMonster: Monsters.Spider.id,
+		efficientMethod: 'cannon'
+	}
+];
 function determineAutoslayMethod(autoslayOptions: AutoslayOptionsEnum[]) {
 	let method = 'default';
 	if (autoslayOptions.includes(AutoslayOptionsEnum.MaxEfficiency)) {
@@ -294,21 +452,23 @@ export async function autoSlayCommand({
 		return;
 	}
 	if (method === 'ehp') {
-		const ehpMonster = AutoSlayMaxEfficiencyTable.find(e => {
+		let ehpMonster = AutoSlayMaxEfficiencyTable.find(e => {
 			const masterMatch = !e.slayerMasters || e.slayerMasters.includes(usersTask.currentTask?.slayer_master_id);
 			return masterMatch && e.monsterID === usersTask.assignedTask?.monster.id;
 		});
 
+		if (usersTask.currentTask.slayer_master_id === 8) {
+			ehpMonster = WildyAutoSlayMaxEfficiencyTable.find(e => {
+				const masterMatch =
+					!e.slayerMasters || e.slayerMasters.includes(usersTask.currentTask!.slayer_master_id);
+				return masterMatch && e.monsterID === usersTask.assignedTask!.monster.id;
+			});
+		}
+
 		const ehpKillable = killableMonsters.find(m => m.id === ehpMonster?.efficientMonster);
 
 		// If we don't have the requirements for the efficient monster, revert to default monster
-		if (
-			(ehpKillable?.levelRequirements !== undefined && !hasSkillReqs(user, ehpKillable.levelRequirements)[0]) ||
-			(usersTask.currentTask?.slayer_master_id === 8 &&
-				[Monsters.Jelly.id, Monsters.Bloodveld.id, Monsters.BlackDragon.id].includes(
-					usersTask.assignedTask?.monster.id
-				))
-		) {
+		if (ehpKillable?.levelRequirements !== undefined && !hasSkillReqs(user, ehpKillable.levelRequirements)[0]) {
 			runCommand({
 				commandName: 'k',
 				args: {

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -579,7 +579,7 @@ export async function minionKillCommand(
 				degItemBeingUsed.push(degItem);
 			}
 		}
-	} else if (!isInWilderness) {
+	} else {
 		for (const degItem of degradeablePvmBoostItems) {
 			const isUsing = convertPvmStylesToGearSetup(attackStyles).includes(degItem.attackStyle);
 			const gearCheck = isInWilderness


### PR DESCRIPTION
Several fixes that were made after the original wildy slayer pr was merged.

- [x] I have tested all my changes thoroughly.

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2939d51c995fb7fc1fe81d25bca487601f9e8ec7  | 
|--------|--------|

### Summary:
Fixed and improved Wildy Slayer functionality by updating monster properties, PK chance calculations, and auto-slay logic.

**Key points**:
- **`src/lib/minions/data/killableMonsters/krystiliaMonsters.ts`**: Added `wildyMulti` and `canCannon` properties to several monsters.
- **`src/lib/minions/data/killableMonsters/vannakaMonsters.ts`**: Added `pkActivityRating` and `pkBaseDeathChance` to Green Dragon.
- **`src/lib/slayer/slayerUtil.ts`**: Renamed `wildyJelly` to `wildyBurst` in `determineBoostChoice` function.
- **`src/lib/util/calcWildyPkChance.ts`**: Added `cannonMulti` parameter to `calcWildyPKChance` function.
- **`src/mahoji/lib/abstracted_commands/autoSlayCommand.ts`**: Added `WildyAutoSlayMaxEfficiencyTable` for Wildy Slayer tasks.
- **`src/mahoji/lib/abstracted_commands/minionKill.ts`**: Updated logic to handle `wildyBurst` and `cannonMulti` in wilderness scenarios.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->