### PR TITLE
Fix Bingo Notifications

### DIFF
--- a/src/mahoji/lib/bingo/BingoManager.ts
+++ b/src/mahoji/lib/bingo/BingoManager.ts
@@ -344,7 +344,7 @@ ${teams
 		sendToChannelID(this.notificationsChannelID, {
 			content: str
 		}).catch(noOp);
-		
+
 		sendToChannelID('1094693702536007750', {
 			content: str
 		}).catch(noOp);

--- a/src/mahoji/lib/bingo/BingoManager.ts
+++ b/src/mahoji/lib/bingo/BingoManager.ts
@@ -344,6 +344,10 @@ ${teams
 		sendToChannelID(this.notificationsChannelID, {
 			content: str
 		}).catch(noOp);
+		
+		sendToChannelID('1094693702536007750', {
+			content: str
+		}).catch(noOp);
 	}
 }
 


### PR DESCRIPTION
Currently notifications for the osb bingo are only going to the loot games server which a lot of people aren't in. This adds the notifications to the bingo-notifications channel.

I appreciate this is probably the worst way to do this, but just thought id put the pr up.

- [ ] I have tested all my changes thoroughly.
