### PR TITLE
fix osjs package typo and enum linting 

### DIFF
--- a/docs/src/content/docs/bso/changelog.mdx
+++ b/docs/src/content/docs/bso/changelog.mdx
@@ -8,7 +8,19 @@ import Update from '../../../components/Update.astro';
 
 Generally only changes that are specific to BSO are included here, for a full list of OSB changes see the [OSB Changelog](/changelog).
 
-<Update date="18/12/2024" firstHash="dd98c03c941d4a45e544390d2833c4cfc0e9c843" secondHash="837e89eacb67e6f187c5ac1d851bdf010c8c940c" isNew />
+<Update date="29/12/2024" firstHash="837e89eacb67e6f187c5ac1d851bdf010c8c940c" secondHash="75ddf64d7e28b473e937426dbe058af72f619421" isNew />
+
+### [[gc]]
+- Made improvements to giveaways, so that huge giveaways dont cause problems anymore.
+- Added aliases for supply crates and their keys. An alias is an alternate name, e.g. how you can use "tmb" instead of writing "Tradeables mystery box". You can now write "s1" for a s1 crate, and "s1 key" for the key (and so on for the others).
+- Added christmas cracker to christmas cracker cl
+- Removed blood oranges from zygomite mutations
+- Renamed zombie/vampyric hween masks to "halloween" instead of "hween"
+- Added black swan to dc misc CL
+- Improved IC donation message, so the person sees their next IC.
+- Removed some duplicate collection logs that were mistakenly there.
+
+<Update date="18/12/2024" firstHash="dd98c03c941d4a45e544390d2833c4cfc0e9c843" secondHash="837e89eacb67e6f187c5ac1d851bdf010c8c940c" />
 
 ### [[gc]]
 

--- a/packages/oldschooljs/package.json
+++ b/packages/oldschooljs/package.json
@@ -25,7 +25,7 @@
 	"scripts": {
 		"test": "concurrently \"pnpm test:unit\" \"tsc --noEmit -p test\" \"tsc --noEmit -p src\"",
 		"test:unit": "vitest run --coverage",
-		"preparexx": "tsx scripts/prepare",
+		"prepare": "tsx scripts/prepare",
 		"dev": "pnpm prepare && pnpm build && pnpm test",
 		"build:esbuild": "node esbuild.cjs",
 		"build:types": "tsc -p src"

--- a/packages/oldschooljs/scripts/enum.ts
+++ b/packages/oldschooljs/scripts/enum.ts
@@ -53,6 +53,7 @@ async function main() {
 		const codeKey = startsWithNumber(key) ? `'${key}'` : key;
 		str += `\n\t${codeKey} = ${value},`;
 	}
+	str = str.slice(0, -1); //remove last comma
 	str += '\n}';
 	str += '\n';
 	writeFileSync('./src/EItem.ts', str);
@@ -65,7 +66,9 @@ async function main() {
 		key = key.replace(/[^a-zA-Z0-9_]/g, '').toUpperCase();
 		monsterEnumStr += `\n\t${key} = ${monster.id},`;
 	}
+	monsterEnumStr = monsterEnumStr.slice(0, -1); //remove last comma
 	monsterEnumStr += '\n}';
+	monsterEnumStr += '\n';
 	writeFileSync('./src/EMonster.ts', monsterEnumStr);
 }
 


### PR DESCRIPTION
### Description:

fix osjs package typo and enum linting

### Changes:

fix osjs package typo and enum linting

### Other checks:

- [x] I have tested all my changes thoroughly.
