### PR TITLE
Remove duplicate lamp filter

### DIFF
--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -1017,11 +1017,6 @@ export const baseFilters: Filterable[] = [
 	{
 		name: 'Lamps',
 		aliases: ['lamps'],
-		items: () => XPLamps.map(i => i.itemID)
-	},
-	{
-		name: 'Lamps',
-		aliases: ['lamps'],
 		items: () => Lampables.flatMap(i => i.items)
 	},
 	{

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -23,7 +23,6 @@ import PotionsMixable from '../skilling/skills/herblore/mixables/potions';
 import unfinishedPotions from '../skilling/skills/herblore/mixables/unfinishedPotions';
 import itemID from '../util/itemID';
 import resolveItems from '../util/resolveItems';
-import { XPLamps } from '../xpLamps';
 import { allCollectionLogs } from './Collections';
 import {
 	allClueItems,


### PR DESCRIPTION
### Description:
Remove duplicate lamp filter
### Changes:
- Remove the old lamp filter and leave the updated one from https://github.com/oldschoolgg/oldschoolbot/pull/6039
### Other checks:
- [X] I have tested all my changes thoroughly.
