### PR TITLE
Correct ammo and charge messages for /k

### DIFF
--- a/src/lib/colosseum.ts
+++ b/src/lib/colosseum.ts
@@ -667,6 +667,9 @@ export async function colosseumCommand(user: MUser, channelID: string) {
 
 		const degradeResults = await degradeChargeBank(user, chargeBank);
 		messages.push(degradeResults.map(i => i.userMessage).join(', '));
+		if (user.hasEquipped("Ghommal's lucky penny")) {
+			messages.push("5% reduced charges for Ghommal's lucky penny.");
+		}
 	}
 
 	await addSubTaskToActivityTask<ColoTaskOptions>({

--- a/src/lib/colosseum.ts
+++ b/src/lib/colosseum.ts
@@ -666,10 +666,7 @@ export async function colosseumCommand(user: MUser, channelID: string) {
 		}
 
 		const degradeResults = await degradeChargeBank(user, chargeBank);
-		messages.push(degradeResults.map(i => i.userMessage).join(', '));
-		if (user.hasEquipped("Ghommal's lucky penny")) {
-			messages.push("5% reduced charges for Ghommal's lucky penny.");
-		}
+		messages.push(degradeResults);
 	}
 
 	await addSubTaskToActivityTask<ColoTaskOptions>({

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -399,9 +399,8 @@ export async function degradeItem({
 	const chargesAfter = user.user[degItem.settingsKey];
 	assert(typeof chargesAfter === 'number' && chargesAfter > 0);
 	return {
-		userMessage: `Your ${item.name} degraded by ${chargesToDegrade} charges, and now has ${chargesAfter} remaining${
-			pennyReduction > 0 ? `. Your Ghommal's lucky penny saved ${pennyReduction} charges` : ''
-		}`
+		chargesToDegrade: chargesToDegrade,
+		userMessage: `Your ${item.name} degraded by ${chargesToDegrade} charges`
 	};
 }
 

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -428,10 +428,12 @@ export async function degradeChargeBank(user: MUser, chargeBank: ChargeBank) {
 	for (const [key, chargesToDegrade] of chargeBank.entries()) {
 		const { item } = degradeableItems.find(i => i.settingsKey === key)!;
 		const result = await degradeItem({ item, chargesToDegrade, user });
-		results.push(result);
+		results.push(result.userMessage);
 	}
 
-	return results;
+	if (user.hasEquipped("Ghommal's lucky penny")) results.push("5% reduced charges for Ghommal's lucky penny");
+
+	return results.join(', ');
 }
 
 export async function refundChargeBank(user: MUser, chargeBank: ChargeBank): Promise<RefundResult[]> {

--- a/src/lib/structures/UpdateBank.ts
+++ b/src/lib/structures/UpdateBank.ts
@@ -72,14 +72,9 @@ export class UpdateBank {
 
 		// Charges
 		if (this.chargeBank.length() > 0) {
-			const res = await degradeChargeBank(user, this.chargeBank).then(res =>
-				res.map(p => p.userMessage).join(', ')
-			);
-			if (res) {
-				results.push(res);
-				if (user.hasEquipped("Ghommal's lucky penny")) {
-					results.push("5% reduced charges for Ghommal's lucky penny");
-				}
+			const degradeResults = await degradeChargeBank(user, this.chargeBank);
+			if (degradeResults) {
+				results.push(degradeResults);
 			}
 		}
 

--- a/src/lib/structures/UpdateBank.ts
+++ b/src/lib/structures/UpdateBank.ts
@@ -77,12 +77,17 @@ export class UpdateBank {
 			);
 			if (res) {
 				results.push(res);
+				if (user.hasEquipped("Ghommal's lucky penny")) {
+					results.push("5% reduced charges for Ghommal's lucky penny");
+				}
 			}
 		}
 
 		// Loot/Cost
+		const totalCost = new Bank();
 		if (this.itemCostBank.length > 0) {
-			await user.specialRemoveItems(this.itemCostBank, { isInWilderness });
+			const { realCost } = await user.specialRemoveItems(this.itemCostBank, { isInWilderness });
+			totalCost.add(realCost);
 		}
 		let itemTransactionResult: Awaited<ReturnType<MUserClass['addItemsToBank']>> | null = null;
 		if (this.itemLootBank.length > 0) {
@@ -142,6 +147,7 @@ export class UpdateBank {
 		await user.sync();
 		return {
 			itemTransactionResult,
+			totalCost,
 			rawResults: results,
 			message: results.filter(r => typeof r === 'string').join(', ')
 		};

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -97,6 +97,12 @@ export async function minionKillCommand(
 		return updateResult;
 	}
 
+	if (updateResult.message.length > 0) result.messages.push(updateResult.message);
+
+	if (updateResult.totalCost.length > 0) {
+		result.messages.push(`Removing items: ${updateResult.totalCost}`);
+	}
+
 	if (result.updateBank.itemCostBank.length > 0) {
 		await updateBankSetting('economyStats_PVMCost', result.updateBank.itemCostBank);
 		await trackLoot({

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -263,10 +263,6 @@ export function newMinionKillCommand(args: MinionKillOptions) {
 	speedDurationResult.updateBank.itemCostBank.freeze();
 	speedDurationResult.updateBank.itemLootBank.freeze();
 
-	if (speedDurationResult.updateBank.itemCostBank.length > 0) {
-		speedDurationResult.messages.push(`Removing items: ${speedDurationResult.updateBank.itemCostBank}`);
-	}
-
 	const result = newMinionKillReturnSchema.parse({
 		duration,
 		quantity,

--- a/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
@@ -397,7 +397,7 @@ export const mainBoostEffects: (Boost | Boost[])[] = [
 						const actualDegItem = degradeableItems.find(i => i.item.id === degItem.item.id);
 						if (!actualDegItem) throw new Error(`Missing actual degradeable item for ${rawItem.item.name}`);
 						charges.add(actualDegItem.settingsKey, chargesNeeded);
-						messages.push(`${rawItem.boostPercent}% for ${rawItem.item.name} (${chargesNeeded} charges)`);
+						messages.push(`${rawItem.boostPercent}% for ${rawItem.item.name}`);
 					}
 
 					return {


### PR DESCRIPTION
### Description:

Currently, for monster killing trips the message outputs ammo and charge usage that haven't been reduced by ava's / penny. 

Updates messages to correct amount reduced. Also removes some of the charge message as it was too much clutter. Includes final message to confirm charges reduced by ghommal penny for monster killing and colo

### Changes:

- Remove old charge use from `\k` messages, and instead add the message output from removing charge function.
- Shorted reduce charge message to just the number of charges used per item.
- Where applicable, add message for reduction from penny
- Update item costs based on the actual items removed from bank

### Other checks:

- [x] I have tested all my changes thoroughly.
