### PR TITLE
[WIKI] Fix command formatting, broken links OSB Activites

### DIFF
--- a/docs/src/content/docs/osb/Activities/aerial-fishing.md
+++ b/docs/src/content/docs/osb/Activities/aerial-fishing.md
@@ -4,9 +4,9 @@ title: "Aerial Fishing"
 
 Requirements: 35 Hunter, 43 fishing.
 
-You can start aerial fishing with either `/activities aerial_fishing`
+You can start aerial fishing with either [[/activities aerial_fishing]]
 
-You can purchase buyables via `/buy name:[itemName]`
+You can purchase buyables via [[/buy name\:[itemName]]]
 
 You can sell Golden Tenches for 100 Molch pearls via [[/sell items\:golden tench]]
 

--- a/docs/src/content/docs/osb/Activities/fountain-of-rune.md
+++ b/docs/src/content/docs/osb/Activities/fountain-of-rune.md
@@ -6,7 +6,7 @@ You can use the Fountain of Rune to charge Rings of wealth and Amulets of glory.
 
 To charge at the Fountain of Rune, use the following command:
 
-- `/activities charge item:[Amulet of glory/Ring of wealth]`
+- [[/activities charge item\:[Amulet of glory/Ring of wealth]]]
 
 **Note:** quantity refers to 1 inventory (1 invent = 26 items)
 
@@ -17,13 +17,13 @@ To charge at the Fountain of Rune, use the following command:
 
 ### Charging Glories
 
-- Amulet of glory(6) are only used in the [Gnome Restaurant](https://wiki.oldschool.gg/minigames/gnome-restaurant) minigame.
+- Amulet of glory(6) are only used in the [Gnome Restaurant](https://wiki.oldschool.gg/osb/minigames/gnome-restaurant) minigame.
 - Gnome Restaurant is currently the only way to remove charges from a glory.
-- If you want to create Amulet of glory(4), use the `/activities cast spell:recharge glory` command. However, these are not used in Gnome restaurant and are only used to create the Ornate jewelley box in your POH.
+- If you want to create Amulet of glory(4), use the [[/activities cast spell\:recharge glory]] command. However, these are not used in Gnome restaurant and are only used to create the Ornate jewelley box in your POH.
 
 ### Amulet of Eternal Glory
 
 - You can obtain this amulet at a 1/25,000 chance when charging glories here.
 - Possessing the stats for the Wilderness elite diary provides a 3x speed boost.
   - It is **not recommended** to charge glories unless you have this unlocked.
-- Currently, the only use of the Eternal glory is at the [Gnome Restaurant](https://wiki.oldschool.gg/minigames/gnome-restaurant) minigame.
+- Currently, the only use of the Eternal glory is at the [Gnome Restaurant](https://wiki.oldschool.gg/osb/minigames/gnome-restaurant) minigame.

--- a/docs/src/content/docs/osb/Activities/guardians-of-the-rift.md
+++ b/docs/src/content/docs/osb/Activities/guardians-of-the-rift.md
@@ -20,7 +20,7 @@ Mining xp scales with mined fragments.
 
 **Raiments of the eye** outfit will boost the number of runes created during the minigame.
 
-- 10% extra runes for each piece or 60% extra runes for the full outfit _(MUSTbe equipped in skilling)_
+- 10% extra runes for each piece or 60% extra runes for the full outfit _(MUST be equipped in skilling)_
 - This extra runes effect also applies to other runes outside of GOTR
 
 **Fragments**

--- a/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
+++ b/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
@@ -34,7 +34,7 @@ Most of the boosts will come from items purchased from the shop.
 
 ## Hallowed Sepulchre Shop
 
-The following items can be purchased with hallowed marks by using the `/buy` command.
+The following items can be purchased with hallowed marks by using the [[/buy]] command.
 
 | **Item**               | **Hallowed marks required** | **Uses**                                    |
 | ---------------------- | :-------------------------: | ------------------------------------------- |
@@ -49,7 +49,7 @@ The following items can be purchased with hallowed marks by using the `/buy` com
 | Dark dye               |             300             | Used to dye graceful                        |
 | Dark acorn             |            3,000            | Used to transmogrify the Dark squirrel pet. |
 
-- If you have obtained a Giant Squirrel agility pet, you can `/buyname: ``Dark squirrel` after purchasing the dark acorn from the shop to transmogrify the pet. Be advised that you **CANNOT**revert the dark squirrel.
+- If you have obtained a Giant Squirrel agility pet, you can [[/buy name\: Dark squirrel]] after purchasing the dark acorn from the shop to transmogrify the pet. Be advised that you **CANNOT** revert the dark squirrel.
 
 ## Mysterious Pages
 
@@ -61,8 +61,8 @@ You **cannot** revert Dark graceful! If you are trying to obtain all graceful se
 
 - The dark graceful set can be acquired through purchasing the dark dye from the shop. It requires a full set of the base graceful and 1 dark dye per piece.
 - To create the set, simply type:
-  - `/createitem:Dark graceful [piece]` - piece by piece
-  - `/createitem:Dark graceful` - whole set in one command
+  - [[/create item\:Dark graceful [piece]]] - piece by piece
+  - [[/create item\:Dark graceful]] - whole set in one command
 - You need 6 dark dyes to create the full set, totaling 1800 hallowed marks.
 
 ## **Strange Old Lockpick**
@@ -87,7 +87,7 @@ The Ring of endurance also provides boosts to several activities within the bot.
 
 To create the charged Ring of endurance, use the following command:
 
-- `/createitem:Ring of endurance`
+- [[/create item\:Ring of endurance]]
   - Requires 125 Stamina potion(4)
 
 The boosts apply to the following activities:

--- a/docs/src/content/docs/osb/Activities/mage-training-arena.md
+++ b/docs/src/content/docs/osb/Activities/mage-training-arena.md
@@ -4,15 +4,15 @@ title: "Mage Training Arena"
 
 Your minion can train magic in the Mage Training Arena and buy all the regular rewards such as infinity gear, wands, and the mages book.
 
-To start a trip, use `/minigames mage_training_arena start`
+To start a trip, use [[/minigames mage_training_arena start]]
 
-To check your points, use `/minigames mage_training_arena points`
+To check your points, use [[/minigames mage_training_arena points]]
 
 The Mage Training Arena is combined into 1 room, and 1 set of points. A single room costs 45 fire-, 20 nature-, 18 cosmic- and 14 law runes. Each room takes 14 minutes to complete and awards 23 Pizazz points (100/hr). Training in the Mage Training Arena grants between 23,750-26,250 magic XP/hr.
 
 ### Rewards
 
-Rewards can be bought using `/minigames mage_training_arena buy`
+Rewards can be bought using [[/minigames mage_training_arena buy]]
 
 Rewards take approximately the same amount of time to get. Earning 5659 Pizazz points to buy one of every item from the rewards shop, takes approximately 56½ hours.
 

--- a/docs/src/content/docs/osb/Activities/mahogany-homes.md
+++ b/docs/src/content/docs/osb/Activities/mahogany-homes.md
@@ -4,7 +4,7 @@ title: "Mahogany Homes"
 
 Mahogany Homes is the construction minigame and it provides more xp per plank as well as some rewards which will improve your construction experience.
 
-To start a contract, use the `/minigames mahogany_homes start` command.
+To start a contract, use the [[/minigames mahogany_homes start]] command.
 
 Your minion will automatically complete the highest level contract.
 
@@ -31,9 +31,9 @@ All contracts use a random amount of steel bars and planks, scaled to the amount
 
 ## **Mahogany Homes Buyables**
 
-You can buy the following items with the `/minigames mahogany_homes buy` command.
+You can buy the following items with the [[/minigames mahogany_homes buy]] command.
 
-To view how many points you have, use `/minigames mahogany_homes points`
+To view how many points you have, use [[/minigames mahogany_homes points]]
 
 - The full carpenter's outfit provides a 2.5% boost to construction XP
 

--- a/docs/src/content/docs/osb/Activities/motherlode-mine.md
+++ b/docs/src/content/docs/osb/Activities/motherlode-mine.md
@@ -4,6 +4,8 @@ title: "Motherlode Mine"
 
 You can select to mine here for a chance to receive golden nuggets and a vast array of ores. You cannot receive clue scrolls from mining here, and you cannot powermine here. The Varrock armour effect does not work here. The xp with all boosts before collecting 100 golden nuggets and 99 mining is roughly 44k xp/h, whereas after unlocking the upper level, it is around 54k xp/h.
 
+[[/mine name\:Motherlode mine]]
+
 ## Requirements
 
 - 30 Mining
@@ -13,8 +15,8 @@ You can select to mine here for a chance to receive golden nuggets and a vast ar
 - Approx 20% faster mining for having 100 golden nuggets in your skilling CL + 72 mining
 - Falador elite diary provides slightly increased better ores
 - Invisible 4 mining levels boost for Celestial ring/Celestial signet - Works from bank
-- Pickaxe boost (see [Mining page](./#pickaxes))
-- Prospector outfit (see [Mining page](./#prospectors-outfit)) - **MUST BE EQUIPPED IN SKILLING SETUP**
+- Pickaxe boost (see [Mining page](https://wiki.oldschool.gg/osb/skills/mining/#pickaxes))
+- Prospector outfit (see [Mining page](https://wiki.oldschool.gg/osb/skills/mining//#prospectors-outfit)) - **MUST BE EQUIPPED IN SKILLING SETUP**
 
 ## Golden Nuggets
 
@@ -22,7 +24,7 @@ Motherlode mine is the only place where you can obtain Golden nuggets. They are 
 
 ## Golden Nugget Shop
 
-You can use golden nuggets to purchase the Prospector's outfit through the `/buy` command. The outfit must be equipped in the **skilling setup**, and provides bonus xp on the return of your trip.
+You can use golden nuggets to purchase the Prospector's outfit through the [[/buy]] command. The outfit must be equipped in the **skilling setup**, and provides bonus xp on the return of your trip.
 
 | **Item**          | **XP Boost** | **Golden Nugget Cost** |
 | ----------------- | ------------ | ---------------------- |

--- a/docs/src/content/docs/osb/Activities/shooting-stars.md
+++ b/docs/src/content/docs/osb/Activities/shooting-stars.md
@@ -20,7 +20,7 @@ Shooting stars is a mining event, that you can join after a activity trip.
 
 ## **Rewards**
 
-Each star you mine will give you star dust. This can be used to buy rewards such as star fragments and the celestial ring. You can buy items using the `/buy` command.
+Each star you mine will give you star dust. This can be used to buy rewards such as star fragments and the celestial ring. You can buy items using the [[/buy]] command.
 
 | Item name                  | Cost of dust |
 | -------------------------- | ------------ |
@@ -33,4 +33,4 @@ Each star you mine will give you star dust. This can be used to buy rewards such
 
 The Celestial ring can be combined with the Elven signet to make the Celestial signet. The Celestial signet performs in the exact same way the Celestial ring does, giving an invisible +4 boost to the players mining level. Charging the ring doesn't add any extra effects or give any benefits, however, the ring needs to have at least 1 charge to be able to combine it with the Elven signet. It also requires an additional 1,000 stardust and 100 crystal shards to combine.
 
-- `/createitem: ``Celestial signet`
+- [[/create item\: Celestial signet]]

--- a/docs/src/content/docs/osb/Activities/volcanic-mine.md
+++ b/docs/src/content/docs/osb/Activities/volcanic-mine.md
@@ -6,7 +6,7 @@ title: "Volcanic Mine"
 
 OSRS Wiki page: [https://oldschool.runescape.wiki/w/Volcanic_Mine](https://oldschool.runescape.wiki/w/Volcanic_Mine)
 
-You can do the Volcanic Mine using: `/minigames volcanic_mine start`
+You can do the Volcanic Mine using: [[/minigames volcanic_mine start]]
 
 ---
 
@@ -23,7 +23,7 @@ You can do the Volcanic Mine using: `/minigames volcanic_mine start`
 Boosts must be equipped in the skilling setup.
 
 - 30% more points & XP for 61+ mining and dragon pickaxe
-- 50% more points & XP for 71+ mining and [crystal pickaxe](zalcano.md)
+- 50% more points & XP for 71+ mining and [crystal pickaxe](https://wiki.oldschool.gg/osb/miscelleanous/zalcano/)
 - 2.5% XP for full prospector
 
 If you have all the boosts you should get the following message upon starting a trip. Supply usage can vary depending on your maximum trip length.
@@ -45,9 +45,9 @@ These costs can be reduced with:
 
 ## Volcanic Mine Shop
 
-You can buy everything you can buy in OSRS with the `/minigames volcanic_mine` command.
+You can buy everything you can buy in OSRS with the [[/minigames volcanic_mine buy]] command.
 
-E.g. `/minigames volcanic_mine buyitem:Gold orequantity:1000`
+E.g. [[/minigames volcanic_mine buy item\:Gold ore quantity\:1000]]
 
 <table><thead><tr><th width="209.39241663052366"></th><th align="center"></th></tr></thead><tbody><tr><td><strong>Item</strong></td><td align="center"><strong>Point Cost</strong></td></tr><tr><td>Iron ore</td><td align="center">30</td></tr><tr><td>Silver ore</td><td align="center">55</td></tr><tr><td>Coal</td><td align="center">60</td></tr><tr><td>Gold ore</td><td align="center">150</td></tr><tr><td>Mithril ore</td><td align="center">150</td></tr><tr><td>Adamantite ore</td><td align="center">300</td></tr><tr><td>Runite ore</td><td align="center">855</td></tr><tr><td>Volcanic ash</td><td align="center">40</td></tr><tr><td>Calcite</td><td align="center">70</td></tr><tr><td>Pyrophosphite</td><td align="center">70</td></tr><tr><td>Ore pack (Volcanic mine)</td><td align="center">4,000</td></tr><tr><td>Volcanic mine teleport</td><td align="center">200</td></tr><tr><td>Large water container</td><td align="center">10,000</td></tr><tr><td>Ash covered tome</td><td align="center">40,000</td></tr></tbody></table>
 

--- a/docs/src/content/docs/osb/Activities/wintertodt.md
+++ b/docs/src/content/docs/osb/Activities/wintertodt.md
@@ -20,7 +20,7 @@ You can train Firemaking via the Wintertodt minigame using the command below. Yo
 
 ## Warm Clothing
 
-While optional, it is highly advised to equip **at least 4 pieces** of warm clothing **in your skilling setup**to reduce your food consumption by up to 37.5%. This will take your food consumption down from 160hp/kill, to 100hp/kill. The easiest warm gear you can obtain on the bot is Clue hunter, to do this see [Crack The Clue](../../miscellaneous/crack-the-clue.md). Warm clothes can be a combination of anything from the following list:
+While optional, it is highly advised to equip **at least 4 pieces** of warm clothing **in your skilling setup**to reduce your food consumption by up to 37.5%. This will take your food consumption down from 160hp/kill, to 100hp/kill. The easiest warm gear you can obtain on the bot is Clue hunter, to do this see [Crack The Clue](https://wiki.oldschool.gg/osb/miscelleanous/crack-the-clue/). Warm clothes can be a combination of anything from the following list:
 
 <details>
 


### PR DESCRIPTION
### Description:

Review and fix command formatting and broken links in /docs/src/content/docs/osb/Activites


### Changes:

Fix command formatting aerial-fishing.md
Fix formatting, broken links fountain-of-rune.md
Fix typo spacing guardians-of-the-rift.md
Fix command formatting hallowed-sepulchre.md
Fix command formatting mage-training-arena.md
Fix command formatting mahogany-homes.md
Add command, fix broken links motherlode-mine.md
Fix command formatting shooting-stars.md
Fix command formatting, broken link volcanic-mine.md

Fix broken link wintertodt.md

### Other checks:

- [ x] I have tested all my changes thoroughly.
