### PR TITLE
[WIKI] Fix broken links BSO Raids

### DIFF
--- a/docs/src/content/docs/bso/Monsters/Raids/README.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/README.md
@@ -4,11 +4,11 @@ title: "Raids"
 
 The OSB Wiki has most of the information on each raid, the purpose of this space is to highlight the BSO specific differences.
 
-[OSB Chambers of Xeric (CoX)](https://wiki.oldschool.gg/raids/cox-raids)
+[OSB Chambers of Xeric (CoX)](https://wiki.oldschool.gg/osb/raids/cox)
 
-[OSB Theatre of Blood (ToB)](https://wiki.oldschool.gg/raids/theatre-of-blood)
+[OSB Theatre of Blood (ToB)](https://wiki.oldschool.gg/osb/raids/tob)
 
-[OSB Tombs of Amascut (ToA)](https://wiki.oldschool.gg/raids/tombs-of-amascut-toa)
+[OSB Tombs of Amascut (ToA)](https://wiki.oldschool.gg/osb/raids/toa)
 
 ## How does 'BiS gear' work?
 

--- a/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
@@ -2,7 +2,7 @@
 title: "Chambers of Xeric (CoX)"
 ---
 
-See the [OSB wiki](https://wiki.oldschool.gg/minigames/cox-raids) for general info.
+See the [OSB wiki](https://wiki.oldschool.gg/osb/raids/cox/) for general info.
 
 ### Boosts
 

--- a/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
@@ -33,7 +33,7 @@ All boosts work from the bank unless otherwise specified. Gorajan armour does no
 
 ### Reference Setups
 
-See [How does 'BiS gear' work?](./#how-does-bis-gear-work) for an explanation on gear setups.
+See [How does 'BiS gear' work?](https://wiki.oldschool.gg/bso/monsters/raids/readme/#how-does-bis-gear-work) for an explanation on gear setups.
 
 <figure><figcaption>Mage</figcaption></figure>
 

--- a/docs/src/content/docs/bso/Monsters/Raids/theatre-of-blood-tob.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/theatre-of-blood-tob.md
@@ -2,7 +2,7 @@
 title: "Theatre of Blood (ToB)"
 ---
 
-See the [OSB wiki](https://wiki.oldschool.gg/raids/theatre-of-blood) for general info.
+See the [OSB wiki](https://wiki.oldschool.gg/osb/raids/tob) for general info.
 
 ## Boosts
 
@@ -41,7 +41,7 @@ See the [OSB wiki](https://wiki.oldschool.gg/raids/theatre-of-blood) for general
 
 ## Reference Setups
 
-See [How does 'BiS gear' work?](./#how-does-bis-gear-work) for an explanation on gear setups.
+See [How does 'BiS gear' work?](https://wiki.oldschool.gg/bso/monsters/raids/readme/#how-does-bis-gear-work) for an explanation on gear setups.
 
 <figure><figcaption>Melee - not bis</figcaption></figure>
 

--- a/docs/src/content/docs/bso/Monsters/Raids/tombs-of-amascut-toa.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/tombs-of-amascut-toa.md
@@ -2,7 +2,7 @@
 title: "Tombs of Amascut (ToA)"
 ---
 
-See the [OSB wiki ](https://wiki.oldschool.gg/raids/tombs-of-amascut-toa)for general info.
+See the [OSB wiki ](https://wiki.oldschool.gg/osb/raids/toa)for general info.
 
 ## Boosts
 
@@ -18,7 +18,7 @@ Boosts are different in BSO to the OSB version, they are as followed:
 
 ## Reference Setups
 
-See [How does 'BiS gear' work?](./#how-does-bis-gear-work) for an explanation on gear setups.
+See [How does 'BiS gear' work?](https://wiki.oldschool.gg/bso/monsters/raids/readme/#how-does-bis-gear-work) for an explanation on gear setups.
 
 ### Melee
 


### PR DESCRIPTION
### Description:

Fix broken links on BSO raids

### Changes:

README.md:
/raids/cox-raids -> /osb/raids/cox
/raids/theatre-of-blood -> /osb/raids/tob
/raids/tombs-of-amascut-toa -> /osb/raids/toa

chambers-of-xeric.md: /minigames/cox-raids -> /osb/raids/cox
theatre-of-blood-tob.md: /raids/theatre-of-blood -> /osb/raids/tob
tombs-of-amascut-toa.md: /raids/tombs-of-amascut-toa -> /osb/raids/toa

ON ALL THREE (COX, TOB, TOA):

`Old: [How does 'BiS gear' work?](./#how-does-bis-gear-work)`
`New: [How does 'BiS gear' work?](https://wiki.oldschool.gg/bso/monsters/raids/readme/#how-does-bis-gear-work)`
### Other checks:

- I have tested all my changes thoroughly. --YES
