### PR TITLE
Fix silent interaction inhibitors

### DIFF
--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -110,7 +110,6 @@ export async function runCommand({
 	continueDeltaMillis,
 	ephemeral
 }: RunCommandArgs): Promise<null | CommandResponse> {
-	await deferInteraction(interaction);
 	const channel = globalClient.channels.cache.get(channelID);
 	const mahojiCommand = Array.from(globalClient.mahojiClient.commands.values()).find(c => c.name === commandName);
 	if (!mahojiCommand || !channelIsSendable(channel)) {
@@ -145,10 +144,12 @@ export async function runCommand({
 
 			await interactionReply(interaction, {
 				content: response,
-				ephemeral: true
+				ephemeral: inhibitedReason.silent
 			});
 			return null;
 		}
+
+		await deferInteraction(interaction, ephemeral);
 
 		const result = await runMahojiCommand({
 			options: args,

--- a/src/mahoji/lib/preCommand.ts
+++ b/src/mahoji/lib/preCommand.ts
@@ -21,6 +21,7 @@ type PrecommandReturn = Promise<
 	| {
 			reason: InteractionReplyOptions;
 			dontRunPostCommand?: boolean;
+			silent?: boolean;
 	  }
 >;
 


### PR DESCRIPTION
### Description:

Closes #6380. 

Adds correct `ephemeral` (i.e. private message) property to inhibitor replies based on if error should be silent / sent privately or not. I am assuming that's what the `silent` flags are for in the inhibitor definitions - they aren't used anywhere after being defined atm. 

As `deferInteraction` fixes whether a reply is private, deferring needs to be done after the inhibitor checks in case the normal response needs to be public. Shouldn't be an issue as all the checks are fast enough, but can't thoroughly test. 

I've added `ephemeral` to the defer interaction as it is a parameter in the function, but it is unused. Any messages that should be private (e.g. 'slayer task assigned') need to have their commands fixed.

### Changes:

- Delay `deferInteraction` until after inhibitor checks, so that `ephemeral` flag can be used correctly - as defined in from `runCommand`  input. 
- Set Inhibitor checks to be `ephemeral` based on underlying inhibitor `silent` flag. 

### Other checks:

- [ ] I have tested all my changes thoroughly.
