### PR TITLE
Change Amascut's Remnant CA

### DIFF
--- a/src/lib/combat_achievements/grandmaster.ts
+++ b/src/lib/combat_achievements/grandmaster.ts
@@ -1,5 +1,5 @@
 import { Time } from 'e';
-import { Monsters } from 'oldschooljs';
+import { Bank, Monsters } from 'oldschooljs';
 
 import { PHOSANI_NIGHTMARE_ID } from '../constants';
 import { Requirements } from '../structures/Requirements';
@@ -12,7 +12,6 @@ import type {
 	TOAOptions,
 	TheatreOfBloodTaskOptions
 } from '../types/minions';
-import { anyoneDiedInTOARaid } from '../util';
 import { isCertainMonsterTrip } from './caUtils';
 import type { CombatAchievement } from './combatAchievements';
 
@@ -696,13 +695,9 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 		desc: 'Complete the Tombs of Amascut at raid level 500 or above without anyone dying.',
 		type: 'mechanical',
 		monster: 'Tombs of Amascut: Expert Mode',
-		rng: {
-			chancePerKill: 1,
-			hasChance: data =>
-				data.type === 'TombsOfAmascut' &&
-				(data as TOAOptions).raidLevel >= 500 &&
-				!anyoneDiedInTOARaid(data as TOAOptions)
-		}
+		requirements: new Requirements().add({
+			clRequirement: new Bank().add('Cursed phalanx', 1)
+		})
 	},
 	{
 		id: 3060,


### PR DESCRIPTION
### Description:
Fix the issues outlined in this thread: https://github.com/oldschoolgg/oldschoolbot/issues/6057
### Changes:
- Make Amascut's Remnant Grandmaster CA claimable with /ca claim based off the users cl having Cursed phalanx.
### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/6057
