### PR TITLE
Remove snooze spell activity from music cape requirments

### DIFF
--- a/src/lib/musicCape.ts
+++ b/src/lib/musicCape.ts
@@ -149,7 +149,8 @@ export const musicCapeRequirements = new Requirements()
 				activity_type_enum.Revenants, // This is now under monsterActivity,
 				activity_type_enum.HalloweenMiniMinigame,
 				activity_type_enum.Mortimer,
-				activity_type_enum.BirthdayCollectIngredients
+				activity_type_enum.BirthdayCollectIngredients,
+				activity_type_enum.SnoozeSpellActive
 			];
 			const notDoneActivities = Object.values(activity_type_enum).filter(
 				type => !typesNotRequiredForMusicCape.includes(type) && !uniqueActivitiesDone.includes(type)


### PR DESCRIPTION
### Description:
Remove snooze spell activity from music cape requirements since this is a seasonal activity. 

### Changes:
- add `activity_type_enum.SnoozeSpellActive` to `typesNotRequiredForMusicCape`

### Other checks:
- [X] I have tested all my changes thoroughly.
