### PR TITLE
Fix Farmer role

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -66,6 +66,7 @@ export const Roles = {
 	TopMinigamer: DISCORD_SETTINGS.Roles?.TopMinigamer ?? '832798997033779220',
 	TopClueHunter: DISCORD_SETTINGS.Roles?.TopClueHunter ?? '839135887467610123',
 	TopSlayer: DISCORD_SETTINGS.Roles?.TopSlayer ?? '856080958247010324',
+	TopFarmer: DISCORD_SETTINGS.Roles?.TopFarmer ?? '894194027363205150',
 	TopGlobalCL: '1072426869028294747'
 };
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -346,7 +346,8 @@ export const BadgesEnum = {
 	TopMinigame: 11,
 	SotWTrophy: 12,
 	Slayer: 13,
-	TopGiveawayer: 14
+	TopGiveawayer: 14,
+	Farmer: 15
 } as const;
 
 export const badges: { [key: number]: string } = {
@@ -364,7 +365,8 @@ export const badges: { [key: number]: string } = {
 	[BadgesEnum.TopMinigame]: Emoji.MinigameIcon,
 	[BadgesEnum.SotWTrophy]: Emoji.SOTWTrophy,
 	[BadgesEnum.Slayer]: Emoji.Slayer,
-	[BadgesEnum.TopGiveawayer]: Emoji.SantaHat
+	[BadgesEnum.TopGiveawayer]: Emoji.SantaHat,
+	[BadgesEnum.Farmer]: Emoji.Farming
 };
 
 export const MAX_XP = 200_000_000;

--- a/src/lib/rolesTask.ts
+++ b/src/lib/rolesTask.ts
@@ -241,7 +241,7 @@ LIMIT 2;`
 	for (const { id, desc } of res.flat()) {
 		results.push({
 			userID: id,
-			roleID: '894194027363205150',
+			roleID: Roles.TopFarmer,
 			reason: desc,
 			badge: BadgesEnum.Farmer
 		});

--- a/src/lib/rolesTask.ts
+++ b/src/lib/rolesTask.ts
@@ -243,7 +243,7 @@ LIMIT 2;`
 			userID: id,
 			roleID: '894194027363205150',
 			reason: desc,
-			badge: BadgesEnum.Slayer
+			badge: BadgesEnum.Farmer
 		});
 	}
 	return results;


### PR DESCRIPTION
Currently the top farmers have the slayer emoji on the leaderboards, this changes them to have the farming emoji.

- [ ] I have tested all my changes thoroughly.
