### PR TITLE
Fix clue / ring of wealth droprate issue

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -749,7 +749,7 @@ Charge your items using ${mentionCommand(globalClient, 'minion', 'charge')}.`
 
 		const tiers = Object.keys(CombatAchievements) as Array<keyof typeof CombatAchievements>;
 		for (const tier of tiers) {
-			let change = hasRingOfWealthI ? 50 : 0;
+			let change = (hasRingOfWealthI && inWildy) ? 50 : 0;
 			if (this.hasCompletedCATier(tier)) {
 				change += 5;
 			}

--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -749,7 +749,7 @@ Charge your items using ${mentionCommand(globalClient, 'minion', 'charge')}.`
 
 		const tiers = Object.keys(CombatAchievements) as Array<keyof typeof CombatAchievements>;
 		for (const tier of tiers) {
-			let change = (hasRingOfWealthI && inWildy) ? 50 : 0;
+			let change = hasRingOfWealthI && inWildy ? 50 : 0;
 			if (this.hasCompletedCATier(tier)) {
 				change += 5;
 			}


### PR DESCRIPTION
### Description:

Properly adds the "inWildy" check to apply Ring of Wealth (i) clue droprate boost.

### Changes:

- Adds `&& inWildy` to the ringofwealth (i) check.

### Other checks:

- [ ] I have tested all my changes thoroughly.
