### PR TITLE
Fix typo in the finished hunting message

### DIFF
--- a/src/tasks/minions/HunterActivity/hunterActivity.ts
+++ b/src/tasks/minions/HunterActivity/hunterActivity.ts
@@ -179,7 +179,7 @@ export const hunterTask: MinionTask = {
 		let str = `${user}, ${user.minionName} finished hunting ${creature.name}${
 			crystalImpling
 				? '.'
-				: `${quantity}x times, due to clever creatures you missed out on ${
+				: ` ${quantity}x times, due to clever creatures you missed out on ${
 						quantity - successfulQuantity
 					}x catches. `
 		}${xpStr}\n\nYou received: ${loot}.${magicSecStr.length > 1 ? magicSecStr : ''}`;


### PR DESCRIPTION
### Description:

Looks like this typo was already resolved in BSO, just not in OSB for some reason.

closes: #5968

### Changes:

Added a spacebar kek
