### PR TITLE
Add 'funny feeling you're being followed' message to all pet drops

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -108,7 +108,7 @@ const tripFinishEffects: TripFinishEffect[] = [
 
 export function petMessage(loot: Bank | null | undefined) {
 	const emoji = pets.find(p => loot?.has(p.name))?.emoji;
-	return `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
+	return `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling like you're being followed...**`;
 }
 
 export async function handleTripFinish(

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -13,6 +13,8 @@ import { ClueTiers } from '../clues/clueTiers';
 import { buildClueButtons } from '../clues/clueUtils';
 import { combatAchievementTripEffect } from '../combat_achievements/combatAchievements';
 import { BitField, COINS_ID, Emoji, MAX_CLUES_DROPPED, PerkTier } from '../constants';
+import { allPetsCL } from '../data/CollectionsExport';
+import pets from '../data/pets';
 import { handleGrowablePetGrowth } from '../growablePets';
 import { handlePassiveImplings } from '../implings';
 import { triggerRandomEvent } from '../randomEvents';
@@ -161,6 +163,11 @@ export async function handleTripFinish(
 		clueReceived.map(
 			clue => (message.content += `\n${Emoji.Casket} **You got a ${clue.name} clue scroll** in your loot.`)
 		);
+	}
+
+	if (allPetsCL.some(p => loot?.has(p))) {
+		const emoji = pets.find(p => loot?.has(p.name))?.emoji;
+		message.content += `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
 	}
 
 	if (sumArr(ClueTiers.map(t => user.bank.amount(t.scrollID))) >= MAX_CLUES_DROPPED) {

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -106,6 +106,11 @@ const tripFinishEffects: TripFinishEffect[] = [
 	}
 ];
 
+export function petMessage(loot: Bank | null | undefined) {
+	const emoji = pets.find(p => loot?.has(p.name))?.emoji;
+	return `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
+}
+
 export async function handleTripFinish(
 	user: MUser,
 	channelID: string,
@@ -166,8 +171,7 @@ export async function handleTripFinish(
 	}
 
 	if (allPetsCL.some(p => loot?.has(p))) {
-		const emoji = pets.find(p => loot?.has(p.name))?.emoji;
-		message.content += `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
+		message.content += petMessage(loot);
 	}
 
 	if (sumArr(ClueTiers.map(t => user.bank.amount(t.scrollID))) >= MAX_CLUES_DROPPED) {

--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -6,6 +6,7 @@ import { Bank } from 'oldschooljs';
 
 import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { Events } from '../../../lib/constants';
+import pets from '../../../lib/data/pets';
 import { degradeItem } from '../../../lib/degradeableItems';
 import { countUsersWithItemInCl } from '../../../lib/settings/prisma';
 import { getMinigameScore } from '../../../lib/settings/settings';
@@ -202,7 +203,10 @@ export async function barbAssaultGambleCommand(
 		}
 	);
 	const loot = new Bank().add(table.roll(quantity));
-	if (loot.has('Pet penance queen')) {
+	let str = `You spent ${(cost * quantity).toLocaleString()} Honour Points for ${quantity.toLocaleString()}x ${name} Gamble, and received...`;
+	if (loot.has('Pet Penance Queen')) {
+		str += `\n${pets.find(p => p.name === 'Pet Penance Queen')!.emoji} **You have a funny feeling you're being followed...**`;
+
 		const amount = await countUsersWithItemInCl(itemID('Pet penance queen'), false);
 
 		globalClient.emit(
@@ -220,7 +224,7 @@ export async function barbAssaultGambleCommand(
 	const components: ButtonBuilder[] = buildClueButtons(loot, perkTier, user);
 
 	const response: Awaited<CommandResponse> = {
-		content: `You spent ${(cost * quantity).toLocaleString()} Honour Points for ${quantity.toLocaleString()}x ${name} Gamble, and received...`,
+		content: str,
 		files: [
 			(
 				await makeBankImage({

--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -6,7 +6,6 @@ import { Bank } from 'oldschooljs';
 
 import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { Events } from '../../../lib/constants';
-import pets from '../../../lib/data/pets';
 import { degradeItem } from '../../../lib/degradeableItems';
 import { countUsersWithItemInCl } from '../../../lib/settings/prisma';
 import { getMinigameScore } from '../../../lib/settings/settings';
@@ -18,6 +17,7 @@ import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
+import { petMessage } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 import { userStatsUpdate } from '../../mahojiSettings';
 
@@ -205,8 +205,7 @@ export async function barbAssaultGambleCommand(
 	const loot = new Bank().add(table.roll(quantity));
 	let str = `You spent ${(cost * quantity).toLocaleString()} Honour Points for ${quantity.toLocaleString()}x ${name} Gamble, and received...`;
 	if (loot.has('Pet Penance Queen')) {
-		str += `\n${pets.find(p => p.name === 'Pet Penance Queen')!.emoji} **You have a funny feeling you're being followed...**`;
-
+		str += petMessage(loot);
 		const amount = await countUsersWithItemInCl(itemID('Pet penance queen'), false);
 
 		globalClient.emit(

--- a/src/mahoji/lib/abstracted_commands/capegamble.ts
+++ b/src/mahoji/lib/abstracted_commands/capegamble.ts
@@ -3,11 +3,11 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { Bank } from 'oldschooljs';
 
 import { Events } from '../../../lib/constants';
-import pets from '../../../lib/data/pets';
 import { roll } from '../../../lib/util';
 import { newChatHeadImage } from '../../../lib/util/chatHeadImage';
 import getOSItem from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
+import { petMessage } from '../../../lib/util/handleTripFinish';
 import { userStatsUpdate } from '../../mahojiSettings';
 
 export async function capeGambleStatsCommand(user: MUser) {
@@ -110,8 +110,7 @@ export async function capeGambleCommand(
 	await user.transactItems({ itemsToAdd: loot, itemsToRemove: new Bank().add(item.id), collectionLog: true });
 	let str = '';
 	if (gotPet) {
-		const emoji = pets.find(p => loot?.has(p.name))?.emoji;
-		str += `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
+		str += petMessage(loot);
 		globalClient.emit(
 			Events.ServerNotification,
 			`**${user.badgedUsername}'s** just received their ${formatOrdinal(

--- a/src/mahoji/lib/abstracted_commands/capegamble.ts
+++ b/src/mahoji/lib/abstracted_commands/capegamble.ts
@@ -3,6 +3,7 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { Bank } from 'oldschooljs';
 
 import { Events } from '../../../lib/constants';
+import pets from '../../../lib/data/pets';
 import { roll } from '../../../lib/util';
 import { newChatHeadImage } from '../../../lib/util/chatHeadImage';
 import getOSItem from '../../../lib/util/getOSItem';
@@ -107,8 +108,10 @@ export async function capeGambleCommand(
 	const loot = gotPet ? new Bank().add(pet.id) : undefined;
 
 	await user.transactItems({ itemsToAdd: loot, itemsToRemove: new Bank().add(item.id), collectionLog: true });
-
+	let str = '';
 	if (gotPet) {
+		const emoji = pets.find(p => loot?.has(p.name))?.emoji;
+		str += `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
 		globalClient.emit(
 			Events.ServerNotification,
 			`**${user.badgedUsername}'s** just received their ${formatOrdinal(
@@ -116,6 +119,7 @@ export async function capeGambleCommand(
 			)} ${pet.name} pet by sacrificing a ${item.name} for the ${formatOrdinal(newSacrificedCount)} time!`
 		);
 		return {
+			content: str,
 			files: [
 				{
 					name: 'image.jpg',

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -6,6 +6,8 @@ import { Bank } from 'oldschooljs';
 
 import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { BitField } from '../../../lib/constants';
+import { allPetsCL } from '../../../lib/data/CollectionsExport';
+import pets from '../../../lib/data/pets';
 import type { UnifiedOpenable } from '../../../lib/openables';
 import { allOpenables, getOpenableLoot } from '../../../lib/openables';
 import { makeComponents } from '../../../lib/util';
@@ -143,6 +145,10 @@ ${messages.join(', ')}`.trim(),
 
 		response.content =
 			'Due to opening so many things at once, you will have to download the attached text file to read the response.';
+	}
+	if (allPetsCL.some(p => loot?.has(p))) {
+		const emoji = pets.find(p => loot?.has(p.name))?.emoji;
+		response.content += `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
 	}
 	return response;
 }

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -7,12 +7,12 @@ import { Bank } from 'oldschooljs';
 import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { BitField } from '../../../lib/constants';
 import { allPetsCL } from '../../../lib/data/CollectionsExport';
-import pets from '../../../lib/data/pets';
 import type { UnifiedOpenable } from '../../../lib/openables';
 import { allOpenables, getOpenableLoot } from '../../../lib/openables';
 import { makeComponents } from '../../../lib/util';
 import getOSItem, { getItem } from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
+import { petMessage } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 import { addToOpenablesScores, patronMsg, updateClientGPTrackSetting } from '../../mahojiSettings';
 
@@ -147,8 +147,7 @@ ${messages.join(', ')}`.trim(),
 			'Due to opening so many things at once, you will have to download the attached text file to read the response.';
 	}
 	if (allPetsCL.some(p => loot?.has(p))) {
-		const emoji = pets.find(p => loot?.has(p.name))?.emoji;
-		response.content += `\n${emoji ? `${emoji} ` : ''}**You have a funny feeling you're being followed...**`;
+		response.content += petMessage(loot);
 	}
 	return response;
 }

--- a/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
+++ b/src/tasks/minions/HunterActivity/aerialFishingActivity.ts
@@ -138,7 +138,6 @@ export const aerialFishingTask: MinionTask = {
 		const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Fishing, 636_833);
 		if (roll(petDropRate / totalFishCaught)) {
 			loot.add('Heron');
-			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Fishing} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a **Heron** while Aerial fishing at level ${currentFishLevel} Fishing!`

--- a/src/tasks/minions/HunterActivity/hunterActivity.ts
+++ b/src/tasks/minions/HunterActivity/hunterActivity.ts
@@ -193,7 +193,6 @@ export const hunterTask: MinionTask = {
 		}
 
 		if (loot.amount('Baby chinchompa') > 0 || loot.amount('Herbi') > 0) {
-			str += "\n\n**You have a funny feeling like you're being followed....**";
 			globalClient.emit(
 				Events.ServerNotification,
 				`**${user.usernameOrMention}'s** minion, ${user.minionName}, just received a ${

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -142,7 +142,7 @@ export const agilityTask: MinionTask = {
 			updateClientGPTrackSetting('gp_alch', alchGP);
 		}
 
-		let str = `${user}, ${user.minionName} finished ${quantity} ${
+		const str = `${user}, ${user.minionName} finished ${quantity} ${
 			course.name
 		} laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${
 			diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
@@ -156,7 +156,6 @@ export const agilityTask: MinionTask = {
 		);
 		if (roll(petDropRate / quantity)) {
 			loot.add('Giant squirrel');
-			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Agility} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Giant squirrel while running ${course.name} laps at level ${currentLevel} Agility!`

--- a/src/tasks/minions/camdozaalActivity/camdozaalFishingActivity.ts
+++ b/src/tasks/minions/camdozaalActivity/camdozaalFishingActivity.ts
@@ -115,7 +115,6 @@ export const camdozaalFishingTask: MinionTask = {
 		const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Fishing, guppy.petChance!);
 		if (roll(petDropRate / quantity)) {
 			loot.add('Heron');
-			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Fishing} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Heron while fishing in Camdozaal at level ${currentFishLevel} Fishing!`

--- a/src/tasks/minions/camdozaalActivity/camdozaalMiningActivity.ts
+++ b/src/tasks/minions/camdozaalActivity/camdozaalMiningActivity.ts
@@ -102,7 +102,6 @@ export const camdozaalMiningTask: MinionTask = {
 		const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Mining, camdozaalMine.petChance!);
 		if (roll(petDropRate / quantity)) {
 			loot.add('Rock golem');
-			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Mining} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Rock golem while mining in Camdozaal at level ${currentLevel} Mining!`

--- a/src/tasks/minions/darkAltarActivity.ts
+++ b/src/tasks/minions/darkAltarActivity.ts
@@ -73,7 +73,6 @@ export const darkAltarTask: MinionTask = {
 		}
 
 		if (loot.amount('Rift guardian') > 0) {
-			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
 				`**${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -372,9 +372,6 @@ export const farmingTask: MinionTask = {
 			}
 
 			if (loot.has('Tangleroot')) {
-				infoStr.push('\n```diff');
-				infoStr.push("\n- You have a funny feeling you're being followed...");
-				infoStr.push('```');
 				globalClient.emit(
 					Events.ServerNotification,
 					`${Emoji.Farming} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a Tangleroot while farming ${patchType.lastPlanted} at level ${currentFarmingLevel} Farming!`

--- a/src/tasks/minions/fishingActivity.ts
+++ b/src/tasks/minions/fishingActivity.ts
@@ -200,7 +200,6 @@ export const fishingTask: MinionTask = {
 			for (let i = 0; i < quantity; i++) {
 				if (roll(petDropRate)) {
 					loot.add('Heron');
-					str += "\nYou have a funny feeling you're being followed...";
 					globalClient.emit(
 						Events.ServerNotification,
 						`${Emoji.Fishing} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a Heron while fishing ${fish.name} at level ${currentLevel} Fishing!`

--- a/src/tasks/minions/minigames/agilityArenaActivity.ts
+++ b/src/tasks/minions/minigames/agilityArenaActivity.ts
@@ -61,7 +61,6 @@ export const agilityArenaTask: MinionTask = {
 					items: new Bank().add('Giant Squirrel'),
 					collectionLog: true
 				});
-				str += "**\n\nYou have a funny feeling you're being followed...**";
 				globalClient.emit(
 					Events.ServerNotification,
 					`${Emoji.Agility} **${user.badgedUsername}'s** minion, ${user.minionName}, just received a Giant squirrel while running at the Agility Arena at level ${currentLevel} Agility!`

--- a/src/tasks/minions/minigames/gauntletActivity.ts
+++ b/src/tasks/minions/minigames/gauntletActivity.ts
@@ -53,10 +53,9 @@ export const gauntletTask: MinionTask = {
 
 		const newKc = await getMinigameScore(user.id, key);
 
-		let str = `${user}, ${user.minionName} finished completing ${quantity}x ${name}. **${chanceOfDeath}% chance of death**, you died in ${deaths}/${quantity} of the attempts.\nYour ${name} KC is now ${newKc}.`;
+		const str = `${user}, ${user.minionName} finished completing ${quantity}x ${name}. **${chanceOfDeath}% chance of death**, you died in ${deaths}/${quantity} of the attempts.\nYour ${name} KC is now ${newKc}.`;
 
 		if (loot.amount('Youngllef') > 0) {
-			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
 				`**${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
+++ b/src/tasks/minions/minigames/guardiansOfTheRiftActivity.ts
@@ -170,7 +170,6 @@ export const guardiansOfTheRiftTask: MinionTask = {
 			str += `\n\n**Blood essence used:** ${bonusBloods.toLocaleString()}`;
 		}
 		if (rewardsGuardianLoot.amount('Abyssal Protector') > 0) {
-			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
 				`**${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/minigames/plunderActivity.ts
+++ b/src/tasks/minions/minigames/plunderActivity.ts
@@ -39,10 +39,9 @@ export const plunderTask: MinionTask = {
 		});
 		const xpRes = await user.addXP({ skillName: SkillsEnum.Thieving, amount: thievingXP, duration: data.duration });
 
-		let str = `${user}, ${user.minionName} finished doing the Pyramid Plunder ${quantity}x times. ${totalAmountUrns}x urns opened. ${xpRes}`;
+		const str = `${user}, ${user.minionName} finished doing the Pyramid Plunder ${quantity}x times. ${totalAmountUrns}x urns opened. ${xpRes}`;
 
 		if (loot.amount('Rocky') > 0) {
-			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
 				`**${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/minigames/titheFarmActivity.ts
+++ b/src/tasks/minions/minigames/titheFarmActivity.ts
@@ -98,9 +98,6 @@ export const titheFarmTask: MinionTask = {
 		const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Farming, 7_494_389);
 		if (roll(petDropRate / determineHarvest)) {
 			loot.add('Tangleroot');
-			lootStr.push('\n\n```diff');
-			lootStr.push("\n- You have a funny feeling you're being followed...");
-			lootStr.push('```');
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Farming} **${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -65,7 +65,6 @@ export function determineMiningResult({
 		const { petDropRate } = skillingPetDropRate(gearBank, SkillsEnum.Mining, ore.petChance);
 		if (roll(petDropRate / quantity)) {
 			updateBank.itemLootBank.add('Rock golem');
-			messages.push("You have a funny feeling you're being followed...");
 		}
 	}
 

--- a/src/tasks/minions/motherlodeMineActivity.ts
+++ b/src/tasks/minions/motherlodeMineActivity.ts
@@ -102,7 +102,6 @@ export const motherlodeMiningTask: MinionTask = {
 		const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Mining, motherlode.petChance!);
 		if (roll(petDropRate / quantity)) {
 			loot.add('Rock golem');
-			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Mining} **${user.usernameOrMention}'s** minion, ${user.minionName}, just received a Rock golem while mining at the ${Mining.MotherlodeMine.name} at level ${currentLevel} Mining!`

--- a/src/tasks/minions/ouraniaAltarActivity.ts
+++ b/src/tasks/minions/ouraniaAltarActivity.ts
@@ -65,14 +65,13 @@ const ouraniaAltarTask: MinionTask = {
 			source: 'OuraniaAltar'
 		})}`;
 
-		let str = `${user}, ${user.minionName} finished runecrafting at the Ourania altar, you received ${loot}.${
+		const str = `${user}, ${user.minionName} finished runecrafting at the Ourania altar, you received ${loot}.${
 			diaryQuantity > 0 ? `\n${diaryQuantity} bonus runes for completing the medium Ardougne diary.` : ''
 		}${
 			raimentQuantity > 0 ? `\n${raimentQuantity} bonus runes from the Raiments of the eye outfit.` : ''
 		} ${xpRes}`;
 
 		if (loot.amount('Rift guardian') > 0) {
-			str += "\n\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
 				`**${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -130,7 +130,6 @@ export const pickpocketTask: MinionTask = {
 		}
 
 		if (loot.amount('Rocky') > 0) {
-			str += "\n**You have a funny feeling you're being followed...**";
 			globalClient.emit(
 				Events.ServerNotification,
 				`**${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/runecraftActivity.ts
+++ b/src/tasks/minions/runecraftActivity.ts
@@ -65,7 +65,6 @@ export const runecraftTask: MinionTask = {
 		const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Runecraft, 1_795_758);
 		if (roll(petDropRate / essenceQuantity)) {
 			loot.add('Rift guardian');
-			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Runecraft} **${user.badgedUsername}'s** minion, ${

--- a/src/tasks/minions/shootingStarActivity.ts
+++ b/src/tasks/minions/shootingStarActivity.ts
@@ -20,11 +20,10 @@ export async function shootingStarsActivity(data: ShootingStarsOptions) {
 		duration: data.duration
 	});
 
-	let str = `${user}, ${user.minionName} finished mining a size ${star.size} Crashed Star, there was ${
+	const str = `${user}, ${user.minionName} finished mining a size ${star.size} Crashed Star, there was ${
 		usersWith - 1 || 'no'
 	} other players mining with you.\nYou received ${loot}.\n${xpStr}`;
 	if (loot.has('Rock golem')) {
-		str += "\nYou have a funny feeling you're being followed...";
 		globalClient.emit(
 			Events.ServerNotification,
 			`${Emoji.Mining} **${user.badgedUsername}'s** minion, ${user.minionName}, just received ${

--- a/src/tasks/minions/volcanicMineActivity.ts
+++ b/src/tasks/minions/volcanicMineActivity.ts
@@ -78,12 +78,11 @@ export const vmTask: MinionTask = {
 			if (roll(petDropRate)) loot.add('Rock golem');
 		}
 
-		let str = `${user}, ${user.minionName} finished playing ${quantity} games of Volcanic Mine.\n${xpRes}${
+		const str = `${user}, ${user.minionName} finished playing ${quantity} games of Volcanic Mine.\n${xpRes}${
 			loot.length > 0 ? `\nYou received ${loot}` : ''
 		}\nYou received **${pointsReceived.toLocaleString()}** Volcanic Mine points. ${warningMessage}`;
 
 		if (loot.has('Rock golem')) {
-			str += "\nYou have a funny feeling you're being followed...";
 			globalClient.emit(
 				Events.ServerNotification,
 				`${Emoji.Mining} **${user.badgedUsername}'s** minion, ${user.minionName}, just received ${

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -323,7 +323,6 @@ export const woodcuttingTask: MinionTask = {
 			const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Woodcutting, log.petChance);
 			if (roll(petDropRate / quantity)) {
 				loot.add('Beaver');
-				str += "\n**You have a funny feeling you're being followed...**";
 				globalClient.emit(
 					Events.ServerNotification,
 					`${Emoji.Woodcutting} **${user.badgedUsername}'s** minion, ${


### PR DESCRIPTION
### Description:

Moved the pet messages to `handleTripFinish` rather than having a message in every activity, so they are all handled. Also added messages to open (soul wars and bloodhound) and BA/Cape/Quiver gambles.

### Changes:

- Add pet check and message to `handleTripFinish`, `\open` and relevant `\gamble` commands
- Removed message from activities to avoid dupes
- Added pet emoji to the message if it's available, just like daily reward pet message

### Other checks:

- [x] I have tested all my changes thoroughly.
