### PR TITLE
Nerf smoke devils

### DIFF
--- a/src/lib/minions/data/killableMonsters/konarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/konarMonsters.ts
@@ -252,8 +252,8 @@ export const konarMonsters: KillableMonster[] = [
 		healAmountNeeded: 16,
 		attackStyleToUse: GearStat.AttackMagic,
 		attackStylesUsed: [GearStat.AttackMagic],
-		canCannon: true,
-		cannonMulti: true,
+		canCannon: false,
+		cannonMulti: false,
 		canBarrage: true
 	},
 	{


### PR DESCRIPTION
### Description:

Current smoke devils can be killed ~1850 per hour (on task) in bot. Removes cannon flag to reduce to ~850 per hour, giving more reasonable slayer rates compared to in game. Perhaps some balanced combination of cannon/ barrage can be re-added in future.

### Changes:

- Remove cannon flag from smoke devils

### Other checks:

- [x] I have tested all my changes thoroughly.
