### PR TITLE
Fancier boots

### DIFF
--- a/src/mahoji/lib/abstracted_commands/strongHoldOfSecurityCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/strongHoldOfSecurityCommand.ts
@@ -1,8 +1,9 @@
 import { Time } from 'e';
 
 import type { ActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { randomVariation } from '../../../lib/util';
+import { randomVariation, resolveItems } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
+import { Bank } from 'oldschooljs';
 
 export async function strongHoldOfSecurityCommand(user: MUser, channelID: string) {
 	if (user.minionIsBusy) {
@@ -14,8 +15,23 @@ export async function strongHoldOfSecurityCommand(user: MUser, channelID: string
 			type: 'StrongholdOfSecurity'
 		}
 	});
+	const strongHoldBoots = resolveItems(['Fancy boots', 'Fighting boots', 'Fancier boots']);
+
 	if (count !== 0) {
-		return "You've already completed the Stronghold of Security!";
+		const bootsBank = new Bank();
+		for (const boots of strongHoldBoots){
+			if (!user.owns(boots)){
+				bootsBank.add(boots);
+			}
+		}
+
+		await transactItems({
+			userID: user.id,
+			collectionLog: true,
+			itemsToAdd: bootsBank
+		});
+
+		return `You've already completed the Stronghold of Security!${bootsBank.length > 0 ? ` You reclaimed these items: ${bootsBank}.` : ''}`;
 	}
 
 	await addSubTaskToActivityTask<ActivityTaskOptionsWithNoChanges>({

--- a/src/mahoji/lib/abstracted_commands/strongHoldOfSecurityCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/strongHoldOfSecurityCommand.ts
@@ -1,9 +1,9 @@
 import { Time } from 'e';
 
+import { Bank } from 'oldschooljs';
 import type { ActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
 import { randomVariation, resolveItems } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
-import { Bank } from 'oldschooljs';
 
 export async function strongHoldOfSecurityCommand(user: MUser, channelID: string) {
 	if (user.minionIsBusy) {
@@ -19,8 +19,8 @@ export async function strongHoldOfSecurityCommand(user: MUser, channelID: string
 
 	if (count !== 0) {
 		const bootsBank = new Bank();
-		for (const boots of strongHoldBoots){
-			if (!user.owns(boots)){
+		for (const boots of strongHoldBoots) {
+			if (!user.owns(boots)) {
 				bootsBank.add(boots);
 			}
 		}

--- a/src/tasks/minions/strongholdOfSecurityActivity.ts
+++ b/src/tasks/minions/strongholdOfSecurityActivity.ts
@@ -9,7 +9,7 @@ export const strongholdTask: MinionTask = {
 		const { channelID, userID } = data;
 		const user = await mUserFetch(userID);
 
-		const loot = new Bank().add('Coins', 10_000).add('Fancy boots').add('Fighting boots');
+		const loot = new Bank().add('Coins', 10_000).add('Fancy boots').add('Fighting boots').add('Fancier boots');
 
 		await transactItems({
 			userID: user.id,


### PR DESCRIPTION
### Description:
Add Fancier boots to stronghold of security and ability to reclaim boots.

### Changes:
- Add fancier boots to stronghold loot
- Add a way to reclaim boots if lost (by running the command again)
  - Also allows users to claim fancier boots if they have already completed the stronghold

### Other checks:
- [X] I have tested all my changes thoroughly.
