### PR TITLE
Champion Challenge related fixes

### DIFF
--- a/src/lib/minions/data/killableMonsters/low.ts
+++ b/src/lib/minions/data/killableMonsters/low.ts
@@ -25,6 +25,8 @@ const killableMonsters: KillableMonster[] = [
 		timeToFinish: Time.Second * 19.5,
 		table: Monsters.Jogre,
 		wildy: false,
+		canCannon: true,
+		cannonMulti: true,
 		difficultyRating: 1,
 		qpRequired: 0,
 		respawnTime: Time.Second * 1.5,

--- a/src/mahoji/commands/activities.ts
+++ b/src/mahoji/commands/activities.ts
@@ -18,7 +18,6 @@ import { buryCommand } from '../lib/abstracted_commands/buryCommand';
 import { butlerCommand } from '../lib/abstracted_commands/butlerCommand';
 import { camdozaalCommand } from '../lib/abstracted_commands/camdozaalCommand';
 import { castCommand } from '../lib/abstracted_commands/castCommand';
-import { championsChallengeCommand } from '../lib/abstracted_commands/championsChallenge';
 import { chargeGloriesCommand } from '../lib/abstracted_commands/chargeGloriesCommand';
 import { chargeWealthCommand } from '../lib/abstracted_commands/chargeWealthCommand';
 import { chompyHuntClaimCommand, chompyHuntCommand } from '../lib/abstracted_commands/chompyHuntCommand';
@@ -88,11 +87,6 @@ export const activitiesCommand: OSBMahojiCommand = {
 					required: true
 				}
 			]
-		},
-		{
-			type: ApplicationCommandOptionType.Subcommand,
-			name: 'champions_challenge',
-			description: 'Send your minion to do the Champions Challenge.'
 		},
 		{
 			type: ApplicationCommandOptionType.Subcommand,
@@ -515,7 +509,6 @@ export const activitiesCommand: OSBMahojiCommand = {
 	}: CommandRunOptions<{
 		plank_make?: { action: string; type: string; quantity?: number };
 		chompy_hunt?: { action: 'start' | 'claim' };
-		champions_challenge?: {};
 		my_notes?: {};
 		warriors_guild?: { action: string; quantity?: number };
 		camdozaal?: { action: string; quantity?: number };
@@ -578,9 +571,6 @@ export const activitiesCommand: OSBMahojiCommand = {
 		}
 		if (options.chompy_hunt?.action === 'claim') {
 			return chompyHuntClaimCommand(user);
-		}
-		if (options.champions_challenge) {
-			return championsChallengeCommand(user, channelID);
 		}
 		if (options.my_notes) {
 			return myNotesCommand(user, channelID);


### PR DESCRIPTION
### Description:
Champion Challenge related fixes
### Changes:
- Remove `/activities champions_challenge` and retain the one under `/activities other activity: Champions Challenge`
- Add cannon + multi to jogres. Source: https://youtu.be/5nCk11k19G4?t=129
### Other checks:
- [X] I have tested all my changes thoroughly.

closes: https://github.com/oldschoolgg/oldschoolbot/issues/4979
