### PR TITLE
Dungeoneering fail message

### DIFF
--- a/src/mahoji/commands/dg.ts
+++ b/src/mahoji/commands/dg.ts
@@ -68,16 +68,6 @@ async function startCommand(channelID: string, user: MUser, floor: string | unde
 				return [true, 'your minion is busy.'];
 			}
 
-			const max = calcMaxFloorUserCanDo(user);
-			if (max < floorToDo) {
-				return [
-					true,
-					`this party is doing Floor ${floorToDo}, you can't do this floor because you need level ${determineDgLevelForFloor(
-						floorToDo
-					)} Dungeoneering.`
-				];
-			}
-
 			if (!hasRequiredLevels(user, floorToDo)) {
 				return [
 					true,


### PR DESCRIPTION
### Description:
Remove a dungeoneering fail message that doesn't really tell the user anything. If the user is missing any of the required stats for the floor, the return message is defaulted to saying they are missing the dungeoneering level even if the user has the required dungeoneering level. 
### Changes:
- Remove the block of code from customDeiner in `dg.ts` so the user gets a full list of the requirements needed.
### Other checks:
- [X] I have tested all my changes thoroughly.
fixes this:
![Discord_eP3iESnjMp](https://github.com/user-attachments/assets/1e007740-d15c-42ff-9b6b-c94ad8988f88)
after this PR:
![Discord_CN60HTn7Qj](https://github.com/user-attachments/assets/dce193a6-b598-478c-a625-4bb1382c1514)

