### PR TITLE
Remove cannon message

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/wildy.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/wildy.ts
@@ -501,7 +501,6 @@ export const wildyKillableMonsters: KillableMonster[] = [
 		wildy: true,
 		wildyMulti: true,
 		canBePked: true,
-		canCannon: true,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 9,
 

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -214,7 +214,7 @@ export async function minionKillCommand(
 	// determines what pvm methods the user can use
 	const myCBOpts = user.combatOptions;
 	const methods = [method] as PvMMethod[];
-	const combatMethods = determineCombatBoosts({
+	let combatMethods = determineCombatBoosts({
 		cbOpts: myCBOpts as CombatOptionsEnum[],
 		user,
 		monster,
@@ -528,7 +528,7 @@ export async function minionKillCommand(
 
 	if (!usingCannon) {
 		if (combatMethods.includes('cannon') && !monster?.canCannon) {
-			return `${monster?.name} cannot be killed with a cannon.\n\n- Try removing: \`method:cannon\` from \`/k\` \n- Try: \`/config user combat_options action:Remove input:Always Cannon\``;
+			combatMethods = combatMethods.filter(method => method !== 'cannon');
 		}
 	}
 

--- a/src/mahoji/lib/abstracted_commands/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill.ts
@@ -501,7 +501,7 @@ export async function minionKillCommand(
 		// wildy bosses
 		for (const wildyMonster of wildyKillableMonsters) {
 			if (monster.id === wildyMonster.id) {
-				usingCannon = wildyMonster.canCannon ? isInWilderness : false;
+				usingCannon = false;
 				cannonMulti = false;
 				break;
 			}


### PR DESCRIPTION
### Description:
Remove the `Monster cannot be killed with a cannon message`.
### Changes:
- Remove the combat option of cannon instead of returning an error message. This allows the user to not have to manually remove the `Always cannon` option each time they go from a cannonable monster to a non cannonable monster.
- Remove cannon from venenatis (The wildy rework moved its location so I was working on outdated information)
### Other checks:
- [X] I have tested all my changes thoroughly.

