### PR TITLE
Fishing rework

### DIFF
--- a/src/lib/allObtainableItems.ts
+++ b/src/lib/allObtainableItems.ts
@@ -69,7 +69,7 @@ for (const a of Enchantables) {
 	totalBankToAdd.add(a.output);
 }
 for (const fish of Fishing.Fishes) {
-	ALL_OBTAINABLE_ITEMS.add(fish.id);
+	ALL_OBTAINABLE_ITEMS.add(fish.id!);
 }
 for (const clue of ClueTiers) {
 	ALL_OBTAINABLE_ITEMS.add(clue.id);

--- a/src/lib/skilling/skills/fishing.ts
+++ b/src/lib/skilling/skills/fishing.ts
@@ -1,7 +1,7 @@
 import { sumArr } from 'e';
+import { EItem } from 'oldschooljs';
 import { Emoji } from '../../constants';
 import type { GearBank } from '../../structures/GearBank';
-import { EItem } from 'oldschooljs';
 import itemID from '../../util/itemID';
 import type { Fish } from '../types';
 import { SkillsEnum } from '../types';

--- a/src/lib/skilling/skills/fishing.ts
+++ b/src/lib/skilling/skills/fishing.ts
@@ -1,239 +1,400 @@
+import { sumArr } from 'e';
 import { Emoji } from '../../constants';
+import type { GearBank } from '../../structures/GearBank';
+import { EItem } from 'oldschooljs';
 import itemID from '../../util/itemID';
 import type { Fish } from '../types';
 import { SkillsEnum } from '../types';
 
 const fishes: Fish[] = [
 	{
-		level: 1,
-		xp: 10,
-		id: itemID('Raw shrimps'),
-		name: 'Shrimps',
+		name: 'Shrimps/Anchovies',
+		subfishes: [
+			{
+				id: itemID('Raw shrimps'),
+				level: 1,
+				xp: 10,
+				intercept: 0.1373, // catch chance for fish 1 at lvl 1
+				slope: 0.0083
+			},
+			{
+				id: itemID('Raw anchovies'),
+				level: 15,
+				xp: 40,
+				intercept: 0.0937,
+				slope: 0.0042
+			}
+		],
+
 		petChance: 435_165,
-		timePerFish: 3.6,
-		clueScrollChance: 870_330
+		clueScrollChance: 435_165,
+		lostTicks: 0.1, // percentage of ticks spent moving/dropping,
+		bankingTime: 30,
+		ticksPerRoll: 6
 	},
 	{
-		level: 5,
-		xp: 20,
-		id: itemID('Raw sardine'),
-		name: 'Sardine',
-		petChance: 528_000,
+		name: 'Sardine/Herring',
+		subfishes: [
+			{
+				id: itemID('Raw sardine'),
+				level: 5,
+				xp: 20,
+				intercept: 0.1267,
+				slope: 0.0064
+			},
+			{
+				id: itemID('Raw herring'),
+				level: 10,
+				xp: 30,
+				intercept: 0.1273,
+				slope: 0.0038
+			}
+		],
+
 		bait: itemID('Fishing bait'),
-		timePerFish: 3.6,
-		clueScrollChance: 1_056_000
+		petChance: 528_000,
+		clueScrollChance: 528_000,
+		lostTicks: 0.1,
+		bankingTime: 30,
+		ticksPerRoll: 5
 	},
 	{
-		level: 5,
-		xp: 20,
-		id: itemID('Raw karambwanji'),
 		name: 'Karambwanji',
+		subfishes: [
+			{
+				id: itemID('Raw karambwanji'),
+				level: 5,
+				xp: 5,
+				intercept: 0.3945,
+				slope: 0.006
+			}
+		],
+
 		petChance: 443_697,
 		qpRequired: 15,
-		timePerFish: 3.6,
-		clueScrollChance: 443_697
+		clueScrollChance: 443_697,
+		lostTicks: 0.01,
+		bankingTime: 0,
+		ticksPerRoll: 6
 	},
 	{
-		level: 10,
-		xp: 30,
-		id: itemID('Raw herring'),
-		name: 'Herring',
-		petChance: 528_000,
-		bait: itemID('Fishing bait'),
-		timePerFish: 3.6,
-		clueScrollChance: 1_056_000
-	},
-	{
-		level: 15,
-		xp: 40,
-		id: itemID('Raw anchovies'),
-		name: 'Anchovies',
-		petChance: 435_165,
-		timePerFish: 7,
-		clueScrollChance: 870_330
-	},
-	{
-		level: 16,
-		xp: 20,
-		id: itemID('Raw mackerel'),
-		name: 'Mackerel',
+		name: 'Mackerel/Cod/Bass',
+		subfishes: [
+			{
+				id: itemID('Raw mackerel'),
+				level: 16,
+				xp: 20,
+				intercept: 0.0645,
+				slope: 0.0023
+			},
+			{
+				id: itemID('Raw cod'),
+				level: 23,
+				xp: 45,
+				intercept: 0.0173,
+				slope: 0.0021
+			},
+			{
+				id: itemID('Raw bass'),
+				level: 46,
+				xp: 100,
+				intercept: 0.0156,
+				slope: 0.0015,
+				tertiary: { chance: 1000, id: itemID('Big bass') }
+			}
+		],
+
 		petChance: 382_609,
-		timePerFish: 3.6,
-		clueScrollChance: 1_147_827
+		clueScrollChance: 382_609,
+		lostTicks: 0.1,
+		bankingTime: 25,
+		ticksPerRoll: 6
 	},
 	{
-		level: 20,
-		xp: 50,
-		id: itemID('Raw trout'),
-		name: 'Trout',
+		name: 'Trout/Salmon',
+		subfishes: [
+			{
+				id: itemID('Raw trout'),
+				level: 20,
+				xp: 50,
+				intercept: 0.0174,
+				slope: 0.0075
+			},
+			{
+				id: itemID('Raw salmon'),
+				level: 30,
+				xp: 70,
+				intercept: 0.0683,
+				slope: 0.0032
+			}
+		],
+
 		petChance: 461_808,
 		bait: itemID('Feather'),
-		timePerFish: 4.5,
-		clueScrollChance: 923_616
+		clueScrollChance: 461_808,
+		lostTicks: 0.1,
+		bankingTime: 30,
+		ticksPerRoll: 5
 	},
 	{
-		level: 23,
-		xp: 45,
-		id: itemID('Raw cod'),
-		name: 'Cod',
-		petChance: 382_609,
-		timePerFish: 5,
-		clueScrollChance: 1_147_827
-	},
-	{
-		level: 25,
-		xp: 60,
-		id: itemID('Raw pike'),
 		name: 'Pike',
+		subfishes: [
+			{
+				id: itemID('Raw pike'),
+				level: 25,
+				xp: 60,
+				intercept: 0.0685,
+				slope: 0.0032
+			}
+		],
+
 		petChance: 305_792,
 		bait: itemID('Fishing bait'),
-		timePerFish: 6,
-		clueScrollChance: 305_792
+		clueScrollChance: 305_792,
+		lostTicks: 0.1,
+		bankingTime: 30,
+		ticksPerRoll: 5
 	},
 	{
-		level: 30,
-		xp: 70,
-		id: itemID('Raw salmon'),
-		name: 'Salmon',
-		petChance: 461_808,
-		bait: itemID('Feather'),
-		timePerFish: 5.04,
-		clueScrollChance: 923_616
+		name: 'Tuna/Swordfish',
+		alias: ['sword, sf'],
+		subfishes: [
+			{
+				id: itemID('Raw tuna'),
+				level: 35,
+				xp: 80,
+				intercept: 0.0326,
+				slope: 0.0023
+			},
+			{
+				id: itemID('Raw swordfish'),
+				level: 50,
+				xp: 100,
+				intercept: 0.0196,
+				slope: 0.0018,
+				tertiary: { chance: 2500, id: itemID('Big swordfish') }
+			}
+		],
+
+		petChance: 257_770,
+		clueScrollChance: 257_770,
+		lostTicks: 0.1,
+		bankingTime: 25,
+		ticksPerRoll: 6
 	},
 	{
-		level: 35,
-		xp: 80,
-		id: itemID('Raw tuna'),
-		name: 'Tuna',
-		petChance: 128_885,
-		timePerFish: 9.6,
-		clueScrollChance: 257_770
-	},
-	{
-		level: 38,
-		xp: 80,
-		id: itemID('Raw cave eel'),
 		name: 'Cave eel',
-		timePerFish: 12.6
+		subfishes: [
+			{
+				id: itemID('Raw cave eel'),
+				level: 38,
+				xp: 80,
+				intercept: 0.19,
+				slope: 0.0013
+			}
+		],
+
+		petChance: 257_770,
+		clueScrollChance: 257_770,
+		lostTicks: 0.1,
+		bankingTime: 40,
+		ticksPerRoll: 5
 	},
 	{
-		level: 40,
-		xp: 90,
-		id: itemID('Raw lobster'),
 		name: 'Lobster',
+		alias: ['lobs'],
+		subfishes: [
+			{
+				id: itemID('Raw lobster'),
+				level: 40,
+				xp: 90,
+				intercept: 0.0247,
+				slope: 0.0036
+			}
+		],
+
 		petChance: 116_129,
-		timePerFish: 11,
-		clueScrollChance: 116_129
+		clueScrollChance: 116_129,
+		lostTicks: 0.1,
+		bankingTime: 25,
+		ticksPerRoll: 6
 	},
 	{
-		level: 46,
-		xp: 100,
-		id: itemID('Raw bass'),
-		name: 'Bass',
-		petChance: 382_609,
-		timePerFish: 10.3,
-		bigFish: itemID('Big bass'),
-		bigFishRate: 1000,
-		clueScrollChance: 1_147_827
-	},
-	{
-		level: 50,
-		xp: 100,
-		id: itemID('Raw swordfish'),
-		name: 'Swordfish',
-		alias: ['sword'],
-		petChance: 128_885,
-		timePerFish: 11,
-		bigFish: itemID('Big swordfish'),
-		bigFishRate: 2500,
-		clueScrollChance: 257_770
-	},
-	{
-		level: 62,
-		xp: 120,
-		id: itemID('Raw monkfish'),
 		name: 'Monkfish',
 		alias: ['monk'],
+		subfishes: [
+			{
+				id: itemID('Raw monkfish'),
+				level: 62,
+				xp: 120,
+				intercept: 0.19,
+				slope: 0.0017
+			}
+		],
+
 		petChance: 138_583,
 		qpRequired: 100,
-		timePerFish: 13.5,
-		clueScrollChance: 138_583
+		clueScrollChance: 138_583,
+		lostTicks: 0.13,
+		bankingTime: 20,
+		ticksPerRoll: 6
 	},
 	{
-		level: 65,
-		xp: 50,
-		id: itemID('Raw karambwan'),
 		name: 'Karambwan',
+		alias: ['karam'],
+		subfishes: [
+			{
+				id: itemID('Raw karambwan'),
+				level: 65,
+				xp: 50,
+				intercept: 0.021,
+				slope: 0.0062
+			}
+		],
+
 		petChance: 170_874,
 		bait: itemID('Raw karambwanji'),
-		timePerFish: 4.5,
-		clueScrollChance: 170_874
+		clueScrollChance: 170_874,
+		lostTicks: 0.01, // fishing spots never moves
+		bankingTime: 25,
+		ticksPerRoll: 4
 	},
 	{
-		level: 76,
-		xp: 110,
-		id: itemID('Raw shark'),
 		name: 'Shark',
+		alias: ['shark'],
+		subfishes: [
+			{
+				id: itemID('Raw shark'),
+				level: 76,
+				xp: 110,
+				intercept: 0.0102,
+				slope: 0.0015,
+				tertiary: { chance: 5000, id: itemID('Big shark') }
+			}
+		],
+
 		petChance: 82_243,
-		timePerFish: 30,
-		bigFish: itemID('Big shark'),
-		bigFishRate: 5000,
-		clueScrollChance: 82_243
+		clueScrollChance: 82_243,
+		lostTicks: 0.1,
+		bankingTime: 25,
+		ticksPerRoll: 6
 	},
 	{
-		level: 82,
-		xp: 120,
-		id: itemID('Raw anglerfish'),
+		name: 'Infernal eel',
+		subfishes: [
+			{
+				id: itemID('Infernal eel'),
+				level: 80,
+				xp: 95,
+				intercept: 0.1253,
+				slope: 0.0025
+			}
+		],
+
+		petChance: 160_000,
+		bait: itemID('Fishing bait'),
+		clueScrollChance: 165_000,
+		lostTicks: 0.13,
+		bankingTime: 0,
+		ticksPerRoll: 5
+	},
+	{
 		name: 'Anglerfish',
 		alias: ['angler'],
+		subfishes: [
+			{
+				id: itemID('Raw anglerfish'),
+				level: 82,
+				xp: 120,
+				intercept: 0.0096,
+				slope: 0.0014
+			}
+		],
+
 		petChance: 78_649,
 		bait: itemID('Sandworms'),
 		qpRequired: 40,
-		timePerFish: 18.75,
-		clueScrollChance: 78_649
+		clueScrollChance: 78_649,
+		lostTicks: 0.1,
+		bankingTime: 30,
+		ticksPerRoll: 5
 	},
 	{
-		level: 82,
-		xp: 26.1,
-		id: itemID('Minnow'),
 		name: 'Minnow',
 		alias: ['minnows'],
+		subfishes: [
+			{
+				id: itemID('Minnow'),
+				level: 82,
+				xp: 26.1,
+				intercept: -0.569, // no info on catch chance
+				slope: 0.0153 // handpicked to match wiki rates
+			}
+		],
+
 		petChance: 977_778,
 		qpRequired: 1,
-		timePerFish: 2.14,
-		clueScrollChance: 977_778
+		clueScrollChance: 977_778,
+		lostTicks: 0.33,
+		bankingTime: 0, // stackable
+		ticksPerRoll: 2
 	},
 	{
-		level: 85,
-		xp: 130,
-		id: itemID('Raw dark crab'),
 		name: 'Dark crab',
 		alias: ['crab', 'dark'],
+		subfishes: [
+			{
+				id: itemID('Raw dark crab'),
+				level: 85,
+				xp: 130,
+				intercept: 0.023,
+				slope: 0.0014
+			}
+		],
+
 		petChance: 149_434,
 		bait: itemID('Dark fishing bait'),
-		timePerFish: 11.7,
-		clueScrollChance: 149_434
+		clueScrollChance: 149_434,
+		lostTicks: 0.1,
+		bankingTime: 0,
+		ticksPerRoll: 6
 	},
 	{
-		level: 48,
-		xp: 130,
-		id: itemID('Leaping trout'),
 		name: 'Barbarian fishing',
 		alias: ['barb', 'barbarian'],
+		subfishes: [
+			{
+				id: itemID('Leaping trout'),
+				level: 48,
+				xp: 50,
+				intercept: 32 / 255,
+				slope: (192 - 32) / 255 / 98,
+				otherXP: 5
+			},
+			{
+				id: itemID('Leaping salmon'),
+				level: 58,
+				xp: 70,
+				intercept: 16 / 255,
+				slope: (96 - 16) / 255 / 98,
+				otherXP: 6
+			},
+			{
+				id: itemID('Leaping sturgeon'),
+				level: 70,
+				xp: 80,
+				intercept: 8 / 255,
+				slope: (64 - 8) / 255 / 98,
+				otherXP: 7
+			}
+		],
+
 		petChance: 426_954,
 		bait: itemID('Feather'),
-		timePerFish: 3,
-		clueScrollChance: 1_280_862
-	},
-	{
-		level: 80,
-		xp: 95,
-		id: itemID('Infernal eel'),
-		name: 'Infernal eel',
-		petChance: 160_000,
-		bait: itemID('Fishing bait'),
-		timePerFish: 12.4,
-		clueScrollChance: 165_000
+		clueScrollChance: 426_954,
+		lostTicks: 0.09,
+		bankingTime: 40,
+		ticksPerRoll: 5
 	}
 ];
 
@@ -276,6 +437,34 @@ const camdozaalFishes: Fish[] = [
 		clueScrollChance: 257_770
 	}
 ];
+
+export const anglerItemsArr = [
+	{
+		id: EItem.ANGLER_HAT,
+		boost: 0.4
+	},
+
+	{
+		id: EItem.ANGLER_TOP,
+		boost: 0.8
+	},
+
+	{
+		id: EItem.ANGLER_WADERS,
+		boost: 0.6
+	},
+
+	{
+		id: EItem.ANGLER_BOOTS,
+		boost: 0.2
+	}
+] as const;
+
+export function determineAnglerBoost({ gearBank }: { gearBank: GearBank }) {
+	const equippedPieces = anglerItemsArr.filter(item => gearBank.hasEquipped(item.id));
+	if (equippedPieces.length === 4) return 2.5;
+	return sumArr(equippedPieces.map(item => item.boost));
+}
 
 const anglerItems: { [key: number]: number } = {
 	[itemID('Angler hat')]: 0.4,

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -109,19 +109,43 @@ export interface Burnable {
 	inputLogs: number;
 }
 
-export interface Fish {
+export interface FishInSpot {
+	id: number;
 	level: number;
 	xp: number;
-	id: number;
+	intercept: number;
+	slope: number;
+	otherXP?: number; // Omit<Skills, 'fishing'>;
+	/**
+	 * Items that have a tertiary chance to drop from catching one of these fish, i.e "Big swordfish" from swordfish.
+	 *
+	 * 1 in X chance, to receive item with the id
+	 */
+	tertiary?: { chance: number; id: number };
+}
+
+export interface Fish {
 	name: string;
+	alias?: string[];
+	subfishes?: FishInSpot[]; // Array of subfishes with level, xp, and id
+
 	petChance?: number;
-	timePerFish: number;
+	clueScrollChance?: number;
+	lostTicks?: number;
+	bankingTime?: number;
+	ticksPerRoll?: number;
 	bait?: number;
 	qpRequired?: number;
 	bigFish?: number;
 	bigFishRate?: number;
-	clueScrollChance?: number;
-	alias?: string[];
+
+	// still needed for camdozaal
+	timePerFish?: number;
+	level?: number;
+	xp?: number;
+	id?: number;
+
+	skillReqs?: Omit<LevelRequirements, 'fishing'>;
 }
 
 export interface Course {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -159,10 +159,14 @@ export interface ClueActivityTaskOptions extends ActivityTaskOptions {
 
 export interface FishingActivityTaskOptions extends ActivityTaskOptions {
 	type: 'Fishing';
-	fishID: number;
-	quantity: number;
-	flakesQuantity?: number;
-	iQty?: number;
+	fishID: string;
+	duration: number;
+	quantity?: number;
+	Qty: number[];
+	loot?: number[];
+	flakesToRemove?: number;
+	powerfish?: boolean;
+	spirit_flakes?: boolean;
 }
 
 export interface MiningActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/calcMaxTripLength.ts
+++ b/src/lib/util/calcMaxTripLength.ts
@@ -18,11 +18,6 @@ export function calcMaxTripLength(user: MUser, activity?: activity_type_enum) {
 	max += patronMaxTripBonus(user);
 
 	switch (activity) {
-		case 'Fishing':
-			if (user.allItemsOwned.has('Fish sack barrel') || user.allItemsOwned.has('Fish barrel')) {
-				max += Time.Minute * 9;
-			}
-			break;
 		case 'Nightmare':
 		case 'GroupMonsterKilling':
 		case 'MonsterKilling':

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -150,7 +150,7 @@ export function minionStatus(user: MUser) {
 		case 'Fishing': {
 			const data = currentTask as FishingActivityTaskOptions;
 
-			const fish = Fishing.Fishes.find(fish => fish.id === data.fishID);
+			const fish = Fishing.Fishes.find(fish => fish.name === data.fishID);
 
 			return `${name} is currently fishing ${data.quantity}x ${fish?.name}. ${formattedDuration} Your ${
 				Emoji.Fishing

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -330,8 +330,8 @@ const tripHandlers = {
 		commandName: 'fish',
 		args: (data: FishingActivityTaskOptions) => ({
 			name: data.fishID,
-			quantity: data.iQty,
-			flakes: data.flakesQuantity !== undefined
+			quantity: data.quantity,
+			flakes: data.spirit_flakes
 		})
 	},
 	[activity_type_enum.FishingTrawler]: {

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -1,16 +1,335 @@
 import { stringMatches } from '@oldschoolgg/toolkit/util';
 import type { CommandRunOptions } from '@oldschoolgg/toolkit/util';
 import { ApplicationCommandOptionType } from 'discord.js';
-import { Time, calcPercentOfNum, randInt } from 'e';
-import { Bank, Monsters } from 'oldschooljs';
+import { Time } from 'e';
+import { Bank, EItem, Monsters } from 'oldschooljs';
 
-import Fishing from '../../lib/skilling/skills/fishing';
-import { SkillsEnum } from '../../lib/skilling/types';
+import { WildernessDiary, userhasDiaryTier } from '../../lib/diaries';
+import Fishing, { anglerItemsArr } from '../../lib/skilling/skills/fishing';
+import type { Fish } from '../../lib/skilling/types';
+import type { GearBank } from '../../lib/structures/GearBank';
 import type { FishingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, itemID, itemNameFromID } from '../../lib/util';
+import { formatDuration, formatSkillRequirements, itemNameFromID } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import type { OSBMahojiCommand } from '../lib/util';
+
+function radasBlessing(gearBank: GearBank) {
+	const blessingBoosts = [
+		["Rada's blessing 4", 8],
+		["Rada's blessing 3", 6],
+		["Rada's blessing 2", 4],
+		["Rada's blessing 1", 2]
+	];
+
+	for (const [itemName, boostPercent] of blessingBoosts) {
+		if (gearBank.hasEquipped(itemName)) {
+			return { blessingEquipped: true, blessingChance: boostPercent as number };
+		}
+	}
+	return { blessingEquipped: false, blessingChance: 0 };
+}
+
+function rollExtraLoot(
+	lootAmount: number,
+	flakesUsed: number,
+	currentInv: number,
+	blessingChance: number,
+	spirit_flakes: boolean,
+	flakesQuantity: number
+): [number, number, number] {
+	currentInv++;
+	if (Math.random() < blessingChance / 100) {
+		lootAmount++;
+		currentInv++;
+	}
+	if (spirit_flakes && flakesUsed < flakesQuantity && Math.random() < 0.5) {
+		lootAmount++;
+		flakesUsed++;
+		currentInv++;
+	}
+	// Return updated values
+	return [lootAmount, flakesUsed, currentInv];
+}
+
+function determineFishingTime({
+	quantity,
+	tripTicks,
+	isPowerfishing,
+	isUsingSpiritFlakes,
+	fish,
+	gearBank,
+	invSlots,
+	blessingChance,
+	flakesQuantity,
+	harpoonBoost,
+	hasWildyEliteDiary
+}: {
+	quantity: number;
+	tripTicks: number;
+	isPowerfishing: boolean;
+	isUsingSpiritFlakes: boolean;
+	fish: Fish;
+	gearBank: GearBank;
+	invSlots: number;
+	blessingChance: number;
+	flakesQuantity: number;
+	harpoonBoost: number;
+	hasWildyEliteDiary: boolean;
+}) {
+	let ticksElapsed = 0;
+	let flakesUsed = 0;
+	let currentInv = 0;
+
+	const fishCount = fish.subfishes!.length; // how many fish in the spot
+	const catches: number[] = new Array(fishCount).fill(0);
+	const lootAmount: number[] = new Array(fishCount).fill(0);
+
+	const fishLvl = gearBank.skillsAsLevels.fishing;
+	let effFishLvl = fishLvl;
+
+	// Apply fishing guild boost
+	if (fishLvl > 68) {
+		if (fish.name === 'Shark' || fish.name === 'Mackerel/Cod/Bass' || fish.name === 'Lobster') {
+			effFishLvl += 7; // fishing guild boost
+		} else if (fish.name === 'Tuna/Swordfish' && !isPowerfishing) {
+			effFishLvl += 7; // can't 2t in the guild
+		}
+	}
+
+	// Calculate the base probabilities
+	const probabilities = fish.subfishes!.map(subfish => {
+		return harpoonBoost * (subfish.intercept + (effFishLvl - 1) * subfish.slope);
+	});
+
+	// Dark Crab with Wildy Elite Diary
+	if (fish.name === 'Dark crab' && hasWildyEliteDiary) {
+		const adjustedIntercept = 0.0961;
+		const adjustedSlope = 0.0025;
+
+		probabilities[0] = harpoonBoost * (adjustedIntercept + (effFishLvl - 1) * adjustedSlope);
+	}
+
+	let ticksPerRoll = fish.ticksPerRoll!;
+	let lostTicks = fish.lostTicks!;
+	let bankingTime = fish.bankingTime;
+
+	// tick manipulation
+	if (fish.name === 'Barbarian fishing') {
+		if (isPowerfishing) {
+			ticksPerRoll = 3;
+			lostTicks = 0.06; // more focused
+		}
+		if (gearBank.hasEquippedOrInBank(['Fishing cape', 'Fishing cape (t)', 'Max cape'])) {
+			bankingTime = 20;
+		}
+	} else if (fish.name === 'Trout/Salmon') {
+		if (isPowerfishing) {
+			ticksPerRoll = 3;
+			lostTicks = 0.06;
+		}
+	} else if (fish.name === 'Tuna/Swordfish') {
+		if (isPowerfishing) {
+			ticksPerRoll = 2;
+			lostTicks = 0.05;
+		}
+	}
+
+	// Main fishing logic
+	if (isPowerfishing) {
+		while (ticksElapsed < tripTicks) {
+			// Loop over subfishes in reverse order (highest level first)
+			for (let i = fishCount - 1; i >= 0; i--) {
+				if (fishLvl >= fish.subfishes![i].level && Math.random() < probabilities[i]) {
+					catches[i]++;
+					break; // Only catch one fish per roll, exit loop
+				}
+			}
+
+			ticksElapsed += ticksPerRoll * (1 + lostTicks);
+
+			if (catches.reduce((acc, curr) => acc + curr, 0) >= quantity) {
+				break;
+			}
+		}
+	} else {
+		while (ticksElapsed < tripTicks) {
+			for (let i = fishCount - 1; i >= 0; i--) {
+				if (fishLvl >= fish.subfishes![i].level && Math.random() < probabilities[i]) {
+					catches[i]++;
+					lootAmount[i]++;
+					[lootAmount[i], flakesUsed, currentInv] = rollExtraLoot(
+						lootAmount[i],
+						flakesUsed,
+						currentInv,
+						blessingChance,
+						isUsingSpiritFlakes,
+						flakesQuantity
+					);
+					break;
+				}
+			}
+
+			ticksElapsed += ticksPerRoll * (1 + lostTicks);
+
+			if (catches.reduce((acc, curr) => acc + curr, 0) >= quantity) {
+				break;
+			}
+
+			// Check if the inventory is full and add banking time if necessary
+			if (currentInv >= invSlots) {
+				ticksElapsed += bankingTime!;
+				currentInv = 0; // Reset inventory count after banking
+			}
+		}
+	}
+
+	return {
+		catches: catches,
+		lootAmount: lootAmount,
+		ticksElapsed,
+		flakesUsed
+	};
+}
+
+const harpoonBoosts = [
+	{
+		id: EItem.CRYSTAL_HARPOON,
+		boostPercent: 35
+	},
+	{
+		id: EItem.DRAGON_HARPOON,
+		boostPercent: 20
+	},
+	{
+		id: EItem.INFERNAL_HARPOON,
+		boostPercent: 20
+	}
+];
+
+function isHarpoonFishSpot(fish: Fish) {
+	return fish.name === 'Tuna/Swordfish' || fish.name === 'Shark';
+}
+
+export function determineFishingTrip({
+	gearBank,
+	spot,
+	hasWildyEliteDiary,
+	baseMaxTripLength,
+	...options
+}: {
+	baseMaxTripLength: number;
+	hasWildyEliteDiary: boolean;
+	gearBank: GearBank;
+	quantity: number | undefined;
+	powerfish: boolean | undefined;
+	spirit_flakes: boolean | undefined;
+	spot: Fish;
+}) {
+	let quantity = options.quantity ?? 3000;
+	let isUsingSpiritFlakes = options.spirit_flakes ?? false;
+	let isPowerfishing = options.powerfish ?? false;
+
+	if (spot.name === 'Minnow' || spot.name === 'Karambwanji') {
+		isPowerfishing = false; // stackable fish
+	}
+	if (isPowerfishing) {
+		isUsingSpiritFlakes = false;
+	}
+
+	const boosts: string[] = [];
+
+	if (isPowerfishing) boosts.push('**Powerfishing**');
+
+	let harpoonBoost = 1.0;
+	if (isHarpoonFishSpot(spot)) {
+		for (const { id, boostPercent } of harpoonBoosts) {
+			if (gearBank.hasEquipped(id)) {
+				harpoonBoost = 1 + boostPercent / 100;
+				boosts.push(`+${boostPercent}% for ${itemNameFromID(id)}`);
+				break;
+			}
+		}
+	}
+
+	if (spot.name === 'Dark crab' && hasWildyEliteDiary) {
+		boosts.push('Increased dark crab catch rate from having the Elite Wilderness Diary');
+	}
+
+	if (isUsingSpiritFlakes) {
+		if (!gearBank.bank.has('Spirit flakes')) {
+			return 'You need to have at least one spirit flake!';
+		}
+		boosts.push('50% more fish from using spirit flakes');
+	}
+
+	const { blessingEquipped, blessingChance } = radasBlessing(gearBank);
+	if (blessingEquipped && !isPowerfishing) {
+		boosts.push(`\nYour Rada's Blessing gives ${blessingChance}% chance of extra fish`);
+	}
+
+	let invSlots = 26;
+	if (gearBank.hasEquippedOrInBank(['Fish sack barrel', 'Fish barrel'])) {
+		invSlots += 28;
+	}
+
+	let maxTripLength = baseMaxTripLength;
+	if (
+		!isPowerfishing &&
+		gearBank.hasEquippedOrInBank(['Fish sack barrel', 'Fish barrel']) &&
+		spot.name !== 'Minnow'
+	) {
+		maxTripLength += Time.Minute * 9;
+		boosts.push('+9 minutes for Fish barrel');
+	}
+	const tripTicks = maxTripLength / (Time.Second * 0.6);
+
+	const flakesQuantity = gearBank.bank.amount('Spirit flakes');
+
+	if (spot.bait) {
+		const baseCost = new Bank().add(spot.bait);
+		const maxCanDo = gearBank.bank.fits(baseCost);
+		if (maxCanDo === 0) {
+			return `You need ${itemNameFromID(spot.bait)} to fish ${spot.name}!`;
+		}
+
+		if (maxCanDo < quantity) {
+			quantity = maxCanDo;
+		}
+	}
+
+	// determining fish time and quantities
+	const {
+		catches: Qty,
+		lootAmount: loot,
+		ticksElapsed: tripLength,
+		flakesUsed: flakesToRemove
+	} = determineFishingTime({
+		quantity,
+		tripTicks,
+		isUsingSpiritFlakes,
+		isPowerfishing,
+		fish: spot,
+		invSlots,
+		blessingChance,
+		flakesQuantity,
+		harpoonBoost,
+		gearBank,
+		hasWildyEliteDiary
+	});
+
+	const duration = Time.Second * 0.6 * tripLength;
+
+	return {
+		duration,
+		Qty,
+		loot,
+		flakesToRemove,
+		boosts,
+		isPowerfishing,
+		isUsingSpiritFlakes
+	};
+}
 
 export const fishCommand: OSBMahojiCommand = {
 	name: 'fish',
@@ -44,8 +363,14 @@ export const fishCommand: OSBMahojiCommand = {
 		},
 		{
 			type: ApplicationCommandOptionType.Boolean,
-			name: 'flakes',
-			description: 'Use spirit flakes?',
+			name: 'powerfish',
+			description: 'Set this to true to powerfish. Higher xp/hour, no loot (default false, optional).',
+			required: false
+		},
+		{
+			type: ApplicationCommandOptionType.Boolean,
+			name: 'spirit_flakes',
+			description: 'Set this to true to use spirit flakes (default false, optional).',
 			required: false
 		}
 	],
@@ -53,160 +378,80 @@ export const fishCommand: OSBMahojiCommand = {
 		options,
 		userID,
 		channelID
-	}: CommandRunOptions<{ name: string; quantity?: number; flakes?: boolean }>) => {
+	}: CommandRunOptions<{
+		name: string;
+		quantity?: number;
+		powerfish?: boolean;
+		spirit_flakes?: boolean;
+	}>) => {
 		const user = await mUserFetch(userID);
-		const fish = Fishing.Fishes.find(
+		const spot = Fishing.Fishes.find(
 			fish =>
 				stringMatches(fish.id, options.name) ||
 				stringMatches(fish.name, options.name) ||
 				fish.alias?.some(alias => stringMatches(alias, options.name))
 		);
-		if (!fish) return 'Thats not a valid fish to catch.';
+		if (!spot) return 'Thats not a valid spot you can fish at.';
 
-		if (user.skillLevel(SkillsEnum.Fishing) < fish.level) {
-			return `${user.minionName} needs ${fish.level} Fishing to fish ${fish.name}.`;
+		if (user.skillsAsLevels.fishing < spot.subfishes![0].level) {
+			return `${user.minionName} needs ${spot.subfishes![0].level} Fishing to fish ${spot.name}.`;
 		}
 
-		if (fish.qpRequired) {
-			if (user.QP < fish.qpRequired) {
-				return `You need ${fish.qpRequired} qp to catch those!`;
+		if ('skillReqs' in spot && spot.skillReqs && !user.hasSkillReqs(spot.skillReqs)) {
+			return `To fish ${spot.name}, you need ${formatSkillRequirements(spot.skillReqs)}.`;
+		}
+
+		if (spot.qpRequired) {
+			if (user.QP < spot.qpRequired) {
+				return `You need ${spot.qpRequired} qp to catch those!`;
 			}
 		}
 
-		if (
-			fish.name === 'Barbarian fishing' &&
-			(user.skillLevel(SkillsEnum.Agility) < 15 || user.skillLevel(SkillsEnum.Strength) < 15)
-		) {
-			return 'You need at least 15 Agility and Strength to do Barbarian Fishing.';
-		}
-
-		if (fish.name === 'Infernal eel') {
+		if (spot.name === 'Infernal eel') {
 			const jadKC = await user.getKC(Monsters.TzTokJad.id);
 			if (jadKC === 0) {
 				return 'You are not worthy JalYt. Before you can fish Infernal Eels, you need to have defeated the mighty TzTok-Jad!';
 			}
 		}
-		const anglerOutfit = Object.keys(Fishing.anglerItems).map(i => itemNameFromID(Number.parseInt(i)));
-		if (fish.name === 'Minnow' && anglerOutfit.some(test => !user.hasEquippedOrInBank(test!))) {
+
+		if (spot.name === 'Minnow' && anglerItemsArr.some(i => !user.hasEquipped(i.id))) {
 			return 'You need to own the Angler Outfit to fish for Minnows.';
 		}
 
-		// If no quantity provided, set it to the max.
-		let scaledTimePerFish =
-			Time.Second * fish.timePerFish * (1 + (100 - user.skillLevel(SkillsEnum.Fishing)) / 100);
+		const { quantity, powerfish, spirit_flakes } = options;
 
-		const boosts = [];
-		switch (fish.bait) {
-			case itemID('Fishing bait'):
-				if (fish.name === 'Infernal eel') {
-					scaledTimePerFish *= 1;
-				} else if (user.hasEquipped('Pearl fishing rod') && fish.name !== 'Infernal eel') {
-					scaledTimePerFish *= 0.95;
-					boosts.push('5% for Pearl fishing rod');
-				}
-				break;
-			case itemID('Feather'):
-				if (fish.name === 'Barbarian fishing' && user.hasEquipped('Pearl barbarian rod')) {
-					scaledTimePerFish *= 0.95;
-					boosts.push('5% for Pearl barbarian rod');
-				} else if (user.hasEquipped('Pearl fly fishing rod') && fish.name !== 'Barbarian fishing') {
-					scaledTimePerFish *= 0.95;
-					boosts.push('5% for Pearl fly fishing rod');
-				}
-				break;
-			default:
-				if (user.hasEquipped('Crystal harpoon')) {
-					scaledTimePerFish *= 0.95;
-					boosts.push('5% for Crystal harpoon');
-				}
-				break;
-		}
-
-		if (fish.id === itemID('Minnow')) {
-			scaledTimePerFish *= Math.max(
-				0.83,
-				-0.000_541_351 * user.skillLevel(SkillsEnum.Fishing) ** 2 +
-					0.089_066_3 * user.skillLevel(SkillsEnum.Fishing) -
-					2.681_53
-			);
-		}
-
-		if (user.allItemsOwned.has('Fish sack barrel') || user.allItemsOwned.has('Fish barrel')) {
-			boosts.push(
-				`+9 trip minutes for having a ${
-					user.allItemsOwned.has('Fish sack barrel') ? 'Fish sack barrel' : 'Fish barrel'
-				}`
-			);
-		}
-
-		const maxTripLength = calcMaxTripLength(user, 'Fishing');
-
-		let { quantity, flakes } = options;
-		if (!quantity) {
-			quantity = Math.floor(maxTripLength / scaledTimePerFish);
-		}
-		let flakesQuantity: number | undefined;
-		const cost = new Bank();
-
-		if (flakes) {
-			if (!user.bank.has('Spirit flakes')) {
-				return 'You need to have at least one spirit flake!';
-			}
-
-			flakesQuantity = Math.min(user.bank.amount('Spirit flakes'), quantity);
-			boosts.push(`More fish from using ${flakesQuantity}x Spirit flakes`);
-			cost.add('Spirit flakes', flakesQuantity);
-		}
-
-		if (fish.bait) {
-			const baseCost = new Bank().add(fish.bait);
-
-			const maxCanDo = user.bank.fits(baseCost);
-			if (maxCanDo === 0) {
-				return `You need ${itemNameFromID(fish.bait)} to fish ${fish.name}!`;
-			}
-			if (maxCanDo < quantity) {
-				quantity = maxCanDo;
-			}
-
-			cost.add(fish.bait, quantity);
-		}
-
-		if (cost.length > 0) {
-			// Remove the bait and/or spirit flakes from their bank.
-			await user.removeItemsFromBank(cost);
-		}
-
-		let duration = quantity * scaledTimePerFish;
-
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${fish.name} you can fish is ${Math.floor(
-				maxTripLength / scaledTimePerFish
-			)}.`;
-		}
-
-		const tenPercent = Math.floor(calcPercentOfNum(10, duration));
-		duration += randInt(-tenPercent, tenPercent);
-
-		await addSubTaskToActivityTask<FishingActivityTaskOptions>({
-			fishID: fish.id,
-			userID: user.id,
-			channelID: channelID.toString(),
+		const result = determineFishingTrip({
+			hasWildyEliteDiary: (await userhasDiaryTier(user, WildernessDiary.elite))[0],
+			baseMaxTripLength: calcMaxTripLength(user, 'Fishing'),
+			spot,
+			gearBank: user.gearBank,
 			quantity,
-			iQty: options.quantity ? options.quantity : undefined,
-			duration,
-			type: 'Fishing',
-			flakesQuantity
+			powerfish,
+			spirit_flakes
 		});
 
-		let response = `${user.minionName} is now fishing ${quantity}x ${fish.name}, it'll take around ${formatDuration(
-			duration
-		)} to finish.`;
+		if (typeof result === 'string') {
+			return result;
+		}
 
-		if (boosts.length > 0) {
-			response += `\n\n**Boosts:** ${boosts.join(', ')}.`;
+		await addSubTaskToActivityTask<FishingActivityTaskOptions>({
+			fishID: spot.name,
+			userID: user.id,
+			channelID: channelID.toString(),
+			duration: result.duration,
+			quantity: quantity,
+			Qty: result.Qty,
+			loot: result.loot,
+			flakesToRemove: result.flakesToRemove,
+			powerfish: powerfish,
+			spirit_flakes: spirit_flakes,
+			type: 'Fishing'
+		});
+
+		let response = `${user.minionName} is now fishing ${spot.name}, it'll take ${formatDuration(result.duration)} to finish.`;
+
+		if (result.boosts.length > 0) {
+			response += `\n\n**Boosts:** ${result.boosts.join(', ')}.`;
 		}
 
 		return response;

--- a/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
@@ -138,7 +138,7 @@ async function fishingCommand(user: MUser, channelID: string, quantity: number |
 
 	const maxTripLength = calcMaxTripLength(user, 'CamdozaalFishing');
 	const camdozaalfish = Fishing.camdozaalFishes.find(_fish => _fish.name === 'Raw guppy')!;
-	const timePerFish = camdozaalfish.timePerFish * Time.Second;
+	const timePerFish = camdozaalfish.timePerFish! * Time.Second;
 
 	if (!quantity) {
 		quantity = Math.floor(maxTripLength / timePerFish);

--- a/src/tasks/minions/camdozaalActivity/camdozaalFishingActivity.ts
+++ b/src/tasks/minions/camdozaalActivity/camdozaalFishingActivity.ts
@@ -26,15 +26,15 @@ export const camdozaalFishingTask: MinionTask = {
 		const camdozaalFishTable = new LootTable()
 			.oneIn(256, 'Barronite handle')
 			.oneIn(5, 'Barronite shards', 3)
-			.add(guppy.id, 1, 4);
-		if (currentFishLevel >= cavefish.level) {
-			camdozaalFishTable.add(cavefish.id, 1, 3);
+			.add(guppy.id!, 1, 4);
+		if (currentFishLevel >= cavefish.level!) {
+			camdozaalFishTable.add(cavefish.id!, 1, 3);
 		}
-		if (currentFishLevel >= tetra.level) {
-			camdozaalFishTable.add(tetra.id, 1, 2);
+		if (currentFishLevel >= tetra.level!) {
+			camdozaalFishTable.add(tetra.id!, 1, 2);
 		}
-		if (currentFishLevel >= catfish.level) {
-			camdozaalFishTable.add(catfish.id, 1, 1);
+		if (currentFishLevel >= catfish.level!) {
+			camdozaalFishTable.add(catfish.id!, 1, 1);
 		}
 
 		let guppyCaught = 0;
@@ -47,16 +47,16 @@ export const camdozaalFishingTask: MinionTask = {
 
 		for (let i = 0; i < quantity; i++) {
 			const fishCaught = camdozaalFishTable.roll();
-			if (fishCaught.has(guppy.id)) {
+			if (fishCaught.has(guppy.id!)) {
 				guppyCaught++;
 				loot.add(guppy.id);
-			} else if (fishCaught.has(cavefish.id)) {
+			} else if (fishCaught.has(cavefish.id!)) {
 				cavefishCaught++;
 				loot.add(cavefish.id);
-			} else if (fishCaught.has(tetra.id)) {
+			} else if (fishCaught.has(tetra.id!)) {
 				tetraCaught++;
 				loot.add(tetra.id);
-			} else if (fishCaught.has(catfish.id)) {
+			} else if (fishCaught.has(catfish.id!)) {
 				catfishCaught++;
 				loot.add(catfish.id);
 			} else {


### PR DESCRIPTION
### Description:

The fishing skill in the bot currently works nothing like in the OSRS, where fishing spots can have different types of fish. This PR makes the skill work exactly like in original game, changing it to a tick system, which allows methods like 2t swordfish and 3t barb to be added. It also allows spirit flakes to be used for a chance to catch more fish.

### Changes:

- Grouped fish into fishing spots (e.g. Tuna/Swordfish).
- Added optional `powerfish` and `spirit_flakes` parameters to the `fish` command. If **powerfish** is `True`, the minion will receive more exp at the cost of not banking the fish, and will use tick manipulation methods if applicable.
- Removed the +9min boost from having a fish barrel **if powerfishing**, trips are still longer if banking the fish.
- Removed other nonsense boosts like pearl fishing rods, and added dragon/crystal harpoon boosts only for fish that they actually affect.


### Other checks:

- [ ] I have tested all my changes thoroughly.
