### PR TITLE
Fix consumable requirement messages for monsters

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -190,7 +190,7 @@ export function formatItemCosts(consumable: Consumable, timeToFinish: number) {
 	}
 
 	if (consumables.length > 1) {
-		return `${formatList(str, 'or')}`;
+		return str.join(' OR ');
 	}
 
 	return str.join('');

--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -19,6 +19,7 @@ import {
 	anglerBoosts,
 	formatItemCosts,
 	formatItemReqs,
+	formatList,
 	hasSkillReqs,
 	itemNameFromID,
 	readableStatName,
@@ -329,16 +330,12 @@ export async function hasMonsterRequirements(user: MUser, monster: KillableMonst
 				if (user.owns(consumablesCost.itemCost.filter(i => group.itemCost.has(i)))) {
 					continue;
 				}
-				if (
-					!group.alternativeConsumables?.some(alt =>
-						user.owns(consumablesCost.itemCost.filter(i => alt.itemCost.has(i)))
-					)
-				) {
-					continue;
-				}
-				messages.push(`This monster requires (per kill) ${formatItemCosts(group, timeToFinish)}.`);
+				messages.push(formatItemCosts(group, timeToFinish));
 			}
-			return [false, `You don't have the items needed to kill this monster. ${messages.join(' ')}`];
+			return [
+				false,
+				`You don't have the items needed to kill ${monster.name}. This monster requires (per kill) ${formatList(messages)}.`
+			];
 		}
 	}
 


### PR DESCRIPTION
### Description:

Currently there is an unnecessary alternative item cost check that is removing message for item costs that don't have alternatives. Also tidies the item cost message a bit.

### Changes:

- Removes unnecessary `alternativeConsumables` check (already done in `getItemCostFromConsumables`).
- Shortens output text for item costs and improves readability. 

### Other checks:

- [x] I have tested all my changes thoroughly.
