### PR TITLE
Add 'onTask' flag for repeating monsterkilling trips

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -446,7 +446,8 @@ const tripHandlers = {
 				name: autocompleteMonsters.find(i => i.id === data.mi)?.name ?? data.mi.toString(),
 				quantity: data.iQty,
 				method,
-				wilderness: data.isInWilderness
+				wilderness: data.isInWilderness,
+				onTask: data.onTask
 			};
 		}
 	},


### PR DESCRIPTION
### Description:

A change was missing when remaking the PR for #6185 / #6213, needs `onTask` flag for repeat trip for logic to work 

### Changes:

Add `onTask` property to trip handler data for monsterkilling

### Other checks:

- [x] I have tested all my changes thoroughly.
