### PR TITLE
Bot rules link update

### DIFF
--- a/src/mahoji/commands/help.ts
+++ b/src/mahoji/commands/help.ts
@@ -9,7 +9,7 @@ export const helpCommand: OSBMahojiCommand = {
 	options: [],
 	run: async () => {
 		return {
-			content: `🧑‍⚖️ **Rules:** You *must* follow our 5 simple rules, breaking any rule can result in a ban: <https://wiki.oldschool.gg/rules>
+			content: `🧑‍⚖️ **Rules:** You *must* follow our 5 simple rules, breaking any rule can result in a ban: <https://wiki.oldschool.gg/getting-started/rules/>
 
 <:patreonLogo:679334888792391703> **Patreon:** If you're able too, please consider supporting my work on Patreon, it's highly appreciated and helps me hugely <https://www.patreon.com/oldschoolbot> ❤️
 

--- a/src/mahoji/lib/abstracted_commands/minionBuyCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/minionBuyCommand.ts
@@ -28,7 +28,7 @@ export async function minionBuyCommand(user: MUser, ironman: boolean): CommandRe
 
 <:ironman:626647335900020746> You can make your new minion an Ironman by using the command: \`/minion ironman\`.
 
-🧑‍⚖️ **Rules:** You *must* follow our 5 simple rules, breaking any rule can result in a permanent ban - and "I didn't know the rules" is not a valid excuse, read them here: <https://wiki.oldschool.gg/rules>
+🧑‍⚖️ **Rules:** You *must* follow our 5 simple rules, breaking any rule can result in a permanent ban - and "I didn't know the rules" is not a valid excuse, read them here: <https://wiki.oldschool.gg/getting-started/rules/>
 
 <:patreonLogo:679334888792391703> **Patreon:** If you're able too, please consider supporting my work on Patreon, it's highly appreciated and helps me hugely <https://www.patreon.com/oldschoolbot> ❤️
 


### PR DESCRIPTION
### Description:

Changed two locations of old rules links in the discord bot.

### Changes:

src/mahoji/commands/help.ts (line 12): changed `https://wiki.oldschool.gg/rules` to `https://wiki.oldschool.gg/getting-started/rules/`.
src/mahoji/lib/abstracted_commands/minionBuyCommand.ts (line 12): changed `https://wiki.oldschool.gg/rules` to `https://wiki.oldschool.gg/getting-started/rules/`.
### Other checks:

- [ ] I have tested all my changes thoroughly.
(This box intentionally left unchecked.)