### PR TITLE
Fix DHCB boost 

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKillData.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKillData.ts
@@ -10,7 +10,7 @@ export const dragonHunterWeapons = [
 	},
 	{
 		item: getOSItem('Dragon hunter crossbow'),
-		attackStyle: 'ranged',
+		attackStyle: 'range',
 		boost: 15
 	}
 ] as const;


### PR DESCRIPTION
### Description:

Global DHCB boost is not being applied due to a typo.

### Changes:

-Changed `attackStyle` in `dragonHunterWeapons` from `'ranged'`, to `'range'`.

### Other checks:

- [x] I have tested all my changes thoroughly.
