### PR TITLE
Fix 1/128 chance of integration tests failing due to Skotizo dropping dark totem

### DIFF
--- a/tests/integration/pvm/pvm.test.ts
+++ b/tests/integration/pvm/pvm.test.ts
@@ -257,7 +257,7 @@ describe('PVM', async () => {
 		});
 		const result = await user.kill(EMonster.SKOTIZO, { quantity: 1 });
 		expect(result.commandResult).toContain('is now killing 1x Skotizo');
-		expect(user.bank.amount('Dark totem')).toBe(99);
+		expect(result.tripStartBank.amount('Dark totem')).toBe(99);
 	});
 
 	describe(

--- a/tests/integration/util.ts
+++ b/tests/integration/util.ts
@@ -160,6 +160,7 @@ export class TestUser extends MUserClass {
 		if (shouldFail) {
 			expect(commandResult).not.toContain('is now killing');
 		}
+		const tripStartBank = this.bank.clone();
 		const activityResult = (await this.runActivity()) as MonsterActivityTaskOptions | undefined;
 		const newKC = await this.getKC(monster);
 		const newXP = clone(this.skillsAsXP);
@@ -169,7 +170,7 @@ export class TestUser extends MUserClass {
 			xpGained[skill as SkillNameType] = newXP[skill] - currentXP[skill];
 		}
 
-		return { commandResult, newKC, xpGained, previousBank, activityResult };
+		return { commandResult, newKC, xpGained, previousBank, tripStartBank, activityResult };
 	}
 
 	async runCommand(command: OSBMahojiCommand, options: object = {}, syncAfter = false) {


### PR DESCRIPTION
### Description:

Currently integration test for Skotizo checks for 1 totem less in bank after trip. But wont be true if Skotizo drops it when killed

### Changes:

- Add `tripStartBank` to integration test kill result that contains bank after sending command, but before trip finishes
- Check this bank for Skotizo totem check

### Other checks:

- [x] I have tested all my changes thoroughly.
