### PR TITLE
Correct slayer tasks

### DIFF
--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -2,11 +2,14 @@ import { Monsters } from 'oldschooljs';
 
 import type { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
+import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 
 export const chaeldarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.AberrantSpectre,
-		amount: [110, 170],
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.SmellYaLater,
 		weight: 8,
 		monsters: [Monsters.AberrantSpectre.id, Monsters.DeviantSpectre.id],
 		combatLevel: 65,
@@ -16,7 +19,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.AbyssalDemon,
-		amount: [110, 170],
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.AugmentMyAbbies,
 		weight: 12,
 		monsters: [Monsters.AbyssalDemon.id, Monsters.AbyssalSire.id],
 		combatLevel: 85,
@@ -26,24 +31,18 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Aviansie,
-		amount: [110, 170],
+		amount: [70, 130],
+		extendedAmount: [130, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.BirdsOfAFeather,
 		weight: 9,
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
 		unlocked: false
 	},
 	{
-		monster: Monsters.Banshee,
-		amount: [110, 170],
-		weight: 5,
-		monsters: [Monsters.Banshee.id, Monsters.TwistedBanshee.id],
-		combatLevel: 20,
-		slayerLevel: 15,
-		questPoints: 1,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Basilisk,
-		amount: [110, 170],
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.Basilonger,
 		weight: 7,
 		monsters: [Monsters.Basilisk.id, Monsters.BasiliskKnight.id],
 		combatLevel: 40,
@@ -52,7 +51,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.BlackDemon,
-		amount: [110, 170],
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.ItsDarkInHere,
 		weight: 10,
 		monsters: [Monsters.BlackDemon.id, Monsters.DemonicGorilla.id, Monsters.Skotizo.id],
 		combatLevel: 80,
@@ -60,7 +61,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Bloodveld,
-		amount: [110, 170],
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.BleedMeDry,
 		weight: 8,
 		monsters: [Monsters.Bloodveld.id, Monsters.MutatedBloodveld.id],
 		combatLevel: 50,
@@ -70,7 +73,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.BlueDragon,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 8,
 		monsters: [
 			Monsters.BlueDragon.id,
@@ -84,7 +87,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.BrineRat,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 7,
 		monsters: [Monsters.BrineRat.id],
 		combatLevel: 45,
@@ -93,27 +96,10 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.BronzeDragon,
-		amount: [10, 20],
-		weight: 11,
-		monsters: [Monsters.BronzeDragon.id],
-		combatLevel: 75,
-		questPoints: 34,
-		unlocked: true
-	},
-	{
-		monster: Monsters.CaveCrawler,
-		amount: [110, 170],
-		weight: 5,
-		monsters: [Monsters.CaveCrawler.id],
-		combatLevel: 10,
-		slayerLevel: 10,
-		unlocked: true
-	},
-	{
 		monster: Monsters.CaveHorror,
-		amount: [110, 170],
-
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.Horrorific,
 		weight: 10,
 		monsters: [Monsters.CaveHorror.id],
 		combatLevel: 85,
@@ -124,6 +110,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.CaveKraken,
 		amount: [30, 50],
+		extendedAmount: [150, 200],
+		extendedUnlockId: SlayerTaskUnlocksEnum.KrackOn,
 		weight: 12,
 		monsters: [Monsters.CaveKraken.id, Monsters.Kraken.id],
 		combatLevel: 80,
@@ -131,26 +119,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.CaveSlime,
-		amount: [10, 20],
-		weight: 6,
-		monsters: [Monsters.CaveSlime.id],
-		combatLevel: 15,
-		slayerLevel: 17,
-		unlocked: true
-	},
-	{
-		monster: Monsters.Cockatrice,
-		amount: [110, 170],
-		weight: 6,
-		monsters: [Monsters.Cockatrice.id],
-		combatLevel: 25,
-		slayerLevel: 25,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Dagannoth,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 11,
 		monsters: [
 			Monsters.Dagannoth.id,
@@ -166,8 +136,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.DustDevil,
-		amount: [110, 170],
-
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.ToDustYouShallReturn,
 		weight: 9,
 		monsters: [Monsters.DustDevil.id],
 		combatLevel: 70,
@@ -177,7 +148,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.ElfWarrior,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 8,
 		monsters: [
 			Monsters.ElfWarrior.id,
@@ -192,7 +163,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.FeverSpider,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 7,
 		monsters: [Monsters.FeverSpider.id],
 		combatLevel: 40,
@@ -202,7 +173,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.FireGiant,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 12,
 		monsters: [Monsters.FireGiant.id],
 		combatLevel: 65,
@@ -211,6 +182,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.FossilIslandWyvernSpitting,
 		amount: [10, 20],
+		extendedAmount: [55, 75],
+		extendedUnlockId: SlayerTaskUnlocksEnum.WyverNotherTwo,
 		weight: 7,
 		monsters: [
 			Monsters.FossilIslandWyvernSpitting.id,
@@ -225,8 +198,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Gargoyle,
-		amount: [110, 170],
-
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.GetSmashed,
 		weight: 11,
 		monsters: [Monsters.Gargoyle.id, Monsters.GrotesqueGuardians.id],
 		combatLevel: 80,
@@ -236,7 +210,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.GreaterDemon,
-		amount: [110, 170],
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.GreaterChallenge,
 		weight: 9,
 		monsters: [
 			Monsters.GreaterDemon.id,
@@ -248,49 +224,16 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.HarpieBugSwarm,
-		amount: [110, 170],
-		weight: 6,
-		monsters: [Monsters.HarpieBugSwarm.id],
-		combatLevel: 45,
-		slayerLevel: 33,
-		levelRequirements: {
-			firemaking: 33,
-			slayer: 33
-		},
-		unlocked: true
-	},
-	{
 		monster: Monsters.Hellhound,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 9,
 		monsters: [Monsters.Hellhound.id, Monsters.Cerberus.id],
 		combatLevel: 75,
 		unlocked: true
 	},
 	{
-		monster: Monsters.InfernalMage,
-		amount: [110, 170],
-		weight: 7,
-		monsters: [Monsters.InfernalMage.id],
-		combatLevel: 40,
-		slayerLevel: 45,
-		questPoints: 1,
-		unlocked: true
-	},
-	{
-		monster: Monsters.IronDragon,
-		amount: [25, 45],
-
-		weight: 12,
-		monsters: [Monsters.IronDragon.id],
-		combatLevel: 80,
-		questPoints: 34,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Jelly,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 10,
 		monsters: [Monsters.Jelly.id, Monsters.WarpedJelly.id],
 		combatLevel: 57,
@@ -299,7 +242,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.JungleHorror,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 10,
 		monsters: [Monsters.JungleHorror.id],
 		combatLevel: 65,
@@ -308,7 +251,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.KalphiteWorker,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 11,
 		monsters: [
 			Monsters.KalphiteWorker.id,
@@ -321,7 +264,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Kurask,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 12,
 		monsters: [Monsters.Kurask.id],
 		combatLevel: 65,
@@ -330,7 +273,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.LesserDemon,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 9,
 		monsters: [Monsters.LesserDemon.id],
 		combatLevel: 60,
@@ -338,37 +281,10 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Lizardman,
-		amount: [70, 90],
+		amount: [50, 90],
 		weight: 8,
 		monsters: [Monsters.Lizardman.id, Monsters.LizardmanBrute.id, Monsters.LizardmanShaman.id],
 		unlocked: false
-	},
-	{
-		monster: Monsters.Lizard,
-		amount: [110, 170],
-		weight: 5,
-		monsters: [Monsters.Lizard.id, Monsters.SmallLizard.id, Monsters.DesertLizard.id, Monsters.SulphurLizard.id],
-		slayerLevel: 22,
-		unlocked: true
-	},
-	{
-		monster: Monsters.Mogre,
-		amount: [110, 170],
-		weight: 6,
-		monsters: [Monsters.Mogre.id],
-		combatLevel: 30,
-		slayerLevel: 32,
-		unlocked: true
-	},
-	{
-		monster: Monsters.Molanisk,
-		amount: [39, 50],
-		weight: 6,
-		monsters: [Monsters.Molanisk.id],
-		combatLevel: 50,
-		slayerLevel: 39,
-		questPoints: 8,
-		unlocked: true
 	},
 	{
 		monster: Monsters.Zygomite,
@@ -382,8 +298,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Nechryael,
-		amount: [110, 170],
-
+		amount: [70, 130],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.NechsPlease,
 		weight: 12,
 		monsters: [Monsters.Nechryael.id, Monsters.GreaterNechryael.id],
 		combatLevel: 85,
@@ -392,26 +309,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.Pyrefiend,
-		amount: [110, 170],
-		weight: 6,
-		monsters: [Monsters.Pyrefiend.id, Monsters.Pyrelord.id],
-		combatLevel: 25,
-		slayerLevel: 30,
-		unlocked: true
-	},
-	{
-		monster: Monsters.Rockslug,
-		amount: [110, 170],
-		weight: 5,
-		monsters: [Monsters.Rockslug.id],
-		combatLevel: 20,
-		slayerLevel: 20,
-		unlocked: true
-	},
-	{
 		monster: Monsters.ShadowWarrior,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 8,
 		monsters: [Monsters.ShadowWarrior.id],
 		combatLevel: 60,
@@ -421,6 +320,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.SkeletalWyvern,
 		amount: [10, 20],
+		extendedAmount: [50, 70],
+		extendedUnlockId: SlayerTaskUnlocksEnum.WyverNotherOne,
 		weight: 7,
 		monsters: [Monsters.SkeletalWyvern.id],
 		combatLevel: 70,
@@ -430,13 +331,11 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.SpiritualRanger,
-		amount: [110, 170],
-
+		amount: [70, 130],
+		extendedAmount: [181, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.SpiritualFervour,
 		weight: 12,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		levelRequirements: {
-			slayer: 60
-		},
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
@@ -444,7 +343,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.MountainTroll,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 11,
 		monsters: [Monsters.MountainTroll.id, Monsters.IceTroll.id, Monsters.TrollGeneral.id],
 		combatLevel: 60,
@@ -452,7 +351,7 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Turoth,
-		amount: [110, 170],
+		amount: [70, 130],
 		weight: 10,
 		monsters: [Monsters.Turoth.id],
 		combatLevel: 60,
@@ -468,7 +367,9 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.FeralVampyre,
-		amount: [80, 120],
+		amount: [80, 100],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.MoreAtStake,
 		weight: 6,
 		monsters: [
 			Monsters.FeralVampyre.id,
@@ -481,17 +382,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		unlocked: false
 	},
 	{
-		monster: Monsters.WallBeast,
-		amount: [10, 20],
-		weight: 6,
-		monsters: [Monsters.WallBeast.id],
-		combatLevel: 30,
-		slayerLevel: 35,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Wyrm,
-		amount: [60, 120],
+		amount: [60, 100],
 		weight: 6,
 		monsters: [Monsters.Wyrm.id],
 		slayerLevel: 62,

--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -1,8 +1,8 @@
 import { Monsters } from 'oldschooljs';
 
+import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import type { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
-import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 
 export const chaeldarTasks: AssignableSlayerTask[] = [
 	{

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -45,7 +45,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [50, 80],
 		weight: 5,
 		monsters: [Monsters.Ankou.id],
-		extendedAmount: [90, 150],
+		extendedAmount: [91, 150],
 		extendedUnlockId: SlayerTaskUnlocksEnum.AnkouVeryMuch,
 		combatLevel: 40,
 		unlocked: true
@@ -55,7 +55,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [120, 200],
 		weight: 8,
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
-		extendedAmount: [130, 250],
+		extendedAmount: [200, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.BirdsOfAFeather,
 		unlocked: false
 	},
@@ -66,8 +66,8 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		monsters: [Monsters.Basilisk.id, Monsters.BasiliskKnight.id],
 		extendedAmount: [200, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.Basilonger,
-		combatLevel: 40,
 		slayerLevel: 40,
+		combatLevel: 40,
 		unlocked: false
 	},
 	{
@@ -92,7 +92,6 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		],
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,
-		slayerLevel: 77,
 		combatLevel: 80,
 		questPoints: 34,
 		unlocked: true
@@ -167,7 +166,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [10, 20],
 		weight: 11,
 		monsters: [Monsters.DarkBeast.id],
-		extendedAmount: [100, 150],
+		extendedAmount: [110, 135],
 		extendedUnlockId: SlayerTaskUnlocksEnum.NeedMoreDarkness,
 		combatLevel: 90,
 		slayerLevel: 90,
@@ -219,8 +218,8 @@ export const duradelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.FossilIslandWyvernSpitting,
-		amount: [20, 60],
-		weight: 5,
+		amount: [20, 50],
+		weight: 7,
 		monsters: [
 			Monsters.FossilIslandWyvernAncient.id,
 			Monsters.FossilIslandWyvernLongTailed.id,
@@ -237,7 +236,6 @@ export const duradelTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Gargoyle,
 		amount: [130, 200],
-
 		weight: 8,
 		monsters: [Monsters.Gargoyle.id, Monsters.GrotesqueGuardians.id],
 		extendedAmount: [200, 250],
@@ -257,9 +255,9 @@ export const duradelTasks: AssignableSlayerTask[] = [
 			Monsters.Skotizo.id,
 			Monsters.TormentedDemon.id
 		],
-		extendedAmount: [150, 250],
+		extendedAmount: [200, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.GreaterChallenge,
-		combatLevel: 70,
+		combatLevel: 75,
 		unlocked: true
 	},
 	{
@@ -315,7 +313,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [5, 10],
 		weight: 9,
 		monsters: [Monsters.MithrilDragon.id],
-		extendedAmount: [20, 40],
+		extendedAmount: [25, 35],
 		extendedUnlockId: SlayerTaskUnlocksEnum.IReallyMithYou,
 		unlocked: false
 	},
@@ -331,7 +329,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Nechryael,
-		amount: [110, 200],
+		amount: [130, 200],
 		weight: 9,
 		monsters: [Monsters.Nechryael.id, Monsters.GreaterNechryael.id],
 		extendedAmount: [200, 250],
@@ -376,20 +374,19 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [130, 200],
 		weight: 9,
 		monsters: [Monsters.SmokeDevil.id, Monsters.ThermonuclearSmokeDevil.id],
-		combatLevel: 75,
+		combatLevel: 85,
 		slayerLevel: 93,
 		unlocked: true
 	},
 	{
 		monster: Monsters.SpiritualRanger,
-		amount: [110, 170],
-
+		amount: [130, 200],
 		weight: 7,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		extendedAmount: [180, 250],
+		extendedAmount: [181, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.SpiritualFervour,
 		levelRequirements: {
-			slayer: 60
+			slayer: 63
 		},
 		combatLevel: 60,
 		slayerLevel: 63,
@@ -413,7 +410,7 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [60, 90],
 		weight: 8,
 		monsters: [Monsters.Suqah.id],
-		extendedAmount: [180, 250],
+		extendedAmount: [186, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.SuqANotherOne,
 		combatLevel: 85,
 		questPoints: 12,
@@ -446,7 +443,6 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		],
 		extendedAmount: [200, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.MoreAtStake,
-		combatLevel: 35,
 		questPoints: 1,
 		unlocked: false
 	},

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -43,7 +43,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [50, 50],
 		weight: 5,
 		monsters: [Monsters.Ankou.id],
-		extendedAmount: [90, 150],
+		extendedAmount: [91, 150],
 		extendedUnlockId: SlayerTaskUnlocksEnum.AnkouVeryMuch,
 		combatLevel: 40,
 		unlocked: true
@@ -53,7 +53,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [120, 170],
 		weight: 6,
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
-		extendedAmount: [130, 250],
+		extendedAmount: [200, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.BirdsOfAFeather,
 		unlocked: false
 	},
@@ -85,7 +85,6 @@ export const konarTasks: AssignableSlayerTask[] = [
 		monsters: [Monsters.BlackDragon.id, Monsters.BabyBlackDragon.id, Monsters.BrutalBlackDragon.id],
 		extendedAmount: [40, 60],
 		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,
-		slayerLevel: 77,
 		combatLevel: 80,
 		questPoints: 34,
 		unlocked: true
@@ -164,7 +163,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [10, 15],
 		weight: 5,
 		monsters: [Monsters.DarkBeast.id],
-		extendedAmount: [100, 150],
+		extendedAmount: [110, 135],
 		extendedUnlockId: SlayerTaskUnlocksEnum.NeedMoreDarkness,
 		combatLevel: 90,
 		slayerLevel: 90,
@@ -173,7 +172,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Drake,
-		amount: [75, 138],
+		amount: [75, 140],
 		weight: 10,
 		monsters: [Monsters.Drake.id],
 		slayerLevel: 84,
@@ -182,7 +181,6 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.DustDevil,
 		amount: [120, 170],
-
 		weight: 6,
 		monsters: [Monsters.DustDevil.id],
 		extendedAmount: [200, 250],
@@ -203,7 +201,6 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.FossilIslandWyvernSpitting,
 		amount: [15, 30],
-
 		weight: 5,
 		monsters: [
 			Monsters.FossilIslandWyvernAncient.id,
@@ -221,7 +218,6 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Gargoyle,
 		amount: [120, 170],
-
 		weight: 6,
 		monsters: [Monsters.Gargoyle.id, Monsters.GrotesqueGuardians.id],
 		extendedAmount: [200, 250],
@@ -236,7 +232,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [120, 170],
 		weight: 7,
 		monsters: [Monsters.GreaterDemon.id, Monsters.Skotizo.id],
-		extendedAmount: [150, 223],
+		extendedAmount: [200, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.GreaterChallenge,
 		combatLevel: 75,
 		unlocked: true
@@ -260,10 +256,9 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.IronDragon,
 		amount: [30, 50],
-
 		weight: 5,
 		monsters: [Monsters.IronDragon.id],
-		extendedAmount: [60, 100],
+		extendedAmount: [61, 100],
 		extendedUnlockId: SlayerTaskUnlocksEnum.PedalToTheMetals,
 		combatLevel: 80,
 		questPoints: 34,
@@ -312,7 +307,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [3, 6],
 		weight: 5,
 		monsters: [Monsters.MithrilDragon.id],
-		extendedAmount: [20, 40],
+		extendedAmount: [25, 35],
 		extendedUnlockId: SlayerTaskUnlocksEnum.IReallyMithYou,
 		unlocked: false
 	},
@@ -329,7 +324,6 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Nechryael,
 		amount: [110, 110],
-
 		weight: 7,
 		monsters: [Monsters.Nechryael.id, Monsters.GreaterNechryael.id],
 		extendedAmount: [200, 250],
@@ -374,7 +368,7 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [120, 170],
 		weight: 7,
 		monsters: [Monsters.SmokeDevil.id, Monsters.ThermonuclearSmokeDevil.id],
-		combatLevel: 75,
+		combatLevel: 85,
 		slayerLevel: 93,
 		unlocked: true
 	},
@@ -410,7 +404,6 @@ export const konarTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.FeralVampyre,
 		amount: [100, 160],
-
 		weight: 4,
 		monsters: [
 			Monsters.FeralVampyre.id,

--- a/src/lib/slayer/tasks/mazchnaTasks.ts
+++ b/src/lib/slayer/tasks/mazchnaTasks.ts
@@ -1,8 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
-import killableMonsters from '../../minions/data/killableMonsters';
-import type { AssignableSlayerTask } from '../types';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
+import type { AssignableSlayerTask } from '../types';
 
 export const mazchnaTasks: AssignableSlayerTask[] = [
 	{

--- a/src/lib/slayer/tasks/mazchnaTasks.ts
+++ b/src/lib/slayer/tasks/mazchnaTasks.ts
@@ -2,11 +2,12 @@ import { Monsters } from 'oldschooljs';
 
 import killableMonsters from '../../minions/data/killableMonsters';
 import type { AssignableSlayerTask } from '../types';
+import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 
 export const mazchnaTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Banshee,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.Banshee.id, Monsters.TwistedBanshee.id],
 		combatLevel: 20,
@@ -16,7 +17,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Bat,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [Monsters.Bat.id, Monsters.GiantBat.id],
 		combatLevel: 5,
@@ -24,7 +25,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.BlackBear,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 6,
 		monsters: [
 			Monsters.BlackBear.id,
@@ -54,7 +55,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.CaveCrawler,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.CaveCrawler.id],
 		combatLevel: 10,
@@ -72,7 +73,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Cockatrice,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.Cockatrice.id],
 		combatLevel: 25,
@@ -81,7 +82,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.CrawlingHand,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.CrawlingHand.id],
 		slayerLevel: 5,
@@ -90,19 +91,10 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.GuardDog,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [Monsters.GuardDog.id, Monsters.Jackal.id, Monsters.WildDog.id],
 		combatLevel: 15,
-		unlocked: true
-	},
-	{
-		monster: Monsters.EarthWarrior,
-		amount: [40, 70],
-		weight: 6,
-		monsters: [Monsters.EarthWarrior.id],
-		levelRequirements: killableMonsters.find(k => k.id === Monsters.EarthWarrior.id)?.levelRequirements,
-		combatLevel: 35,
 		unlocked: true
 	},
 	{
@@ -115,7 +107,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Ghost,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [Monsters.Ghost.id, Monsters.TorturedSoul.id],
 		combatLevel: 13,
@@ -132,7 +124,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.HillGiant,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [Monsters.HillGiant.id, Monsters.Obor.id, Monsters.Cyclops.id],
 		combatLevel: 25,
@@ -140,7 +132,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Hobgoblin,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [Monsters.Hobgoblin.id],
 		combatLevel: 20,
@@ -148,7 +140,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.IceWarrior,
-		amount: [40, 70],
+		amount: [40, 50],
 		weight: 7,
 		monsters: [Monsters.IceWarrior.id],
 		combatLevel: 45,
@@ -156,7 +148,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.KalphiteWorker,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 6,
 		monsters: [
 			Monsters.KalphiteWorker.id,
@@ -169,7 +161,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Killerwatt,
-		amount: [30, 80],
+		amount: [30, 50],
 		weight: 6,
 		monsters: [Monsters.Killerwatt.id],
 		combatLevel: 50,
@@ -179,7 +171,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Lizard,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.Lizard.id, Monsters.SmallLizard.id, Monsters.DesertLizard.id, Monsters.SulphurLizard.id],
 		slayerLevel: 22,
@@ -187,7 +179,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Mogre,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.Mogre.id],
 		combatLevel: 30,
@@ -196,7 +188,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Pyrefiend,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.Pyrefiend.id, Monsters.Pyrelord.id],
 		combatLevel: 25,
@@ -205,7 +197,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Rockslug,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 8,
 		monsters: [Monsters.Rockslug.id],
 		combatLevel: 20,
@@ -214,7 +206,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Scorpion,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [
 			Monsters.Scorpion.id,
@@ -229,7 +221,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Shade,
-		amount: [40, 70],
+		amount: [30, 70],
 		weight: 8,
 		monsters: [
 			Monsters.Shade.id,
@@ -245,7 +237,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Skeleton,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [
 			Monsters.Skeleton.id,
@@ -260,6 +252,8 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.FeralVampyre,
 		amount: [10, 20],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.MoreAtStake,
 		weight: 6,
 		monsters: [
 			Monsters.FeralVampyre.id,
@@ -282,7 +276,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Wolf,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [
 			Monsters.Wolf.id,
@@ -297,7 +291,7 @@ export const mazchnaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Zombie,
-		amount: [40, 70],
+		amount: [30, 50],
 		weight: 7,
 		monsters: [
 			Monsters.Zombie.id,

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -9,6 +9,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.AberrantSpectre,
 		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.SmellYaLater,
 		weight: 6,
 		monsters: [Monsters.AberrantSpectre.id, Monsters.DeviantSpectre.id],
 		combatLevel: 65,
@@ -19,6 +21,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.AbyssalDemon,
 		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.AugmentMyAbbies,
 		weight: 9,
 		monsters: [Monsters.AbyssalDemon.id, Monsters.AbyssalSire.id],
 		combatLevel: 85,
@@ -29,6 +33,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.AdamantDragon,
 		amount: [3, 7],
+		extendedAmount: [20, 30],
+		extendedUnlockId: SlayerTaskUnlocksEnum.AdamindSomeMore,
 		weight: 2,
 		monsters: [Monsters.AdamantDragon.id],
 		questPoints: 205,
@@ -37,6 +43,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Ankou,
 		amount: [50, 90],
+		extendedAmount: [91, 150],
+		extendedUnlockId: SlayerTaskUnlocksEnum.AnkouVeryMuch,
 		weight: 5,
 		monsters: [Monsters.Ankou.id],
 		combatLevel: 40,
@@ -45,22 +53,27 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Aviansie,
 		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.BirdsOfAFeather,
 		weight: 6,
 		monsters: [Monsters.Aviansie.id, Monsters.Kreearra.id],
 		unlocked: false
 	},
 	{
 		monster: Monsters.Basilisk,
-		amount: [120, 180],
+		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.Basilonger,
 		weight: 6,
 		monsters: [Monsters.Basilisk.id, Monsters.BasiliskKnight.id],
-		combatLevel: 40,
 		slayerLevel: 40,
 		unlocked: false
 	},
 	{
 		monster: Monsters.BlackDemon,
 		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.ItsDarkInHere,
 		weight: 9,
 		monsters: [Monsters.BlackDemon.id, Monsters.DemonicGorilla.id, Monsters.Skotizo.id],
 		combatLevel: 80,
@@ -76,7 +89,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 			Monsters.BrutalBlackDragon.id,
 			Monsters.KingBlackDragon.id
 		],
-		slayerLevel: 77,
+		extendedAmount: [40, 60],
+		extendedUnlockId: SlayerTaskUnlocksEnum.FireAndDarkness,
 		combatLevel: 80,
 		questPoints: 34,
 		unlocked: true
@@ -84,6 +98,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Bloodveld,
 		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.BleedMeDry,
 		weight: 9,
 		monsters: [Monsters.Bloodveld.id, Monsters.MutatedBloodveld.id],
 		combatLevel: 50,
@@ -118,6 +134,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.CaveHorror,
 		amount: [120, 180],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.Horrorific,
 		weight: 5,
 		monsters: [Monsters.CaveHorror.id],
 		combatLevel: 85,
@@ -128,6 +146,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.CaveKraken,
 		amount: [100, 120],
+		extendedAmount: [150, 200],
+		extendedUnlockId: SlayerTaskUnlocksEnum.KrackOn,
 		weight: 6,
 		monsters: [Monsters.CaveKraken.id, Monsters.Kraken.id],
 		combatLevel: 80,
@@ -153,6 +173,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.DarkBeast,
 		amount: [10, 20],
+		extendedAmount: [110, 135],
+		extendedUnlockId: SlayerTaskUnlocksEnum.NeedMoreDarkness,
 		weight: 5,
 		monsters: [Monsters.DarkBeast.id],
 		combatLevel: 90,
@@ -171,7 +193,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.DustDevil,
 		amount: [120, 185],
-
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.ToDustYouShallReturn,
 		weight: 6,
 		monsters: [Monsters.DustDevil.id],
 		combatLevel: 70,
@@ -204,7 +227,9 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.FossilIslandWyvernSpitting,
-		amount: [20, 60],
+		amount: [5, 25],
+		extendedAmount: [55, 75],
+		extendedUnlockId: SlayerTaskUnlocksEnum.WyverNotherTwo,
 		weight: 5,
 		monsters: [
 			Monsters.FossilIslandWyvernAncient.id,
@@ -220,6 +245,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Gargoyle,
 		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.GetSmashed,
 		weight: 6,
 		monsters: [Monsters.Gargoyle.id, Monsters.GrotesqueGuardians.id],
 		combatLevel: 80,
@@ -230,6 +257,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.GreaterDemon,
 		amount: [120, 185],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.GreaterChallenge,
 		weight: 7,
 		monsters: [
 			Monsters.GreaterDemon.id,
@@ -237,7 +266,7 @@ export const nieveTasks: AssignableSlayerTask[] = [
 			Monsters.Skotizo.id,
 			Monsters.TormentedDemon.id
 		],
-		combatLevel: 70,
+		combatLevel: 75,
 		unlocked: true
 	},
 	{
@@ -251,7 +280,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.IronDragon,
 		amount: [30, 60],
-
+		extendedAmount: [60, 100],
+		extendedUnlockId: SlayerTaskUnlocksEnum.PedalToTheMetals,
 		weight: 5,
 		monsters: [Monsters.IronDragon.id],
 		combatLevel: 80,
@@ -290,6 +320,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.ScarabMage,
 		amount: [30, 60],
+		extendedAmount: [130, 170],
+		extendedUnlockId: SlayerTaskUnlocksEnum.GetScabarightOnIt,
 		weight: 4,
 		monsters: [Monsters.ScarabMage.id, Monsters.LocustRider.id],
 		combatLevel: 85,
@@ -298,7 +330,9 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.MithrilDragon,
-		amount: [4, 9],
+		amount: [4, 8],
+		extendedAmount: [25, 35],
+		extendedUnlockId: SlayerTaskUnlocksEnum.IReallyMithYou,
 		weight: 5,
 		monsters: [Monsters.MithrilDragon.id],
 		unlocked: false
@@ -316,7 +350,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Nechryael,
 		amount: [110, 170],
-
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.NechsPlease,
 		weight: 7,
 		monsters: [Monsters.Nechryael.id, Monsters.GreaterNechryael.id],
 		combatLevel: 85,
@@ -330,11 +365,14 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		weight: 5,
 		monsters: [Monsters.RedDragon.id, Monsters.BabyRedDragon.id, Monsters.BrutalRedDragon.id],
 		questPoints: 34,
+		combatLevel: 68,
 		unlocked: false
 	},
 	{
 		monster: Monsters.RuneDragon,
 		amount: [3, 6],
+		extendedAmount: [30, 60],
+		extendedUnlockId: SlayerTaskUnlocksEnum.RUUUUUNE,
 		weight: 2,
 		monsters: [Monsters.RuneDragon.id],
 		questPoints: 205,
@@ -343,6 +381,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.SkeletalWyvern,
 		amount: [5, 15],
+		extendedAmount: [50, 70],
+		extendedUnlockId: SlayerTaskUnlocksEnum.WyverNotherOne,
 		weight: 5,
 		monsters: [Monsters.SkeletalWyvern.id],
 		combatLevel: 70,
@@ -355,18 +395,17 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		amount: [120, 185],
 		weight: 7,
 		monsters: [Monsters.SmokeDevil.id, Monsters.ThermonuclearSmokeDevil.id],
-		combatLevel: 75,
+		combatLevel: 85,
 		slayerLevel: 93,
 		unlocked: true
 	},
 	{
 		monster: Monsters.SpiritualRanger,
 		amount: [120, 185],
+		extendedAmount: [181, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.SpiritualFervour,
 		weight: 6,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		levelRequirements: {
-			slayer: 60
-		},
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
@@ -375,6 +414,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.SteelDragon,
 		amount: [30, 60],
+		extendedAmount: [40, 60],
+		extendedUnlockId: SlayerTaskUnlocksEnum.PedalToTheMetals,
 		weight: 5,
 		monsters: [Monsters.SteelDragon.id],
 		levelRequirements: killableMonsters.find(k => k.id === Monsters.SteelDragon.id)?.levelRequirements,
@@ -385,7 +426,7 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Suqah,
 		amount: [120, 185],
-		extendedAmount: [180, 250],
+		extendedAmount: [186, 250],
 		extendedUnlockId: SlayerTaskUnlocksEnum.SuqANotherOne,
 		weight: 8,
 		monsters: [Monsters.Suqah.id],
@@ -420,7 +461,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.FeralVampyre,
 		amount: [110, 170],
-
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.MoreAtStake,
 		weight: 6,
 		monsters: [
 			Monsters.FeralVampyre.id,
@@ -428,7 +470,6 @@ export const nieveTasks: AssignableSlayerTask[] = [
 			Monsters.Vyrewatch.id,
 			Monsters.VyrewatchSentinel.id
 		],
-		combatLevel: 35,
 		questPoints: 1,
 		unlocked: false
 	},

--- a/src/lib/slayer/tasks/turaelTasks.ts
+++ b/src/lib/slayer/tasks/turaelTasks.ts
@@ -5,7 +5,7 @@ import type { AssignableSlayerTask } from '../types';
 export const turaelTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Banshee,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 8,
 		monsters: [Monsters.Banshee.id, Monsters.TwistedBanshee.id],
 		combatLevel: 20,
@@ -15,7 +15,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Bat,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [Monsters.Bat.id, Monsters.GiantBat.id],
 		combatLevel: 5,
@@ -23,7 +23,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.BlackBear,
-		amount: [15, 50],
+		amount: [10, 20],
 		weight: 7,
 		monsters: [
 			Monsters.BlackBear.id,
@@ -37,7 +37,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Bird,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 6,
 		monsters: [
 			Monsters.Chicken.id,
@@ -54,7 +54,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.CaveBug,
-		amount: [10, 20],
+		amount: [10, 30],
 		weight: 8,
 		monsters: [Monsters.CaveBug.id],
 		slayerLevel: 7,
@@ -62,7 +62,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.CaveCrawler,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 8,
 		monsters: [Monsters.CaveCrawler.id],
 		combatLevel: 10,
@@ -80,7 +80,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Cow,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 8,
 		monsters: [Monsters.Cow.id, Monsters.CowCalf.id],
 		combatLevel: 5,
@@ -88,7 +88,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.CrawlingHand,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 8,
 		monsters: [Monsters.CrawlingHand.id],
 		slayerLevel: 5,
@@ -97,7 +97,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.GuardDog,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [Monsters.GuardDog.id, Monsters.Jackal.id, Monsters.WildDog.id],
 		combatLevel: 15,
@@ -105,7 +105,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Dwarf,
-		amount: [15, 50],
+		amount: [10, 25],
 		weight: 7,
 		monsters: [Monsters.Dwarf.id, Monsters.BlackGuard.id, Monsters.ChaosDwarf.id, Monsters.DwarfGangMember.id],
 		combatLevel: 6,
@@ -113,7 +113,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Ghost,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [Monsters.Ghost.id, Monsters.TorturedSoul.id],
 		combatLevel: 13,
@@ -121,14 +121,14 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Goblin,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [Monsters.Goblin.id, Monsters.CaveGoblinGuard.id],
 		unlocked: true
 	},
 	{
 		monster: Monsters.Icefiend,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 8,
 		monsters: [Monsters.Icefiend.id],
 		combatLevel: 20,
@@ -136,7 +136,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.KalphiteWorker,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 6,
 		monsters: [
 			Monsters.KalphiteWorker.id,
@@ -149,7 +149,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Lizard,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 8,
 		monsters: [Monsters.Lizard.id, Monsters.SmallLizard.id, Monsters.DesertLizard.id, Monsters.SulphurLizard.id],
 		slayerLevel: 22,
@@ -165,7 +165,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Monkey,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 6,
 		monsters: [
 			Monsters.Monkey.id,
@@ -179,7 +179,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Rat,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [
 			Monsters.Rat.id,
@@ -194,7 +194,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Scorpion,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [
 			Monsters.Scorpion.id,
@@ -209,7 +209,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Skeleton,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [
 			Monsters.Skeleton.id,
@@ -223,7 +223,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Spider,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 6,
 		monsters: [
 			Monsters.Spider.id,
@@ -239,7 +239,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Wolf,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [
 			Monsters.Wolf.id,
@@ -254,7 +254,7 @@ export const turaelTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Zombie,
-		amount: [15, 50],
+		amount: [15, 30],
 		weight: 7,
 		monsters: [
 			Monsters.Zombie.id,

--- a/src/lib/slayer/tasks/vannakaTasks.ts
+++ b/src/lib/slayer/tasks/vannakaTasks.ts
@@ -1,12 +1,14 @@
 import { Monsters } from 'oldschooljs';
 
-import killableMonsters from '../../minions/data/killableMonsters';
 import type { AssignableSlayerTask } from '../types';
+import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 
 export const vannakaTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.AberrantSpectre,
-		amount: [60, 120],
+		amount: [40, 90],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.SmellYaLater,
 		weight: 8,
 		monsters: [Monsters.AberrantSpectre.id, Monsters.DeviantSpectre.id],
 		combatLevel: 65,
@@ -16,7 +18,9 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.AbyssalDemon,
-		amount: [60, 120],
+		amount: [40, 90],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.AugmentMyAbbies,
 		weight: 5,
 		monsters: [Monsters.AbyssalDemon.id, Monsters.AbyssalSire.id],
 		combatLevel: 85,
@@ -26,24 +30,18 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.Ankou,
 		amount: [25, 35],
+		extendedAmount: [91, 150],
+		extendedUnlockId: SlayerTaskUnlocksEnum.AnkouVeryMuch,
 		weight: 7,
 		monsters: [Monsters.Ankou.id],
 		combatLevel: 40,
 		unlocked: true
 	},
 	{
-		monster: Monsters.Banshee,
-		amount: [60, 120],
-		weight: 6,
-		monsters: [Monsters.Banshee.id, Monsters.TwistedBanshee.id],
-		combatLevel: 20,
-		slayerLevel: 15,
-		questPoints: 1,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Basilisk,
-		amount: [60, 120],
+		amount: [40, 90],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.Basilonger,
 		weight: 8,
 		monsters: [Monsters.Basilisk.id, Monsters.BasiliskKnight.id],
 		combatLevel: 40,
@@ -52,7 +50,9 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Bloodveld,
-		amount: [60, 120],
+		amount: [40, 90],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.BleedMeDry,
 		weight: 8,
 		monsters: [Monsters.Bloodveld.id, Monsters.MutatedBloodveld.id],
 		combatLevel: 50,
@@ -62,7 +62,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.BlueDragon,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [
 			Monsters.BlueDragon.id,
@@ -76,7 +76,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.BrineRat,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.BrineRat.id],
 		combatLevel: 45,
@@ -85,43 +85,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.BronzeDragon,
-		amount: [10, 20],
-		weight: 7,
-		monsters: [Monsters.BronzeDragon.id],
-		combatLevel: 75,
-		questPoints: 34,
-		unlocked: true
-	},
-	{
-		monster: Monsters.CaveBug,
-		amount: [10, 20],
-		weight: 7,
-		monsters: [Monsters.CaveBug.id],
-		slayerLevel: 7,
-		unlocked: true
-	},
-	{
-		monster: Monsters.CaveCrawler,
-		amount: [60, 120],
-		weight: 7,
-		monsters: [Monsters.CaveCrawler.id],
-		combatLevel: 10,
-		slayerLevel: 10,
-		unlocked: true
-	},
-	{
-		monster: Monsters.CaveSlime,
-		amount: [10, 20],
-		weight: 7,
-		monsters: [Monsters.CaveSlime.id],
-		combatLevel: 15,
-		slayerLevel: 17,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Cockatrice,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [Monsters.Cockatrice.id],
 		combatLevel: 25,
@@ -129,17 +94,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.CrawlingHand,
-		amount: [60, 120],
-		weight: 6,
-		monsters: [Monsters.CrawlingHand.id],
-		slayerLevel: 5,
-		questPoints: 1,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Crocodile,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 6,
 		monsters: [Monsters.Crocodile.id],
 		combatLevel: 50,
@@ -147,7 +103,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Dagannoth,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [
 			Monsters.Dagannoth.id,
@@ -163,7 +119,9 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.DustDevil,
-		amount: [60, 120],
+		amount: [40, 90],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.ToDustYouShallReturn,
 		weight: 8,
 		monsters: [Monsters.DustDevil.id],
 		combatLevel: 70,
@@ -172,17 +130,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.EarthWarrior,
-		amount: [40, 80],
-		weight: 6,
-		monsters: [Monsters.EarthWarrior.id],
-		levelRequirements: killableMonsters.find(k => k.id === Monsters.EarthWarrior.id)?.levelRequirements,
-		combatLevel: 35,
-		unlocked: true
-	},
-	{
 		monster: Monsters.ElfWarrior,
-		amount: [40, 100],
+		amount: [30, 70],
 		weight: 7,
 		monsters: [
 			Monsters.ElfWarrior.id,
@@ -197,7 +146,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.FeverSpider,
-		amount: [60, 120],
+		amount: [30, 90],
 		weight: 7,
 		monsters: [Monsters.FeverSpider.id],
 		combatLevel: 40,
@@ -207,7 +156,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.FireGiant,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.FireGiant.id],
 		combatLevel: 65,
@@ -215,7 +164,9 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Gargoyle,
-		amount: [60, 120],
+		amount: [40, 90],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.GetSmashed,
 		weight: 5,
 		monsters: [Monsters.Gargoyle.id, Monsters.GrotesqueGuardians.id],
 		combatLevel: 80,
@@ -233,17 +184,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.GreenDragon,
-		amount: [40, 80],
-		weight: 6,
-		monsters: [Monsters.GreenDragon.id, Monsters.BabyGreenDragon.id, Monsters.BrutalGreenDragon.id],
-		combatLevel: 52,
-		questPoints: 34,
-		unlocked: true
-	},
-	{
 		monster: Monsters.HarpieBugSwarm,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [Monsters.HarpieBugSwarm.id],
 		combatLevel: 45,
@@ -256,7 +198,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Hellhound,
-		amount: [40, 80],
+		amount: [30, 60],
 		weight: 7,
 		monsters: [Monsters.Hellhound.id, Monsters.Cerberus.id],
 		combatLevel: 75,
@@ -264,7 +206,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.HillGiant,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.HillGiant.id, Monsters.Obor.id, Monsters.Cyclops.id],
 		combatLevel: 25,
@@ -272,7 +214,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Hobgoblin,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.Hobgoblin.id],
 		combatLevel: 20,
@@ -280,7 +222,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.IceGiant,
-		amount: [40, 80],
+		amount: [30, 80],
 		weight: 7,
 		monsters: [Monsters.IceGiant.id],
 		combatLevel: 50,
@@ -288,7 +230,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.IceWarrior,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.IceWarrior.id],
 		combatLevel: 45,
@@ -296,7 +238,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.InfernalMage,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [Monsters.InfernalMage.id],
 		combatLevel: 40,
@@ -306,7 +248,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Jelly,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [Monsters.Jelly.id, Monsters.WarpedJelly.id],
 		combatLevel: 57,
@@ -315,7 +257,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.JungleHorror,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [Monsters.JungleHorror.id],
 		combatLevel: 65,
@@ -324,7 +266,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.KalphiteWorker,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [
 			Monsters.KalphiteWorker.id,
@@ -336,18 +278,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.Killerwatt,
-		amount: [30, 80],
-		weight: 6,
-		monsters: [Monsters.Killerwatt.id],
-		combatLevel: 50,
-		slayerLevel: 37,
-		questPoints: 4,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Kurask,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.Kurask.id],
 		combatLevel: 65,
@@ -355,16 +287,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.Lizard,
-		amount: [60, 120],
-		weight: 7,
-		monsters: [Monsters.Lizard.id, Monsters.SmallLizard.id, Monsters.DesertLizard.id, Monsters.SulphurLizard.id],
-		slayerLevel: 22,
-		unlocked: true
-	},
-	{
 		monster: Monsters.LesserDemon,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.LesserDemon.id],
 		combatLevel: 60,
@@ -372,7 +296,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Mogre,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.Mogre.id],
 		combatLevel: 30,
@@ -381,7 +305,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Molanisk,
-		amount: [39, 50],
+		amount: [40, 50],
 		weight: 7,
 		monsters: [Monsters.Molanisk.id],
 		combatLevel: 50,
@@ -391,7 +315,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.MossGiant,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.MossGiant.id, Monsters.Bryophyta.id],
 		combatLevel: 40,
@@ -399,7 +323,9 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Nechryael,
-		amount: [60, 120],
+		amount: [40, 90],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.NechsPlease,
 		weight: 5,
 		monsters: [Monsters.Nechryael.id, Monsters.GreaterNechryael.id],
 		combatLevel: 85,
@@ -409,7 +335,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Ogre,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.Ogre.id, Monsters.OgressShaman.id, Monsters.OgressWarrior.id],
 		combatLevel: 40,
@@ -417,7 +343,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Otherworldlybeing,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [Monsters.Otherworldlybeing.id],
 		combatLevel: 40,
@@ -426,7 +352,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Pyrefiend,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [Monsters.Pyrefiend.id, Monsters.Pyrelord.id],
 		combatLevel: 25,
@@ -434,17 +360,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.Rockslug,
-		amount: [60, 120],
-		weight: 7,
-		monsters: [Monsters.Rockslug.id],
-		combatLevel: 20,
-		slayerLevel: 20,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Shade,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 8,
 		monsters: [
 			Monsters.Shade.id,
@@ -460,7 +377,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.SeaSnakeHatchling,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 6,
 		monsters: [Monsters.SeaSnakeHatchling.id, Monsters.SeaSnakeYoung.id],
 		combatLevel: 50,
@@ -470,22 +387,20 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.ShadowWarrior,
-		amount: [40, 80],
+		amount: [30, 80],
 		weight: 8,
 		monsters: [Monsters.ShadowWarrior.id],
-		combatLevel: 57,
+		combatLevel: 60,
 		questPoints: 111,
 		unlocked: true
 	},
 	{
 		monster: Monsters.SpiritualRanger,
-		amount: [110, 170],
-
+		amount: [40, 90],
+		extendedAmount: [181, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.SpiritualFervour,
 		weight: 8,
 		monsters: [Monsters.SpiritualRanger.id, Monsters.SpiritualWarrior.id, Monsters.SpiritualMage.id],
-		levelRequirements: {
-			slayer: 60
-		},
 		combatLevel: 60,
 		slayerLevel: 63,
 		questPoints: 3,
@@ -503,7 +418,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.MountainTroll,
-		amount: [60, 120],
+		amount: [40, 90],
 		weight: 7,
 		monsters: [Monsters.MountainTroll.id, Monsters.IceTroll.id, Monsters.TrollGeneral.id],
 		combatLevel: 60,
@@ -511,7 +426,7 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Turoth,
-		amount: [60, 120],
+		amount: [30, 90],
 		weight: 8,
 		monsters: [Monsters.Turoth.id],
 		combatLevel: 60,
@@ -521,6 +436,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 	{
 		monster: Monsters.FeralVampyre,
 		amount: [10, 20],
+		extendedAmount: [200, 250],
+		extendedUnlockId: SlayerTaskUnlocksEnum.MoreAtStake,
 		weight: 7,
 		monsters: [
 			Monsters.FeralVampyre.id,
@@ -533,17 +450,8 @@ export const vannakaTasks: AssignableSlayerTask[] = [
 		unlocked: true
 	},
 	{
-		monster: Monsters.WallBeast,
-		amount: [10, 20],
-		weight: 6,
-		monsters: [Monsters.WallBeast.id],
-		combatLevel: 30,
-		slayerLevel: 35,
-		unlocked: true
-	},
-	{
 		monster: Monsters.Werewolf,
-		amount: [40, 80],
+		amount: [30, 60],
 		weight: 7,
 		monsters: [Monsters.Werewolf.id],
 		combatLevel: 60,

--- a/src/lib/slayer/tasks/vannakaTasks.ts
+++ b/src/lib/slayer/tasks/vannakaTasks.ts
@@ -1,7 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
-import type { AssignableSlayerTask } from '../types';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
+import type { AssignableSlayerTask } from '../types';
 
 export const vannakaTasks: AssignableSlayerTask[] = [
 	{


### PR DESCRIPTION
### Description:

Corrected some slayer task requirements, extended slayer amounts, and synced all tasks with wiki to match  
[update](https://oldschool.runescape.wiki/w/Update:Project_Rebalance:_Skilling_%26_Poll_81_MTA_Changes).

Closes #6021, closes #6132.

### Changes:

- Updated slayer task info for all (non wildy) masters.

### Other checks:

- [x] I have tested all my changes thoroughly.
