### PR TITLE
Fix wcing message

### DIFF
--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -242,7 +242,7 @@ export const chopCommand: OSBMahojiCommand = {
 		});
 
 		let response = `${minionName(user)} is now chopping ${log.name} until your minion ${
-			quantity ? `chopped ${quantity}x or gets tired` : 'is satisfied'
+			quantity ? `chopped ${newQuantity}x or gets tired` : 'is satisfied'
 		}, it'll take ${
 			quantity
 				? `between ${formatDuration(fakeDurationMin)} **and** ${formatDuration(fakeDurationMax)}`


### PR DESCRIPTION
### Description:
Fix the wcing start trip message from saying something like: `Your minion is now chopping Logs until your minion chopped 999999999999999x or gets tired`
### Changes:
- Display the newQuantity to the user not the inputed quantity.
### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/6033
