### PR TITLE
Tidy and fix show_info

### DIFF
--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -56,10 +56,7 @@ const otherMonsters = [
 	}
 ];
 
-export const autocompleteMonsters = [
-	...killableMonsters,
-	...otherMonsters,
-]
+export const autocompleteMonsters = [...killableMonsters, ...otherMonsters];
 
 const wikiPrefix = 'https://wiki.oldschool.gg/osb';
 
@@ -181,7 +178,7 @@ export const minionKCommand: OSBMahojiCommand = {
 };
 
 export async function monsterInfo(user: MUser, name: string): Promise<string | InteractionReplyOptions> {
-	const otherMon = otherMonsters.find(m => m.name == name || m.aliases.includes(name));
+	const otherMon = otherMonsters.find(m => m.name === name || m.aliases.includes(name));
 	if (otherMon) {
 		return `View information, item costs, boosts and requirements for ${otherMon.name} on the [wiki](<${wikiPrefix}${otherMon.link}>).\n`;
 	}

--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -15,54 +15,53 @@ import findMonster from '../../lib/util/findMonster';
 import { minionKillCommand } from '../lib/abstracted_commands/minionKill/minionKill';
 import type { OSBMahojiCommand } from '../lib/util';
 
-export const autocompleteMonsters = [
-	...killableMonsters,
+const otherMonsters = [
 	{
 		id: -1,
 		name: 'Tempoross',
-		aliases: ['temp', 'tempoross']
+		aliases: ['temp', 'tempoross'],
+		link: '/skills/fishing/tempoross/'
 	},
 	...["Phosani's Nightmare", 'Mass Nightmare', 'Solo Nightmare'].map(s => ({
 		id: -1,
 		name: s,
-		aliases: [s.toLowerCase()]
+		aliases: [s.toLowerCase()],
+		link: `/bosses/the-nightmare/${stringMatches(s.split(' ')[0], "Phosani's") ? '#phosanis-nightmare' : ''}`
 	})),
 	{
 		name: 'Nex',
 		aliases: ['nex'],
-		id: NEX_ID
+		id: NEX_ID,
+		link: '/bosses/nex/'
 	},
 	{
 		name: 'Zalcano',
 		aliases: ['zalcano'],
 		id: ZALCANO_ID,
-		emoji: '<:Smolcano:604670895113633802>'
+		emoji: '<:Smolcano:604670895113633802>',
+		link: '/miscelleanous/zalcano/'
 	},
 	{
 		name: 'Wintertodt',
 		aliases: ['wt', 'wintertodt', 'todt'],
 		id: -1,
-		emoji: '<:Phoenix:324127378223792129>'
+		emoji: '<:Phoenix:324127378223792129>',
+		link: '/activities/wintertodt/'
 	},
 	{
 		name: 'Colosseum',
 		aliases: ['colo', 'colosseum'],
-		id: -1
+		id: -1,
+		link: '/bosses/colosseum/'
 	}
 ];
 
-const wikiPrefix = 'https://wiki.oldschool.gg/osb';
+export const autocompleteMonsters = [
+	...killableMonsters,
+	...otherMonsters,
+]
 
-const otherMonsters = [
-	{ name: 'nex', link: '/bosses/nex/' },
-	{ name: 'colosseum', link: '/bosses/colosseum/' },
-	{ name: 'wintertodt', link: '/activities/wintertodt/' },
-	{ name: 'tempoross', link: '/skills/fishing/tempoross/' },
-	{ name: 'zalcano', link: '/miscelleanous/zalcano/' },
-	{ name: "phosani's nightmare", link: '/bosses/the-nightmare/#phosanis-nightmare' },
-	{ name: 'mass nightmare', link: '/bosses/the-nightmare/' },
-	{ name: 'solo nightmare', link: '/bosses/the-nightmare/' }
-];
+const wikiPrefix = 'https://wiki.oldschool.gg/osb';
 
 async function fetchUsersRecentlyKilledMonsters(userID: string) {
 	const res = await prisma.$queryRawUnsafe<{ mon_id: string; last_killed: Date }[]>(
@@ -182,13 +181,12 @@ export const minionKCommand: OSBMahojiCommand = {
 };
 
 export async function monsterInfo(user: MUser, name: string): Promise<string | InteractionReplyOptions> {
-	const monster = findMonster(name);
-
-	const otherMon = otherMonsters.find(m => stringMatches(name, m.name));
+	const otherMon = otherMonsters.find(m => m.name == name || m.aliases.includes(name));
 	if (otherMon) {
-		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${wikiPrefix}${otherMon.link}>).\n`;
+		return `View information, item costs, boosts and requirements for ${otherMon.name} on the [wiki](<${wikiPrefix}${otherMon.link}>).\n`;
 	}
 
+	const monster = findMonster(name);
 	if (!monster) {
 		return "That's not a valid monster";
 	}
@@ -197,13 +195,13 @@ export async function monsterInfo(user: MUser, name: string): Promise<string | I
 
 	if (wikiMonsters.includes(monster)) {
 		str.push(
-			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${wikiPrefix}/monsters/#${monster.name.toLowerCase().replace(/\s/g, '-')}>).\n`
+			`View information, item costs, boosts and requirements for ${monster.name} on the [wiki](<${wikiPrefix}/monsters/#${monster.name.toLowerCase().replace(/\s/g, '-')}>).\n`
 		);
 	}
 
 	if (monster.name.includes('Revenant')) {
 		str.push(
-			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${wikiPrefix}/bosses/wildy/#revenants>).\n`
+			`View information, item costs, boosts and requirements for ${monster.name} on the [wiki](<${wikiPrefix}/bosses/wildy/#revenants>).\n`
 		);
 	}
 

--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -206,7 +206,7 @@ export async function monsterInfo(user: MUser, name: string): Promise<string | I
 
 	if (wikiMonsters.includes(monster)) {
 		str.push(
-			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/monsters/#${monster.name.toLowerCase().replace(' ', '-')}>).\n`
+			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/monsters/#${monster.name.toLowerCase().replace(/\s/g, '-')}>).\n`
 		);
 	}
 

--- a/src/mahoji/commands/k.ts
+++ b/src/mahoji/commands/k.ts
@@ -51,6 +51,19 @@ export const autocompleteMonsters = [
 	}
 ];
 
+const wikiPrefix = 'https://wiki.oldschool.gg/osb';
+
+const otherMonsters = [
+	{ name: 'nex', link: '/bosses/nex/' },
+	{ name: 'colosseum', link: '/bosses/colosseum/' },
+	{ name: 'wintertodt', link: '/activities/wintertodt/' },
+	{ name: 'tempoross', link: '/skills/fishing/tempoross/' },
+	{ name: 'zalcano', link: '/miscelleanous/zalcano/' },
+	{ name: "phosani's nightmare", link: '/bosses/the-nightmare/#phosanis-nightmare' },
+	{ name: 'mass nightmare', link: '/bosses/the-nightmare/' },
+	{ name: 'solo nightmare', link: '/bosses/the-nightmare/' }
+];
+
 async function fetchUsersRecentlyKilledMonsters(userID: string) {
 	const res = await prisma.$queryRawUnsafe<{ mon_id: string; last_killed: Date }[]>(
 		`SELECT DISTINCT((data->>'mi')) AS mon_id, MAX(start_date) as last_killed
@@ -171,31 +184,9 @@ export const minionKCommand: OSBMahojiCommand = {
 export async function monsterInfo(user: MUser, name: string): Promise<string | InteractionReplyOptions> {
 	const monster = findMonster(name);
 
-	const prefix = 'https://wiki.oldschool.gg/osb';
-
-	if (stringMatches(name, 'nex')) {
-		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/bosses/nex/>).\n`;
-	}
-
-	if (stringMatches(name, 'colosseum')) {
-		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/bosses/colosseum/>).\n`;
-	}
-
-	if (stringMatches(name, 'wintertodt')) {
-		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/activities/wintertodt/>).\n`;
-	}
-
-	if (stringMatches(name, 'tempoross')) {
-		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/skills/fishing/tempoross/>).\n`;
-	}
-
-	if (stringMatches(name, 'zalcano')) {
-		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/miscelleanous/zalcano/>).\n`;
-	}
-
-	if (stringMatches(name.split(' ').pop(), 'nightmare')) {
-		const link = stringMatches(name.split(' ')[0], 'phosanis') ? '#phosanis-nightmare' : '';
-		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/bosses/the-nightmare/${link}>).\n`;
+	const otherMon = otherMonsters.find(m => stringMatches(name, m.name));
+	if (otherMon) {
+		return `View information, item costs, boosts and requirements for ${name} on the [wiki](<${wikiPrefix}${otherMon.link}>).\n`;
 	}
 
 	if (!monster) {
@@ -206,13 +197,13 @@ export async function monsterInfo(user: MUser, name: string): Promise<string | I
 
 	if (wikiMonsters.includes(monster)) {
 		str.push(
-			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/monsters/#${monster.name.toLowerCase().replace(/\s/g, '-')}>).\n`
+			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${wikiPrefix}/monsters/#${monster.name.toLowerCase().replace(/\s/g, '-')}>).\n`
 		);
 	}
 
 	if (monster.name.includes('Revenant')) {
 		str.push(
-			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${prefix}/bosses/wildy/#revenants>).\n`
+			`View information, item costs, boosts and requirements for ${name} on the [wiki](<${wikiPrefix}/bosses/wildy/#revenants>).\n`
 		);
 	}
 


### PR DESCRIPTION
### Description:

A few fixes for `/k show_info:true`.

### Changes:

- Replace ' ' search with global regex, so all instances of whitespace are changed instead of just first
- Add non-standard monster wiki links to existing objects to tidy link-finding
- Change `name` to actual name in text, so alias isn't used

### Other checks:

- [x] I have tested all my changes thoroughly.
