### PR TITLE
Update Falador Hard Diary

### DIFF
--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -470,10 +470,7 @@ export const FaladorDiary: Diary = {
 		qp: 32,
 		collectionLogReqs: resolveItems([
 			'Mind rune',
-			'Prospector jacket',
-			'Prospector helmet',
-			'Prospector legs',
-			'Prospector boots'
+			'Prospector helmet'
 		]),
 		monsterScores: {
 			'Skeletal Wyvern': 1,

--- a/src/lib/diaries.ts
+++ b/src/lib/diaries.ts
@@ -468,10 +468,7 @@ export const FaladorDiary: Diary = {
 			woodcutting: 71
 		},
 		qp: 32,
-		collectionLogReqs: resolveItems([
-			'Mind rune',
-			'Prospector helmet'
-		]),
+		collectionLogReqs: resolveItems(['Mind rune', 'Prospector helmet']),
 		monsterScores: {
 			'Skeletal Wyvern': 1,
 			'Blue Dragon': 1


### PR DESCRIPTION
### Description:

Updating the Falador Hard Diary in line with the update on the 8th of May, 2024.(https://oldschool.runescape.wiki/w/Update:Project_Rebalance:_Skilling_%26_Poll_81_MTA_Changes)

### Changes:

Removed the requirements for the Prospector Jacket, Legs and Boots in line with the update.
