### PR TITLE
Fix tame s6 crates

### DIFF
--- a/src/tasks/tames/tameTasks.ts
+++ b/src/tasks/tames/tameTasks.ts
@@ -142,12 +142,11 @@ export async function runTameTask(activity: TameActivity, tame: Tame) {
 
 	async function handleFinish(res: { loot: Bank | null; message: string; user: MUser }) {
 		const previousTameCl = new Bank({ ...(tame.max_total_loot as ItemBank) });
-
-		const loot = res.loot?.clone() ?? new Bank();
-		const crateRes = handleCrateSpawns(user, activity.duration);
-		if (crateRes !== null) loot.add(crateRes);
+		const { loot } = res;
 
 		if (loot) {
+			const crateRes = handleCrateSpawns(user, activity.duration);
+			if (crateRes !== null) loot.add(crateRes);
 			await prisma.tame.update({
 				where: {
 					id: tame.id


### PR DESCRIPTION
### Description:

Fixes bug where Tame's s6  crates fell into the aether.

### Changes:

- Reverts to modifying the passed loot object

### Other checks:

- [x] I have tested all my changes thoroughly.

### Notes:

- I appreciate that the change was made to allow (in theory) Tame trips that don't return loot to still earn boxes, however that is not the intention of the rest of the code. The only current example of this is Tame trips that don't get any kills  (ie. Cox), but in those cases the code explicitly is written to deny ALL loot; there is no `user.addItemsToBank()` function call in that path.
- Additional reworking would be required, to centralize the call to `addItemsToBank()`, and potentially update `handleFinish()` to return a loot Bank object rather than manipulate the one passed to it.
