### PR TITLE
add book of the dead buyable

### DIFF
--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -745,6 +745,12 @@ const questBuyables: Buyable[] = [
 		name: 'Ring of shadows',
 		gpCost: 75_000,
 		requiredQuests: [QuestID.DesertTreasureII]
+	},
+	{
+		name: 'Book of the dead',
+		gpCost: 1_000_000,
+		qpRequired: 120,
+		ironmanPrice: 9_750
 	}
 ];
 

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -750,7 +750,7 @@ const questBuyables: Buyable[] = [
 		name: 'Book of the dead',
 		gpCost: 1_000_000,
 		qpRequired: 120,
-		ironmanPrice: 9_750
+		ironmanPrice: 9_500
 	}
 ];
 

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -1381,6 +1381,14 @@ exports[`OSB Buyables 1`] = `
   },
   {
     "gpCost": 1000000,
+    "ironmanPrice": 9750,
+    "itemCost": {},
+    "name": "Book of the dead",
+    "outputItems": undefined,
+    "qpRequired": 120,
+  },
+  {
+    "gpCost": 1000000,
     "itemCost": {},
     "name": "Beer",
     "outputItems": undefined,

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -1381,7 +1381,7 @@ exports[`OSB Buyables 1`] = `
   },
   {
     "gpCost": 1000000,
-    "ironmanPrice": 9750,
+    "ironmanPrice": 9500,
     "itemCost": {},
     "name": "Book of the dead",
     "outputItems": undefined,


### PR DESCRIPTION
### Description:

add book of the dead buyable. Requires kingdom divided, set to 120 qp as roughly same difficulty as lunar diplomacy. Cost to buy from perdu is 9500 so that's ironman price, and regular price is 1m.

Closes #6196

### Changes:

- add book of the dead buyable

### Other checks:

- [x] I have tested all my changes thoroughly.
