### PR TITLE
Sand gecko buff

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -799,7 +799,7 @@ const globalConfigSchema = z.object({
 	isProduction: z.boolean(),
 	timeZone: z.literal('UTC'),
 	sentryDSN: z.string().url().optional(),
-	adminUserIDs: z.array(z.string()).default(['157797566833098752', '425134194436341760', '610666234836418581']),
+	adminUserIDs: z.array(z.string()).default(['157797566833098752', '425134194436341760']),
 	maxingMessage: z.string().default('Congratulations on maxing!'),
 	moderatorLogsChannels: z.string().default(''),
 	supportServerID: z.string()

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -799,7 +799,7 @@ const globalConfigSchema = z.object({
 	isProduction: z.boolean(),
 	timeZone: z.literal('UTC'),
 	sentryDSN: z.string().url().optional(),
-	adminUserIDs: z.array(z.string()).default(['157797566833098752', '425134194436341760']),
+	adminUserIDs: z.array(z.string()).default(['157797566833098752', '425134194436341760', '610666234836418581']),
 	maxingMessage: z.string().default('Congratulations on maxing!'),
 	moderatorLogsChannels: z.string().default(''),
 	supportServerID: z.string()

--- a/src/lib/skilling/skills/hunter/creatures/bso.ts
+++ b/src/lib/skilling/skills/hunter/creatures/bso.ts
@@ -1,6 +1,7 @@
 import { Bank, LootTable } from 'oldschooljs';
 
 import { type Creature, HunterTechniqueEnum } from '../../../types';
+import { MysteryBoxes } from '../../../../bsoOpenables';
 
 const customBSOCreatures: Creature[] = [
 	{
@@ -10,15 +11,8 @@ const customBSOCreatures: Creature[] = [
 		level: 120,
 		hunterXP: 2100,
 		table: new LootTable()
-			.tertiary(
-				22,
-				new LootTable()
-					.oneIn(90, 'Pet Mystery Box')
-					.oneIn(30, 'Equippable mystery box')
-					.add('Tradeable Mystery Box')
-					.add('Untradeable Mystery Box')
-			)
-			.tertiary(500, 'Clue scroll (hard)')
+			.tertiary(8, MysteryBoxes)
+			.tertiary(200, 'Clue scroll (grandmaster)')
 			.tertiary(5, 'Sand')
 			.tertiary(10, 'Sandworms', [2, 20]),
 		qpRequired: 3,

--- a/src/lib/skilling/skills/hunter/creatures/bso.ts
+++ b/src/lib/skilling/skills/hunter/creatures/bso.ts
@@ -1,7 +1,7 @@
 import { Bank, LootTable } from 'oldschooljs';
 
-import { type Creature, HunterTechniqueEnum } from '../../../types';
 import { MysteryBoxes } from '../../../../bsoOpenables';
+import { type Creature, HunterTechniqueEnum } from '../../../types';
 
 const customBSOCreatures: Creature[] = [
 	{

--- a/src/mahoji/commands/hunt.ts
+++ b/src/mahoji/commands/hunt.ts
@@ -67,7 +67,7 @@ export function calculateHunterInput({
 	let wildyScore = 0;
 
 	if (
-		creature.id === 3251 &&
+		creature.name === 'Sand Gecko' &&
 		(skillsAsLevels.hunter < 120 || skillsAsLevels.agility < 99 || skillsAsLevels.fishing < 99)
 	) {
 		return "You need level 120 Hunter, 99 Agility, 99 Fishing to hunt Sand Gecko's.";
@@ -348,7 +348,7 @@ export const huntCommand: OSBMahojiCommand = {
 
 		const hunterInputArgs: Parameters<typeof calculateHunterInput>['0'] = {
 			creature,
-			hasHunterMasterCape: user.hasEquipped('Hunter master cape'),
+			hasHunterMasterCape: user.hasEquippedOrInBank('Hunter master cape'),
 			hasGraceful: userHasGracefulEquipped(user),
 			maxTripLength,
 			quantityInput: options.quantity,

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -391,7 +391,9 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 							required: false,
 							autocomplete: async value => {
 								return Object.entries(BitFieldData)
-									.filter(bf => (!value ? true : bf[1].name.toLowerCase().includes(value.toLowerCase())))
+									.filter(bf =>
+										!value ? true : bf[1].name.toLowerCase().includes(value.toLowerCase())
+									)
 									.map(i => ({ name: i[1].name, value: i[0] }));
 							}
 						},
@@ -402,7 +404,9 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 							required: false,
 							autocomplete: async value => {
 								return Object.entries(BitFieldData)
-									.filter(bf => (!value ? true : bf[1].name.toLowerCase().includes(value.toLowerCase())))
+									.filter(bf =>
+										!value ? true : bf[1].name.toLowerCase().includes(value.toLowerCase())
+									)
 									.map(i => ({ name: i[1].name, value: i[0] }));
 							}
 						}
@@ -618,7 +622,7 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 							.join('\n');
 					}
 					const bit = Number.parseInt(bitEntry[0]);
-		
+
 					if (
 						!bit ||
 						!(BitFieldData as any)[bit] ||
@@ -627,9 +631,9 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 					) {
 						return 'Invalid bitfield.';
 					}
-		
+
 					let newBits = [...user.bitfield];
-		
+
 					if (action === 'add') {
 						if (newBits.includes(bit)) {
 							return "Already has this bit, so can't add.";
@@ -641,11 +645,11 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 						}
 						newBits = newBits.filter(i => i !== bit);
 					}
-		
+
 					await user.update({
 						bitfield: uniqueArr(newBits)
 					});
-		
+
 					return `${action === 'add' ? 'Added' : 'Removed'} '${(BitFieldData as any)[bit].name}' bit.`;
 				}
 				if (options.bingo_tools) {

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -4,7 +4,7 @@ import type { Prisma } from '@prisma/client';
 import { tame_growth, xp_gains_skill_enum } from '@prisma/client';
 import type { User } from 'discord.js';
 import { ApplicationCommandOptionType } from 'discord.js';
-import { Time, noOp } from 'e';
+import { Time, noOp, uniqueArr } from 'e';
 import { Bank, Items, calcDropRatesFromBankWithoutUniques } from 'oldschooljs';
 import { itemID, toKMB } from 'oldschooljs/dist/util';
 
@@ -12,7 +12,7 @@ import { getItem, resolveItems } from 'oldschooljs/dist/util/util';
 import { mahojiUserSettingsUpdate } from '../../lib/MUser';
 import { allStashUnitTiers, allStashUnitsFlat } from '../../lib/clues/stashUnits';
 import { CombatAchievements } from '../../lib/combat_achievements/combatAchievements';
-import { MAX_INT_JAVA, MAX_XP, globalConfig } from '../../lib/constants';
+import { BitFieldData, MAX_INT_JAVA, MAX_XP, globalConfig } from '../../lib/constants';
 import { Eatables } from '../../lib/data/eatables';
 import { TOBMaxMageGear, TOBMaxMeleeGear, TOBMaxRangeGear } from '../../lib/data/tob';
 import killableMonsters, { effectiveMonsters } from '../../lib/minions/data/killableMonsters';
@@ -381,40 +381,30 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 				},
 				{
 					type: ApplicationCommandOptionType.Subcommand,
-					name: 'patron',
-					description: 'Set your patron perk level.',
+					name: 'bitfield',
+					description: 'Manage your bitfields',
 					options: [
 						{
 							type: ApplicationCommandOptionType.String,
-							name: 'tier',
-							description: 'The patron tier to give yourself.',
-							required: true,
-							choices: [
-								{
-									name: 'Non-patron',
-									value: '0'
-								},
-								{
-									name: 'Tier 1',
-									value: '1'
-								},
-								{
-									name: 'Tier 2',
-									value: '2'
-								},
-								{
-									name: 'Tier 3',
-									value: '3'
-								},
-								{
-									name: 'Tier 4',
-									value: '4'
-								},
-								{
-									name: 'Tier 5',
-									value: '5'
-								}
-							]
+							name: 'add',
+							description: 'The bitfield to add',
+							required: false,
+							autocomplete: async value => {
+								return Object.entries(BitFieldData)
+									.filter(bf => (!value ? true : bf[1].name.toLowerCase().includes(value.toLowerCase())))
+									.map(i => ({ name: i[1].name, value: i[0] }));
+							}
+						},
+						{
+							type: ApplicationCommandOptionType.String,
+							name: 'remove',
+							description: 'The bitfield to remove',
+							required: false,
+							autocomplete: async value => {
+								return Object.entries(BitFieldData)
+									.filter(bf => (!value ? true : bf[1].name.toLowerCase().includes(value.toLowerCase())))
+									.map(i => ({ name: i[1].name, value: i[0] }));
+							}
 						}
 					]
 				},
@@ -586,7 +576,7 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 				userID
 			}: CommandRunOptions<{
 				max?: {};
-				patron?: { tier: string };
+				bitfield?: { add?: string; remove?: string };
 				gear?: { thing: string };
 				reset?: { thing: string };
 				setminigamekc?: { minigame: string; kc: number };
@@ -617,6 +607,46 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 						}
 					});
 					return events.map(userEventToStr).join('\n');
+				}
+				if (options.bitfield) {
+					const bitInput = options.bitfield.add ?? options.bitfield.remove;
+					const bitEntry = Object.entries(BitFieldData).find(i => i[0] === bitInput);
+					const action: 'add' | 'remove' = options.bitfield.add ? 'add' : 'remove';
+					if (!bitEntry) {
+						return Object.entries(BitFieldData)
+							.map(entry => `**${entry[0]}:** ${entry[1]?.name}`)
+							.join('\n');
+					}
+					const bit = Number.parseInt(bitEntry[0]);
+		
+					if (
+						!bit ||
+						!(BitFieldData as any)[bit] ||
+						[7, 8].includes(bit) ||
+						(action !== 'add' && action !== 'remove')
+					) {
+						return 'Invalid bitfield.';
+					}
+		
+					let newBits = [...user.bitfield];
+		
+					if (action === 'add') {
+						if (newBits.includes(bit)) {
+							return "Already has this bit, so can't add.";
+						}
+						newBits.push(bit);
+					} else {
+						if (!newBits.includes(bit)) {
+							return "Doesn't have this bit, so can't remove.";
+						}
+						newBits = newBits.filter(i => i !== bit);
+					}
+		
+					await user.update({
+						bitfield: uniqueArr(newBits)
+					});
+		
+					return `${action === 'add' ? 'Added' : 'Removed'} '${(BitFieldData as any)[bit].name}' bit.`;
 				}
 				if (options.bingo_tools) {
 					if (options.bingo_tools.start_bingo) {

--- a/src/tasks/minions/HunterActivity/hunterActivity.ts
+++ b/src/tasks/minions/HunterActivity/hunterActivity.ts
@@ -250,7 +250,7 @@ export function calculateHunterResult({
 	}
 
 	if (equippedPet === itemID('Sandy') && creature.name !== 'Eastern ferret') {
-		if (creature.id === 3251) {
+		if (creature.name === 'Sand Gecko') {
 			if (hasHunterMasterCape) {
 				messages.push('You received **double** loot because of Sandy, and being a master hunter.');
 				loot.multiply(2);


### PR DESCRIPTION
### Description:
Revert Sand gecko's loot table back to its original loottable.

### Changes:
- Add back the original sand gecko loottable
- Allow Hunter master cape perk to work from bank similar to other master capes
- Remove and replace sand gecko id check and use name for clarity
- Remove and replace `/testpotato patron` with `/testpotato bitfield`

### Other checks:
- [X] I have tested all my changes thoroughly.
- Poll: https://discord.com/channels/342983479501389826/1032668754561224734/1350965461554302996
- closes: https://github.com/oldschoolgg/oldschoolbot/issues/6363
