### PR TITLE
Allow multiple combat options for PVM trips

### DIFF
--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -243,7 +243,6 @@ export const vannakaMonsters: KillableMonster[] = [
 		healAmountNeeded: 12,
 		attackStyleToUse: GearStat.AttackRanged,
 		attackStylesUsed: [GearStat.AttackMagic],
-		canCannon: true,
 		pkActivityRating: 4,
 		pkBaseDeathChance: 6,
 		revsWeaponBoost: true

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -1067,7 +1067,6 @@ export const vannakaMonsters: KillableMonster[] = [
 		},
 		superior: Monsters.Nechryarch,
 		healAmountNeeded: 24,
-		canBarrage: true,
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackCrush]
 	},

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -1067,6 +1067,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		},
 		superior: Monsters.Nechryarch,
 		healAmountNeeded: 24,
+		canBarrage: true,
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackCrush]
 	},

--- a/src/lib/minions/functions/index.ts
+++ b/src/lib/minions/functions/index.ts
@@ -50,7 +50,7 @@ export function resolveAttackStyles(
 	// Automatically use magic if barrage/burst is chosen
 	if (
 		params.boostMethod &&
-		(params.boostMethod === 'barrage' || params.boostMethod === 'burst') &&
+		(params.boostMethod.includes('barrage') || params.boostMethod.includes('burst')) &&
 		!attackStyles.includes(SkillsEnum.Magic)
 	) {
 		if (attackStyles.includes(SkillsEnum.Defence)) {
@@ -63,7 +63,7 @@ export function resolveAttackStyles(
 }
 
 export async function addMonsterXP(user: MUser, params: AddMonsterXpParams) {
-	const boostMethod = params.burstOrBarrage ? 'barrage' : 'none';
+	const boostMethod = params.burstOrBarrage ? ['barrage'] : ['none'];
 
 	const [, osjsMon, attackStyles] = resolveAttackStyles(user, {
 		monsterID: params.monsterID,

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -177,7 +177,7 @@ export interface AddMonsterXpParams {
 
 export interface ResolveAttackStylesParams {
 	monsterID: number | undefined;
-	boostMethod?: string;
+	boostMethod?: string[];
 }
 
 export interface BlowpipeData {

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -47,18 +47,25 @@ export function determineCombatBoosts(params: DetermineBoostParams) {
 	if(params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)){
 		boostMethods.includes('cannon') ? null : boostMethods.push('cannon')
 	}
+	if (params.wildyBurst){
+		if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
+			boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
+		}
+		if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst)) {
+			boostMethods.includes('burst') ? null : boostMethods.push('burst')
+		}
+	}
 
 	if (params.monster.canBarrage){
-		if (!params.monster.cannonMulti || params.monster.existsInCatacombs) { // Don't allow bursting in single combat
+		if (!params.monster.cannonMulti || params.monster.existsInCatacombs) { 
+			// Don't allow bursting in single combat
 			console.log(`Check failed here, methods being returned: ${boostMethods}`)
 			return boostMethods;
 		} else {
-			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
-			(params.monster.canBarrage || params.wildyBurst)) {
+			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
 				boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
 			}
-			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
-			(params.monster.canBarrage || params.wildyBurst)){
+			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst)) {
 				boostMethods.includes('burst') ? null : boostMethods.push('burst')
 			}
 		}

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -40,24 +40,32 @@ interface DetermineBoostParams {
 }
 export function determineCombatBoosts(params: DetermineBoostParams) {
 
-    const boostMethods = (params.methods ?? ['none']).flat();
-    //console.log(`methods passed in to determineBoostChouice: ${boostMethods}`);
-	//console.log(`Combat options selected: ${params.cbOpts}`)
+    const boostMethods = (params.methods ?? ['none']).flat().filter(method => method);
+    console.log(`methods passed in to determineBoostChouice: ${boostMethods}`);
+	console.log(`Combat options selected: ${params.cbOpts}`)
 
-	if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
-	(params.monster?.canBarrage || params.wildyBurst)) {
-		boostMethods.push('barrage')
-	}
-	if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
-	(params.monster?.canBarrage || params.wildyBurst)){
-		boostMethods.push('burst')
-	}
 	if(params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)){
-		boostMethods.push('cannon')
+		boostMethods.includes('cannon') ? null : boostMethods.push('cannon')
 	}
-	//console.log(`methods being returned: ${boostMethods}`)
+
+	if (params.monster.canBarrage){
+		if (!params.monster.cannonMulti || params.monster.existsInCatacombs) { // Don't allow bursting in single combat
+			console.log(`Check failed here, methods being returned: ${boostMethods}`)
+			return boostMethods;
+		} else {
+			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
+			(params.monster?.canBarrage || params.wildyBurst)) {
+				boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
+			}
+			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
+			(params.monster?.canBarrage || params.wildyBurst)){
+				boostMethods.includes('burst') ? null : boostMethods.push('burst')
+			}
+		}
+	}
+
+	console.log(`methods being returned: ${boostMethods}`)
     return boostMethods;
-	
 }
 
 

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -34,43 +34,32 @@ interface DetermineBoostParams {
 	cbOpts: CombatOptionsEnum[];
 	user: MUser;
 	monster: KillableMonster;
-	method?: PvMMethod | null;
+	methods?: PvMMethod[] | null;
 	isOnTask?: boolean;
 	wildyBurst?: boolean;
 }
-export function determineBoostChoice(params: DetermineBoostParams) {
-	let boostChoice = 'none';
+export function determineCombatBoosts(params: DetermineBoostParams) {
 
-	if (params.method && params.method === 'none') {
-		return boostChoice;
-	}
-	if (params.method && params.method === 'chinning') {
-		boostChoice = 'chinning';
-	} else if (params.method && params.method === 'barrage') {
-		boostChoice = 'barrage';
-	} else if (params.method && params.method === 'burst') {
-		boostChoice = 'burst';
-	} else if (params.method && params.method === 'cannon') {
-		boostChoice = 'cannon';
-	} else if (
-		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
-		(params.monster?.canBarrage || params.wildyBurst)
-	) {
-		boostChoice = 'barrage';
-	} else if (
-		params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
-		(params.monster?.canBarrage || params.wildyBurst)
-	) {
-		boostChoice = 'burst';
-	} else if (params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)) {
-		boostChoice = 'cannon';
-	}
+    const boostMethods = (params.methods ?? ['none']).flat();
+    //console.log(`methods passed in to determineBoostChouice: ${boostMethods}`);
+	//console.log(`Combat options selected: ${params.cbOpts}`)
 
-	if (boostChoice === 'barrage' && params.user.skillLevel(SkillsEnum.Magic) < 94) {
-		boostChoice = 'burst';
+	if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
+	(params.monster?.canBarrage || params.wildyBurst)) {
+		boostMethods.push('barrage')
 	}
-	return boostChoice;
+	if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
+	(params.monster?.canBarrage || params.wildyBurst)){
+		boostMethods.push('burst')
+	}
+	if(params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)){
+		boostMethods.push('cannon')
+	}
+	//console.log(`methods being returned: ${boostMethods}`)
+    return boostMethods;
+	
 }
+
 
 export async function calculateSlayerPoints(currentStreak: number, master: SlayerMaster, user: MUser) {
 	const streaks = [1000, 250, 100, 50, 10];

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -84,7 +84,6 @@ export function determineCombatBoosts(params: DetermineBoostParams) {
     return boostMethods;
 }
 
-
 export async function calculateSlayerPoints(currentStreak: number, master: SlayerMaster, user: MUser) {
 	const streaks = [1000, 250, 100, 50, 10];
 	const multiplier = [50, 35, 25, 15, 5];

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -54,11 +54,11 @@ export function determineCombatBoosts(params: DetermineBoostParams) {
 			return boostMethods;
 		} else {
 			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage) &&
-			(params.monster?.canBarrage || params.wildyBurst)) {
+			(params.monster.canBarrage || params.wildyBurst)) {
 				boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
 			}
 			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst) &&
-			(params.monster?.canBarrage || params.wildyBurst)){
+			(params.monster.canBarrage || params.wildyBurst)){
 				boostMethods.includes('burst') ? null : boostMethods.push('burst')
 			}
 		}

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -39,49 +39,48 @@ interface DetermineBoostParams {
 	wildyBurst?: boolean;
 }
 export function determineCombatBoosts(params: DetermineBoostParams) {
-
 	// if EHP slayer (PvMMethod) the methods are initialized with boostMethods variable
-    const boostMethods = (params.methods ?? ['none']).flat().filter(method => method);
-   
+	const boostMethods = (params.methods ?? ['none']).flat().filter(method => method);
+
 	// check if user has cannon combat option turned on
-	if(params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)){
-		boostMethods.includes('cannon') ? null : boostMethods.push('cannon')
+	if (params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)) {
+		boostMethods.includes('cannon') ? null : boostMethods.push('cannon');
 	}
 
 	// check for special burst case under wildyBurst variable
-	if (params.wildyBurst){
+	if (params.wildyBurst) {
 		if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
-			boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
+			boostMethods.includes('barrage') ? null : boostMethods.push('barrage');
 		}
 		if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst)) {
-			boostMethods.includes('burst') ? null : boostMethods.push('burst')
+			boostMethods.includes('burst') ? null : boostMethods.push('burst');
 		}
 	}
-	
+
 	// check if the monster can be barraged
-	if (params.monster.canBarrage){
+	if (params.monster.canBarrage) {
 		// check if the monster exists in catacombs
-		if(params.monster.existsInCatacombs){
+		if (params.monster.existsInCatacombs) {
 			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
-				boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
+				boostMethods.includes('barrage') ? null : boostMethods.push('barrage');
 			}
 			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst)) {
-				boostMethods.includes('burst') ? null : boostMethods.push('burst')
+				boostMethods.includes('burst') ? null : boostMethods.push('burst');
 			}
-		} else if (!params.monster.cannonMulti) { 
+		} else if (!params.monster.cannonMulti) {
 			// prevents cases such as: cannoning in singles but receiving multi combat bursting boost
 			return boostMethods;
 		} else {
 			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
-				boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
+				boostMethods.includes('barrage') ? null : boostMethods.push('barrage');
 			}
 			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst)) {
-				boostMethods.includes('burst') ? null : boostMethods.push('burst')
+				boostMethods.includes('burst') ? null : boostMethods.push('burst');
 			}
 		}
 	}
 
-    return boostMethods;
+	return boostMethods;
 }
 
 export async function calculateSlayerPoints(currentStreak: number, master: SlayerMaster, user: MUser) {

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -40,11 +40,9 @@ interface DetermineBoostParams {
 }
 export function determineCombatBoosts(params: DetermineBoostParams) {
 
-	// if EHP slayer (PvMMethod) the methods are initilized with boostMethods variable
+	// if EHP slayer (PvMMethod) the methods are initialized with boostMethods variable
     const boostMethods = (params.methods ?? ['none']).flat().filter(method => method);
-    console.log(`methods passed in to determineBoostChouice: ${boostMethods}`);
-	console.log(`Combat options selected: ${params.cbOpts}`)
-
+   
 	// check if user has cannon combat option turned on
 	if(params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)){
 		boostMethods.includes('cannon') ? null : boostMethods.push('cannon')
@@ -72,7 +70,6 @@ export function determineCombatBoosts(params: DetermineBoostParams) {
 			}
 		} else if (!params.monster.cannonMulti) { 
 			// prevents cases such as: cannoning in singles but receiving multi combat bursting boost
-			console.log(`Check failed here, methods being returned: ${boostMethods}`)
 			return boostMethods;
 		} else {
 			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
@@ -84,7 +81,6 @@ export function determineCombatBoosts(params: DetermineBoostParams) {
 		}
 	}
 
-	console.log(`methods being returned: ${boostMethods}`)
     return boostMethods;
 }
 

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -40,13 +40,17 @@ interface DetermineBoostParams {
 }
 export function determineCombatBoosts(params: DetermineBoostParams) {
 
+	// if EHP slayer (PvMMethod) the methods are initilized with boostMethods variable
     const boostMethods = (params.methods ?? ['none']).flat().filter(method => method);
     console.log(`methods passed in to determineBoostChouice: ${boostMethods}`);
 	console.log(`Combat options selected: ${params.cbOpts}`)
 
+	// check if user has cannon combat option turned on
 	if(params.cbOpts.includes(CombatOptionsEnum.AlwaysCannon)){
 		boostMethods.includes('cannon') ? null : boostMethods.push('cannon')
 	}
+
+	// check for special burst case under wildyBurst variable
 	if (params.wildyBurst){
 		if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
 			boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
@@ -55,10 +59,19 @@ export function determineCombatBoosts(params: DetermineBoostParams) {
 			boostMethods.includes('burst') ? null : boostMethods.push('burst')
 		}
 	}
-
+	
+	// check if the monster can be barraged
 	if (params.monster.canBarrage){
-		if (!params.monster.cannonMulti || params.monster.existsInCatacombs) { 
-			// Don't allow bursting in single combat
+		// check if the monster exists in catacombs
+		if(params.monster.existsInCatacombs){
+			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBarrage)) {
+				boostMethods.includes('barrage') ? null : boostMethods.push('barrage')
+			}
+			if (params.cbOpts.includes(CombatOptionsEnum.AlwaysIceBurst)) {
+				boostMethods.includes('burst') ? null : boostMethods.push('burst')
+			}
+		} else if (!params.monster.cannonMulti) { 
+			// prevents cases such as: cannoning in singles but receiving multi combat bursting boost
 			console.log(`Check failed here, methods being returned: ${boostMethods}`)
 			return boostMethods;
 		} else {

--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -240,7 +240,7 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		monsterID: Monsters.Bloodveld.id,
 		efficientName: Monsters.Bloodveld.name,
 		efficientMonster: Monsters.Bloodveld.id,
-		efficientMethod: 'barrage'
+		efficientMethod: 'none'
 	},
 	{
 		monsterID: Monsters.ChaosDruid.id,

--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -348,7 +348,7 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		monsterID: Monsters.GreaterNechryael.id,
 		efficientName: Monsters.GreaterNechryael.name,
 		efficientMonster: Monsters.GreaterNechryael.id,
-		efficientMethod: 'barrage'
+		efficientMethod: ['barrage', 'cannon']
 	},
 	{
 		monsterID: Monsters.RevenantImp.id,

--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -17,7 +17,7 @@ interface AutoslayLink {
 	// Name and Monster must be specified if either is.
 	efficientName?: string;
 	efficientMonster?: number;
-	efficientMethod?: PvMMethod;
+	efficientMethod?: PvMMethod | PvMMethod[];
 	slayerMasters?: SlayerMasterEnum[];
 }
 
@@ -147,7 +147,7 @@ const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		monsterID: Monsters.SmokeDevil.id,
 		efficientName: Monsters.SmokeDevil.name,
 		efficientMonster: Monsters.SmokeDevil.id,
-		efficientMethod: 'barrage'
+		efficientMethod: ['barrage', 'cannon']
 	},
 	{
 		monsterID: Monsters.DarkBeast.id,
@@ -216,13 +216,13 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		monsterID: Monsters.AbyssalDemon.id,
 		efficientName: Monsters.AbyssalDemon.name,
 		efficientMonster: Monsters.AbyssalDemon.id,
-		efficientMethod: 'barrage'
+		efficientMethod: ['barrage', 'cannon']
 	},
 	{
 		monsterID: Monsters.Ankou.id,
 		efficientName: Monsters.Ankou.name,
 		efficientMonster: Monsters.Ankou.id,
-		efficientMethod: 'barrage'
+		efficientMethod: ['barrage', 'cannon']
 	},
 	{
 		monsterID: Monsters.BlackDemon.id,
@@ -264,7 +264,7 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		monsterID: Monsters.DustDevil.id,
 		efficientName: Monsters.DustDevil.name,
 		efficientMonster: Monsters.DustDevil.id,
-		efficientMethod: 'barrage'
+		efficientMethod: ['barrage', 'cannon']
 	},
 	{
 		monsterID: Monsters.ElderChaosDruid.id,
@@ -318,7 +318,7 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		monsterID: Monsters.Jelly.id,
 		efficientName: Monsters.Jelly.name,
 		efficientMonster: Monsters.Jelly.id,
-		efficientMethod: 'barrage'
+		efficientMethod: ['barrage', 'cannon']
 	},
 	{
 		monsterID: Monsters.LesserDemon.id,
@@ -345,10 +345,10 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		efficientMethod: 'cannon'
 	},
 	{
-		monsterID: Monsters.Nechryael.id,
+		monsterID: Monsters.GreaterNechryael.id,
 		efficientName: Monsters.Nechryael.name,
 		efficientMonster: Monsters.Nechryael.id,
-		efficientMethod: 'barrage'
+		efficientMethod: ['barrage', 'cannon']
 	},
 	{
 		monsterID: Monsters.RevenantImp.id,
@@ -485,7 +485,7 @@ export async function autoSlayCommand({
 				name: ehpMonster.efficientName
 			};
 			if (ehpMonster.efficientMethod) {
-				args.method = ehpMonster.efficientMethod;
+				args.method = ehpMonster.efficientMethod as unknown as CommandOptions;
 			}
 			runCommand({
 				commandName: 'k',

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -473,6 +473,10 @@ export async function minionKillCommand(
 		if (monster.id === Monsters.HillGiant.id || monster.id === Monsters.MossGiant.id) {
 			usingCannon = isInWilderness;
 		}
+		if (monster.id === Monsters.Spider.id || Monsters.Scorpion.id){
+			usingCannon = isInWilderness;
+			cannonMulti = isInWilderness;
+		}
 		if (monster.wildySlayerCave) {
 			usingCannon = isInWilderness;
 			cannonMulti = isInWilderness;

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -206,11 +206,9 @@ export async function minionKillCommand(
 		}
 	}
 
-	// Add jelly check as can barrage in wilderness
+	// Add check for burstable monsters in wilderness
 	const jelly = monster.id === Monsters.Jelly.id;
-	const bloodveld = monster.id === Monsters.Bloodveld.id;
-
-	const wildyBurst = (jelly || bloodveld) && isInWilderness;
+	const wildyBurst = (jelly) && isInWilderness;
 
 	// determines what pvm methods the user can use
 	const myCBOpts = user.combatOptions;
@@ -468,7 +466,7 @@ export async function minionKillCommand(
 		return `You need 65 Ranged to use Chinning method. You have ${user.skillLevel(SkillsEnum.Ranged)}`;
 	}
 
-	// Wildy Monster checks
+	// Wildy monster cannon checks
 	if (isInWilderness === true && combatMethods.includes('cannon')) {
 		if (monster.id === Monsters.HillGiant.id || monster.id === Monsters.MossGiant.id) {
 			usingCannon = isInWilderness;
@@ -487,8 +485,9 @@ export async function minionKillCommand(
 		}
 	}
 
+	// Burst/barrage check with wilderness conditions
 	if ((method === 'burst' || method === 'barrage') && !monster?.canBarrage) {
-		if (jelly || bloodveld) {
+		if (jelly) {
 			if (!isInWilderness) {
 				return `${monster.name} can only be barraged or burst in the wilderness.`;
 			}

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -208,7 +208,7 @@ export async function minionKillCommand(
 
 	// Add check for burstable monsters in wilderness
 	const jelly = monster.id === Monsters.Jelly.id;
-	const wildyBurst = (jelly) && isInWilderness;
+	const wildyBurst = jelly && isInWilderness;
 
 	// determines what pvm methods the user can use
 	const myCBOpts = user.combatOptions;
@@ -471,7 +471,7 @@ export async function minionKillCommand(
 		if (monster.id === Monsters.HillGiant.id || monster.id === Monsters.MossGiant.id) {
 			usingCannon = isInWilderness;
 		}
-		if (monster.id === Monsters.Spider.id || Monsters.Scorpion.id){
+		if (monster.id === Monsters.Spider.id || Monsters.Scorpion.id) {
 			usingCannon = isInWilderness;
 			cannonMulti = isInWilderness;
 		}
@@ -500,7 +500,11 @@ export async function minionKillCommand(
 		}
 	}
 
-	if (combatMethods.includes('barrage') && attackStyles.includes(SkillsEnum.Magic) && (monster?.canBarrage || wildyBurst)) {
+	if (
+		combatMethods.includes('barrage') &&
+		attackStyles.includes(SkillsEnum.Magic) &&
+		(monster?.canBarrage || wildyBurst)
+	) {
 		consumableCosts.push(iceBarrageConsumables);
 		calculateVirtusBoost();
 		timeToFinish = reduceNumByPercent(timeToFinish, boostIceBarrage + virtusBoost);


### PR DESCRIPTION
### Description:
Currently the bot only allows for 1 combat option such as cannon or bursting. It is possible to burst/cannon in multiple places in osrs. This PR allows for multiple combat options to be used. ex. cannon and bursting ankous.

### Changes:
- Allow multiple combat options if the attack style/monster attributes allow for it
- Change wilderness Nechryael to Greater Nechryael
- Update EHP methods to allow for cannon and barrage
  - Smoke devils
  - Abyssal demons (wilderness)
  - Ankous (wilderness)
  - Greater Nechryael (wilderness)
  - Jelly (wilderness)
  - Dust devils (wilderness)
- Remove ability to burst/cannon bloodvelds in wilderness
- Remove ability to cannon bloodvelds everywhere

### Other checks:
- [X] I have tested all my changes thoroughly.
