### PR TITLE
Toggle to disable pets when opening items

### DIFF
--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -47,7 +47,7 @@ import { mahojiUsersSettingsFetch } from '../mahojiSettings';
 
 export const gifs = [
 	'https://tenor.com/view/angry-stab-monkey-knife-roof-gif-13841993',
-	'https://gfycat.com/serenegleamingfruitbat',
+	'https://tenor.com/view/bat-fruit-bat-eating-gif-26036539',
 	'https://tenor.com/view/monkey-monito-mask-gif-23036908'
 ];
 

--- a/src/mahoji/commands/open.ts
+++ b/src/mahoji/commands/open.ts
@@ -57,13 +57,19 @@ export const openCommand: OSBMahojiCommand = {
 					value: i.name
 				}));
 			}
+		},
+		{
+			type: ApplicationCommandOptionType.Boolean,
+			name: 'disable_pets',
+			description: 'Disables octo & smokey when opening.',
+			required: false
 		}
 	],
 	run: async ({
 		userID,
 		options,
 		interaction
-	}: CommandRunOptions<{ name?: string; quantity?: number; open_until?: string }>) => {
+	}: CommandRunOptions<{ name?: string; quantity?: number; open_until?: string; disable_pets?: boolean }>) => {
 		if (interaction) await deferInteraction(interaction);
 		const user = await mUserFetch(userID);
 		if (!options.name) {
@@ -74,11 +80,11 @@ export const openCommand: OSBMahojiCommand = {
 		}
 		options.quantity = clamp(options.quantity ?? 1, 1, 100_000_000);
 		if (options.open_until) {
-			return abstractedOpenUntilCommand(user.id, options.name, options.open_until);
+			return abstractedOpenUntilCommand(user.id, options.name, options.open_until, options.disable_pets);
 		}
 		if (options.name.toLowerCase() === 'all') {
-			return abstractedOpenCommand(interaction, user.id, ['all'], 'auto');
+			return abstractedOpenCommand(interaction, user.id, ['all'], 'auto', false);
 		}
-		return abstractedOpenCommand(interaction, user.id, [options.name], options.quantity);
+		return abstractedOpenCommand(interaction, user.id, [options.name], options.quantity, options.disable_pets);
 	}
 };

--- a/src/mahoji/lib/abstracted_commands/farmingContractCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingContractCommand.ts
@@ -186,7 +186,7 @@ export async function autoContract(user: MUser, channelID: string, userID: strin
 	const bestContractTierCanDo = bestFarmingContractUserCanDo(user);
 
 	if (user.owns('Seed pack')) {
-		const openResponse = await abstractedOpenCommand(null, user.id, ['seed pack'], 'auto');
+		const openResponse = await abstractedOpenCommand(null, user.id, ['seed pack'], 'auto', false);
 		const contractResponse = await farmingContractCommand(userID, bestContractTierCanDo);
 		return roughMergeMahojiResponse(openResponse, contractResponse);
 	}

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -28,7 +28,12 @@ export const OpenUntilItems = uniqueArr(allOpenables.map(i => i.allItems).flat(2
 		return 0;
 	});
 
-export async function abstractedOpenUntilCommand(userID: string, name: string, openUntilItem: string) {
+export async function abstractedOpenUntilCommand(
+	userID: string,
+	name: string,
+	openUntilItem: string,
+	disable_pets: boolean | undefined
+) {
 	const user = await mUserFetch(userID);
 	const perkTier = user.perkTier();
 	if (perkTier < PerkTier.Three) return patronMsg(PerkTier.Three);
@@ -90,7 +95,8 @@ export async function abstractedOpenUntilCommand(userID: string, name: string, o
 			}`
 		],
 		openables: [openable],
-		kcBank: new Bank().add(openable.openedItem.id, amountOpened)
+		kcBank: new Bank().add(openable.openedItem.id, amountOpened),
+		disable_pets: Boolean(disable_pets)
 	});
 }
 
@@ -114,7 +120,8 @@ async function finalizeOpening({
 	loot,
 	messages,
 	openables,
-	kcBank
+	kcBank,
+	disable_pets
 }: {
 	kcBank: Bank;
 	user: MUser;
@@ -122,12 +129,13 @@ async function finalizeOpening({
 	loot: Bank;
 	messages: string[];
 	openables: UnifiedOpenable[];
+	disable_pets: boolean;
 }) {
 	if (!user.bank.has(cost)) return `You don't have ${cost}.`;
 	const newOpenableScores = await addToOpenablesScores(user, kcBank);
 
-	const hasSmokey = user.allItemsOwned.has('Smokey');
-	const hasOcto = user.allItemsOwned.has('Octo');
+	const hasSmokey = !disable_pets && user.allItemsOwned.has('Smokey');
+	const hasOcto = !disable_pets && user.allItemsOwned.has('Octo');
 	let smokeyMsg: string | null = null;
 
 	if (hasSmokey || hasOcto) {
@@ -255,7 +263,8 @@ export async function abstractedOpenCommand(
 	interaction: ChatInputCommandInteraction | null,
 	userID: string,
 	_names: string[],
-	_quantity: number | 'auto' = 1
+	_quantity: number | 'auto',
+	disable_pets: boolean | undefined
 ) {
 	const user = await mUserFetch(userID);
 	const favorites = user.user.favoriteItems;
@@ -319,5 +328,5 @@ export async function abstractedOpenCommand(
 		if (thisLoot.message) messages.push(thisLoot.message);
 	}
 
-	return finalizeOpening({ user, cost, loot, messages, openables, kcBank });
+	return finalizeOpening({ user, cost, loot, messages, openables, kcBank, disable_pets: Boolean(disable_pets) });
 }


### PR DESCRIPTION
### Description:
add `disable_pets` to `/open` command

### Changes:
- add `disable_pets` to `/open` command mainly for use when users want to gamble but don't want to have octo/smokey roll extra loot.
- add a new gif since gfycat.com no longer exists

### Other checks:
- [X] I have tested all my changes thoroughly.
