### PR TITLE
Fix Superior Tormented Demons alias

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -798,7 +798,7 @@ export const allCollectionLogs: ICollection = {
 			},
 			'Superior Tormented Demons': {
 				items: superiorTormentedDemonCL,
-				alias: ['td', 'tormented demon', 'tormented demons'],
+				alias: ['superior tormented demon', 'std', 'stds', 'sup torm', 'sup torm demon', 'superior tormented demons'],
 				fmtProg: kcProg(BSOMonsters.SuperiorTormentedDemon.id)
 			},
 			"Champion's Challenge": {

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -798,7 +798,14 @@ export const allCollectionLogs: ICollection = {
 			},
 			'Superior Tormented Demons': {
 				items: superiorTormentedDemonCL,
-				alias: ['superior tormented demon', 'std', 'stds', 'sup torm', 'sup torm demon', 'superior tormented demons'],
+				alias: [
+					'superior tormented demon',
+					'std',
+					'stds',
+					'sup torm',
+					'sup torm demon',
+					'superior tormented demons'
+				],
 				fmtProg: kcProg(BSOMonsters.SuperiorTormentedDemon.id)
 			},
 			"Champion's Challenge": {


### PR DESCRIPTION
### Description:
Differentiate the alias to prevent overriding the normal tormented demons when using bank filter or cl.

### Changes:
- Update `Superior Tormented Demons` alias

### Other checks:
- [X] I have tested all my changes thoroughly.
- closes: https://github.com/oldschoolgg/oldschoolbot/issues/6269
