### PR TITLE
Add quantity to /clue

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -96,6 +96,7 @@ const tripHandlers = {
 		commandName: 'clue',
 		args: (data: ClueActivityTaskOptions) => ({
 			tier: data.ci,
+			quantity: data.q,
 			implings: data.implingID ? getOSItem(data.implingID!).name : undefined
 		})
 	},


### PR DESCRIPTION
### Description:

Allows user to choose a quantity of clues to complete instead of always sending the maximum.

### Changes:

-Added an optional `quantity` parameter to `/clue`.

### Other checks:

- [ ] I have tested all my changes thoroughly.
