### PR TITLE
Add chance column to CA wiki table, fix padding

### DIFF
--- a/docs/src/components/Leagues.tsx
+++ b/docs/src/components/Leagues.tsx
@@ -131,6 +131,7 @@ export function Leagues() {
 						<tr>
 							<th>Name</th>
 							<th>Description</th>
+							<th>Chance</th>
 							<th>Tier</th>
 						</tr>
 					</thead>
@@ -146,6 +147,7 @@ export function Leagues() {
 							>
 								<td>{task.name}</td>
 								<td>{task.desc}</td>
+								<td>{task.rng?.chancePerKill > 1 ? `1 / ${task.rng?.chancePerKill}` : undefined}</td>
 								<td>{toTitleCase(task.tier)}</td>
 							</tr>
 						))}

--- a/docs/src/styles/main.css
+++ b/docs/src/styles/main.css
@@ -361,7 +361,6 @@ starlight-tabs ul, starlight-tabs ol {
 }
 
 .sl-markdown-content td {
-  @apply py-2 px-2;
   @apply text-sm;
 }
 


### PR DESCRIPTION
### Description:

Add chance column to CA wiki table, and fix content padding so it aligns with title

### Changes:

Add chance column to CA wiki table, fix padding

### Other checks:

- [x] I have tested all my changes thoroughly.
