### PR TITLE
[WIKI] Update toa.mdx

### DIFF
--- a/docs/src/content/docs/osb/Raids/toa.mdx
+++ b/docs/src/content/docs/osb/Raids/toa.mdx
@@ -25,7 +25,7 @@ Solo Tombs of Amascut requires 1 KC for every 10 levels of invocation. E.g. a 50
 - Charged Blowpipe in bank
   - Minimum of 150 darts and 1,000 scales within Blowpipe.
 
-## Boosts
+## Gear and Boosts
 
 At 250 kc you will have the minimum death chance possible. At 350 attempts you will have the maximum speed boost possible.
 
@@ -37,7 +37,11 @@ Specific items will give a hidden speed boost to your raids, these are:
 - Lightbearer (5%) **(works from bank)**
 - Zaryte crossbow (9%) **OR** Dragon claws (6%) **(works from bank)**
 
-View the best in slot and alternate gear setups for ToA [here](toa-gear-setups.md).
+- For BiS in Entry Mode (0-149) or Normal mode (150-299), equip a Ghrazi rapier in melee.
+- Equipping the Serpentine helm in your melee setup removes the need for sanfews and only sacrifices 0.4% of your gear score. It uses 600 charges/hour.
+- The following image is for Expert mode raids (300+).
+
+[[toamaxgear.webp]]
 
 ## Choosing an Invocation level
 
@@ -64,14 +68,14 @@ Higher levels will take longer but offer better chances at uniques.
 - Can be charged with chaos and soul runes.
 - Provides a 25% speed boost to ToA when equipped in magic setup.
 - Requires 85 magic to equip.
-- `/minion chargeitem: ``Tumeken's shadowamount: ``100`
+- [[/minion chargeitem\: ``Tumeken's shadow amount\:100]]
 
 ### Masori Armour
 
 - Can be combined with Armadylean plates to create the fortified version.
 - Requires 90 crafting to create and 80 range + 30 defence to equip.
-- `/create item: ``Revert Armadyl [piece]quantity: ``1`
-- `/create item: ``Masori [piece] (f)quantity: ``1`
+- [[/create item\:Revert Armadyl [piece] quantity\:1]]
+- [[/create item\:Masori [piece] (f) quantity\:1]]
 
 ### Elidinis' Ward
 
@@ -90,8 +94,9 @@ Higher levels will take longer but offer better chances at uniques.
 ### Ornament Kits
 
 - These can be obtained by completing a level 350, 425, and 500 invocation raid with no deaths.
+- You can receive additional kits as long as there is not one currently in your bank.
 - They can be attached to their respective items to create (or) versions.
-- The fang (or) **cannot**be reverted, the assembler and ward **can**be reverted
+- The fang (or) **cannot** be reverted, the assembler and ward **can** be reverted
 
 ### Pet Transmogs
 


### PR DESCRIPTION


### Description:

Add info on toa gear and ornament kits.  Add toa max gear image.  Fix formatting.

### Changes:

Boosts -> Gear and Boosts
Remove outdated link to toa gear setups.
Condense and add info from that outdated link:
Ghrazi rapier BIS for normals.
Serpentine helm info.
Picture of max gear. -New to this will submit a separate pull request for the image, not sure how to combine into 1 pull request
Fix formatting on Tumeken shadow and Masori armour commands.

Add note about how to receive additional ornament kits.
Fix typo spacing in ornament kit section.
