### PR TITLE
Fix combat skill item requirements

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -43,7 +43,7 @@ import { ChargeBank } from './structures/Bank';
 import { Gear, defaultGear } from './structures/Gear';
 import { GearBank } from './structures/GearBank';
 import type { XPBank } from './structures/XPBank';
-import {ItemBank, SkillRequirements, Skills} from './types';
+import type { ItemBank, SkillRequirements, Skills } from './types';
 import { addItemToBank, convertXPtoLVL, fullGearToBank, hasSkillReqsRaw, itemNameFromID } from './util';
 import { determineRunes } from './util/determineRunes';
 import { getKCByName } from './util/getKCByName';
@@ -175,7 +175,7 @@ export class MUserClass {
 	}
 
 	get skillsAsRequirements(): Required<SkillRequirements> {
-		return { ... this.skillsAsLevels, combat: this.combatLevel}
+		return { ...this.skillsAsLevels, combat: this.combatLevel };
 	}
 
 	favAlchs(duration: number, agility?: boolean) {

--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -43,7 +43,7 @@ import { ChargeBank } from './structures/Bank';
 import { Gear, defaultGear } from './structures/Gear';
 import { GearBank } from './structures/GearBank';
 import type { XPBank } from './structures/XPBank';
-import type { ItemBank, Skills } from './types';
+import {ItemBank, SkillRequirements, Skills} from './types';
 import { addItemToBank, convertXPtoLVL, fullGearToBank, hasSkillReqsRaw, itemNameFromID } from './util';
 import { determineRunes } from './util/determineRunes';
 import { getKCByName } from './util/getKCByName';
@@ -172,6 +172,10 @@ export class MUserClass {
 		const range = 0.325 * (Math.floor(ranged / 2) + ranged);
 		const mage = 0.325 * (Math.floor(magic / 2) + magic);
 		return Math.floor(base + Math.max(melee, range, mage));
+	}
+
+	get skillsAsRequirements(): Required<SkillRequirements> {
+		return { ... this.skillsAsLevels, combat: this.combatLevel}
 	}
 
 	favAlchs(duration: number, agility?: boolean) {
@@ -666,8 +670,8 @@ Charge your items using ${mentionCommand(globalClient, 'minion', 'charge')}.`
 		return updates;
 	}
 
-	hasSkillReqs(requirements: Skills) {
-		return hasSkillReqsRaw(this.skillsAsLevels, requirements);
+	hasSkillReqs(requirements: SkillRequirements) {
+		return hasSkillReqsRaw(this.skillsAsRequirements, requirements);
 	}
 
 	allEquippedGearBank() {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -18,6 +18,7 @@ export type Skills = Partial<{
 	[key in SkillsEnum]: number;
 }>;
 
+export type SkillRequirements = Skills & { combat?: number };
 export type SkillsRequired = Required<Skills>;
 
 export type CategoryFlag =

--- a/src/lib/util/smallUtils.ts
+++ b/src/lib/util/smallUtils.ts
@@ -9,7 +9,7 @@ import z from 'zod';
 
 import { skillEmoji } from '../data/emojis';
 import type { UserFullGearSetup } from '../gear/types';
-import {SkillRequirements, Skills} from '../types';
+import type { SkillRequirements, Skills } from '../types';
 
 export function itemNameFromID(itemID: number | string) {
 	return Items.get(itemID)?.name;

--- a/src/lib/util/smallUtils.ts
+++ b/src/lib/util/smallUtils.ts
@@ -9,7 +9,7 @@ import z from 'zod';
 
 import { skillEmoji } from '../data/emojis';
 import type { UserFullGearSetup } from '../gear/types';
-import type { Skills } from '../types';
+import {SkillRequirements, Skills} from '../types';
 
 export function itemNameFromID(itemID: number | string) {
 	return Items.get(itemID)?.name;
@@ -192,7 +192,7 @@ export function parseStaticTimeInterval(input: string): input is StaticTimeInter
 	return false;
 }
 
-export function hasSkillReqsRaw(skills: Skills, requirements: Skills) {
+export function hasSkillReqsRaw(skills: SkillRequirements, requirements: SkillRequirements) {
 	for (const [skillName, requiredLevel] of objectEntries(requirements)) {
 		const lvl = skills[skillName];
 		if (!lvl || lvl < requiredLevel!) {
@@ -203,7 +203,7 @@ export function hasSkillReqsRaw(skills: Skills, requirements: Skills) {
 }
 
 export function hasSkillReqs(user: MUser, reqs: Skills): [boolean, string | null] {
-	const hasReqs = hasSkillReqsRaw(user.skillsAsLevels, reqs);
+	const hasReqs = hasSkillReqsRaw(user.skillsAsRequirements, reqs);
 	if (!hasReqs) {
 		return [false, formatSkillRequirements(reqs)];
 	}


### PR DESCRIPTION
### Description:

Fixes issue where black mask, and other items with `combat` skill requirements are broken / unequippable.

### Changes:

- Creates new type, SkillRequirements, that does contain combat. There is already a similar type, ItemRequirements (in OSJS), but the new SkillRequirements type exists with all of the other skill requirement code in the bot (not in OSJS), so I think this makes the most sense.

### Other checks:

- [ ] I have tested all my changes thoroughly.
