### PR TITLE
Remove max quantity from skotizo (and everywhere else)

### DIFF
--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -419,7 +419,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		difficultyRating: 0,
 		notifyDrops: resolveItems(['Jar of darkness', 'Skotos']),
 		qpRequired: 0,
-		// Skotizo requires 1 totem per kill, and arclight makes kill 2x faster irl.
+		// Skotizo requires 1 totems per kill, and arclight makes kill 2x faster irl.
 		itemInBankBoosts: [
 			{
 				[itemID('Arclight')]: 50,
@@ -429,8 +429,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		itemCost: { itemCost: new Bank().add('Dark totem', 1), qtyPerKill: 1 },
 		healAmountNeeded: 20 * 15,
 		attackStyleToUse: GearStat.AttackSlash,
-		attackStylesUsed: [GearStat.AttackSlash, GearStat.AttackMagic],
-		maxQuantity: 1
+		attackStylesUsed: [GearStat.AttackSlash, GearStat.AttackMagic]
 	},
 	{
 		id: Monsters.TzHaarKet.id,

--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -419,7 +419,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		difficultyRating: 0,
 		notifyDrops: resolveItems(['Jar of darkness', 'Skotos']),
 		qpRequired: 0,
-		// Skotizo requires 1 totems per kill, and arclight makes kill 2x faster irl.
+		// Skotizo requires 1 totem per kill, and arclight makes kill 2x faster irl.
 		itemInBankBoosts: [
 			{
 				[itemID('Arclight')]: 50,

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -140,7 +140,6 @@ export interface KillableMonster {
 	deathProps?: Omit<Parameters<typeof calculateSimpleMonsterDeathChance>['0'], 'currentKC'>;
 	diaryRequirement?: [DiaryID, DiaryTierName];
 	wildySlayerCave?: boolean;
-	maxQuantity?: number;
 }
 /*
  * Monsters will have an array of Consumables

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -1,5 +1,5 @@
 import type { PlayerOwnedHouse } from '@prisma/client';
-import { clamp, increaseNumByPercent, reduceNumByPercent } from 'e';
+import { increaseNumByPercent, reduceNumByPercent } from 'e';
 import { Monsters } from 'oldschooljs';
 import { mergeDeep } from 'remeda';
 import z from 'zod';
@@ -165,10 +165,6 @@ export function newMinionKillCommand(args: MinionKillOptions) {
 				slayerUnlocks
 			})
 		: null;
-
-	if (monster.maxQuantity) {
-		args.inputQuantity = clamp(args.inputQuantity ?? 1, 1, monster.maxQuantity);
-	}
 
 	const ephemeralPostTripEffects: PostBoostEffect[] = [];
 	const speedDurationResult = speedCalculations({

--- a/tests/integration/pvm/pvm.test.ts
+++ b/tests/integration/pvm/pvm.test.ts
@@ -260,35 +260,6 @@ describe('PVM', async () => {
 		expect(user.bank.amount('Dark totem')).toBe(99);
 	});
 
-	describe('should default to 1 skotizo kill', async () => {
-		const user = await client.mockUser({
-			bank: new Bank().add('Dark totem', 5),
-			rangeLevel: 99,
-			QP: 300,
-			maxed: true,
-			meleeGear: resolveItems(["Verac's flail", "Black d'hide body", "Black d'hide chaps"])
-		});
-		let lastKc = await user.getKC(EMonster.SKOTIZO);
-		for (const quantity of [undefined, 1, 2, 5]) {
-			it(`should default to 1 skotizo kill with input of ${quantity}`, async () => {
-				await user.update({ bank: new Bank().add('Dark totem', 5).toJSON() });
-				expect(user.bank.amount('Dark totem')).toBe(5);
-				const result = await user.kill(EMonster.SKOTIZO, { quantity });
-				expect(result.activityResult!.q).toEqual(1);
-				expect(result.activityResult?.userID).toEqual(user.id);
-				expect(result.activityResult?.mi).toEqual(EMonster.SKOTIZO);
-				expect(result.commandResult).toContain('is now killing 1x Skotizo');
-				await user.sync();
-				expect(
-					result.newKC,
-					`LastKC=${lastKc} NewKC=${result.newKC} RawNEWKC=${await user.getKC(EMonster.SKOTIZO)}`
-				).toEqual(lastKc + 1);
-				expect(user.bank.amount('Dark totem')).toBe(4);
-				lastKc = result.newKC;
-			});
-		}
-	});
-
 	describe(
 		'should fail to kill skotizo with no totems',
 		async () => {


### PR DESCRIPTION
### Description:

To be merged after clue juggling update. Removes max quantity for skotizo so you can kill as many as you want in one trip. Was only reduced before now due to clues. As `maxQuantity` is not used for any other monster, and I can't see it be useful in future, I've removed the functionality. 

Closes #6107.

### Changes:

- Removes `maxQuantity` from `KillableMonster` and all instances of it

### Other checks:

- [x] I have tested all my changes thoroughly.
