### PR TITLE
Add total kc and kc/h to temp/todt return message

### DIFF
--- a/src/tasks/minions/minigames/temporossActivity.ts
+++ b/src/tasks/minions/minigames/temporossActivity.ts
@@ -1,4 +1,4 @@
-import { formatOrdinal } from '@oldschoolgg/toolkit/util';
+import { calcPerHour, formatOrdinal } from '@oldschoolgg/toolkit/util';
 import { increaseNumByPercent, randInt } from 'e';
 
 import { Emoji, Events } from '../../../lib/constants';
@@ -83,7 +83,7 @@ export const temporossTask: MinionTask = {
 
 		let output = `${user}, ${
 			user.minionName
-		} finished fighting Tempoross ${quantity}x times. ${xpStr.toLocaleString()}`;
+		} finished fighting Tempoross ${quantity}x times (${calcPerHour(quantity, data.duration).toFixed(1)}/hr), you now have ${newScore} KC. ${xpStr.toLocaleString()}`;
 
 		if (fBonusXP > 0) {
 			output += `\n\n**Fishing Bonus XP:** ${fBonusXP.toLocaleString()}`;

--- a/src/tasks/minions/minigames/wintertodtActivity.ts
+++ b/src/tasks/minions/minigames/wintertodtActivity.ts
@@ -1,9 +1,10 @@
 import { randInt } from 'e';
 import { Bank } from 'oldschooljs';
 
+import { calcPerHour } from '@oldschoolgg/toolkit';
 import { Emoji, Events } from '../../../lib/constants';
 import { trackLoot } from '../../../lib/lootTrack';
-import { getMinigameScore, incrementMinigameScore } from '../../../lib/settings/settings';
+import { incrementMinigameScore } from '../../../lib/settings/settings';
 import { winterTodtPointsTable } from '../../../lib/simulation/simulatedKillables';
 import { WintertodtCrate } from '../../../lib/simulation/wintertodt';
 import Firemaking from '../../../lib/skilling/skills/firemaking';
@@ -18,7 +19,7 @@ export const wintertodtTask: MinionTask = {
 	async run(data: ActivityTaskOptionsWithQuantity) {
 		const { userID, channelID, quantity } = data;
 		const user = await mUserFetch(userID);
-
+		const { newScore } = await incrementMinigameScore(user.id, 'wintertodt', quantity);
 		const loot = new Bank();
 
 		let totalPoints = 0;
@@ -46,7 +47,7 @@ export const wintertodtTask: MinionTask = {
 				`${Emoji.Phoenix} **${user.badgedUsername}'s** minion, ${
 					user.minionName
 				}, just received a Phoenix! Their Wintertodt KC is ${
-					(await getMinigameScore(user.id, 'wintertodt')) + quantity
+					newScore
 				}, and their Firemaking level is ${user.skillLevel(SkillsEnum.Firemaking)}.`
 			);
 		}
@@ -111,7 +112,6 @@ export const wintertodtTask: MinionTask = {
 			collectionLog: true,
 			itemsToAdd: loot
 		});
-		incrementMinigameScore(user.id, 'wintertodt', quantity);
 
 		const image = await makeBankImage({
 			title: `Loot From ${quantity}x Wintertodt`,
@@ -120,7 +120,7 @@ export const wintertodtTask: MinionTask = {
 			previousCL
 		});
 
-		let output = `${user}, ${user.minionName} finished subduing Wintertodt ${quantity}x times. ${xpStr}, you cut ${numberOfRoots}x Bruma roots.`;
+		let output = `${user}, ${user.minionName} finished subduing Wintertodt ${quantity}x times (${calcPerHour(quantity, data.duration).toFixed(1)}/hr), you now have ${newScore} KC. ${xpStr}, you cut ${numberOfRoots}x Bruma roots.`;
 
 		if (fmBonusXP > 0) {
 			output += `\n\n**Firemaking Bonus XP:** ${fmBonusXP.toLocaleString()}`;


### PR DESCRIPTION
### Description:

Add `(X/hr), you now have Y KC` to wintertodt and tempoross return messages, like you get with `/k` for regular monsters. 

### Changes:

- Add `(X/hr), you now have Y KC` to wintertodt and tempoross return messages

### Other checks:

- [x] I have tested all my changes thoroughly.
