### PR TITLE
Warped creature fixes

### DIFF
--- a/src/lib/minions/data/killableMonsters/low.ts
+++ b/src/lib/minions/data/killableMonsters/low.ts
@@ -280,7 +280,9 @@ const killableMonsters: KillableMonster[] = [
 		healAmountNeeded: 200,
 		attackStyleToUse: GearStat.AttackCrush,
 		attackStylesUsed: [GearStat.AttackCrush],
-		requiredQuests: [QuestID.ThePathOfGlouphrie]
+		requiredQuests: [QuestID.ThePathOfGlouphrie],
+		customMonsterHP: 150,
+		canCannon: true
 	},
 	{
 		id: Monsters.WarpedTortoise.id,
@@ -291,7 +293,8 @@ const killableMonsters: KillableMonster[] = [
 		healAmountNeeded: 200,
 		attackStyleToUse: GearStat.AttackCrush,
 		attackStylesUsed: [GearStat.AttackCrush],
-		requiredQuests: [QuestID.ThePathOfGlouphrie]
+		requiredQuests: [QuestID.ThePathOfGlouphrie],
+		canCannon: true
 	}
 ];
 

--- a/src/lib/slayer/slayerUnlocks.ts
+++ b/src/lib/slayer/slayerUnlocks.ts
@@ -562,6 +562,7 @@ export const SlayerRewardsShop: SlayerTaskUnlocks[] = [
 		name: 'Warped Reality',
 		desc: 'Konar, Duradel, Nieve, and Chaeldar will be able to assign warped creatures as your task.',
 		slayerPointCost: 60,
+		canBeRemoved: true,
 		aliases: ['warped reality']
 	}
 ];

--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -141,6 +141,7 @@ function userCanUseTask(user: MUser, task: AssignableSlayerTask, master: SlayerM
 	if (myLastTask === task.monster.id) return false;
 	if (task.combatLevel && task.combatLevel > user.combatLevel) return false;
 	if (task.questPoints && task.questPoints > user.QP) return false;
+	if (task.requiredQuests?.find(quest => !user.user.finished_quest_ids.includes(quest))) return false;
 	if (task.slayerLevel && task.slayerLevel > user.skillLevel(SkillsEnum.Slayer)) return false;
 	if (task.levelRequirements && !user.hasSkillReqs(task.levelRequirements)) return false;
 	const myBlockList = user.user.slayer_blocked_ids ?? [];
@@ -175,7 +176,7 @@ function userCanUseTask(user: MUser, task: AssignableSlayerTask, master: SlayerM
 	)
 		return false;
 
-	if (stringMatches(lmon, 'warped tortoise') && !myUnlocks.includes(SlayerTaskUnlocksEnum.WarpedReality))
+	if (stringMatches(lmon, 'warped terrorbird') && !myUnlocks.includes(SlayerTaskUnlocksEnum.WarpedReality))
 		return false;
 	return true;
 }

--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -402,7 +402,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		amount: [70, 130],
 		weight: 6,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
-		unlocked: false
+		unlocked: false,
+		slayerLevel: 56
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/tasks/chaeldarTasks.ts
+++ b/src/lib/slayer/tasks/chaeldarTasks.ts
@@ -1,5 +1,6 @@
 import { Monsters } from 'oldschooljs';
 
+import { QuestID } from '../../minions/data/quests';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import type { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -403,7 +404,8 @@ export const chaeldarTasks: AssignableSlayerTask[] = [
 		weight: 6,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
 		unlocked: false,
-		slayerLevel: 56
+		slayerLevel: 56,
+		requiredQuests: [QuestID.ThePathOfGlouphrie]
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -477,7 +477,8 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		amount: [130, 200],
 		weight: 8,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
-		unlocked: false
+		unlocked: false,
+		slayerLevel: 56
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/tasks/duradelTasks.ts
+++ b/src/lib/slayer/tasks/duradelTasks.ts
@@ -1,6 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
 import killableMonsters from '../../minions/data/killableMonsters';
+import { QuestID } from '../../minions/data/quests';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import type { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -478,7 +479,8 @@ export const duradelTasks: AssignableSlayerTask[] = [
 		weight: 8,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
 		unlocked: false,
-		slayerLevel: 56
+		slayerLevel: 56,
+		requiredQuests: [QuestID.ThePathOfGlouphrie]
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -446,7 +446,8 @@ export const konarTasks: AssignableSlayerTask[] = [
 		amount: [110, 170],
 		weight: 4,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
-		unlocked: false
+		unlocked: false,
+		slayerLevel: 56
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/tasks/konarTasks.ts
+++ b/src/lib/slayer/tasks/konarTasks.ts
@@ -1,6 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
 import killableMonsters from '../../minions/data/killableMonsters';
+import { QuestID } from '../../minions/data/quests';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import type { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -447,7 +448,8 @@ export const konarTasks: AssignableSlayerTask[] = [
 		weight: 4,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
 		unlocked: false,
-		slayerLevel: 56
+		slayerLevel: 56,
+		requiredQuests: [QuestID.ThePathOfGlouphrie]
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -496,7 +496,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		amount: [120, 185],
 		weight: 6,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
-		unlocked: false
+		unlocked: false,
+		slayerLevel: 56
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/tasks/nieveTasks.ts
+++ b/src/lib/slayer/tasks/nieveTasks.ts
@@ -1,6 +1,7 @@
 import { Monsters } from 'oldschooljs';
 
 import killableMonsters from '../../minions/data/killableMonsters';
+import { QuestID } from '../../minions/data/quests';
 import { SlayerTaskUnlocksEnum } from '../slayerUnlocks';
 import type { AssignableSlayerTask } from '../types';
 import { bossTasks } from './bossTasks';
@@ -497,7 +498,8 @@ export const nieveTasks: AssignableSlayerTask[] = [
 		weight: 6,
 		monsters: [Monsters.WarpedTerrorbird.id, Monsters.WarpedTortoise.id],
 		unlocked: false,
-		slayerLevel: 56
+		slayerLevel: 56,
+		requiredQuests: [QuestID.ThePathOfGlouphrie]
 	},
 	...bossTasks
 ];

--- a/src/lib/slayer/types.ts
+++ b/src/lib/slayer/types.ts
@@ -1,5 +1,6 @@
 import type { Item, Monster, MonsterSlayerMaster } from 'oldschooljs';
 
+import type { QuestID } from '../minions/data/quests';
 import type { LevelRequirements } from '../skilling/types';
 
 export interface AssignableSlayerTask {
@@ -17,6 +18,7 @@ export interface AssignableSlayerTask {
 	extendedAmount?: [number, number];
 	extendedUnlockId?: number;
 	wilderness?: boolean;
+	requiredQuests?: QuestID[];
 }
 
 export interface SlayerMaster {

--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -214,6 +214,12 @@ const AutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		efficientName: Monsters.RevenantDemon.name,
 		efficientMonster: Monsters.RevenantDemon.id,
 		efficientMethod: 'none'
+	},
+	{
+		monsterID: Monsters.WarpedTerrorbird.id,
+		efficientName: Monsters.WarpedTerrorbird.name,
+		efficientMonster: Monsters.WarpedTerrorbird.id,
+		efficientMethod: 'cannon'
 	}
 ];
 


### PR DESCRIPTION
### Description:

Warped creature fixes

### Changes:

- Add singles cannon to warped terrorbird and tortoises 
- Add 56 slayer req and quest req for getting warped creature tasks
- Corrected warped reality unlock check 
- Add custom HP for warped terrorbird as osjs lookup is messed up 

### Other checks:

- [x] I have tested all my changes thoroughly.
