### PR TITLE
fix broken bso gear items

### DIFF
--- a/src/lib/bankImage.ts
+++ b/src/lib/bankImage.ts
@@ -463,11 +463,11 @@ export class BankImageTask {
 			}
 		}
 
-		const data = this.spriteSheetData[itemID] ?? this.bsoSpriteSheetData[itemID];
+		const data = this.bsoSpriteSheetData[itemID] ?? this.spriteSheetData[itemID];
 		if (data) {
 			const [sX, sY, width, height] = data;
 			const image = await getClippedRegionImage(
-				this.spriteSheetData[itemID] ? this.spriteSheetImage : this.bsoSpriteSheetImage,
+				this.bsoSpriteSheetData[itemID] ? this.bsoSpriteSheetImage : this.spriteSheetImage,
 				sX,
 				sY,
 				width,


### PR DESCRIPTION
### Description:
Fix broken bso gear items

### Changes:
- change the order of which sprite sheet is checked for `getItemImage`
  - bso virtus robe top (id 983) & osb brass key (id 983) overlap and cause image conflicts

### Other checks:
- [X] I have tested all my changes thoroughly.
- closes: https://github.com/oldschoolgg/oldschoolbot/issues/6274#issue-2762017436

before:
![Discord_4yN97KKLpR](https://github.com/user-attachments/assets/49a64f79-cfd6-4988-8374-51fb67ca8f19)
after:
![Discord_8p4pFEYVO8](https://github.com/user-attachments/assets/a4413f82-1112-4907-91c5-6de1b7749c6c)

