### PR TITLE
Update Barrows elite clue rate and allow elite CA to boost odds

### DIFF
--- a/packages/oldschooljs/src/simulation/monsters/special/Barrows.ts
+++ b/packages/oldschooljs/src/simulation/monsters/special/Barrows.ts
@@ -1,5 +1,6 @@
 import { roll } from 'e';
 
+import type { MonsterKillOptions } from '../../../meta/types';
 import Bank from '../../../structures/Bank';
 import LootTable from '../../../structures/LootTable';
 import Monster from '../../../structures/Monster';
@@ -48,16 +49,16 @@ const OtherTable = new LootTable()
 	.add(new LootTable().add('Loop half of key').add('Tooth half of key'), 1, 6)
 	.add('Dragon med helm');
 
-const ClueTable = new LootTable().tertiary(34, 'Clue scroll (elite)');
+const ClueTable = new LootTable().tertiary(29, 'Clue scroll (elite)');
 
 const NUMBER_OF_BROTHERS = 6;
 
 export class Barrows extends Monster {
-	public kill(quantity = 1): Bank {
+	public kill(quantity: number, options: MonsterKillOptions): Bank {
 		const loot = new Bank();
 
 		for (let i = 0; i < quantity; i++) {
-			ClueTable.roll(1, { targetBank: loot });
+			ClueTable.roll(1, { ...options.lootTableOptions, targetBank: loot });
 
 			// We use a set to track items received, you cannot get
 			// the same item twice per chest.


### PR DESCRIPTION
### Description:

Update base rate for elite clues from barrows to 1/29 to match [wiki](https://oldschool.runescape.wiki/w/Chest_(Barrows)#Tertiary) and add `lootTableOptions` to clue table roll so chance can be increased with combat achievement completion.
Partially closes #6306 

### Changes:

- Change elite rate for Barrows from 1/34 to 1/29
- Add `MonsterKillOptions` to `kill` and `ClueTable`, just like regular monsters

### Other checks:

- [x] I have tested all my changes thoroughly.
