### PR TITLE
Fix Slepey tablet logic for bso

### DIFF
--- a/src/tasks/minions/minigames/nightmareActivity.ts
+++ b/src/tasks/minions/minigames/nightmareActivity.ts
@@ -58,9 +58,10 @@ export const nightmareTask: MinionTask = {
 
 		const { newKC } = await user.incrementKC(monsterID, kc);
 
-		const ownsOrUsedTablet =
-			user.bank.has('Slepey tablet') ||
-			(user.bitfield.includes(BitField.HasSlepeyTablet) && user.cl.has('Slepey Tablet'));
+		const ownsOrUsedTablet = user.cl.has('Slepey Tablet')
+			? user.bank.has('Slepey tablet') || user.bitfield.includes(BitField.HasSlepeyTablet)
+			: false;
+
 		if (isPhosani) {
 			if (ownsOrUsedTablet) {
 				userLoot.remove('Slepey tablet', userLoot.amount('Slepey tablet'));


### PR DESCRIPTION
### Description:
Fix Slepey tablet logic for bso
### Changes:
- Correct the ownsOrUsedTablet to check the users cl before all else. 
### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5797