### PR TITLE
ToB Hard Mode - CA adjustment

### DIFF
--- a/src/lib/combat_achievements/master.ts
+++ b/src/lib/combat_achievements/master.ts
@@ -1029,7 +1029,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 		type: 'speed',
 		monster: 'Theatre of Blood: Hard Mode',
 		rng: {
-			chancePerKill: 55,
+			chancePerKill: 5,
 			hasChance: data => data.type === 'TheatreOfBlood' && (data as TheatreOfBloodTaskOptions).hardMode
 		}
 	},


### PR DESCRIPTION
Change the tob "hard mode? completed it" ca from 1/55 to 1/5. It's the most obtained hard mode ca for tob and is easier to get than any of the other cas, the rate on the bot should reflect that.

Source - https://oldschool.runescape.wiki/w/Hard_Mode%3F_Completed_It

- [ ] I have tested all my changes thoroughly.
