### PR TITLE
Amulet of torture simItems

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -110,7 +110,7 @@ const source: [string, (string | number)[]][] = [
 	['Tzhaar-ket-om', ['Tzhaar-ket-om (t)']],
 	['Berserker necklace', ['Berserker necklace (or)']],
 	['Amulet of fury', ['Amulet of fury (or)', 'Amulet of blood fury']],
-	['Amulet of torture', ['Amulet of torture (or)']],
+	['Amulet of torture', ['Amulet of torture (or)', 'Amulet of rancour', 'Amulet of rancour (s)']],
 	['Tormented bracelet', ['Tormented bracelet (or)']],
 	['Necklace of anguish', ['Necklace of anguish (or)']],
 	['Occult necklace', ['Occult necklace (or)']],


### PR DESCRIPTION
### Description:
Add Amulet of rancour and Amulet of rancour(s) to Amulet of torture similar items.
### Changes:
- Update Amulet of torture under `similarItems.ts`
### Other checks:
- [X] I have tested all my changes thoroughly.
