### PR TITLE
Fix elite clue drop rates for TOB

### DIFF
--- a/src/lib/simulation/tob.ts
+++ b/src/lib/simulation/tob.ts
@@ -109,7 +109,7 @@ class TheatreOfBloodClass {
 
 			clueRate = 3.5 / 25;
 		}
-		console.log(clueRate)
+
 		if (Math.random() < clueRate) {
 			loot.add('Clue scroll (elite)');
 		}

--- a/src/lib/simulation/tob.ts
+++ b/src/lib/simulation/tob.ts
@@ -98,6 +98,7 @@ class TheatreOfBloodClass {
 			loot.add(NonUniqueTable.roll());
 		}
 
+		let clueRate = 3 / 25;
 		if (isHardMode) {
 			// Add 15% extra regular loot for hard mode:
 			for (const [itemID] of Object.entries(loot.bank)) {
@@ -105,9 +106,11 @@ class TheatreOfBloodClass {
 			}
 			// Add HM Tertiary drops: dust / kits
 			loot.add(HardModeExtraTable.roll());
-		}
 
-		if (roll(25)) {
+			clueRate = 3.5 / 25;
+		}
+		console.log(clueRate)
+		if (Math.random() < clueRate) {
 			loot.add('Clue scroll (elite)');
 		}
 


### PR DESCRIPTION
### Description:

TOB currently uses the entry mode drop rate for elite clues, this PR adjusts the rates to match OSRS.

### Changes:

-Changed elite clue rate to 3/25 for normal mode and 3.5/25 for HM.

### Other checks:

- [ ] I have tested all my changes thoroughly.
