### PR TITLE
Let repeat trips use combat methods, get correct xp for cannoning, prevent cannoning in catacombs

### DIFF
--- a/src/lib/minions/functions/index.ts
+++ b/src/lib/minions/functions/index.ts
@@ -175,7 +175,7 @@ export function addMonsterXPRaw(params: {
 	});
 
 	// Add cannon xp last so it's easy to distinguish
-	if (params.usingCannon) {
+	if (params.usingCannon || params.cannonMulti) {
 		xpBank.add('ranged', Math.floor(hp * 2 * cannonQty), {
 			duration: params.duration,
 			minimal: params.minimal ?? true

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -427,7 +427,7 @@ const tripHandlers = {
 		commandName: 'k',
 		args: (data: MonsterActivityTaskOptions) => {
 			let method: PvMMethod = 'none';
-			if (data.usingCannon) method = 'cannon';
+			if (data.usingCannon || data.cannonMulti) method = 'cannon';
 			if (data.chinning) method = 'chinning';
 			else if (data.bob === SlayerActivityConstants.IceBarrage) method = 'barrage';
 			else if (data.bob === SlayerActivityConstants.IceBurst) method = 'burst';

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -5,7 +5,7 @@ import { mergeDeep } from 'remeda';
 import z from 'zod';
 import type { BitField, PvMMethod } from '../../../../lib/constants';
 import { getSimilarItems } from '../../../../lib/data/similarItems';
-import { type CombatOptionsEnum, SlayerActivityConstants } from '../../../../lib/minions/data/combatConstants';
+import type { CombatOptionsEnum } from '../../../../lib/minions/data/combatConstants';
 import { revenantMonsters } from '../../../../lib/minions/data/killableMonsters/revs';
 import {
 	type AttackStyles,
@@ -19,18 +19,11 @@ import { type CurrentSlayerInfo, determineCombatBoosts } from '../../../../lib/s
 import type { GearBank } from '../../../../lib/structures/GearBank';
 import { UpdateBank } from '../../../../lib/structures/UpdateBank';
 import type { Peak } from '../../../../lib/tickers';
-import {
-	checkRangeGearWeapon,
-	formatDuration,
-	isWeekend,
-	itemNameFromID,
-	numberEnum,
-	zodEnum
-} from '../../../../lib/util';
+import { checkRangeGearWeapon, formatDuration, isWeekend, itemNameFromID, zodEnum } from '../../../../lib/util';
 import getOSItem from '../../../../lib/util/getOSItem';
 import { killsRemainingOnTask } from './calcTaskMonstersRemaining';
 import { type PostBoostEffect, postBoostEffects } from './postBoostEffects';
-import { speedCalculations } from './timeAndSpeed';
+import { CombatMethodOptionsSchema, speedCalculations } from './timeAndSpeed';
 
 const newMinionKillReturnSchema = z.object({
 	duration: z.number().int().positive(),
@@ -38,22 +31,11 @@ const newMinionKillReturnSchema = z.object({
 	isOnTask: z.boolean(),
 	isInWilderness: z.boolean(),
 	attackStyles: z.array(z.enum(zodEnum(attackStylesArr))),
-	currentTaskOptions: z.object({
-		bob: z
-			.number()
-			.superRefine(numberEnum([SlayerActivityConstants.IceBarrage, SlayerActivityConstants.IceBurst]))
-			.optional(),
-		usingCannon: z.boolean().optional(),
-		cannonMulti: z.boolean().optional(),
-		chinning: z.boolean().optional(),
-		hasWildySupplies: z.boolean().optional(),
-		died: z.boolean().optional(),
-		pkEncounters: z.number().int().min(0).optional(),
-		isInWilderness: z.boolean().optional()
-	}),
+	currentTaskOptions: CombatMethodOptionsSchema,
 	messages: z.array(z.string()),
 	updateBank: z.instanceof(UpdateBank)
 });
+
 export type MinionKillReturn = z.infer<typeof newMinionKillReturnSchema>;
 export interface MinionKillOptions {
 	attackStyles: AttackStyles[];

--- a/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
@@ -109,7 +109,10 @@ const cannonBoost: Boost = {
 			return {
 				percentageReduction: boostCannon,
 				consumables: [cannonSingleConsumables],
-				message: `${boostCannon}% for Cannon in singles`
+				message: `${boostCannon}% for Cannon in singles`,
+				changes: {
+					usingCannon: true
+				}
 			};
 		}
 

--- a/src/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.ts
@@ -3,19 +3,35 @@ import { Bank } from 'oldschooljs';
 import { mergeDeep } from 'remeda';
 import z from 'zod';
 
+import { SlayerActivityConstants } from '../../../../lib/minions/data/combatConstants';
 import { type AttackStyles, getAttackStylesContext } from '../../../../lib/minions/functions';
 import reducedTimeFromKC from '../../../../lib/minions/functions/reducedTimeFromKC';
 import type { Consumable } from '../../../../lib/minions/types';
 import { ChargeBank } from '../../../../lib/structures/Bank';
 import { UpdateBank } from '../../../../lib/structures/UpdateBank';
 import type { SkillsRequired } from '../../../../lib/types';
+import { numberEnum } from '../../../../lib/util';
 import { getItemCostFromConsumables } from './handleConsumables';
 import { type BoostArgs, type BoostResult, type CombatMethodOptions, mainBoostEffects } from './speedBoosts';
+
+export const CombatMethodOptionsSchema = z.object({
+	bob: z
+		.number()
+		.superRefine(numberEnum([SlayerActivityConstants.IceBarrage, SlayerActivityConstants.IceBurst]))
+		.optional(),
+	usingCannon: z.boolean().optional(),
+	cannonMulti: z.boolean().optional(),
+	chinning: z.boolean().optional(),
+	hasWildySupplies: z.boolean().optional(),
+	died: z.boolean().optional(),
+	pkEncounters: z.number().int().min(0).optional(),
+	isInWilderness: z.boolean().optional()
+});
 
 const schema = z.object({
 	timeToFinish: z.number().int().positive(),
 	messages: z.array(z.string()),
-	currentTaskOptions: z.object({}),
+	currentTaskOptions: CombatMethodOptionsSchema,
 	finalQuantity: z.number().int().positive().min(1),
 	confirmations: z.array(z.string()),
 	updateBank: z.instanceof(UpdateBank)

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -286,7 +286,8 @@ export function doMonsterTrip(data: newOptions) {
 	});
 
 	const superiorTable = slayerContext.hasSuperiorsUnlocked && monster.superior ? monster.superior : undefined;
-	const isInCatacombs = (!usingCannon ? (monster.existsInCatacombs ?? undefined) : undefined) && !isInWilderness;
+	const isInCatacombs =
+		(!(usingCannon || cannonMulti) ? (monster.existsInCatacombs ?? undefined) : undefined) && !isInWilderness;
 
 	const hasRingOfWealthI = gearBank.gear.wildy.hasEquipped('Ring of wealth (i)') && isInWilderness;
 	if (hasRingOfWealthI) {


### PR DESCRIPTION
### Description:

Saw that the parsing [here](https://github.com/oldschoolgg/oldschoolbot/blob/d9a95c6782a2b2c9013ce75c39d38e9e22288219/src/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.ts#L129) removed combat options, so i've just bypassed it and returned the options separately. Perhaps there is a better way but i don't know how the parsing works. Made a handful of changes to make sure repeat trips saves all combat options. Also noticed multi cannoning wasn't giving ranged xp and was using catacombs, so fixed that. 
https://github.com/oldschoolgg/oldschoolbot/pull/6169

### Changes:

- `speedCalculations` now returns `currentTaskOptions` non-parsed.
- Added `multiCannon` check for getting xp from cannoning.
- Added `!multiCannon` check for `isInCatacombs`

### Other checks:

- [x] I have tested all my changes thoroughly.
