### PR TITLE
Bring back show_info

### DIFF
--- a/scripts/wiki.ts
+++ b/scripts/wiki.ts
@@ -8,7 +8,7 @@ import process from 'node:process';
 import { groupBy } from 'remeda';
 import { type CombatAchievement, CombatAchievements } from '../src/lib/combat_achievements/combatAchievements';
 import { COXMaxMageGear, COXMaxMeleeGear, COXMaxRangeGear, itemBoosts } from '../src/lib/data/cox';
-import killableMonsters from '../src/lib/minions/data/killableMonsters';
+import { wikiMonsters } from '../src/lib/minions/data/killableMonsters';
 import { quests } from '../src/lib/minions/data/quests';
 import { sorts } from '../src/lib/sorts';
 import { itemNameFromID } from '../src/lib/util';
@@ -70,13 +70,11 @@ function escapeItemName(str: string) {
 }
 
 const name = (id: number) => escapeItemName(itemNameFromID(id)!);
+
 async function renderMonstersMarkdown() {
 	const markdown = new Markdown();
 
-	for (const monster of killableMonsters
-		.filter(m => m.equippedItemBoosts || m.itemInBankBoosts || m.itemCost)
-		.filter(m => Monsters.get(m.id)!.data.combatLevel >= 80 && !m.name.includes('Revenant'))
-		.sort((a, b) => a.name.localeCompare(b.name))) {
+	for (const monster of wikiMonsters) {
 		const monstermd = new Markdown();
 		monstermd.addLine(`## ${monster.name}`);
 

--- a/scripts/wiki.ts
+++ b/scripts/wiki.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { toTitleCase } from '@oldschoolgg/toolkit';
 import { glob } from 'glob';
-import { Bank, Monsters } from 'oldschooljs';
+import { Bank } from 'oldschooljs';
 
 import '../src/lib/safeglobals';
 import process from 'node:process';

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -397,3 +397,8 @@ export const effectiveMonsters = [
 ];
 
 export const allKillableMonsterIDs = new Set(effectiveMonsters.map(m => m.id));
+
+export const wikiMonsters = killableMonsters
+	.filter(m => m.equippedItemBoosts || m.itemInBankBoosts || m.itemCost)
+	.filter(m => Monsters.get(m.id)!.data.combatLevel >= 80 && !m.name.includes('Revenant'))
+	.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
### Description:

Brings back `/k show_info:True` with reduced functionality. If a wiki page for the monster exists (including nex, wintertodt etc) it will be linked, and boost / item req info has been removed. Included cannon-barrage info as it is good to have quickly. Trip and healing info is kept as it is user-specific and not on the wiki. Note that phosani and regular nightmare wiki pages from #6204 are linked, so will be 404 without that PR. 

Example:
![image](https://github.com/user-attachments/assets/8e9a9143-3066-45fd-b2cc-2d318ad4e371)


### Changes:

- Bring back most of `/k show_info:True`
- Include links to wiki where available

### Other checks:

- [x] I have tested all my changes thoroughly.
