### PR TITLE
Fix box spawn replies

### DIFF
--- a/src/lib/boxSpawns.ts
+++ b/src/lib/boxSpawns.ts
@@ -32,7 +32,8 @@ const triviaChallenge: Challenge = async (msg: Message): Promise<User | null> =>
 			'https://cdn.discordapp.com/attachments/357422607982919680/1100378550189707314/534px-Mystery_box_detail.png'
 		);
 
-	await sendToChannelID(msg.channelId, { embed: embed });
+	// This needs to be msg.channel.send() otherwise it will use a webhook and replies won't be readable.
+	await msg.channel.send({ embeds: [embed] });
 
 	try {
 		const collected = await msg.channel.awaitMessages({
@@ -65,7 +66,7 @@ const itemChallenge: Challenge = async (msg: Message): Promise<User | null> => {
 			'https://cdn.discordapp.com/attachments/357422607982919680/1100378550189707314/534px-Mystery_box_detail.png'
 		);
 
-	await sendToChannelID(msg.channelId, { embed });
+	await msg.channel.send({ embeds: [embed] });
 
 	try {
 		const collected = await msg.channel.awaitMessages({
@@ -185,7 +186,7 @@ const collectionLogChallenge: Challenge = async (msg: Message): Promise<User | n
 			'https://cdn.discordapp.com/attachments/357422607982919680/1100378550189707314/534px-Mystery_box_detail.png'
 		);
 
-	await sendToChannelID(msg.channelId, { embed });
+	await msg.channel.send({ embeds: [embed] });
 
 	try {
 		const collected = await msg.channel.awaitMessages({

--- a/src/lib/boxSpawns.ts
+++ b/src/lib/boxSpawns.ts
@@ -32,7 +32,6 @@ const triviaChallenge: Challenge = async (msg: Message): Promise<User | null> =>
 			'https://cdn.discordapp.com/attachments/357422607982919680/1100378550189707314/534px-Mystery_box_detail.png'
 		);
 
-	// This needs to be msg.channel.send() otherwise it will use a webhook and replies won't be readable.
 	await msg.channel.send({ embeds: [embed] });
 
 	try {


### PR DESCRIPTION
### Description:

Most spawn boxes are currently broken because they are being sent as webhooks, so replies aren't readable by the bot.

### Changes:

Reverts to using msg.channel.send() to send messages directly from the bot, so that replies are readable.

### Other checks:

- [x] I have tested all my changes thoroughly.
