### PR TITLE
Update BSO Help and Support & BSO BotLog Channel IDs

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -53,7 +53,7 @@ const BSOChannelConfig: ChannelConfig = {
 	Notifications: '1042760447830536212',
 	GrandExchange: '738780181946171493',
 	EconomyLogs: '802029843712573510',
-	HelpAndSupport: '792691343284764693',
+	HelpAndSupport: '970752140324790384',
 	BotLogs: '792691343284764693',
 	GeneralChannel: GENERAL_CHANNEL_ID
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -54,7 +54,7 @@ const BSOChannelConfig: ChannelConfig = {
 	GrandExchange: '738780181946171493',
 	EconomyLogs: '802029843712573510',
 	HelpAndSupport: '970752140324790384',
-	BotLogs: '792691343284764693',
+	BotLogs: '1051725977320964197',
 	GeneralChannel: GENERAL_CHANNEL_ID
 };
 


### PR DESCRIPTION
### Description
Updates the channel ID for the BSO Help and Support channel to the right ID

### Changes
- Moves BSO's 'READ THIS' help message to #bso-help-and-support. 
- Moves BSO's "BotLogs" channel ID to #bot-logs because right now all those admin-only log messages are going to #bso-general


- [ ] I have tested all my changes thoroughly.
