### PR TITLE
Limit clue quantity to maximum allowed based on trip length

### DIFF
--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -364,7 +364,7 @@ export const clueCommand: OSBMahojiCommand = {
 
 		const maxCanDo = Math.floor(maxTripLength / timePerClue);
 
-		quantity = quantity ?? maxCanDo;
+		quantity = quantity ? Math.min(quantity, maxCanDo) : maxCanDo;
 
 		const response: Awaited<CommandResponse> = {};
 


### PR DESCRIPTION
### Description:

Fixes clue bug where trip is not sent if quantity is too high, but clues are removed anyway

### Changes:

- Crop `quantity` to `maxCanDo` for clues

### Other checks:

- [x] I have tested all my changes thoroughly.
