### PR TITLE
Fix CA & few adjustments

### DIFF
--- a/src/lib/combat_achievements/combatAchievements.ts
+++ b/src/lib/combat_achievements/combatAchievements.ts
@@ -162,13 +162,13 @@ const indexesWithRng = entries.flatMap(i => i[1].tasks.filter(t => 'rng' in t));
 export const combatAchievementTripEffect = async ({ data, messages, user }: Parameters<TripFinishEffect['fn']>[0]) => {
 	const dataCopy = deepClone(data);
 	if (dataCopy.type === 'Inferno' && !dataCopy.diedPreZuk && !dataCopy.diedZuk) {
-		(dataCopy as any).quantity = 1;
+		(dataCopy as any).q = 1;
 	}
 	if (dataCopy.type === 'Colosseum') {
-		(dataCopy as any).quantity = 1;
+		(dataCopy as any).q = 1;
 	}
-	if (!('quantity' in dataCopy)) return;
-	let quantity = Number(dataCopy.quantity);
+	if (!('q' in dataCopy)) return;
+	let quantity = Number(dataCopy.q);
 	if (Number.isNaN(quantity)) return;
 
 	if (data.type === 'TombsOfAmascut') {
@@ -188,6 +188,7 @@ export const combatAchievementTripEffect = async ({ data, messages, user }: Para
 	);
 
 	for (const user of users) {
+		console.log('1');
 		const completedTasks = [];
 		let qty = quantity;
 		for (const task of indexesWithRng) {

--- a/src/lib/combat_achievements/combatAchievements.ts
+++ b/src/lib/combat_achievements/combatAchievements.ts
@@ -188,7 +188,6 @@ export const combatAchievementTripEffect = async ({ data, messages, user }: Para
 	);
 
 	for (const user of users) {
-		console.log('1');
 		const completedTasks = [];
 		let qty = quantity;
 		for (const task of indexesWithRng) {

--- a/src/lib/combat_achievements/hard.ts
+++ b/src/lib/combat_achievements/hard.ts
@@ -597,7 +597,7 @@ export const hardCombatAchievements: CombatAchievement[] = [
 		monster: 'Tempoross',
 		desc: 'Subdue Tempoross, getting rewarded with 10 reward permits from a single Tempoross fight.',
 		rng: {
-			chancePerKill: 30,
+			chancePerKill: 5,
 			hasChance: data => data.type === 'Tempoross'
 		}
 	},

--- a/src/lib/combat_achievements/medium.ts
+++ b/src/lib/combat_achievements/medium.ts
@@ -431,7 +431,7 @@ export const mediumCombatAchievements: CombatAchievement[] = [
 		monster: 'Skotizo',
 		desc: 'Kill Skotizo with no altars active.',
 		rng: {
-			chancePerKill: 15,
+			chancePerKill: 5,
 			hasChance: isCertainMonsterTrip(Monsters.Skotizo.id)
 		}
 	},

--- a/src/mahoji/lib/abstracted_commands/buyFossilIslandNotes.ts
+++ b/src/mahoji/lib/abstracted_commands/buyFossilIslandNotes.ts
@@ -32,7 +32,7 @@ export async function buyFossilIslandNotes(user: MUser, interaction: ChatInputCo
 				? getOSItem(randArrItem(fossilIslandNotesCL))
 				: getOSItem(randArrItem(filteredPages));
 		tempClWithNewUniques.add(outPage);
-		loot.add(outPage);
+		loot.add(outPage);win
 	}
 
 	await transactItems({ userID: user.id, itemsToRemove: cost, itemsToAdd: loot, collectionLog: true });

--- a/src/mahoji/lib/abstracted_commands/buyFossilIslandNotes.ts
+++ b/src/mahoji/lib/abstracted_commands/buyFossilIslandNotes.ts
@@ -32,7 +32,7 @@ export async function buyFossilIslandNotes(user: MUser, interaction: ChatInputCo
 				? getOSItem(randArrItem(fossilIslandNotesCL))
 				: getOSItem(randArrItem(filteredPages));
 		tempClWithNewUniques.add(outPage);
-		loot.add(outPage);win
+		loot.add(outPage);
 	}
 
 	await transactItems({ userID: user.id, itemsToRemove: cost, itemsToAdd: loot, collectionLog: true });


### PR DESCRIPTION
### Description:
Fix combat achievements not properly being distributed and adjust a few CA rng chance.

### Changes:
- Check for 'q' instead of 'quantity'
- Update two CA that have to high of rng due to their ease to get ingame:
    - Kill Skotizo with no altars active. rng: 15 to rng: 5
    - Why Cook? rng: 30 to rng: 5

### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5781
