### PR TITLE
Crystal shard rates buff

### DIFF
--- a/src/lib/simulation/gauntlet.ts
+++ b/src/lib/simulation/gauntlet.ts
@@ -59,7 +59,7 @@ const StandardInnerTable = new LootTable()
 	.add('Coins', [20_000, 80_000]);
 
 const StandardTable = new LootTable()
-	.every('Crystal shard', [3, 7])
+	.every('Crystal shard', [5, 9])
 	.every(StandardInnerTable, 2)
 	.tertiary(25, 'Clue scroll (elite)')
 	.tertiary(120, 'Crystal weapon seed')
@@ -104,7 +104,7 @@ const CorruptedInnerTable = new LootTable()
 
 const CorruptedTable = new LootTable()
 	// Gauntlet cape is given manually in code
-	.every('Crystal shard', [5, 9])
+	.every('Crystal shard', [7, 12])
 	.every(CorruptedInnerTable, 3)
 	.tertiary(20, 'Clue scroll (elite)')
 	.tertiary(50, 'Crystal weapon seed')

--- a/src/lib/skilling/skills/farming/specialPlants.ts
+++ b/src/lib/skilling/skills/farming/specialPlants.ts
@@ -840,7 +840,7 @@ const specialPlants: Plant[] = [
 			[null, 8, 10],
 			['compost', 10, 12],
 			['supercompost', 12, 14],
-			['ultracompost', 14, 16]
+			['ultracompost', 28, 32]
 		],
 		treeWoodcuttingLevel: 1,
 		name: 'Crystal tree',

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -90,8 +90,8 @@ export const agilityTask: MinionTask = {
 
 		// Calculate Crystal Shards for Priff
 		if (course.name === 'Prifddinas Rooftop Course') {
-			// 15 Shards per hour
-			loot.add('Crystal shard', Math.floor((duration / Time.Hour) * 15));
+			// 1 shard per lap
+			loot.add('Crystal shard', quantity);
 		}
 
 		if (course.name === 'Agility Pyramid') {
@@ -119,11 +119,9 @@ export const agilityTask: MinionTask = {
 			updateClientGPTrackSetting('gp_alch', alchGP);
 		}
 
-		let str = `${user}, ${user.minionName} finished ${quantity} ${
-			course.name
-		} laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${
-			diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
-		}.\n${xpRes}`;
+		let str = `${user}, ${user.minionName} finished ${quantity} ${course.name
+			} laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
+			}.\n${xpRes}`;
 
 		if (course.id === 6) {
 			const currentLapCount = (newLapScores as ItemBank)[course.id];

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -119,9 +119,11 @@ export const agilityTask: MinionTask = {
 			updateClientGPTrackSetting('gp_alch', alchGP);
 		}
 
-		let str = `${user}, ${user.minionName} finished ${quantity} ${course.name
-			} laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
-			}.\n${xpRes}`;
+		let str = `${user}, ${user.minionName} finished ${quantity} ${
+			course.name
+		} laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${
+			diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
+		}.\n${xpRes}`;
 
 		if (course.id === 6) {
 			const currentLapCount = (newLapScores as ItemBank)[course.id];

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -152,18 +152,22 @@ async function handleForestry({ user, duration, loot }: { user: MUser; duration:
 		})
 		.filter(Boolean)
 		.join(' & ');
-	strForestry += `${totalEvents > 0 ? `Completed Forestry event${totalEvents > 1 ? 's:' : ':'} ${completedEvents}. ${xpRes}\n` : ''
-		}`;
-	strForestry += `${loot.has('Sturdy beehive parts') && !user.cl.has('Sturdy beehive parts') // only show this message once to reduce spam
-		? '- The temporary beehive was made so well you could repurpose parts of it to build a permanent hive.\n'
-		: ''
-		}`;
-	strForestry += `${loot.has('Golden pheasant egg')
-		? '- You feel a connection to the pheasants as if one wishes to travel with you...\n'
-		: ''
-		}`;
-	strForestry += `${loot.has('Fox whistle') ? '- You feel a connection to the fox as if it wishes to travel with you...\n' : ''
-		}`;
+	strForestry += `${
+		totalEvents > 0 ? `Completed Forestry event${totalEvents > 1 ? 's:' : ':'} ${completedEvents}. ${xpRes}\n` : ''
+	}`;
+	strForestry += `${
+		loot.has('Sturdy beehive parts') && !user.cl.has('Sturdy beehive parts') // only show this message once to reduce spam
+			? '- The temporary beehive was made so well you could repurpose parts of it to build a permanent hive.\n'
+			: ''
+	}`;
+	strForestry += `${
+		loot.has('Golden pheasant egg')
+			? '- You feel a connection to the pheasants as if one wishes to travel with you...\n'
+			: ''
+	}`;
+	strForestry += `${
+		loot.has('Fox whistle') ? '- You feel a connection to the fox as if it wishes to travel with you...\n' : ''
+	}`;
 	strForestry += `${loot.has('Petal garland') ? '- The Dryad also hands you a Petal garland.\n' : ''}`;
 
 	return strForestry;
@@ -285,13 +289,15 @@ export const woodcuttingTask: MinionTask = {
 		}
 
 		// End of trip message
-		let str = `${user}, ${user.minionName} finished woodcutting. ${xpRes}${bonusXP > 0 ? ` **Bonus XP:** ${bonusXP.toLocaleString()}` : ''
-			}\n`;
+		let str = `${user}, ${user.minionName} finished woodcutting. ${xpRes}${
+			bonusXP > 0 ? ` **Bonus XP:** ${bonusXP.toLocaleString()}` : ''
+		}\n`;
 
 		if (!log.clueNestsOnly) {
 			if (wcCapeNestBoost) {
-				str += `Your ${user.hasEquipped('Woodcutting cape') ? 'Woodcutting cape' : 'Forestry basket'
-					} increases the chance of receiving bird nests.\n`;
+				str += `Your ${
+					user.hasEquipped('Woodcutting cape') ? 'Woodcutting cape' : 'Forestry basket'
+				} increases the chance of receiving bird nests.\n`;
 			}
 			if (strungRabbitFoot) {
 				str +=
@@ -317,7 +323,8 @@ export const woodcuttingTask: MinionTask = {
 				str += "\n**You have a funny feeling you're being followed...**";
 				globalClient.emit(
 					Events.ServerNotification,
-					`${Emoji.Woodcutting} **${user.badgedUsername}'s** minion, ${user.minionName
+					`${Emoji.Woodcutting} **${user.badgedUsername}'s** minion, ${
+						user.minionName
 					}, just received a Beaver while cutting ${log.name} at level ${user.skillLevel(
 						'woodcutting'
 					)} Woodcutting!`
@@ -328,11 +335,13 @@ export const woodcuttingTask: MinionTask = {
 		// Loot received, items used, and logs/loot rolls lost message
 		str += `\nYou received ${loot}. `;
 		str += `${itemsToRemove.length > 0 ? `You used ${itemsToRemove}. ` : ''}`;
-		str += `${lostLogs > 0 && !powerchopping
-			? `You lost ${log.lootTable ? `${lostLogs}x ${log.name} loot rolls` : `${lostLogs}x ${log.name}`
-			} due to using a felling axe.`
-			: ''
-			}`;
+		str += `${
+			lostLogs > 0 && !powerchopping
+				? `You lost ${
+						log.lootTable ? `${lostLogs}x ${log.name} loot rolls` : `${lostLogs}x ${log.name}`
+					} due to using a felling axe.`
+				: ''
+		}`;
 
 		// Update cl, give loot, and remove items used
 		await transactItems({

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -262,7 +262,7 @@ export const woodcuttingTask: MinionTask = {
 		if (forestry && priffUnlocked && resolveItems(['Teak logs', 'Mahogany logs']).includes(log.id)) {
 			// 1/40 chance of receiving a crystal shard
 			for (let i = 0; i < quantity; i++) {
-				if (roll(40)) loot.add()
+				if (roll(40)) loot.add('Crystal shard', 1);
 			}
 		}
 

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -261,7 +261,9 @@ export const woodcuttingTask: MinionTask = {
 		// Add crystal shards for chopping teaks/mahogany in priff
 		if (forestry && priffUnlocked && resolveItems(['Teak logs', 'Mahogany logs']).includes(log.id)) {
 			// 1/40 chance of receiving a crystal shard
-			loot.add('Crystal shard', Math.round(quantity / 40));
+			for (let i = 0; i < quantity; i++) {
+				if (roll(40)) loot.add()
+			}
 		}
 
 		// Check for twitcher gloves

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -152,22 +152,18 @@ async function handleForestry({ user, duration, loot }: { user: MUser; duration:
 		})
 		.filter(Boolean)
 		.join(' & ');
-	strForestry += `${
-		totalEvents > 0 ? `Completed Forestry event${totalEvents > 1 ? 's:' : ':'} ${completedEvents}. ${xpRes}\n` : ''
-	}`;
-	strForestry += `${
-		loot.has('Sturdy beehive parts') && !user.cl.has('Sturdy beehive parts') // only show this message once to reduce spam
-			? '- The temporary beehive was made so well you could repurpose parts of it to build a permanent hive.\n'
-			: ''
-	}`;
-	strForestry += `${
-		loot.has('Golden pheasant egg')
-			? '- You feel a connection to the pheasants as if one wishes to travel with you...\n'
-			: ''
-	}`;
-	strForestry += `${
-		loot.has('Fox whistle') ? '- You feel a connection to the fox as if it wishes to travel with you...\n' : ''
-	}`;
+	strForestry += `${totalEvents > 0 ? `Completed Forestry event${totalEvents > 1 ? 's:' : ':'} ${completedEvents}. ${xpRes}\n` : ''
+		}`;
+	strForestry += `${loot.has('Sturdy beehive parts') && !user.cl.has('Sturdy beehive parts') // only show this message once to reduce spam
+		? '- The temporary beehive was made so well you could repurpose parts of it to build a permanent hive.\n'
+		: ''
+		}`;
+	strForestry += `${loot.has('Golden pheasant egg')
+		? '- You feel a connection to the pheasants as if one wishes to travel with you...\n'
+		: ''
+		}`;
+	strForestry += `${loot.has('Fox whistle') ? '- You feel a connection to the fox as if it wishes to travel with you...\n' : ''
+		}`;
 	strForestry += `${loot.has('Petal garland') ? '- The Dryad also hands you a Petal garland.\n' : ''}`;
 
 	return strForestry;
@@ -260,8 +256,8 @@ export const woodcuttingTask: MinionTask = {
 
 		// Add crystal shards for chopping teaks/mahogany in priff
 		if (forestry && priffUnlocked && resolveItems(['Teak logs', 'Mahogany logs']).includes(log.id)) {
-			// 15 Shards per hour
-			loot.add('Crystal shard', Math.floor((duration / Time.Hour) * 15));
+			// 1/40 chance of receiving a crystal shard
+			loot.add('Crystal shard', Math.round(quantity / 40));
 		}
 
 		// Check for twitcher gloves
@@ -289,15 +285,13 @@ export const woodcuttingTask: MinionTask = {
 		}
 
 		// End of trip message
-		let str = `${user}, ${user.minionName} finished woodcutting. ${xpRes}${
-			bonusXP > 0 ? ` **Bonus XP:** ${bonusXP.toLocaleString()}` : ''
-		}\n`;
+		let str = `${user}, ${user.minionName} finished woodcutting. ${xpRes}${bonusXP > 0 ? ` **Bonus XP:** ${bonusXP.toLocaleString()}` : ''
+			}\n`;
 
 		if (!log.clueNestsOnly) {
 			if (wcCapeNestBoost) {
-				str += `Your ${
-					user.hasEquipped('Woodcutting cape') ? 'Woodcutting cape' : 'Forestry basket'
-				} increases the chance of receiving bird nests.\n`;
+				str += `Your ${user.hasEquipped('Woodcutting cape') ? 'Woodcutting cape' : 'Forestry basket'
+					} increases the chance of receiving bird nests.\n`;
 			}
 			if (strungRabbitFoot) {
 				str +=
@@ -323,8 +317,7 @@ export const woodcuttingTask: MinionTask = {
 				str += "\n**You have a funny feeling you're being followed...**";
 				globalClient.emit(
 					Events.ServerNotification,
-					`${Emoji.Woodcutting} **${user.badgedUsername}'s** minion, ${
-						user.minionName
+					`${Emoji.Woodcutting} **${user.badgedUsername}'s** minion, ${user.minionName
 					}, just received a Beaver while cutting ${log.name} at level ${user.skillLevel(
 						'woodcutting'
 					)} Woodcutting!`
@@ -335,13 +328,11 @@ export const woodcuttingTask: MinionTask = {
 		// Loot received, items used, and logs/loot rolls lost message
 		str += `\nYou received ${loot}. `;
 		str += `${itemsToRemove.length > 0 ? `You used ${itemsToRemove}. ` : ''}`;
-		str += `${
-			lostLogs > 0 && !powerchopping
-				? `You lost ${
-						log.lootTable ? `${lostLogs}x ${log.name} loot rolls` : `${lostLogs}x ${log.name}`
-					} due to using a felling axe.`
-				: ''
-		}`;
+		str += `${lostLogs > 0 && !powerchopping
+			? `You lost ${log.lootTable ? `${lostLogs}x ${log.name} loot rolls` : `${lostLogs}x ${log.name}`
+			} due to using a felling axe.`
+			: ''
+			}`;
 
 		// Update cl, give loot, and remove items used
 		await transactItems({


### PR DESCRIPTION
### Description:

Crystal shard rates were buffed in OSRS (Shards from Superior Slayer Creatures, prif slayer dungeon and mining aren't coded in the bot as far as I can tell so I didn't buff those). Crystal chest/impling buffs were implemented in osjs.

### Changes:
-Crystal Acorn: 28-32 shards, up from 14-16 (with ultracompost). 
-Agility Course Portals: rate is improved from 1 in 3 to 1 in 1.
-Woodcutting: Rate is improved to 1/40 from 1/80.
-Regular Gauntlet:  5-9 shards, up from 3-7. 
-Corrupted Gauntlet: 7-12 shards, up from 5-9. 

### Other checks:

- [ ] I have tested all my changes thoroughly.
closes #6053 