### PR TITLE
add teleport scrolls and bugfix

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -140,7 +140,15 @@ const killableBosses: KillableMonster[] = [
 			}
 		},
 		defaultAttackStyles: [SkillsEnum.Ranged, SkillsEnum.Magic],
-		disallowedAttackStyles: [SkillsEnum.Attack, SkillsEnum.Strength]
+		disallowedAttackStyles: [SkillsEnum.Attack, SkillsEnum.Strength],
+		itemCost: [
+			{
+				itemCost: new Bank().add('Zul-andra teleport'),
+				qtyPerKill: 0.25,
+				boostPercent: 10,
+				optional: true
+			}
+		]
 	},
 	{
 		id: Monsters.KalphiteQueen.id,
@@ -347,7 +355,15 @@ const killableBosses: KillableMonster[] = [
 		combatXpMultiplier: 1.15,
 		healAmountNeeded: 20 * 15,
 		attackStyleToUse: GearStat.AttackCrush,
-		attackStylesUsed: [GearStat.AttackCrush]
+		attackStylesUsed: [GearStat.AttackCrush],
+		itemCost: [
+			{
+				itemCost: new Bank().add('Key master teleport'),
+				qtyPerKill: 0.1,
+				boostPercent: 10,
+				optional: true
+			}
+		]
 	},
 	{
 		id: Monsters.KingBlackDragon.id,

--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -518,6 +518,14 @@ export const chaeldarMonsters: KillableMonster[] = [
 		healAmountNeeded: 250,
 		attackStyleToUse: GearStat.AttackStab,
 		attackStylesUsed: [GearStat.AttackSlash, GearStat.AttackRanged, GearStat.AttackMagic],
-		requiredQuests: [QuestID.WhileGuthixSleeps]
+		requiredQuests: [QuestID.WhileGuthixSleeps],
+		itemCost: [
+			{
+				itemCost: new Bank().add('Guthixian temple teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 10,
+				optional: true
+			}
+		]
 	}
 ];

--- a/src/lib/minions/data/killableMonsters/revs.ts
+++ b/src/lib/minions/data/killableMonsters/revs.ts
@@ -15,14 +15,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -36,14 +44,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -57,14 +73,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -78,14 +102,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -99,7 +131,15 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 8,
 		pkBaseDeathChance: 8,
-		canBePked: true
+		canBePked: true,
+		itemCost: [
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		]
 	},
 	{
 		id: Monsters.RevenantHellhound.id,
@@ -112,14 +152,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -133,14 +181,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -154,7 +210,15 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 8,
 		pkBaseDeathChance: 8,
-		canBePked: true
+		canBePked: true,
+		itemCost: [
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		]
 	},
 	{
 		id: Monsters.RevenantKnight.id,
@@ -167,14 +231,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -188,14 +260,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	},
 	{
@@ -209,14 +289,22 @@ export const revenantMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		pkActivityRating: 9,
 		pkBaseDeathChance: 8,
-		itemCost: {
-			itemCost: new Bank().add('Blighted super restore (4)', 1),
-			qtyPerMinute: 0.17,
-			alternativeConsumables: [
-				{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
-				{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
-			]
-		},
+		itemCost: [
+			{
+				itemCost: new Bank().add('Blighted super restore (4)', 1),
+				qtyPerMinute: 0.17,
+				alternativeConsumables: [
+					{ itemCost: new Bank().add('Super restore (4)', 1), qtyPerMinute: 0.17 },
+					{ itemCost: new Bank().add('Prayer potion (4)', 1), qtyPerMinute: 0.17 }
+				]
+			},
+			{
+				itemCost: new Bank().add('Revenant cave teleport'),
+				qtyPerKill: 0.05,
+				boostPercent: 5,
+				optional: true
+			}
+		],
 		canBePked: true
 	}
 ];

--- a/src/mahoji/lib/abstracted_commands/minionKill/handleConsumables.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/handleConsumables.ts
@@ -86,7 +86,11 @@ export function getItemCostFromConsumables({
 
 	const maxBasedOnTime = Math.floor(maxTripLength / timeToFinish);
 	const maxCanKillWithItemCost =
-		consumableCosts.length === 0 ? Number.POSITIVE_INFINITY : Math.floor(floatCostsPerKill.fits(gearBank.bank));
+		consumableCosts.length === 0
+			? Number.POSITIVE_INFINITY
+			: floatCostsPerKill.length() === 0
+				? Number.POSITIVE_INFINITY
+				: Math.floor(floatCostsPerKill.fits(gearBank.bank));
 	const maxAllowed = Math.min(maxBasedOnTime, maxCanKillWithItemCost);
 	let finalQuantity = Math.max(1, inputQuantity ? Math.min(inputQuantity, maxAllowed) : maxAllowed) ?? maxAllowed;
 	if (slayerKillsRemaining && finalQuantity > slayerKillsRemaining) {


### PR DESCRIPTION
### Description:

Added teleport scroll boosts for Zulrah, Tormented Demons, Cerberus, and Revs
+ During testing I found a bug with HandleConsumeableCosts and fixed that as well.
resolves #6134

### Changes:
added optional boosts to zulrah, tds, cerb, and revs.

"maxCanKillWithItemCost" would check if the consumables had a length greater than 1, and in these cases they did. But because they were optional the floatCostPerkKill could come back empty, and the maxCanKill would end up set to 0. Added a check for floatcostperkill being empty.


### Other checks:

- [X] I have tested all my changes thoroughly.
