### PR TITLE
Deathtouched dart fix

### DIFF
--- a/src/lib/bso/handleDTD.ts
+++ b/src/lib/bso/handleDTD.ts
@@ -40,8 +40,12 @@ export async function handleDTD(monster: KillableMonster, user: MUser) {
 			return 'You send your minion off to fight Yeti with a Deathtouched dart, they stand a safe distance and throw the dart - the cold, harsh wind blows it out of the air. Your minion runs back to you in fear.';
 		}
 
-		if ([BSOMonsters.Akumu.id, BSOMonsters.Venatrix.id].includes(monster.id)) {
-			return 'This monster is temporarily unable to be killed with a Deathtouched dart.';
+		if (monster.name === 'Akumu') {
+			return 'You throw your dart into the darkness for it to never return.';
+		}
+
+		if (monster.name === 'Venatrix') {
+			return `You throw your dart but gets stuck in Venatrix's web.`;
 		}
 
 		await userStatsUpdate(user.id, {

--- a/src/lib/bso/handleDTD.ts
+++ b/src/lib/bso/handleDTD.ts
@@ -1,7 +1,6 @@
 import type { Prisma } from '@prisma/client';
 import { findBingosWithUserParticipating } from '../../mahoji/lib/bingo/BingoManager';
 import { userStatsUpdate } from '../../mahoji/mahojiSettings';
-import { BSOMonsters } from '../minions/data/killableMonsters/custom/customMonsters';
 import type { KillableMonster } from '../minions/types';
 import { itemID } from '../util';
 

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -28,6 +28,7 @@ import { vasaCommand } from '../vasaCommand';
 import { wintertodtCommand } from '../wintertodtCommand';
 import { zalcanoCommand } from '../zalcanoCommand';
 import { newMinionKillCommand } from './newMinionKill';
+import { Time } from 'e';
 
 const invalidMonsterMsg = "That isn't a valid monster.\n\nFor example, `/k name:zulrah quantity:5`";
 
@@ -91,10 +92,6 @@ export async function minionKillCommand(
 		return typeof reason === 'string' ? reason : "You don't have the requirements to fight this monster";
 	}
 
-	const dtdResult = await handleDTD(monster, user);
-	if (typeof dtdResult === 'string') {
-		return dtdResult;
-	}
 	const slayerInfo = await getUsersCurrentSlayerInfo(user.id);
 
 	if (slayerInfo.assignedTask === null && onTask) return 'You are no longer on a slayer task for this monster!';
@@ -134,6 +131,11 @@ export async function minionKillCommand(
 		return updateResult;
 	}
 
+	const dtdResult = await handleDTD(monster, user);
+	if (typeof dtdResult === 'string') {
+		return dtdResult;
+	}
+
 	if (updateResult.message.length > 0) result.messages.push(updateResult.message);
 
 	if (updateResult.totalCost.length > 0) {
@@ -163,7 +165,7 @@ export async function minionKillCommand(
 		channelID,
 		q: result.quantity,
 		iQty: inputQuantity,
-		duration: result.duration,
+		duration: dtdResult ? Time.Second * 5 : result.duration,
 		type: 'MonsterKilling',
 		usingCannon: !usingCannon ? undefined : usingCannon,
 		cannonMulti: !cannonMulti ? undefined : cannonMulti,
@@ -175,16 +177,16 @@ export async function minionKillCommand(
 		onTask: slayerInfo.assignedTask !== null
 	});
 
-	if (dtdResult) {
-		return `<:deathtouched_dart:822674661967265843> ${user.minionName} used a **Deathtouched dart**.`;
-	}
-
 	let response = `${minionName} is now killing ${result.quantity}x ${monster.name}, it'll take around ${formatDuration(
 		result.duration
 	)} to finish. Attack styles used: ${result.attackStyles.join(', ')}.`;
 
 	if (result.messages.length > 0) {
 		response += `\n\n${result.messages.join(', ')}`;
+	}
+
+	if (dtdResult) {
+		response += `<:deathtouched_dart:822674661967265843> ${user.minionName} used a **Deathtouched dart**.`;
 	}
 
 	return response;

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -1,5 +1,6 @@
 import type { ChatInputCommandInteraction, InteractionReplyOptions } from 'discord.js';
 
+import { Time } from 'e';
 import { handleDTD } from '../../../../lib/bso/handleDTD';
 import { colosseumCommand } from '../../../../lib/colosseum';
 import type { PvMMethod } from '../../../../lib/constants';
@@ -28,7 +29,6 @@ import { vasaCommand } from '../vasaCommand';
 import { wintertodtCommand } from '../wintertodtCommand';
 import { zalcanoCommand } from '../zalcanoCommand';
 import { newMinionKillCommand } from './newMinionKill';
-import { Time } from 'e';
 
 const invalidMonsterMsg = "That isn't a valid monster.\n\nFor example, `/k name:zulrah quantity:5`";
 
@@ -177,16 +177,10 @@ export async function minionKillCommand(
 		onTask: slayerInfo.assignedTask !== null
 	});
 
-	let response = `${minionName} is now killing ${result.quantity}x ${monster.name}, it'll take around ${formatDuration(
-		result.duration
-	)} to finish. Attack styles used: ${result.attackStyles.join(', ')}.`;
+	let response = `${minionName} is now killing ${result.quantity}x ${monster.name}, ${dtdResult ? `using a <:deathtouched_dart:822674661967265843> **Deathtouched dart**, it'll take around ${formatDuration(Time.Second * 5)}` : `It'll take around ${formatDuration(result.duration)} to finish.`}. Attack styles used: ${result.attackStyles.join(', ')}.`;
 
 	if (result.messages.length > 0) {
 		response += `\n\n${result.messages.join(', ')}`;
-	}
-
-	if (dtdResult) {
-		response += `<:deathtouched_dart:822674661967265843> ${user.minionName} used a **Deathtouched dart**.`;
 	}
 
 	return response;

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -177,7 +177,7 @@ export async function minionKillCommand(
 		onTask: slayerInfo.assignedTask !== null
 	});
 
-	let response = `${minionName} is now killing ${result.quantity}x ${monster.name}, ${dtdResult ? `using a <:deathtouched_dart:822674661967265843> **Deathtouched dart**, it'll take around ${formatDuration(Time.Second * 5)}` : `It'll take around ${formatDuration(result.duration)} to finish.`}. Attack styles used: ${result.attackStyles.join(', ')}.`;
+	let response = `${minionName} is now killing ${result.quantity}x ${monster.name}, ${dtdResult ? `using a <:deathtouched_dart:822674661967265843> **Deathtouched dart**, it'll take around ${formatDuration(Time.Second * 5)}` : `It'll take around ${formatDuration(result.duration)} to finish`}. Attack styles used: ${result.attackStyles.join(', ')}.`;
 
 	if (result.messages.length > 0) {
 		response += `\n\n${result.messages.join(', ')}`;


### PR DESCRIPTION
### Description:
Fix Death touched dart not returning instantly.

### Changes:
- move `dtdResult` further down to prevent accidental dart removal on trip failure.
- adjust `duration` inside `addSubTaskToActivityTask` to reflect dtd usage
  - I made dtd trips 5 seconds just to help prevent any weird lagg issues that could arise with making the trip < 1 second.
- show the full trip send message with the addition of dtd usage message so users can still see the trip info.
- update akumu/venatrix dtd message to match the others so users understand they lost their dart.

### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/6325
ss for new trip send message:
![Discord_2SlWhgE5IE](https://github.com/user-attachments/assets/2936bab4-976c-4dc5-af1f-1875d8ecb918)
