### PR TITLE
Fix wildy nechs task extension

### DIFF
--- a/src/lib/slayer/slayerUnlocks.ts
+++ b/src/lib/slayer/slayerUnlocks.ts
@@ -445,7 +445,7 @@ export const SlayerRewardsShop: SlayerTaskUnlocks[] = [
 		name: 'Nechs please',
 		desc: 'Extends Nechryael tasks',
 		slayerPointCost: 100,
-		extendID: [Monsters.Nechryael.id],
+		extendID: [Monsters.Nechryael.id, Monsters.GreaterNechryael.id],
 		extendMult: 1.5,
 		canBeRemoved: true,
 		aliases: ['extend nechs', 'extend nechryaels']


### PR DESCRIPTION
### Description:

Nechryael tasks assigned by Krystilia are not being extended because she assigns only greater nechs and not regular ones.

### Changes:

-Added `Monsters.GreaterNechryael.id` to `NechsPlease` in `slayerUnlocks.ts`.

### Other checks:

- [ ] I have tested all my changes thoroughly.
