### PR TITLE
quest/lamp fixes

### DIFF
--- a/src/lib/data/itemAliases.ts
+++ b/src/lib/data/itemAliases.ts
@@ -178,11 +178,14 @@ setItemAlias(2993, 'Chompy bird hat (dragon archer)');
 setItemAlias(2994, 'Chompy bird hat (expert ogre dragon archer)');
 setItemAlias(2995, 'Chompy bird hat (expert dragon archer)');
 
-// Item aliases
+// Achievement diary lamps
 setItemAlias(11_137, 'Antique lamp 1');
 setItemAlias(11_139, 'Antique lamp 2');
 setItemAlias(11_141, 'Antique lamp 3');
 setItemAlias(11_185, 'Antique lamp 4');
+
+// Defender of varrock quest lamp
+setItemAlias(28_820, 'Antique lamp (defender of varrock)');
 
 // Dragonfire shields
 setItemAlias(11_284, 'Uncharged dragonfire shield');

--- a/src/lib/minions/data/quests.ts
+++ b/src/lib/minions/data/quests.ts
@@ -84,7 +84,7 @@ export const quests: Quest[] = [
 		},
 		combatLevelReq: 50,
 		qpReq: 10,
-		rewards: new Bank().add(28_587).add(28_587).add(28_588).add(28_589).add(28_590).freeze(),
+		rewards: new Bank().add(28_587).add(28_588).add(28_589).add(28_590).freeze(),
 		calcTime: (user: MUser) => {
 			let duration = Time.Minute * 10;
 			if (user.combatLevel < 90) {
@@ -112,8 +112,7 @@ export const quests: Quest[] = [
 		},
 		combatLevelReq: 65,
 		qpReq: 20,
-		// Awaiting item update for the lamp to be added
-		// rewards: new Bank().add(28_820).freeze(),
+		rewards: new Bank().add(28_820).freeze(),
 		skillsRewards: {
 			smithing: 15_000,
 			hunter: 15_000

--- a/src/mahoji/lib/abstracted_commands/lampCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lampCommand.ts
@@ -84,13 +84,12 @@ export const XPLamps: IXPLamp[] = [
 		minimumLevel: 1,
 		allowedSkills: [SkillsEnum.Magic]
 	},
-	/*	Needs OSJS Update
 	{
 		itemID: 28_820,
 		amount: 5000,
 		name: 'Antique lamp (defender of varrock)',
 		minimumLevel: 1
-	},*/
+	},
 	{
 		itemID: itemID('Antique lamp (easy ca)'),
 		amount: 5000,
@@ -149,6 +148,13 @@ export const Lampables: IXPObject[] = [
 				skills[skill] =
 					data.user.skillLevel(skill) *
 					([
+						SkillsEnum.Attack,
+						SkillsEnum.Strength,
+						SkillsEnum.Defence,
+						SkillsEnum.Magic,
+						SkillsEnum.Ranged,
+						SkillsEnum.Hitpoints,
+						SkillsEnum.Prayer,
 						SkillsEnum.Mining,
 						SkillsEnum.Woodcutting,
 						SkillsEnum.Herblore,
@@ -159,6 +165,7 @@ export const Lampables: IXPObject[] = [
 						SkillsEnum.Thieving,
 						SkillsEnum.Firemaking,
 						SkillsEnum.Agility
+
 					].includes(skill)
 						? 150
 						: 50) *

--- a/src/mahoji/lib/abstracted_commands/lampCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lampCommand.ts
@@ -165,7 +165,6 @@ export const Lampables: IXPObject[] = [
 						SkillsEnum.Thieving,
 						SkillsEnum.Firemaking,
 						SkillsEnum.Agility
-
 					].includes(skill)
 						? 150
 						: 50) *


### PR DESCRIPTION
### Description:
- follow up from: https://github.com/oldschoolgg/oldschoolbot/pull/5927
- restore/fix some quest & lamp rewards
### Changes:
- restore antique lamp to defender of varrock quest loot
- restore antique lamp to be used in /lamp
- add an item alias to properly identify the antique lamp with "Antique lamp (defender of varrock)"
- Update dark relic to include combat skills for the 150 multiplier
- remove a duplicate lamp quest reward from The Path of Glouphrie
### Other checks:
- [X] I have tested all my changes thoroughly.
