### PR TITLE
Superior guarantee konar keys

### DIFF
--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -1,6 +1,6 @@
 import { Time, deepClone, percentChance } from 'e';
 import type { MonsterKillOptions } from 'oldschooljs';
-import { Bank, EMonster, Monsters } from 'oldschooljs';
+import { Bank, EMonster, MonsterSlayerMaster, Monsters } from 'oldschooljs';
 
 import { type BitField, Emoji } from '../../lib/constants';
 import { userhasDiaryTierSync } from '../../lib/diaries';
@@ -335,9 +335,10 @@ export function doMonsterTrip(data: newOptions) {
 			monster.specialLoot({ loot, ownedItems: gearBank.bank, quantity: finalQuantity, cl: data.cl });
 		}
 		if (newSuperiorCount) {
-			loot.add(superiorTable?.kill(newSuperiorCount));
+			loot.add(superiorTable?.kill(newSuperiorCount).set('Brimstone key', 0)); //remove the rng keys, todo: remove drop from superiors in osjs?
 			if (isInCatacombs) loot.add('Dark totem base', newSuperiorCount);
 			if (isInWilderness) loot.add("Larran's key", newSuperiorCount);
+			if (killOptions.slayerMaster === MonsterSlayerMaster.Konar) loot.add('Brimstone key', newSuperiorCount);
 		}
 		if (isInWilderness && monster.name === 'Hill giant') {
 			for (let i = 0; i < quantity; i++) {


### PR DESCRIPTION
### Description:

Ensure superiors always drop brimstone keys on konar tasks. Tidied / merged version of https://github.com/oldschoolgg/oldschoolbot/pull/5942. 

Closes #5999.

### Changes:

- Ensure superiors always drop brimstone keys on konar tasks

### Other checks:

- [x] I have tested all my changes thoroughly.
