### PR TITLE
Fix clues with implings

### DIFF
--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -373,8 +373,8 @@ export const clueCommand: OSBMahojiCommand = {
 		const bankedClues = user.bank.amount(clueTier.scrollID);
 
 		let cluesDone = 0;
-		if (!clueImpling || quantity > 1) {
-			quantity = Math.min(quantity, bankedClues) || 1;
+		if (!clueImpling || bankedClues > 0) {
+			quantity = Math.min(quantity, bankedClues);
 
 			const cost = new Bank().add(clueTier.scrollID, quantity);
 			if (!user.owns(cost)) return `You don't own ${cost}.`;


### PR DESCRIPTION
### Description:

This allows the bot to run clues with implings again.

### Changes:

-Correctly checks `cluesBanked`.

### Other checks:

- [x] I have tested all my changes thoroughly.
