### PR TITLE
Small 2024 updates

### DIFF
--- a/packages/oldschooljs/src/simulation/monsters/low/a-f/Bandit.ts
+++ b/packages/oldschooljs/src/simulation/monsters/low/a-f/Bandit.ts
@@ -2,12 +2,16 @@ import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
 import { GemTable } from '../../../subtables/RareDropTable';
 
-const BanditTable = new LootTable({ limit: 128 })
+const BanditTable = new LootTable({ limit: 143 })
 	.every('Bones')
 	.tertiary(128, 'Clue scroll (hard)')
+	.add('Rune full helm', 1, 5)
+	.add('Rune med helm', 1, 5)
+	.add('Rune Scimitar', 1, 5)
 	.add('Adamant scimitar', 1, 4)
 	.add('Mithril sq shield', 1, 2)
 	.add('Mithril axe', 1, 1)
+	.add('Dragon longsword', 1, 1)
 
 	.add('Chaos rune', 10, 3)
 	.add('Water rune', 11, 3)
@@ -42,7 +46,7 @@ const BanditTable = new LootTable({ limit: 128 })
 
 	.add('Coal', 5, 6)
 	.add('Dark fishing bait', [10, 24], 2)
-	.add(GemTable, 1, 3);
+	.add(GemTable, 1, 4);
 
 export default new SimpleMonster({
 	id: 6605,

--- a/packages/oldschooljs/src/simulation/monsters/low/a-f/FeverSpider.ts
+++ b/packages/oldschooljs/src/simulation/monsters/low/a-f/FeverSpider.ts
@@ -11,7 +11,7 @@ const FeverSpiderTable = new LootTable({ limit: 36 })
 	.add('Coins', [200, 600], 8)
 	.add('Bass', [1, 2], 7)
 	.add('Limpwurt root', 1, 4)
-	.add('pure essence', [100, 200], 2)
+	.add('Pure essence', [100, 200], 2)
 	.add(GemTable, 1, 1);
 
 export default new SimpleMonster({

--- a/packages/oldschooljs/src/simulation/monsters/low/a-f/FeverSpider.ts
+++ b/packages/oldschooljs/src/simulation/monsters/low/a-f/FeverSpider.ts
@@ -1,7 +1,18 @@
 import LootTable from '../../../../structures/LootTable';
 import SimpleMonster from '../../../../structures/SimpleMonster';
+import { GemTable } from '../../../subtables';
 
-const FeverSpiderTable = new LootTable({ limit: 120 }).add('Grimy kwuarm', 10);
+const FeverSpiderTable = new LootTable({ limit: 36 })
+	.add("Red d'hide chaps", 1, 3)
+	.add('Adamant axe', 1, 2)
+	.add('Adamant med helm', 1, 2)
+	.add('Adamant battleaxe', 1, 1)
+	.add('Grimy kwuarm', 6)
+	.add('Coins', [200, 600], 8)
+	.add('Bass', [1, 2], 7)
+	.add('Limpwurt root', 1, 4)
+	.add('pure essence', [100, 200], 2)
+	.add(GemTable, 1, 1);
 
 export default new SimpleMonster({
 	id: 626,

--- a/packages/oldschooljs/src/simulation/monsters/low/n-s/RevenantGoblin.ts
+++ b/packages/oldschooljs/src/simulation/monsters/low/n-s/RevenantGoblin.ts
@@ -3,6 +3,7 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 import { makeRevTable } from '../../../../util';
 
 export const RevenantGoblinTable = new LootTable()
+	.tertiary(5000, 'Goblin champion scroll')
 	.every('Revenant ether', [1, 4])
 
 	/* Weapons and armour */

--- a/packages/oldschooljs/src/simulation/monsters/low/n-s/RevenantHobgoblin.ts
+++ b/packages/oldschooljs/src/simulation/monsters/low/n-s/RevenantHobgoblin.ts
@@ -3,6 +3,7 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 import { makeRevTable } from '../../../../util';
 
 export const RevenantHobgoblinTable = new LootTable()
+	.tertiary(5000, 'Hobgoblin champion scroll')
 	.every('Revenant ether', [1, 8])
 
 	/* Weapons and armour */

--- a/packages/oldschooljs/src/simulation/monsters/low/n-s/RevenantImp.ts
+++ b/packages/oldschooljs/src/simulation/monsters/low/n-s/RevenantImp.ts
@@ -3,6 +3,7 @@ import SimpleMonster from '../../../../structures/SimpleMonster';
 import { makeRevTable } from '../../../../util';
 
 export const RevenantImpTable = new LootTable()
+	.tertiary(5000, 'Imp champion scroll')
 	.every('Revenant ether', [1, 3])
 
 	/* Weapons and armour */

--- a/src/lib/minions/data/templeTrekking.ts
+++ b/src/lib/minions/data/templeTrekking.ts
@@ -19,11 +19,11 @@ interface trekBoost {
 	blisterwood: number;
 }
 
-export const EasyEncounterLoot = new LootTable().add('Riyl remains', 3).add('Nail beast nails', [2, 3]);
+export const EasyEncounterLoot = new LootTable().add('Riyl remains', 3).add('Nail beast nails', [4, 9]);
 
-export const MediumEncounterLoot = new LootTable().add('Asyn remains', 4).add('Nail beast nails', [3, 4]);
+export const MediumEncounterLoot = new LootTable().add('Asyn remains', 4).add('Nail beast nails', [6, 12]);
 
-export const HardEncounterLoot = new LootTable().add('Fiyr remains', 5).add('Nail beast nails', [4, 6]);
+export const HardEncounterLoot = new LootTable().add('Fiyr remains', 5).add('Nail beast nails', [8, 18]);
 
 export const difficulties: TrekDifficulty[] = [
 	{

--- a/src/lib/randomEvents.ts
+++ b/src/lib/randomEvents.ts
@@ -48,7 +48,7 @@ export const RandomEvents: RandomEvent[] = [
 		name: 'Bee keeper',
 		outfit: beekeeperOutfit,
 		uniqueMusic: true,
-		loot: new LootTable().add('Coins', [16, 36]).add('Flax', [1, 27])
+		loot: new LootTable().add('Coins', [16, 36]).add('Flax', [1, 27]).every('Genie lamp')
 	},
 	{
 		id: 2,

--- a/src/lib/skilling/skills/fletching/fletchables/bows.ts
+++ b/src/lib/skilling/skills/fletching/fletchables/bows.ts
@@ -199,7 +199,7 @@ const Bows: Fletchable[] = [
 	{
 		name: 'Toxic blowpipe (empty)',
 		id: itemID('Toxic blowpipe (empty)'),
-		level: 53,
+		level: 78,
 		xp: 120,
 		inputItems: new Bank({ 'Tanzanite fang': 1 }),
 		tickRate: 2

--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -6,6 +6,7 @@ import { Bank, type Item } from 'oldschooljs';
 
 import { MAX_INT_JAVA } from '../../lib/constants';
 
+import { WildernessDiary, userhasDiaryTier } from '../../lib/diaries';
 import { NestBoxesTable } from '../../lib/simulation/misc';
 import { itemID, returnStringOrFile, toKMB } from '../../lib/util';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
@@ -35,7 +36,9 @@ const specialSoldItems = new Map([
 	[itemID('Stone statuette'), 200],
 	[itemID('Gold seal'), 750],
 	[itemID('Golden scarab'), 1000],
-	[itemID('Golden statuette'), 1250]
+	[itemID('Golden statuette'), 1250],
+	// Ecumenical Key - requires wildy hard diary
+	[itemID('Ecumenical key'), 61_500]
 ]);
 
 export const CUSTOM_PRICE_CACHE = new Map<number, number>();
@@ -216,6 +219,13 @@ export const sellCommand: OSBMahojiCommand = {
 
 			await user.transactItems({ itemsToRemove: tenchBank, itemsToAdd: loot });
 			return `You exchanged ${tenchBank} and received: ${loot}.`;
+		}
+
+		if (bankToSell.has('Ecumenical key')) {
+			const [hasWildyHard] = await userhasDiaryTier(user, WildernessDiary.hard);
+			if (!hasWildyHard) {
+				return 'You need to have completed the Wilderness Hard Diary to sell Ecumenical keys.';
+			}
 		}
 
 		let totalPrice = 0;


### PR DESCRIPTION
### Description:

A few of the updates from #6264.
 
### Changes:

- Update Bandit and Fever spider loot tables
- Add champion scrolls to revenants
- Increase nail beast nails from temple trekking
- Add xp lamp to beekeeper random event
- Make blowpipe require 78 fletching
- Add ecumenical keys to `/sell`, with wildy hard req

### Other checks:

- [x] I have tested all my changes thoroughly.
