### PR TITLE
Update toa.mdx

### DIFF
--- a/docs/src/content/docs/osb/Raids/toa.mdx
+++ b/docs/src/content/docs/osb/Raids/toa.mdx
@@ -27,7 +27,7 @@ Solo Tombs of Amascut requires 1 KC for every 10 levels of invocation. E.g. a 50
 
 ## Boosts
 
-At 250 kc you will have the minimum death chance possible. At 350 kc you will have the maximum speed boost possible.
+At 250 kc you will have the minimum death chance possible. At 350 attempts you will have the maximum speed boost possible.
 
 Specific items will give a hidden speed boost to your raids, these are:
 


### PR DESCRIPTION

### Description:

Correction / word change to the boosts section in the OSB ToA Page. ( 350 kc -> 350 attempts)

### Changes:

corrected an error in the boosts section:

"At 350 kc you will have the maximum speed boost possible."

TO

"At 350 attempts you will have the maximum speed boost possible."

### Other checks:
- Reviewed lines 1412 + 1413 in toa.ts to confirm that it's 350 attempts, not kc.
```
1412   // Reduce time for KC
1413   const kcPercent = clamp(calcWhatPercent(u.totalAttempts, maxScaling), 1, 100);
```

- [ ] I have tested all my changes thoroughly.
