### PR TITLE
fix coffin creatables 

### DIFF
--- a/src/lib/data/creatables/shadesOfMorton.ts
+++ b/src/lib/data/creatables/shadesOfMorton.ts
@@ -15,7 +15,7 @@ export const shadesOfMortonCreatables: Createable[] = [
 		name: 'Steel coffin',
 		inputItems: new Bank({
 			'Steel locks': 1,
-			'Bronze coffin': 1
+			'Broken coffin': 1
 		}),
 		outputItems: new Bank({ 'Steel coffin': 1 })
 	},
@@ -23,7 +23,7 @@ export const shadesOfMortonCreatables: Createable[] = [
 		name: 'Black coffin',
 		inputItems: new Bank({
 			'Black locks': 1,
-			'Steel coffin': 1
+			'Broken coffin': 1
 		}),
 		outputItems: new Bank({ 'Black coffin': 1 })
 	},
@@ -31,7 +31,7 @@ export const shadesOfMortonCreatables: Createable[] = [
 		name: 'Silver coffin',
 		inputItems: new Bank({
 			'Silver locks': 1,
-			'Black coffin': 1
+			'Broken coffin': 1
 		}),
 		outputItems: new Bank({ 'Silver coffin': 1 })
 	},
@@ -39,7 +39,7 @@ export const shadesOfMortonCreatables: Createable[] = [
 		name: 'Gold coffin',
 		inputItems: new Bank({
 			'Gold locks': 1,
-			'Silver coffin': 1
+			'Broken coffin': 1
 		}),
 		outputItems: new Bank({ 'Gold coffin': 1 })
 	}

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -22917,7 +22917,7 @@ exports[`OSB Creatables 1`] = `
     "inputItems": Bank {
       "bank": {
         "25445": 1,
-        "25459": 1,
+        "25457": 1,
       },
       "frozen": false,
     },
@@ -22934,7 +22934,7 @@ exports[`OSB Creatables 1`] = `
     "inputItems": Bank {
       "bank": {
         "25448": 1,
-        "25461": 1,
+        "25457": 1,
       },
       "frozen": false,
     },
@@ -22951,7 +22951,7 @@ exports[`OSB Creatables 1`] = `
     "inputItems": Bank {
       "bank": {
         "25451": 1,
-        "25463": 1,
+        "25457": 1,
       },
       "frozen": false,
     },
@@ -22968,7 +22968,7 @@ exports[`OSB Creatables 1`] = `
     "inputItems": Bank {
       "bank": {
         "25454": 1,
-        "25465": 1,
+        "25457": 1,
       },
       "frozen": false,
     },


### PR DESCRIPTION
### Description:
Fixes coffin creatables to use the proper items.
Updated from stale PR: https://github.com/oldschoolgg/oldschoolbot/pull/4846
### Changes:
- Use broken coffin as secondary item for all coffins
### Other checks:
- [X] I have tested all my changes thoroughly.
