### PR TITLE
Slayer & image filtering

### DIFF
--- a/docs/src/content/docs/getting-started/wiki.md
+++ b/docs/src/content/docs/getting-started/wiki.md
@@ -222,9 +222,9 @@ This is an automatically generated list of pages with possible issues to be look
 
 [/bso/Skills/crafting.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/crafting.md): Doesnt use the new command formatting, Contains unintended HTML (e.g. `<td>`)
 
-[/bso/Skills/Divination/efficient-divination-training.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/Divination/efficient-divination-training.md): Doesnt use the new command formatting
+[/bso/Skills/divination/efficient-divination-training.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/divination/efficient-divination-training.md): Doesnt use the new command formatting
 
-[/bso/Skills/Divination/README.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/Divination/README.md): Doesnt use the new command formatting
+[/bso/Skills/divination/README.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/divination/README.md): Doesnt use the new command formatting
 
 [/bso/Skills/Dungeoneering Training/dg-rewards.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/Dungeoneering%20Training/dg-rewards.md): Doesnt use the new command formatting
 
@@ -242,9 +242,9 @@ This is an automatically generated list of pages with possible issues to be look
 
 [/bso/Skills/hunter.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/hunter.md): Doesnt use the new command formatting, Contains unintended HTML (e.g. `<td>`)
 
-[/bso/Skills/Invention/efficient-disassembling-to-99.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/Invention/efficient-disassembling-to-99.md): Doesnt use the new command formatting
+[/bso/Skills/invention/efficient-disassembling-to-99.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/invention/efficient-disassembling-to-99.md): Doesnt use the new command formatting
 
-[/bso/Skills/Invention/README.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/Invention/README.md): Doesnt use the new command formatting, Contains unintended HTML (e.g. `<td>`)
+[/bso/Skills/invention/README.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/invention/README.md): Doesnt use the new command formatting, Contains unintended HTML (e.g. `<td>`)
 
 [/bso/Skills/mining.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/mining.md): Doesnt use the new command formatting
 
@@ -252,9 +252,9 @@ This is an automatically generated list of pages with possible issues to be look
 
 [/bso/Skills/runecraft.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/runecraft.md): Doesnt use the new command formatting, Contains unintended HTML (e.g. `<td>`)
 
-[/bso/Skills/Slayer/README.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/Slayer/README.md): Doesnt use the new command formatting
+[/bso/Skills/slayer/README.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/slayer/README.md): Doesnt use the new command formatting
 
-[/bso/Skills/Slayer/slayer-masks-helms.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/Slayer/slayer-masks-helms.md): Doesnt use the new command formatting, Contains unintended HTML (e.g. `<td>`)
+[/bso/Skills/slayer/slayer-masks-helms.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/slayer/slayer-masks-helms.md): Doesnt use the new command formatting, Contains unintended HTML (e.g. `<td>`)
 
 [/bso/Skills/smithing.md](https://github.com/oldschoolgg/oldschoolbot/blob/master/docs/src/content/docs/bso/Skills/smithing.md): Doesnt use the new command formatting
 

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -701,28 +701,9 @@ const killableBosses: KillableMonster[] = [
 				defence_stab: 0
 			}
 		},
-		specialLoot: ({ loot, ownedItems, cl }) => {
+		specialLoot: ({ loot, ownedItems }) => {
 			if (loot.has('Coagulated venom') && (ownedItems.has('Coagulated venom') || ownedItems.has('Rax'))) {
 				loot.set('Coagulated venom', 0);
-			}
-
-			const noxPieces = resolveItems(['Noxious point', 'Noxious blade', 'Noxious pommel']);
-			const ownedCount = noxPieces.map(o => cl.amount(o));
-			const lootCount = noxPieces.map(l => loot.amount(l));
-
-			for (let i = 0; i < lootCount.length; i++) {
-				while (lootCount[i] > 0) {
-					const sortedPieces = noxPieces
-						.map((piece, index) => ({ piece, owned: ownedCount[index] }))
-						.sort((a, b) => a.owned - b.owned);
-
-					const targetPiece = sortedPieces[0].piece;
-					loot.set(targetPiece, (loot.amount(targetPiece) || 0) + 1);
-					loot.set(noxPieces[i], loot.amount(noxPieces[i]) - 1);
-
-					ownedCount[noxPieces.indexOf(targetPiece)]++;
-					lootCount[i]--;
-				}
 			}
 		},
 		itemCost: [

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -380,12 +380,12 @@ export function hasSlayerUnlock(
 	let success = true;
 	let errors = '';
 
-	required.forEach(req => {
+	for (const req of required) {
 		if (!myUnlocks.includes(req)) {
 			success = false;
 			missing.push(getSlayerReward(req as SlayerTaskUnlocksEnum));
 		}
-	});
+	}
 
 	errors = missing.join(', ');
 	return { success, errors };
@@ -395,23 +395,43 @@ const filterLootItems = resolveItems([
 	"Hydra's eye",
 	"Hydra's fang",
 	"Hydra's heart",
+	'Noxious point',
+	'Noxious blade',
+	'Noxious pommel',
 	'Dark totem base',
 	'Dark totem middle',
 	'Dark totem top',
 	'Bludgeon claw'
 ]);
-const ringPieces = resolveItems(["Hydra's eye", "Hydra's fang", "Hydra's heart"]);
+const hydraPieces = resolveItems(["Hydra's eye", "Hydra's fang", "Hydra's heart"]);
+const noxPieces = resolveItems(['Noxious point', 'Noxious blade', 'Noxious pommel']);
 const totemPieces = resolveItems(['Dark totem base', 'Dark totem middle', 'Dark totem top']);
 const bludgeonPieces = resolveItems(['Bludgeon claw', 'Bludgeon spine', 'Bludgeon axon']);
 
+function filterPieces(myLoot: Bank, myClLoot: Bank, combinedBank: Bank, pieces: number[], numPieces: number) {
+	for (let x = 0; x < numPieces; x++) {
+		const bank: number[] = pieces.map(piece => combinedBank.amount(piece));
+		const minBank = Math.min(...bank);
+		for (let i = 0; i < bank.length; i++) {
+			if (bank[i] === minBank) {
+				myLoot.add(pieces[i]);
+				combinedBank.add(pieces[i]);
+				myClLoot.add(pieces[i]);
+				break;
+			}
+		}
+	}
+}
+
 export function filterLootReplace(myBank: Bank, myLoot: Bank) {
-	// Order: Fang, eye, heart.
-	let numHydraEyes = myLoot.amount("Hydra's eye");
-	numHydraEyes += myLoot.amount("Hydra's fang");
-	numHydraEyes += myLoot.amount("Hydra's heart");
-	const numDarkTotemBases = myLoot.amount('Dark totem base');
+	const numHydraPieces =
+		myLoot.amount("Hydra's eye") + myLoot.amount("Hydra's fang") + myLoot.amount("Hydra's heart");
+	const numNoxPieces =
+		myLoot.amount('Noxious point') + myLoot.amount('Noxious blade') + myLoot.amount('Noxious pommel');
+	const numTotemPieces = myLoot.amount('Dark totem base');
 	const numBludgeonPieces = myLoot.amount('Bludgeon claw');
-	if (!numBludgeonPieces && !numDarkTotemBases && !numHydraEyes) {
+
+	if (!numHydraPieces && !numNoxPieces && !numTotemPieces && !numBludgeonPieces) {
 		return { bankLoot: myLoot, clLoot: myLoot };
 	}
 
@@ -420,61 +440,21 @@ export function filterLootReplace(myBank: Bank, myLoot: Bank) {
 	}
 
 	const myClLoot = myLoot.clone();
-
 	const combinedBank = new Bank(myBank).add(myLoot);
+
+	if (numHydraPieces) {
+		filterPieces(myLoot, myClLoot, combinedBank, hydraPieces, numHydraPieces);
+	}
+	if (numNoxPieces) {
+		filterPieces(myLoot, myClLoot, combinedBank, noxPieces, numNoxPieces);
+	}
+	if (numTotemPieces) {
+		filterPieces(myLoot, myClLoot, combinedBank, totemPieces, numTotemPieces);
+	}
 	if (numBludgeonPieces) {
-		for (let x = 0; x < numBludgeonPieces; x++) {
-			const bank: number[] = [];
+		filterPieces(myLoot, myClLoot, combinedBank, bludgeonPieces, numBludgeonPieces);
+	}
 
-			for (const piece of bludgeonPieces) {
-				bank.push(combinedBank.amount(piece));
-			}
-			const minBank = Math.min(...bank);
-
-			for (let i = 0; i < bank.length; i++) {
-				if (bank[i] === minBank) {
-					myLoot.add(bludgeonPieces[i]);
-					combinedBank.add(bludgeonPieces[i]);
-					myClLoot.add(bludgeonPieces[i]);
-					break;
-				}
-			}
-		}
-	}
-	if (numDarkTotemBases) {
-		for (let x = 0; x < numDarkTotemBases; x++) {
-			const bank: number[] = [];
-			for (const piece of totemPieces) {
-				bank.push(combinedBank.amount(piece));
-			}
-			const minBank = Math.min(...bank);
-			for (let i = 0; i < bank.length; i++) {
-				if (bank[i] === minBank) {
-					myLoot.add(totemPieces[i]);
-					combinedBank.add(totemPieces[i]);
-					myClLoot.add(totemPieces[i]);
-					break;
-				}
-			}
-		}
-	}
-	if (numHydraEyes) {
-		for (let x = 0; x < numHydraEyes; x++) {
-			const bank: number[] = [];
-			for (const piece of ringPieces) {
-				bank.push(combinedBank.amount(piece));
-			}
-			const minBank = Math.min(...bank);
-			for (let i = 0; i < bank.length; i++) {
-				if (bank[i] === minBank) {
-					myLoot.add(ringPieces[i]);
-					combinedBank.add(ringPieces[i]);
-					myClLoot.add(ringPieces[i]);
-					break;
-				}
-			}
-		}
-	}
 	return {
 		bankLoot: myLoot,
 		clLoot: myClLoot

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -514,15 +514,15 @@ export const monsterTask: MinionTask = {
 		announceLoot({
 			user,
 			monsterID: monster.id,
-			loot: updateBank.itemLootBank,
+			loot: itemTransactionResult!.itemsAdded,
 			notifyDrops: monster.notifyDrops
 		});
 
 		const image =
-			updateBank.itemLootBank.length === 0
+			itemTransactionResult!.itemsAdded.length === 0
 				? undefined
 				: await makeBankImage({
-						bank: updateBank.itemLootBank,
+						bank: itemTransactionResult!.itemsAdded,
 						title: `Loot From ${quantity} ${monster.name}:`,
 						user,
 						previousCL: itemTransactionResult?.previousCL


### PR DESCRIPTION
### Description:
Refactor slayer item filtering, add araxxor to filtering, and fix return trip images not showing filtered loot.
### Changes:
- Remove araxxor special code for noxious halberd and put it inside filterLootReplace() in slayerUtil.ts
- Refactor filterLootReplace() to remove redundant code
- convert a forEach to for to remove the biome warning inside hasSlayerUnlock()
- use itemTransactionResult inside monsterActivity.ts to display the filtered loot to the user upon minion return * see below
- This should also address trips showing '22 hard clue scrolls' in the return message
### Other checks:
- [X] I have tested all my changes thoroughly.

Added 3 herbi, 5 noxious blade, 5 hydra's eye to the loot for debug/filter testing.
First picture is before using itemTransactionResult, second picture is while using itemTransactionResult 
![Discord_J1eOlaa4kT](https://github.com/user-attachments/assets/25d9f9fd-815c-4597-8cfb-9acd67161d3a)

Addresses the 2nd issue in: https://github.com/oldschoolgg/oldschoolbot/issues/6066
