### PR TITLE
Slayer Tasks Fixes

### DIFF
--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -289,6 +289,9 @@ export function getCommonTaskName(task: Monster) {
 		case Monsters.RevenantImp.id:
 			commonName = 'Revenant';
 			break;
+		case Monsters.DagannothPrime.id:
+			commonName = 'Dagannoth Kings';
+			break;
 		default:
 	}
 	if (commonName !== 'TzHaar' && !commonName.endsWith('s')) commonName += 's';

--- a/src/lib/slayer/tasks/bossTasks.ts
+++ b/src/lib/slayer/tasks/bossTasks.ts
@@ -33,7 +33,7 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Callisto,
 		amount: [3, 35],
 		weight: 1,
-		monsters: [Monsters.Callisto.id],
+		monsters: [Monsters.Callisto.id, Monsters.Artio.id],
 		isBoss: true,
 		wilderness: true
 	},
@@ -90,27 +90,7 @@ export const bossTasks: AssignableSlayerTask[] = [
 		levelRequirements: {
 			prayer: 43
 		},
-		monsters: [Monsters.DagannothPrime.id],
-		isBoss: true
-	},
-	{
-		monster: Monsters.DagannothSupreme,
-		amount: [3, 35],
-		weight: 1,
-		levelRequirements: {
-			prayer: 43
-		},
-		monsters: [Monsters.DagannothSupreme.id],
-		isBoss: true
-	},
-	{
-		monster: Monsters.DagannothRex,
-		amount: [3, 35],
-		weight: 1,
-		levelRequirements: {
-			prayer: 43
-		},
-		monsters: [Monsters.DagannothRex.id],
+		monsters: [Monsters.DagannothPrime.id, Monsters.DagannothSupreme.id, Monsters.DagannothRex.id],
 		isBoss: true
 	},
 	{
@@ -219,7 +199,7 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Venenatis,
 		amount: [3, 35],
 		weight: 1,
-		monsters: [Monsters.Venenatis.id],
+		monsters: [Monsters.Venenatis.id, Monsters.Spindel.id],
 		isBoss: true,
 		wilderness: true
 	},
@@ -227,7 +207,7 @@ export const bossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Vetion,
 		amount: [3, 35],
 		weight: 1,
-		monsters: [Monsters.Vetion.id],
+		monsters: [Monsters.Vetion.id, Monsters.Calvarion.id],
 		isBoss: true,
 		wilderness: true
 	},
@@ -260,7 +240,7 @@ export const wildernessBossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Callisto,
 		amount: [3, 35],
 		weight: 1,
-		monsters: [Monsters.Callisto.id],
+		monsters: [Monsters.Callisto.id, Monsters.Artio.id],
 		isBoss: true,
 		wilderness: true
 	},
@@ -300,7 +280,7 @@ export const wildernessBossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Venenatis,
 		amount: [3, 35],
 		weight: 1,
-		monsters: [Monsters.Venenatis.id],
+		monsters: [Monsters.Venenatis.id, Monsters.Spindel.id],
 		isBoss: true,
 		wilderness: true
 	},
@@ -308,7 +288,7 @@ export const wildernessBossTasks: AssignableSlayerTask[] = [
 		monster: Monsters.Vetion,
 		amount: [3, 35],
 		weight: 1,
-		monsters: [Monsters.Vetion.id],
+		monsters: [Monsters.Vetion.id, Monsters.Calvarion.id],
 		isBoss: true,
 		wilderness: true
 	}

--- a/src/lib/slayer/tasks/krystiliaTasks.ts
+++ b/src/lib/slayer/tasks/krystiliaTasks.ts
@@ -67,6 +67,8 @@ export const krystiliaTasks: AssignableSlayerTask[] = [
 		amount: [8, 16],
 		weight: 4,
 		monsters: [Monsters.BlackDragon.id],
+		extendedAmount: [40, 60],
+		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,
 		unlocked: true,
 		wilderness: true
 	},
@@ -244,6 +246,8 @@ export const krystiliaTasks: AssignableSlayerTask[] = [
 		amount: [75, 125],
 		weight: 5,
 		monsters: [Monsters.GreaterNechryael.id],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.NechsPlease,
 		slayerLevel: 80,
 		unlocked: true,
 		wilderness: true

--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -345,9 +345,9 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		efficientMethod: 'cannon'
 	},
 	{
-		monsterID: Monsters.Nechryael.id,
-		efficientName: Monsters.Nechryael.name,
-		efficientMonster: Monsters.Nechryael.id,
+		monsterID: Monsters.GreaterNechryael.id,
+		efficientName: Monsters.GreaterNechryael.name,
+		efficientMonster: Monsters.GreaterNechryael.id,
 		efficientMethod: 'barrage'
 	},
 	{


### PR DESCRIPTION
Adds common name for DKS kings and removes the duplicate boss tasks. Adds the relevant extensions to krystilias assigned tasks for black dragons and nechs. Allows people to kill artio/calvarion/spindel for the relevant boss tasks.

- [x] I have tested all my changes thoroughly.
