### PR TITLE
Fix formatting in loot announcement message

### DIFF
--- a/src/lib/minions/functions/announceLoot.ts
+++ b/src/lib/minions/functions/announceLoot.ts
@@ -31,9 +31,9 @@ export default async function announceLoot({
 			notif += `In ${team.leader.badgedUsername}'s party of ${team.size} minions killing ${monsterName}, `;
 		}
 
-		notif += `**${recipient.badgedUsername}'s** minion, **${minionName(
+		notif += `**${recipient.badgedUsername}'s** minion, ${minionName(
 			recipient
-		)}**, just received **${itemsToAnnounce}**, their ${monsterName} KC is ${kc.toLocaleString()}!`;
+		)}, just received **${itemsToAnnounce}**, their ${monsterName} KC is ${kc.toLocaleString()}!`;
 
 		globalClient.emit(Events.ServerNotification, notif);
 	}


### PR DESCRIPTION
### Description:

At the moment, minion names have ** formatting twice which causes mismatch (once in `announceLoot`, once in `minionName`)
![image](https://github.com/user-attachments/assets/78d82e63-374a-4912-aa7d-98341e478699)

### Changes:

- Remove redundant bold formatting from minion name in `announceLoot`

### Other checks:

- [x] I have tested all my changes thoroughly.
