### PR TITLE
Allow gear preset equip command to use similar items (for globals)

### DIFF
--- a/src/lib/structures/Gear.ts
+++ b/src/lib/structures/Gear.ts
@@ -95,7 +95,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'carpenter',
+		name: 'construction',
 		user_id: '123',
 		head: itemID("Carpenter's helmet"),
 		neck: null,
@@ -116,7 +116,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'rogue',
+		name: 'theiving',
 		user_id: '123',
 		head: itemID('Rogue mask'),
 		neck: null,
@@ -158,7 +158,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'angler',
+		name: 'fishing',
 		user_id: '123',
 		head: itemID('Angler hat'),
 		neck: null,
@@ -179,28 +179,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'spirit_angler',
-		user_id: '123',
-		head: itemID('Spirit angler headband'),
-		neck: null,
-		body: itemID('Spirit angler top'),
-		legs: itemID('Spirit angler waders'),
-		cape: null,
-		two_handed: null,
-		hands: null,
-		feet: itemID('Spirit angler boots'),
-		shield: null,
-		weapon: null,
-		ring: null,
-		ammo: null,
-		ammo_qty: null,
-		emoji_id: null,
-		times_equipped: 0,
-		defaultSetup: 'skilling',
-		pinned_setup: null
-	},
-	{
-		name: 'pyromancer',
+		name: 'firemaking',
 		user_id: '123',
 		head: itemID('Pyromancer hood'),
 		neck: null,
@@ -221,7 +200,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'prospector',
+		name: 'mining',
 		user_id: '123',
 		head: itemID('Prospector helmet'),
 		neck: null,
@@ -242,7 +221,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'lumberjack',
+		name: 'woodcutting',
 		user_id: '123',
 		head: itemID('Lumberjack hat'),
 		neck: null,
@@ -263,7 +242,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'farmer',
+		name: 'farming',
 		user_id: '123',
 		head: itemID("Farmer's strawhat"),
 		neck: null,
@@ -284,7 +263,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'runecraft',
+		name: 'runecrafting',
 		user_id: '123',
 		head: itemID('Hat of the eye'),
 		neck: null,
@@ -305,7 +284,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'smith',
+		name: 'smithing',
 		user_id: '123',
 		head: null,
 		neck: null,

--- a/src/lib/structures/Gear.ts
+++ b/src/lib/structures/Gear.ts
@@ -116,7 +116,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'theiving',
+		name: 'thieving',
 		user_id: '123',
 		head: itemID('Rogue mask'),
 		neck: null,
@@ -263,7 +263,7 @@ export const globalPresets: (GearPreset & { defaultSetup: GearSetupType })[] = [
 		pinned_setup: null
 	},
 	{
-		name: 'runecrafting',
+		name: 'runecraft',
 		user_id: '123',
 		head: itemID('Hat of the eye'),
 		neck: null,

--- a/src/mahoji/lib/abstracted_commands/gearCommands.ts
+++ b/src/mahoji/lib/abstracted_commands/gearCommands.ts
@@ -64,19 +64,19 @@ async function gearPresetEquipCommand(user: MUser, gearSetup: string, presetName
 	}
 
 	const toRemove = new Bank();
-	function gearItem(val: null | number) {
-		if (val === null) return null;
-		if (!userBankWithEquippedItems.has(val) && globalPreset) {
-			for (const new_val of getSimilarItems(val)) {
-				if (userBankWithEquippedItems.has(new_val)) {
-					val = new_val;
+	function gearItem(piece: null | number) {
+		if (piece === null) return null;
+		if (!userBankWithEquippedItems.has(piece) && globalPreset) {
+			for (const similarPiece of getSimilarItems(piece)) {
+				if (userBankWithEquippedItems.has(similarPiece)) {
+					piece = similarPiece;
 					break;
 				}
 			}
 		}
-		toRemove.add(val);
+		toRemove.add(piece);
 		return {
-			item: val,
+			item: piece,
 			quantity: 1
 		};
 	}


### PR DESCRIPTION
### Description:

Changed `/gear equip` to use similar items (forestry outfit instead of lumberjack, any graceful recolour etc). Only applies to global presets. Renamed some presets to account for new generality.

Closes #1520.

### Changes:

- Added similar item replacement check to global preset outfit pieces that aren't in bank.
- Removed `spirit_angler` global preset as now redundant.
- Renamed global presets to name of skill.

### Other checks:

- [x] I have tested all my changes thoroughly.
