### PR TITLE
BSO - Colosseum Combat Achievement Fix

### DIFF
--- a/src/lib/combat_achievements/elite.ts
+++ b/src/lib/combat_achievements/elite.ts
@@ -1521,7 +1521,8 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 		rng: {
 			chancePerKill: 12,
 			hasChance: (data, _user, index) =>
-				data.type === 'Colosseum' && (!data.diedAt || (Array.isArray(data.diedAt) && data.diedAt[index]! > 7))
+				data.type === 'Colosseum' &&
+				(!data.diedAt || (Array.isArray(data.diedAt) && (!data.diedAt[index] || data.diedAt[index] > 7)))
 		}
 	},
 	{

--- a/src/lib/combat_achievements/master.ts
+++ b/src/lib/combat_achievements/master.ts
@@ -1472,9 +1472,9 @@ export const masterCombatAchievements: CombatAchievement[] = [
 		rng: {
 			chancePerKill: 15,
 			hasChance: (data, _user, index) =>
-				data.type === 'Colosseum' && 
-				Array.isArray(data.diedAt) && 
-				(!data.diedAt[index] || data.diedAt[index] > 11)
+				data.type === 'Colosseum' &&
+				(!data.diedAt ||
+				(Array.isArray(data.diedAt) && (!data.diedAt[index] || data.diedAt[index] > 11)))
 		}
 	},
 	{

--- a/src/lib/combat_achievements/master.ts
+++ b/src/lib/combat_achievements/master.ts
@@ -1472,7 +1472,9 @@ export const masterCombatAchievements: CombatAchievement[] = [
 		rng: {
 			chancePerKill: 15,
 			hasChance: (data, _user, index) =>
-				data.type === 'Colosseum' && (!data.diedAt || (Array.isArray(data.diedAt) && data.diedAt[index]! > 11))
+				data.type === 'Colosseum' && 
+				Array.isArray(data.diedAt) && 
+				(!data.diedAt[index] || data.diedAt[index] > 11)
 		}
 	},
 	{

--- a/src/lib/combat_achievements/master.ts
+++ b/src/lib/combat_achievements/master.ts
@@ -1473,8 +1473,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 			chancePerKill: 15,
 			hasChance: (data, _user, index) =>
 				data.type === 'Colosseum' &&
-				(!data.diedAt ||
-				(Array.isArray(data.diedAt) && (!data.diedAt[index] || data.diedAt[index] > 11)))
+				(!data.diedAt || (Array.isArray(data.diedAt) && (!data.diedAt[index] || data.diedAt[index] > 11)))
 		}
 	},
 	{


### PR DESCRIPTION
Add a fix for the combat achievements One-Off and Denied which is currently only working if you die at wave 11 and 7 respectively or later, rather than colo completions too.

- [x] I have tested all my changes thoroughly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `One-Off` combat achievement logic in `elite.ts` and `master.ts` to award completion regardless of wave death.
> 
>   - **Behavior**:
>     - Fixes `One-Off` combat achievement in `elite.ts` and `master.ts` to award completion if player dies before or after wave 11.
>   - **Logic**:
>     - Updates `hasChance` function to check if `diedAt[index]` is undefined or greater than 11 in `master.ts` and greater than 7 in `elite.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=oldschoolgg%2Foldschoolbot&utm_source=github&utm_medium=referral)<sup> for 1e2ab175f86e39423a033cb1a04ee41e4f0e2a69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->