### PR TITLE
Adjust mining portent charges

### DIFF
--- a/src/lib/bso/divination.ts
+++ b/src/lib/bso/divination.ts
@@ -351,7 +351,7 @@ export const portents: SourcePortent[] = [
 		description: 'Consumes stone spirits to grant extra mining XP, instead of extra ore.',
 		divinationLevelToCreate: 90,
 		cost: new Bank().add('Incandescent energy', 1200),
-		chargesPerPortent: 1000,
+		chargesPerPortent: 60 * 10,
 		addChargeMessage: portent =>
 			`You used a Spiritual mining portent, it will turn stone spirits into extra mining XP, instead of ore, in your next ${portent.charges_remaining} minutes of mining.`
 	},

--- a/src/lib/bso/divination.ts
+++ b/src/lib/bso/divination.ts
@@ -353,7 +353,7 @@ export const portents: SourcePortent[] = [
 		cost: new Bank().add('Incandescent energy', 1200),
 		chargesPerPortent: 1000,
 		addChargeMessage: portent =>
-			`You used a Spiritual mining portent, your next ${portent.charges_remaining}x stone spirits will grant XP instead of ore.`
+			`You used a Spiritual mining portent, it will turn stone spirits into extra mining XP, instead of ore, in your next ${portent.charges_remaining} minutes of mining.`
 	},
 	{
 		id: PortentID.PacifistPortent,

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -251,6 +251,7 @@ export const miningTask: MinionTask = {
 	async run(data: MiningActivityTaskOptions) {
 		const { oreID, userID, channelID, duration, powermine } = data;
 		const { quantity } = data;
+		const minutes = Math.round(duration / Time.Minute);
 		const user = await mUserFetch(userID);
 		const ore = Mining.Ores.find(ore => ore.id === oreID)!;
 
@@ -264,7 +265,7 @@ export const miningTask: MinionTask = {
 				? await chargePortentIfHasCharges({
 						user,
 						portentID: PortentID.MiningPortent,
-						charges: amountOfSpiritsToUse
+						charges: minutes
 					})
 				: null;
 		const {


### PR DESCRIPTION
### Description:
Reduce the amount of charges the mining portent uses from amount of spirits used to minutes mining (similar to graceful portent)
Community poll for the change: https://discord.com/channels/342983479501389826/1032668754561224734/1206764280901541908
### Changes:
- Use minutes for removing charges of mining portent
- Reduce chargesPerPortent to 600 (10hours)
### Other checks:
- [X] I have tested all my changes thoroughly.
