### PR TITLE
Update Nex

### DIFF
--- a/packages/oldschooljs/src/structures/Bank.ts
+++ b/packages/oldschooljs/src/structures/Bank.ts
@@ -209,7 +209,7 @@ export default class Bank {
 		if (this.frozen) throw new Error(frozenErrorStr);
 		for (const [itemID, quantity] of this.map.entries()) {
 			if (itemsToNotMultiply?.includes(itemID)) continue;
-			this.map.set(itemID, quantity * multiplier);
+			this.map.set(itemID, Math.round(quantity * multiplier));
 		}
 		return this;
 	}

--- a/packages/oldschooljs/src/structures/Bank.ts
+++ b/packages/oldschooljs/src/structures/Bank.ts
@@ -209,7 +209,7 @@ export default class Bank {
 		if (this.frozen) throw new Error(frozenErrorStr);
 		for (const [itemID, quantity] of this.map.entries()) {
 			if (itemsToNotMultiply?.includes(itemID)) continue;
-			this.map.set(itemID, Math.round(quantity * multiplier));
+			this.map.set(itemID, Math.floor(quantity * multiplier));
 		}
 		return this;
 	}

--- a/src/lib/finishables.ts
+++ b/src/lib/finishables.ts
@@ -143,7 +143,7 @@ export const finishables: Finishable[] = [
 		name: 'Nex',
 		aliases: [],
 		cl: NexCL,
-		kill: () => handleNexKills({ quantity: 1, team: [{ id: '1', contribution: 100, deaths: [] }] }).get('1')
+		kill: () => handleNexKills({ quantity: 1, team: [{ id: '1', teamID: 1, deaths: [] }] }).get('1')
 	},
 	{
 		name: 'Wintertodt (500pt crates, Max stats)',

--- a/src/lib/finishables.ts
+++ b/src/lib/finishables.ts
@@ -143,7 +143,8 @@ export const finishables: Finishable[] = [
 		name: 'Nex',
 		aliases: [],
 		cl: NexCL,
-		kill: () => handleNexKills({ quantity: 1, team: [{ id: '1', teamID: 1, deaths: [] }] }).get('1')
+		kill: () =>
+			handleNexKills({ quantity: 1, team: [{ id: '1', teamID: 1, contribution: 100, deaths: [] }] }).get('1')
 	},
 	{
 		name: 'Wintertodt (500pt crates, Max stats)',

--- a/src/lib/simulation/TeamLoot.ts
+++ b/src/lib/simulation/TeamLoot.ts
@@ -44,13 +44,14 @@ export class TeamLoot {
 		return Array.from(this.map.entries());
 	}
 
-	formatLoot(): string {
+	formatLoot(kc?: { id: string; quantity: number }[]): string {
 		let str = '';
 		for (const [id, loot] of this.entries()) {
+			const kcString = kc ? ` (${kc.find(u => u.id === id)?.quantity ?? 0} KC)` : '';
 			const isPurple = this.purpleItems.some(i => loot.has(i));
 			str += isPurple
-				? `${Emoji.Purple} ${userMention(id)} received ${spoiler(loot.toString())}`
-				: `${userMention(id)} received ${loot}`;
+				? `${Emoji.Purple} ${userMention(id)}${kcString} received ${spoiler(loot.toString())}`
+				: `${userMention(id)}${kcString} received ${loot}.`;
 			str += '\n';
 		}
 		return str;

--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -124,7 +124,7 @@ interface TeamMember {
 	totalOffensivePecent: number;
 	totalDefensivePercent: number;
 	teamID: number;
-	fake?: boolean;
+	fake: boolean;
 }
 
 export interface NexContext {
@@ -152,6 +152,7 @@ export function handleNexKills({ quantity, team }: NexContext) {
 		}
 
 		const uniqueRecipient = roll(43) ? randArrItem(survivors).teamID : null;
+		const petRecipient = roll(500) ? randArrItem(survivors).teamID : null;
 		const nonUniqueDrop = NexNonUniqueTable.roll();
 
 		for (const teamMember of survivors.filter(m => !m.fake)) {
@@ -159,20 +160,12 @@ export function handleNexKills({ quantity, team }: NexContext) {
 			if (teamMember.teamID === uniqueRecipient) {
 				teamLoot.add(teamMember.id, NexUniqueTable.roll());
 			}
+			if (teamMember.teamID === petRecipient) {
+				teamLoot.add(teamMember.id, 'Nexling');
+			}
 			if (roll(48)) {
 				teamLoot.add(teamMember.id, 'Clue scroll (elite)');
 			}
-		}
-
-		if (roll(500)) {
-			const recipient = randArrItem(survivors);
-			if (!recipient.fake) teamLoot.add(recipient.id, 'Nexling');
-		}
-	}
-
-	for (const member of team) {
-		if (member.fake) {
-			teamLoot.map.delete(member.id);
 		}
 	}
 
@@ -256,7 +249,7 @@ export async function calculateNexDetails({ team }: { team: MUser[] }) {
 			totalOffensivePecent,
 			totalDefensivePercent,
 			teamID: resultTeam.length,
-			fake: resultTeam.find(m => m.id === member.id) ? true : undefined
+			fake: resultTeam.map(m => m.id).includes(member.id)
 		});
 	}
 

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -500,7 +500,7 @@ export interface NexTaskOptions extends ActivityTaskOptionsWithUsers {
 	type: 'Nex';
 	quantity: number;
 	leader: string;
-	userDetails: [string, number, number[]][];
+	userDetails: [string, number, number[], boolean | null][];
 	fakeDuration: number;
 	wipedKill: number | null;
 }

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -500,7 +500,7 @@ export interface NexTaskOptions extends ActivityTaskOptionsWithUsers {
 	type: 'Nex';
 	quantity: number;
 	leader: string;
-	userDetails: [string, number, number[], boolean][];
+	teamDetails: [string, number, number[], boolean][];
 	fakeDuration: number;
 	wipedKill: number | null;
 }

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -500,7 +500,7 @@ export interface NexTaskOptions extends ActivityTaskOptionsWithUsers {
 	type: 'Nex';
 	quantity: number;
 	leader: string;
-	userDetails: [string, number, number[], boolean | null][];
+	userDetails: [string, number, number[], boolean][];
 	fakeDuration: number;
 	wipedKill: number | null;
 }

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -500,7 +500,7 @@ export interface NexTaskOptions extends ActivityTaskOptionsWithUsers {
 	type: 'Nex';
 	quantity: number;
 	leader: string;
-	teamDetails: [string, number, number[], boolean][];
+	teamDetails: [string, number, number, number[], boolean][];
 	fakeDuration: number;
 	wipedKill: number | null;
 }

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -453,7 +453,7 @@ const tripHandlers = {
 			return {
 				name: 'nex',
 				quantity: data.quantity,
-				solo: data.userDetails.length === 1
+				solo: data.users.length === 1
 			};
 		}
 	},

--- a/src/lib/workers/kill.worker.ts
+++ b/src/lib/workers/kill.worker.ts
@@ -79,10 +79,10 @@ export default async ({
 		const loot = handleNexKills({
 			quantity,
 			team: [
-				{ id: '1', contribution: 100, deaths: [] },
-				{ id: '2', contribution: 100, deaths: [] },
-				{ id: '3', contribution: 100, deaths: [] },
-				{ id: '4', contribution: 100, deaths: [] }
+				{ id: '1', teamID: 1, deaths: [] },
+				{ id: '2', teamID: 2, deaths: [] },
+				{ id: '3', teamID: 3, deaths: [] },
+				{ id: '4', teamID: 4, deaths: [] }
 			]
 		});
 		return {

--- a/src/lib/workers/kill.worker.ts
+++ b/src/lib/workers/kill.worker.ts
@@ -79,10 +79,10 @@ export default async ({
 		const loot = handleNexKills({
 			quantity,
 			team: [
-				{ id: '1', teamID: 1, deaths: [] },
-				{ id: '2', teamID: 2, deaths: [] },
-				{ id: '3', teamID: 3, deaths: [] },
-				{ id: '4', teamID: 4, deaths: [] }
+				{ id: '1', teamID: 1, contribution: 100, deaths: [] },
+				{ id: '2', teamID: 2, contribution: 100, deaths: [] },
+				{ id: '3', teamID: 3, contribution: 100, deaths: [] },
+				{ id: '4', teamID: 4, contribution: 100, deaths: [] }
 			]
 		});
 		return {

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -110,7 +110,7 @@ export async function nexCommand(
 		type: 'Nex',
 		leader: user.id,
 		users: effectiveTeam.map(i => i.id),
-		teamDetails: details.team.map(i => [i.id, i.teamID, i.deaths, i.fake]),
+		teamDetails: details.team.map(i => [i.id, i.teamID, i.contribution, i.deaths, i.fake]),
 		fakeDuration: details.fakeDuration,
 		quantity: details.quantity,
 		wipedKill: details.wipedKill

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -110,7 +110,7 @@ export async function nexCommand(
 		type: 'Nex',
 		leader: user.id,
 		users: effectiveTeam.map(i => i.id),
-		userDetails: effectiveTeam.map(i => [i.id, i.teamID, i.deaths, i.fake ?? null]),
+		userDetails: details.team.map(i => [i.id, i.teamID, i.deaths, i.fake]),
 		fakeDuration: details.fakeDuration,
 		quantity: details.quantity,
 		wipedKill: details.wipedKill

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -110,7 +110,7 @@ export async function nexCommand(
 		type: 'Nex',
 		leader: user.id,
 		users: effectiveTeam.map(i => i.id),
-		userDetails: details.team.map(i => [i.id, i.teamID, i.deaths, i.fake]),
+		teamDetails: details.team.map(i => [i.id, i.teamID, i.deaths, i.fake]),
 		fakeDuration: details.fakeDuration,
 		quantity: details.quantity,
 		wipedKill: details.wipedKill

--- a/src/tasks/minions/nexActivity.ts
+++ b/src/tasks/minions/nexActivity.ts
@@ -23,7 +23,7 @@ export const nexTask: MinionTask = {
 			id: u[0],
 			teamID: u[1],
 			deaths: u[2],
-			fake: u[3] ?? undefined
+			fake: u[3]
 		}));
 
 		const loot = handleNexKills({

--- a/src/tasks/minions/nexActivity.ts
+++ b/src/tasks/minions/nexActivity.ts
@@ -13,13 +13,13 @@ import { updateBankSetting } from '../../lib/util/updateBankSetting';
 export const nexTask: MinionTask = {
 	type: 'Nex',
 	async run(data: NexTaskOptions) {
-		const { quantity, channelID, users, wipedKill, duration, userDetails } = data;
-		const realUsers = userDetails.filter(u => !u[3]);
+		const { quantity, channelID, users, wipedKill, duration, teamDetails } = data;
+		const realUsers = teamDetails.filter(u => !u[3]);
 		const allMention = realUsers.map(t => userMention(t[0])).join(' ');
 		const allMUsers = await Promise.all(users.map(id => mUserFetch(id)));
 
 		const survivedQuantity = wipedKill ? wipedKill - 1 : quantity;
-		const teamResult: NexContext['team'] = userDetails.map(u => ({
+		const teamResult: NexContext['team'] = teamDetails.map(u => ({
 			id: u[0],
 			teamID: u[1],
 			deaths: u[2],
@@ -34,7 +34,7 @@ export const nexTask: MinionTask = {
 		for (const [uID, uLoot] of loot.entries()) {
 			await transactItems({ userID: uID, collectionLog: true, itemsToAdd: uLoot });
 			const user = allMUsers.find(i => i.id === uID)!;
-			await user.incrementKC(NEX_ID, quantity - userDetails.find(i => i[0] === uID)![2].length);
+			await user.incrementKC(NEX_ID, quantity - teamDetails.find(i => i[0] === uID)![2].length);
 		}
 
 		await trackLoot({
@@ -44,7 +44,7 @@ export const nexTask: MinionTask = {
 			changeType: 'loot',
 			duration: duration * users.length,
 			kc: quantity,
-			users: userDetails.map(i => ({
+			users: teamDetails.map(i => ({
 				id: i[0],
 				loot: loot.get(i[0]),
 				duration

--- a/src/tasks/minions/nexActivity.ts
+++ b/src/tasks/minions/nexActivity.ts
@@ -22,8 +22,9 @@ export const nexTask: MinionTask = {
 		const teamResult: NexContext['team'] = teamDetails.map(u => ({
 			id: u[0],
 			teamID: u[1],
-			deaths: u[2],
-			fake: u[3]
+			contribution: u[2],
+			deaths: u[3],
+			fake: u[4]
 		}));
 
 		const loot = handleNexKills({
@@ -34,7 +35,7 @@ export const nexTask: MinionTask = {
 		for (const [uID, uLoot] of loot.entries()) {
 			await transactItems({ userID: uID, collectionLog: true, itemsToAdd: uLoot });
 			const user = allMUsers.find(i => i.id === uID)!;
-			await user.incrementKC(NEX_ID, quantity - teamDetails.find(i => i[0] === uID)![2].length);
+			await user.incrementKC(NEX_ID, quantity - teamResult.find(i => i.id === uID)!.deaths.length);
 		}
 
 		await trackLoot({
@@ -44,11 +45,13 @@ export const nexTask: MinionTask = {
 			changeType: 'loot',
 			duration: duration * users.length,
 			kc: quantity,
-			users: teamDetails.map(i => ({
-				id: i[0],
-				loot: loot.get(i[0]),
-				duration
-			}))
+			users: teamResult
+				.filter(i => !i.fake)
+				.map(i => ({
+					id: i.id,
+					loot: loot.get(i.id),
+					duration
+				}))
 		});
 
 		await updateBankSetting('nex_loot', loot.totalLoot());


### PR DESCRIPTION
### Description:

Fix some Nex bugs, update loot roll mechanics to match in game, and add KC info on return message.

Closes #5817.

### Changes:

- Add `teamID` and `fake` parameters to team members so not all deaths are given to solo player (caused issues with loot and KC increments)
- Add kc to loot messages
- Add contribution weighting and VIP mechanics for loot rolls 
- Roll uniques once for each player, not once in total
- As VIP loot is boosted 10%, might be non integer so add rounding to `bank.multiply`

### Other checks:

- [x] I have tested all my changes thoroughly.
