### PR TITLE
Update Vardorvis, Leviathan, KQ, Zulrah and Muspah boosts

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/dt.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dt.ts
@@ -190,7 +190,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		id: Monsters.TheLeviathan.id,
 		name: Monsters.TheLeviathan.name,
 		aliases: Monsters.TheLeviathan.aliases,
-		timeToFinish: Time.Minute * 5.1,
+		timeToFinish: Time.Minute * 4.8,
 		table: Monsters.TheLeviathan,
 		notifyDrops: resolveItems(['Virtus robe top', "Lil'viathan", 'Virtus robe bottom', 'Virtus mask']),
 		qpRequired: 100,
@@ -229,15 +229,18 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 				gearSetup: 'range'
 			},
 			{
-				items: [
-					{ boostPercent: 5, itemID: itemID('Lightbearer') },
-					{ boostPercent: 5, itemID: itemID('Venator ring') }
-				],
+				items: [{ boostPercent: 5, itemID: itemID('Venator ring') }],
 				gearSetup: 'range'
 			},
 			{
-				items: [{ boostPercent: 5, itemID: itemID('Zaryte crossbow') }],
+				items: [{ boostPercent: 15, itemID: itemID('Zaryte crossbow') }],
 				gearSetup: 'range'
+			}
+		],
+		itemInBankBoosts: [
+			{
+				[itemID('Lightbearer')]: 5,
+				[itemID('Webweaver bow')]: 10
 			}
 		],
 
@@ -552,17 +555,21 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		id: Monsters.Vardorvis.id,
 		name: Monsters.Vardorvis.name,
 		aliases: Monsters.Vardorvis.aliases,
-		timeToFinish: Time.Minute * 5.1,
+		timeToFinish: Time.Minute * 4.1,
 		table: Monsters.Vardorvis,
 		notifyDrops: resolveItems(['Virtus robe top', 'Butch', 'Virtus robe bottom', 'Virtus mask']),
 		qpRequired: 100,
 		equippedItemBoosts: [
 			{
-				items: [{ boostPercent: 3, itemID: itemID('Avernic defender') }],
+				items: [{ boostPercent: 25, itemID: itemID('Soulreaper axe') }],
 				gearSetup: 'melee'
 			},
 			{
-				items: [{ boostPercent: 3, itemID: itemID('Ferocious gloves') }],
+				items: [{ boostPercent: 5, itemID: itemID('Avernic defender') }],
+				gearSetup: 'melee'
+			},
+			{
+				items: [{ boostPercent: 5, itemID: itemID('Ferocious gloves') }],
 				gearSetup: 'melee'
 			},
 			{
@@ -587,6 +594,11 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 					{ boostPercent: 5, itemID: itemID('Ultor ring') }
 				],
 				gearSetup: 'melee'
+			}
+		],
+		itemInBankBoosts: [
+			{
+				[itemID('Voidwaker')]: 10
 			}
 		],
 
@@ -614,7 +626,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 				items: [
 					{
 						itemID: itemID('Scythe of vitur'),
-						boostPercent: 15
+						boostPercent: 20
 					}
 				]
 			}

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -155,7 +155,7 @@ const killableBosses: KillableMonster[] = [
 		id: Monsters.KalphiteQueen.id,
 		name: Monsters.KalphiteQueen.name,
 		aliases: Monsters.KalphiteQueen.aliases,
-		timeToFinish: Time.Minute * 4,
+		timeToFinish: Time.Minute * 3.1,
 		table: Monsters.KalphiteQueen,
 		emoji: '<:Kalphite_princess_2nd_form:324127376915300352>',
 		wildy: false,
@@ -175,7 +175,7 @@ const killableBosses: KillableMonster[] = [
 				[itemID('Elder maul')]: 12
 			},
 			{
-				[itemID('Keris partisan of breaching')]: 5
+				[itemID('Keris partisan of breaching')]: 15
 			}
 		],
 		levelRequirements: {

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -99,7 +99,7 @@ const killableBosses: KillableMonster[] = [
 			{
 				[itemID("Iban's staff")]: 1,
 				[itemID('Trident of the seas')]: 3,
-				[itemID('Harmonised nightmare staff')]: 7,
+				[itemID('Harmonised nightmare staff')]: 7
 			},
 			{
 				[itemID('Barrows gloves')]: 2,

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -93,37 +93,59 @@ const killableBosses: KillableMonster[] = [
 		qpRequired: 75,
 		itemInBankBoosts: [
 			{
-				[itemID('Ranger boots')]: 2,
-				[itemID('Pegasian boots')]: 4
+				[itemID('Ranger boots')]: 1,
+				[itemID('Pegasian boots')]: 2
 			},
 			{
 				[itemID("Iban's staff")]: 1,
-				[itemID('Trident of the seas')]: 2,
-				[itemID('Trident of the swamp')]: 3,
-				[itemID('Sanguinesti staff')]: 4,
-				[itemID('Harmonised nightmare staff')]: 5,
-				[itemID("Tumeken's shadow")]: 8
+				[itemID('Trident of the seas')]: 3,
+				[itemID('Harmonised nightmare staff')]: 7,
 			},
 			{
-				[itemID('Barrows gloves')]: 3
+				[itemID('Barrows gloves')]: 2,
+				[itemID('Zaryte vambraces')]: 3
 			},
 			{
-				[itemID('Twisted bow')]: 5,
-				[itemID('Toxic blowpipe')]: 4,
-				[itemID('Bow of faerdhinen (c)')]: 3,
-				[itemID('Magic shortbow')]: 2
+				[itemID('Tormented bracelet')]: 4
 			},
 			{
-				[itemID('Ancestral hat')]: 2
+				[itemID('Twisted bow')]: 10,
+				[itemID('Toxic blowpipe')]: 7,
+				[itemID('Bow of faerdhinen (c)')]: 6,
+				[itemID('Magic shortbow')]: 3
 			},
 			{
-				[itemID('Ancestral robe top')]: 2
+				[itemID('Ancestral hat')]: 3
 			},
 			{
-				[itemID('Ancestral robe bottom')]: 2
+				[itemID('Ancestral robe top')]: 3
 			},
 			{
-				[itemID('Imbued heart')]: 3
+				[itemID('Ancestral robe bottom')]: 3
+			},
+			{
+				[itemID('Imbued heart')]: 2,
+				[itemID('Saturated heart')]: 4
+			}
+		],
+		degradeableItemUsage: [
+			{
+				required: true,
+				gearSetup: 'mage',
+				items: [
+					{
+						itemID: itemID("Tumeken's shadow"),
+						boostPercent: 10
+					},
+					{
+						itemID: itemID('Sanguinesti staff'),
+						boostPercent: 5
+					},
+					{
+						itemID: itemID('Trident of the swamp'),
+						boostPercent: 4
+					}
+				]
 			}
 		],
 		levelRequirements: {
@@ -448,7 +470,8 @@ const killableBosses: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Saturated heart')]: 4,
-				[itemID('Imbued heart')]: 2
+				[itemID('Imbued heart')]: 2,
+				[itemID('Frozen tablet')]: 10
 			}
 		],
 		projectileUsage: {
@@ -482,13 +505,6 @@ const killableBosses: KillableMonster[] = [
 				gearSetup: 'range'
 			},
 			{
-				items: [
-					{ boostPercent: 11, itemID: itemID("Tumeken's shadow") },
-					{ boostPercent: 6, itemID: itemID('Sanguinesti staff') }
-				],
-				gearSetup: 'mage'
-			},
-			{
 				items: [{ boostPercent: 6, itemID: itemID('Ancestral robe top') }],
 				gearSetup: 'mage'
 			},
@@ -497,12 +513,19 @@ const killableBosses: KillableMonster[] = [
 				gearSetup: 'mage'
 			},
 			{
-				items: [{ boostPercent: 3, itemID: itemID("Ava's assembler") }],
+				items: [
+					{ boostPercent: 5, itemID: itemID("Blessed dizana's quiver") },
+					{ boostPercent: 3, itemID: itemID("Ava's assembler") }
+				],
 				gearSetup: 'range'
 			},
 			{
 				items: [{ boostPercent: 3, itemID: itemID('Zaryte vambraces') }],
 				gearSetup: 'range'
+			},
+			{
+				items: [{ boostPercent: 5, itemID: itemID('Tormented bracelet') }],
+				gearSetup: 'mage'
 			},
 			{
 				items: [{ boostPercent: 3, itemID: itemID('Pegasian boots') }],

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -93,59 +93,38 @@ const killableBosses: KillableMonster[] = [
 		qpRequired: 75,
 		itemInBankBoosts: [
 			{
-				[itemID('Ranger boots')]: 1,
-				[itemID('Pegasian boots')]: 2
+				[itemID('Ranger boots')]: 2,
+				[itemID('Pegasian boots')]: 4
 			},
 			{
 				[itemID("Iban's staff")]: 1,
-				[itemID('Trident of the seas')]: 3,
-				[itemID('Harmonised nightmare staff')]: 7
+				[itemID('Trident of the seas')]: 2,
+				[itemID('Trident of the swamp')]: 3,
+				[itemID('Sanguinesti staff')]: 4,
+				[itemID('Harmonised nightmare staff')]: 5,
+				[itemID("Tumeken's shadow")]: 8
 			},
 			{
-				[itemID('Barrows gloves')]: 2,
-				[itemID('Zaryte vambraces')]: 3
+				[itemID('Barrows gloves')]: 3
 			},
 			{
-				[itemID('Tormented bracelet')]: 4
+				[itemID('Twisted bow')]: 5,
+				[itemID('Toxic blowpipe')]: 4,
+				[itemID('Bow of faerdhinen (c)')]: 3,
+				[itemID('Magic shortbow')]: 2
 			},
 			{
-				[itemID('Twisted bow')]: 10,
-				[itemID('Toxic blowpipe')]: 7,
-				[itemID('Bow of faerdhinen (c)')]: 6,
-				[itemID('Magic shortbow')]: 3
+				[itemID('Ancestral hat')]: 2
 			},
 			{
-				[itemID('Ancestral hat')]: 3
+				[itemID('Ancestral robe top')]: 2
 			},
 			{
-				[itemID('Ancestral robe top')]: 3
+				[itemID('Ancestral robe bottom')]: 2
 			},
 			{
-				[itemID('Ancestral robe bottom')]: 3
-			},
-			{
-				[itemID('Imbued heart')]: 2,
+				[itemID('Imbued heart')]: 3,
 				[itemID('Saturated heart')]: 4
-			}
-		],
-		degradeableItemUsage: [
-			{
-				required: true,
-				gearSetup: 'mage',
-				items: [
-					{
-						itemID: itemID("Tumeken's shadow"),
-						boostPercent: 10
-					},
-					{
-						itemID: itemID('Sanguinesti staff'),
-						boostPercent: 5
-					},
-					{
-						itemID: itemID('Trident of the swamp'),
-						boostPercent: 4
-					}
-				]
 			}
 		],
 		levelRequirements: {
@@ -422,7 +401,7 @@ const killableBosses: KillableMonster[] = [
 		name: Monsters.PhantomMuspah.name,
 		aliases: Monsters.PhantomMuspah.aliases,
 		table: Monsters.PhantomMuspah,
-		timeToFinish: Time.Minute * 8,
+		timeToFinish: Time.Minute * 7,
 		qpRequired: 215,
 		respawnTime: 10_000,
 		levelRequirements: {


### PR DESCRIPTION
### Description:

<!-- What did you change? Describe it here. -->
Updated boosts to some bosses to more closely match OSRS rates. Kph increased to (Adjusted rates to be slightly lower to leave room for a possible thrall boost in the future):
26 -> 36 ([Vardorvis](https://oldschool.runescape.wiki/w/Money_making_guide/Killing_Vardorvis))
24 - > 29 ([Leviathan](https://www.youtube.com/watch?v=z2fUdvdUHAM))
25 -> 35 ([KQ](https://www.youtube.com/watch?v=BS5NFgeInYk&t=0s))
25 -> 29 ([Muspah](https://discord.com/channels/710809284572872805/1104394813807267930/1104394813807267930))

I used melee KQ rates which can be found in the shadow method's vid description because I don't know how to apply mage gear boosts only if using shadow (it would be weird getting a boost for magic gear if using melee, and magic is only viable there with a shadow).

<!-- Write a comprehensive list of changes here. -->
-Added Soulreaper Axe and Voidwaker boosts to Vardorvis.
-Added boost for Webweaver bow to Leviathan and made Lightbearer boost independent from Venator ring (works from bank).
-Adjusted Keris boost to KQ.
-Added Frozen tablet, Tormented bracelet and Dizana's quiver boosts to Muspah, and removed duplicate boosts.
-Slightly adjusted base kill times.

### Other checks:
closes #6012 
- [ ] I have tested all my changes thoroughly.
