### PR TITLE
Fix casket sim

### DIFF
--- a/src/mahoji/commands/casket.ts
+++ b/src/mahoji/commands/casket.ts
@@ -61,7 +61,7 @@ export const casketCommand: OSBMahojiCommand = {
 		await deferInteraction(interaction);
 
 		const [_loot, title] = await Workers.casketOpen({ quantity: options.quantity, clueTierID: clueTier.id });
-		const loot = new Bank(_loot.toJSON());
+		const loot = new Bank(_loot);
 
 		if (loot.length === 0) return `${title} and got nothing :(`;
 


### PR DESCRIPTION
### Description:
- Fix `/casket` command
### Changes:
- Remove .toJSON() to correct console error `TypeError: o.toJSON is not a function` which stops the bot from posting the loot image.
### Other checks:
- [X] I have tested all my changes thoroughly.
