### PR TITLE
Allow clue trip to be repeated if still have clues in bank

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -73,7 +73,7 @@ const taskCanBeRepeated = (activity: Activity, user: MUser) => {
 		const realActivity = convertStoredActivityToFlatActivity(activity) as ClueActivityTaskOptions;
 		return (
 			realActivity.implingID !== undefined ||
-			user.owns(ClueTiers.find(mon => mon.id === realActivity.ci)!.scrollID)
+			user.owns(ClueTiers.find(clue => clue.id === realActivity.ci)!.scrollID)
 		);
 	}
 	return !(


### PR DESCRIPTION
### Description:

Concept for repeating clue trips. `taskCanBeRepeated` checks if you still have a particular tier of clue in bank (or doing implings), and if so lets you carry on, else repeats previous trip. So existing functionality works for non clue trip -> do clue -> repeat button goes back to non-clue trip, but can also spam clue trips. Only downside is there is no indicator/error when you finish clue stack, you just go back to last non-clue trip.

Closes #6227.

### Changes:

Add check for clue scrolls in bank for `ClueCompletion` when checking `taskCanBeRepeated` for repeating task

### Other checks:

- [x] I have tested all my changes thoroughly.
