### PR TITLE
add error message for twitch gloves

### DIFF
--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -151,6 +151,10 @@ export const chopCommand: OSBMahojiCommand = {
 			return `${user.minionName} needs ${log.qpRequired} QP to cut ${log.name}.`;
 		}
 
+		if (twitchers_gloves && !user.hasEquipped("Twitcher's gloves")) {
+			return "You need to have Twitcher's gloves equipped to use them.";
+		}
+
 		const boosts = [];
 
 		let wcLvl = skills.woodcutting;


### PR DESCRIPTION
### Description:

Resolves #6110 
Adds a short error message when trying to use twitcher's gloves without having them equipped

### Changes:

Quick if check for a twitchers glove option selected, and if they have them equipped or not.

### Other checks:

- [x] I have tested all my changes thoroughly.
