### PR TITLE
Correct araxxor boss task requirements

### DIFF
--- a/src/lib/slayer/tasks/bossTasks.ts
+++ b/src/lib/slayer/tasks/bossTasks.ts
@@ -239,7 +239,7 @@ export const bossTasks: AssignableSlayerTask[] = [
 		weight: 1,
 		monsters: [Monsters.Araxxor.id],
 		isBoss: true,
-		wilderness: true
+		slayerLevel: 92
 	}
 ];
 

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -473,7 +473,6 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		extendedUnlockId: SlayerTaskUnlocksEnum.MoreEyesThanSense,
 		weight: 10,
 		monsters: [Monsters.Araxyte.id, Monsters.Araxxor.id],
-		combatLevel: 96,
 		unlocked: true,
 		slayerLevel: 92
 	},

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -447,7 +447,6 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		extendedUnlockId: SlayerTaskUnlocksEnum.MoreEyesThanSense,
 		weight: 8,
 		monsters: [Monsters.Araxyte.id, Monsters.Araxxor.id],
-		combatLevel: 96,
 		unlocked: true,
 		slayerLevel: 92
 	},


### PR DESCRIPTION
### Description:

Araxxor boss task currently has no slayer req and is set in wildy so cant be completed. Issues corrected.

### Changes:

- Added 92 slayer req and removed wilderness parameter
- Removed incorrect 96 combat check for Araxyte task

### Other checks:

- [x] I have tested all my changes thoroughly.
