### PR TITLE
Muliple combat method fixes

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -501,6 +501,7 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		wildy: true,
 		wildyMulti: true,
 		canBePked: true,
+		canCannon: true,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 9,
 

--- a/src/lib/minions/data/killableMonsters/konarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/konarMonsters.ts
@@ -249,12 +249,6 @@ export const konarMonsters: KillableMonster[] = [
 		},
 		slayerOnly: true,
 		superior: Monsters.NuclearSmokeDevil,
-		itemInBankBoosts: [
-			{
-				[itemID('Kodai wand')]: 12,
-				[itemID('Staff of the dead')]: 8
-			}
-		],
 		healAmountNeeded: 16,
 		attackStyleToUse: GearStat.AttackMagic,
 		attackStylesUsed: [GearStat.AttackMagic],

--- a/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/vannakaMonsters.ts
@@ -117,12 +117,6 @@ export const vannakaMonsters: KillableMonster[] = [
 		attackStylesUsed: [GearStat.AttackCrush],
 		canCannon: true,
 		canBarrage: true,
-		itemInBankBoosts: [
-			{
-				[itemID('Kodai wand')]: 12,
-				[itemID('Staff of the dead')]: 8
-			}
-		],
 		pkActivityRating: 4,
 		pkBaseDeathChance: 3,
 		revsWeaponBoost: true,
@@ -458,12 +452,6 @@ export const vannakaMonsters: KillableMonster[] = [
 			slayer: 65
 		},
 		superior: Monsters.ChokeDevil,
-		itemInBankBoosts: [
-			{
-				[itemID('Kodai wand')]: 15,
-				[itemID('Staff of the dead')]: 10
-			}
-		],
 		canCannon: true,
 		cannonMulti: false,
 		canBarrage: true,
@@ -639,9 +627,7 @@ export const vannakaMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		itemInBankBoosts: [
 			{
-				[itemID('Arclight')]: 10,
-				[itemID('Staff of the dead')]: 15,
-				[itemID('Kodai wand')]: 20
+				[itemID('Arclight')]: 10
 			}
 		],
 		existsInCatacombs: true,

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -528,8 +528,6 @@ async function handleCommandEnable(
 	return `Successfully disabled the \`${command.name}\` command.`;
 }
 
-const priorityWarningMsg =
-	"\n\n**Important: By default, 'Always barrage/burst' will take priority if 'Always cannon' is also enabled.**";
 async function handleCombatOptions(user: MUser, command: 'add' | 'remove' | 'list' | 'help', option?: string) {
 	const settings = await mahojiUsersSettingsFetch(user.id, { combat_options: true });
 	if (!command || (command && command === 'list')) {
@@ -557,18 +555,12 @@ async function handleCombatOptions(user: MUser, command: 'add' | 'remove' | 'lis
 		return `"${newcbopt.name}" is already ${currentStatus ? 'enabled' : 'disabled'} for you.`;
 	}
 
-	let warningMsg = '';
-	const hasCannon = settings.combat_options.includes(CombatOptionsEnum.AlwaysCannon);
-	const hasBurstB =
-		settings.combat_options.includes(CombatOptionsEnum.AlwaysIceBurst) ||
-		settings.combat_options.includes(CombatOptionsEnum.AlwaysIceBarrage);
 	// If enabling Ice Barrage, make sure burst isn't also enabled:
 	if (
 		nextBool &&
 		newcbopt.id === CombatOptionsEnum.AlwaysIceBarrage &&
 		settings.combat_options.includes(CombatOptionsEnum.AlwaysIceBurst)
 	) {
-		if (hasCannon) warningMsg = priorityWarningMsg;
 		settings.combat_options = removeFromArr(settings.combat_options, CombatOptionsEnum.AlwaysIceBurst);
 	}
 	// If enabling Ice Burst, make sure barrage isn't also enabled:
@@ -577,12 +569,7 @@ async function handleCombatOptions(user: MUser, command: 'add' | 'remove' | 'lis
 		newcbopt.id === CombatOptionsEnum.AlwaysIceBurst &&
 		settings.combat_options.includes(CombatOptionsEnum.AlwaysIceBarrage)
 	) {
-		if (warningMsg === '' && hasCannon) warningMsg = priorityWarningMsg;
 		settings.combat_options = removeFromArr(settings.combat_options, CombatOptionsEnum.AlwaysIceBarrage);
-	}
-	// Warn if enabling cannon with ice burst/barrage:
-	if (nextBool && newcbopt.id === CombatOptionsEnum.AlwaysCannon && warningMsg === '' && hasBurstB) {
-		warningMsg = priorityWarningMsg;
 	}
 	if (nextBool && !settings.combat_options.includes(newcbopt.id)) {
 		await user.update({
@@ -596,7 +583,7 @@ async function handleCombatOptions(user: MUser, command: 'add' | 'remove' | 'lis
 		return 'Error processing command. This should never happen, please report bug.';
 	}
 
-	return `${newcbopt.name} is now ${nextBool ? 'enabled' : 'disabled'} for you.${warningMsg}`;
+	return `${newcbopt.name} is now ${nextBool ? 'enabled' : 'disabled'} for you.`;
 }
 
 async function handleRSN(user: MUser, newRSN: string) {

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -411,14 +411,15 @@ export async function minionKillCommand(
 
 	// Kodai boost
 	if (style === 'mage' && (combatMethods.includes('barrage') || combatMethods.includes('burst'))) {
-		const kodaiEquipped = isInWilderness ? wildyGear.hasEquipped('Kodai wand') : user.gear.mage.hasEquipped('Kodai wand');
-		
+		const kodaiEquipped = isInWilderness
+			? wildyGear.hasEquipped('Kodai wand')
+			: user.gear.mage.hasEquipped('Kodai wand');
+
 		if (kodaiEquipped) {
 			timeToFinish = reduceNumByPercent(timeToFinish, 15);
 			boosts.push('15% boost for Kodai wand');
 		}
 	}
-
 
 	// Only choose greater boost:
 	if (salveAmuletBoost || blackMaskBoost) {

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -487,13 +487,8 @@ export async function minionKillCommand(
 
 		// wildy bosses
 		for (const wildyMonster of wildyKillableMonsters) {
-			if (monster.id === wildyMonster.id && wildyMonster.canCannon) {
-				usingCannon = isInWilderness;
-				cannonMulti = false;
-				break;
-			}
 			if (monster.id === wildyMonster.id) {
-				usingCannon = false;
+				usingCannon = wildyMonster.canCannon ? isInWilderness : false;
 				cannonMulti = false;
 				break;
 			}

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -281,7 +281,6 @@ export async function minionKillCommand(
 	const isDragon = osjsMon?.data?.attributes?.includes(MonsterAttribute.Dragon);
 
 	function applyRevWeaponBoost() {
-		const style = convertAttackStylesToSetup(user.user.attack_style);
 		const specialWeapon = revSpecialWeapons[style];
 		const upgradedWeapon = revUpgradedWeapons[style];
 
@@ -370,10 +369,6 @@ export async function minionKillCommand(
 		}
 	}
 
-	if (isInWilderness && monster.revsWeaponBoost) {
-		applyRevWeaponBoost();
-	}
-
 	function calculateVirtusBoost() {
 		let virtusPiecesEquipped = 0;
 
@@ -396,6 +391,12 @@ export async function minionKillCommand(
 					: '';
 	}
 
+	if (isInWilderness && monster.revsWeaponBoost) {
+		if (!combatMethods.includes('barrage') || !combatMethods.includes('burst')) {
+			applyRevWeaponBoost();
+		}
+	}
+
 	if (isDragon && monster.name.toLowerCase() !== 'vorkath') {
 		applyDragonBoost();
 	}
@@ -407,6 +408,17 @@ export async function minionKillCommand(
 	if (isUndead) {
 		calculateSalveAmuletBoost();
 	}
+
+	// Kodai boost
+	if (style === 'mage' && (combatMethods.includes('barrage') || combatMethods.includes('burst'))) {
+		const kodaiEquipped = isInWilderness ? wildyGear.hasEquipped('Kodai wand') : user.gear.mage.hasEquipped('Kodai wand');
+		
+		if (kodaiEquipped) {
+			timeToFinish = reduceNumByPercent(timeToFinish, 15);
+			boosts.push('15% boost for Kodai wand');
+		}
+	}
+
 
 	// Only choose greater boost:
 	if (salveAmuletBoost || blackMaskBoost) {

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -493,6 +493,15 @@ export async function minionKillCommand(
 				break;
 			}
 		}
+
+		// revenants
+		for (const revenant of revenantMonsters) {
+			if (monster.id === revenant.id) {
+				usingCannon = false;
+				cannonMulti = false;
+				break;
+			}
+		}
 	}
 
 	// Burst/barrage check with wilderness conditions


### PR DESCRIPTION
### Description:
Some corrections and additions to recent combat method changes in https://github.com/oldschoolgg/oldschoolbot/pull/5962

### Changes:
- Add cannon use to Venenatis
- Remove cannon and multi boost from all other wildy bosses
- Remove cannon from revenant
- Remove rev weapon boost if barraging or bursting
- Remove kodai wand boost from bank for slayer monsters
  - Replace this with a global boost in minionKill.ts that gives 15% boost if training mage and bursting or barraging.
- Remove warning message for burst/barrage priority over cannon since both can be used now
- Add some troubleshooting commands the user can use if the trip fails because cannon isn't allowed
- Replace remaining `method ===` checks with `(combatMethods.includes())`

### Other checks:
- [X] I have tested all my changes thoroughly.
