### PR TITLE
Add bank image spoiler option & apply at solo nex

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -107,7 +107,14 @@ export async function handleTripFinish(
 	user: MUser,
 	channelID: string,
 	_message: string | ({ content: string } & MessageCreateOptions),
-	attachment: AttachmentBuilder | Buffer | undefined,
+	attachment:
+		| AttachmentBuilder
+		| Buffer
+		| undefined
+		| {
+				name: string;
+				attachment: Buffer;
+		  },
 	data: ActivityTaskData,
 	loot: Bank | null,
 	_messages?: string[],

--- a/src/lib/util/makeBankImage.ts
+++ b/src/lib/util/makeBankImage.ts
@@ -8,6 +8,7 @@ interface MakeBankImageOptions {
 	content?: string;
 	title?: string;
 	background?: number;
+	spoiler?: boolean;
 	flags?: Record<string, string | number>;
 	user?: MUser;
 	previousCL?: Bank;
@@ -21,6 +22,7 @@ export async function makeBankImage({
 	background,
 	user,
 	previousCL,
+	spoiler,
 	showNewCL = false,
 	flags = {},
 	mahojiFlags = []
@@ -40,7 +42,7 @@ export async function makeBankImage({
 
 	return {
 		file: {
-			name: isTransparent ? 'bank.png' : 'bank.jpg',
+			name: `${spoiler ? 'SPOILER_' : ''}${isTransparent ? 'bank.png' : 'bank.jpg'}`,
 			attachment: image!
 		}
 	};

--- a/src/tasks/minions/nexActivity.ts
+++ b/src/tasks/minions/nexActivity.ts
@@ -92,9 +92,10 @@ ${loot.formatLoot()}`
 							bank: loot.totalLoot(),
 							title: `Loot From ${survivedQuantity}x Nex`,
 							user: allMUsers[0],
-							previousCL: undefined
+							previousCL: undefined,
+							spoiler: loot.purpleItems.some(i => loot.totalLoot().has(i))
 						})
-					).file.attachment
+					).file
 				: undefined,
 			data,
 			loot.totalLoot()


### PR DESCRIPTION
### Description:

Add parameter to add spoiler tags to bank images, to apply at solo nex when you have a purple.

### Changes:

- Add `spoiler` parameter to `makeBankImage`
- Add purple check to nex command to create spoiler image (and include file name in `handleTripFinish` so it actually uses it)

### Other checks:

- [x] I have tested all my changes thoroughly.
