### PR TITLE
Fix Easter giving multiple identical drops when CL complete

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -531,7 +531,6 @@ export async function handleTripFinish(
 
 	const minutes = Math.floor(data.duration / Time.Minute);
 	if (minutes >= 1) {
-		const shuffledEasterItems = shuffleArr(easterEventMainTable);
 		let effectiveTastyPetChance = tastyPetChance;
 		let effectiveEasterItemChance = easterEventItemChance;
 
@@ -572,6 +571,7 @@ Easter Event:
 				}
 			}
 			if (!roll(effectiveEasterItemChance)) continue;
+			const shuffledEasterItems = shuffleArr(easterEventMainTable);
 			const unownedItem = shuffledEasterItems.find(_item => !effectiveCl.has(_item)) ?? shuffledEasterItems[0];
 			if (unownedItem) {
 				effectiveCl.add(unownedItem);


### PR DESCRIPTION
### Description:

Moves the shuffle to a location that shuffles exactly as many times as needed, instead of just once.

Alternatively, you could simply change the `?? shuffledArray[0]` to `?? shuffledArray.shift()`, but I didn't test that and it could, in theory, underrun.

### Changes:



### Other checks:

- [ ] I have tested all my changes thoroughly.
