### PR TITLE
Brimstone key from Superior

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -135,6 +135,7 @@ export interface MonsterActivityTaskOptions extends ActivityTaskOptions {
 	pkEncounters?: number;
 	hasWildySupplies?: boolean;
 	isInWilderness?: boolean;
+	isUsingKonar?: boolean;
 }
 
 export interface ClueActivityTaskOptions extends ActivityTaskOptions {

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -181,6 +181,9 @@ export async function minionKillCommand(
 		usersTask.currentTask !== null &&
 		usersTask.assignedTask.monsters.includes(monster.id);
 
+	let isUsingKonar = false;
+	if (isOnTask && usersTask.slayerMaster.id === 5) isUsingKonar = true;
+
 	if (monster.slayerOnly && !isOnTask) {
 		return `You can't kill ${monster.name}, because you're not on a slayer task.`;
 	}
@@ -960,7 +963,8 @@ export async function minionKillCommand(
 		died: hasDied,
 		pkEncounters: thePkCount,
 		hasWildySupplies,
-		isInWilderness
+		isInWilderness,
+		isUsingKonar
 	});
 	let response = `${minionName} is now killing ${quantity}x ${monster.name}, it'll take around ${formatDuration(
 		duration

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -202,7 +202,7 @@ export const monsterTask: MinionTask = {
 
 		const superiorTable = isOnTaskResult.hasSuperiorsUnlocked && monster.superior ? monster.superior : undefined;
 		const isInCatacombs = (!usingCannon ? monster.existsInCatacombs ?? undefined : undefined) && !isInWilderness;
-		
+
 		const hasRingOfWealthI = user.gear.wildy.hasEquipped('Ring of wealth (i)') && isInWilderness;
 		if (hasRingOfWealthI) {
 			messages.push('\nYour clue scroll chance is doubled due to wearing a Ring of Wealth (i).');

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -36,7 +36,8 @@ export const monsterTask: MinionTask = {
 			died,
 			pkEncounters,
 			hasWildySupplies,
-			isInWilderness
+			isInWilderness,
+			isUsingKonar
 		} = data;
 
 		const monster = killableMonsters.find(mon => mon.id === monsterID)!;
@@ -256,8 +257,7 @@ export const monsterTask: MinionTask = {
 			loot.add(superiorTable?.kill(newSuperiorCount));
 			if (isInCatacombs) loot.add('Dark totem base', newSuperiorCount);
 			if (isInWilderness) loot.add("Larran's key", newSuperiorCount);
-			const usersTask = await getUsersCurrentSlayerInfo(user.id);
-			if (usersTask.currentTask?.slayer_master_id === 8) loot.add('Brimstone key', newSuperiorCount);
+			if (isUsingKonar) loot.add('Brimstone key', newSuperiorCount);
 		}
 
 		// Hill giant key wildy buff

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -202,7 +202,7 @@ export const monsterTask: MinionTask = {
 
 		const superiorTable = isOnTaskResult.hasSuperiorsUnlocked && monster.superior ? monster.superior : undefined;
 		const isInCatacombs = (!usingCannon ? monster.existsInCatacombs ?? undefined : undefined) && !isInWilderness;
-
+		
 		const hasRingOfWealthI = user.gear.wildy.hasEquipped('Ring of wealth (i)') && isInWilderness;
 		if (hasRingOfWealthI) {
 			messages.push('\nYour clue scroll chance is doubled due to wearing a Ring of Wealth (i).');
@@ -256,6 +256,7 @@ export const monsterTask: MinionTask = {
 			loot.add(superiorTable?.kill(newSuperiorCount));
 			if (isInCatacombs) loot.add('Dark totem base', newSuperiorCount);
 			if (isInWilderness) loot.add("Larran's key", newSuperiorCount);
+			if (e.slayerMasters.includes(usersTask.currentTask?.slayer_master_id === 8)) loot.add('Brimstone key', newSuperiorCount);
 		}
 
 		// Hill giant key wildy buff

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -256,7 +256,7 @@ export const monsterTask: MinionTask = {
 			loot.add(superiorTable?.kill(newSuperiorCount));
 			if (isInCatacombs) loot.add('Dark totem base', newSuperiorCount);
 			if (isInWilderness) loot.add("Larran's key", newSuperiorCount);
-			if (e.slayerMasters.includes(usersTask.currentTask?.slayer_master_id === 8)) loot.add('Brimstone key', newSuperiorCount);
+			if (usersTask.currentTask?.slayer_master_id === 8) loot.add('Brimstone key', newSuperiorCount);
 		}
 
 		// Hill giant key wildy buff

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -256,6 +256,7 @@ export const monsterTask: MinionTask = {
 			loot.add(superiorTable?.kill(newSuperiorCount));
 			if (isInCatacombs) loot.add('Dark totem base', newSuperiorCount);
 			if (isInWilderness) loot.add("Larran's key", newSuperiorCount);
+			const usersTask = await getUsersCurrentSlayerInfo(user.id);
 			if (usersTask.currentTask?.slayer_master_id === 8) loot.add('Brimstone key', newSuperiorCount);
 		}
 


### PR DESCRIPTION
Guarantees a brimstone key drop from a superior on a konar slayer task

- [x] I have tested all my changes thoroughly.

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7a446ca52506438a37e95094d815cbb242596a7f  | 
|--------|--------|

### Summary:
Guarantees a Brimstone key drop from a superior monster on a Konar Slayer task by adding the `isUsingKonar` flag and updating loot logic.

**Key points**:
- Added `isUsingKonar` flag to `MonsterActivityTaskOptions` in `src/lib/types/minions.ts`.
- Updated `minionKillCommand` in `src/mahoji/lib/abstracted_commands/minionKill.ts` to set `isUsingKonar` when on a Konar Slayer task.
- Modified `monsterTask` in `src/tasks/minions/monsterActivity.ts` to add a Brimstone key to the loot if `isUsingKonar` is true and a superior monster is killed.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

closes: https://github.com/oldschoolgg/oldschoolbot/issues/5999