### PR TITLE
Fixed incorrect command name in Hint

### DIFF
--- a/src/mahoji/lib/abstracted_commands/mageTrainingArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/mageTrainingArenaCommand.ts
@@ -113,7 +113,7 @@ ${mageTrainingArenaBuyables
 	.map(i => `${i.item.name} - ${i.cost} pts - ${formatDuration((i.cost / pizazzPointsPerHour) * (Time.Minute * 60))}`)
 	.join('\n')}
         
-Hint: Magic Training Arena is combined into 1 room, and 1 set of points - rewards take approximately the same amount of time to get. To get started use **/minigames mage_training_arena train**. You can buy rewards using **/minigames mage_training_arena buy**.`;
+Hint: Magic Training Arena is combined into 1 room, and 1 set of points - rewards take approximately the same amount of time to get. To get started use **/minigames mage_training_arena start**. You can buy rewards using **/minigames mage_training_arena buy**.`;
 }
 
 export async function mageTrainingArenaStartCommand(user: MUser, channelID: string): CommandResponse {


### PR DESCRIPTION
### Description:

Fixed the incorrectly named command in the Hint text as spotted out in Issue 5930

closes: #5930 

### Changes:

Changed train to start
