### PR TITLE
Fix team appearance/size display and skip text channel check for solo Nex

### DIFF
--- a/src/lib/simulation/nex.ts
+++ b/src/lib/simulation/nex.ts
@@ -146,8 +146,8 @@ export function handleNexKills({ quantity, team }: NexContext) {
 	const teamLoot = new TeamLoot(purpleNexItems);
 
 	for (let i = 0; i < quantity; i++) {
-		// VIP logic: perturb contribution 10%, VIP is choisen randonmly with perturbed contirubtion as weight
-		// Unique loot chance also used perturbed contribution as weight
+		// VIP logic: perturb contribution by 10%, VIP is chosen randomly with perturbed contribution as weight
+		// The unique loot chance also uses the perturbed contribution as weight
 
 		const survivors = team
 			.filter(u => !u.deaths.includes(i))
@@ -173,7 +173,7 @@ export function handleNexKills({ quantity, team }: NexContext) {
 		for (const teamMember of survivors.filter(m => !m.fake)) {
 			const VIPBonus = teamMember.teamID === VIP ? 1.1 : 1;
 
-			teamLoot.add(teamMember.id, nonUniqueDrop.multiply(VIPBonus)); // VIPBonus may not be int, loot amounts rounded down in multply
+			teamLoot.add(teamMember.id, nonUniqueDrop.multiply(VIPBonus)); // VIPBonus may not be an integer, loot amounts rounded down in multiply
 
 			if (teamMember.teamID === VIP) teamLoot.add(teamMember.id, 'Big bones');
 

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -624,7 +624,7 @@ export function minionStatus(user: MUser) {
 			const data = currentTask as NexTaskOptions;
 			const durationRemaining = data.finishDate - data.duration + data.fakeDuration - Date.now();
 			return `${name} is currently killing Nex ${data.quantity} times with a team of ${
-				data.users.length
+				data.teamDetails.length
 			}. The trip should take ${formatDuration(durationRemaining)}.`;
 		}
 		case 'TroubleBrewing': {

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -118,7 +118,7 @@ export async function nexCommand(
 
 	const str = `${user.usernameOrMention}'s party (${mahojiUsers
 		.map(u => u.usernameOrMention)
-		.join(', ')}) is now off to kill ${details.quantity}x Nex! (${calcPerHour(
+		.join(', ')}${solo ? ' and 3 others' : ''}) is now off to kill ${details.quantity}x Nex! (${calcPerHour(
 		details.quantity,
 		details.fakeDuration
 	).toFixed(1)}/hr) - the total trip will take ${formatDuration(details.fakeDuration)}.

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -17,9 +17,6 @@ export async function nexCommand(
 	channelID: string,
 	solo: boolean | undefined
 ) {
-	const channel = globalClient.channels.cache.get(channelID.toString());
-	if (!channel || channel.type !== ChannelType.GuildText) return 'You need to run this in a text channel.';
-
 	const ownerCheck = checkNexUser(user);
 	if (ownerCheck[1]) {
 		return `You can't start a Nex mass: ${ownerCheck[1]}`;
@@ -32,6 +29,9 @@ export async function nexCommand(
 	if (solo) {
 		mahojiUsers = [user];
 	} else {
+		const channel = globalClient.channels.cache.get(channelID.toString());
+		if (!channel || channel.type !== ChannelType.GuildText) return 'You need to run this in a text channel.';
+
 		let usersWhoConfirmed: MUser[] = [];
 		try {
 			usersWhoConfirmed = await setupParty(channel as TextChannel, user, {


### PR DESCRIPTION
### Description:

Adds generic 'and 3 others' to solo nex party on trip send, and include fake team members on `/minion status` team size. Move text channel check out of solo logic so that solo nex can be done in non-text channels (eg bot DMs) 

### Changes:

- Add 'and 3 others' to solo nex party on trip send
- use `teamDetails` instead of `users` for nex status, so true team size is given 
- Move text channel check so it only applies when creating party for mass
- Fix some typos in comments

### Other checks:

- [x] I have tested all my changes thoroughly.
