### PR TITLE
Announce Nex Purples and add CL highlight to solo pics

### DIFF
--- a/src/lib/minions/functions/announceLoot.ts
+++ b/src/lib/minions/functions/announceLoot.ts
@@ -22,20 +22,18 @@ export default async function announceLoot({
 	const notifyDrops = _notifyDrops.flat(Number.POSITIVE_INFINITY);
 	const itemsToAnnounce = loot.clone().filter(i => notifyDrops.includes(i.id));
 	if (itemsToAnnounce.length > 0) {
+		const recipient = team && team.size > 1 ? team.lootRecipient : user;
 		let notif = '';
+		const monsterName = effectiveMonsters.find(m => m.id === monsterID)?.name;
+		const kc = await recipient.getKC(monsterID);
 
 		if (team && team.size > 1) {
-			notif = `In ${team.leader.badgedUsername}'s party of ${team.size} minions killing ${
-				effectiveMonsters.find(m => m.id === monsterID)?.name
-			}, **${team.lootRecipient.badgedUsername}** just received **${itemsToAnnounce}**!`;
-		} else {
-			const kc = await user.getKC(monsterID);
-			notif = `**${user.badgedUsername}'s** minion, ${minionName(
-				user
-			)}, just received **${itemsToAnnounce}**, their ${
-				effectiveMonsters.find(m => m.id === monsterID)?.name
-			} KC is ${kc.toLocaleString()}!`;
+			notif += `In ${team.leader.badgedUsername}'s party of ${team.size} minions killing ${monsterName}, `;
 		}
+
+		notif += `**${recipient.badgedUsername}'s** minion, **${minionName(
+			recipient
+		)}**, just received **${itemsToAnnounce}**, their ${monsterName} KC is ${kc.toLocaleString()}!`;
 
 		globalClient.emit(Events.ServerNotification, notif);
 	}

--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -132,7 +132,7 @@ export interface NexContext {
 	team: { id: string; teamID: number; contribution: number; deaths: number[]; fake?: boolean }[];
 }
 
-const purpleNexItems = resolveItems([
+export const purpleNexItems = resolveItems([
 	'Nexling',
 	'Ancient hilt',
 	'Nihil horn',


### PR DESCRIPTION
### Description:

At the moment, loot pics from solo nex do not feature purple highlights for new cl items, and there is no server notification when you get a purple (solo or mass), unlike other content. 

### Changes:

- Add `previousCL` to solo loot pic at Nex so new items are highlighted 
- Implement `annouceLoot` for Nex server notifications

### Other checks:

- [x] I have tested all my changes thoroughly.
