### PR TITLE
Fix message for reaching 100 clues stacked and add clue stack counter

### DIFF
--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -17,7 +17,7 @@ import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
-import { petMessage } from '../../../lib/util/handleTripFinish';
+import { displayCluesAndPets } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 import { userStatsUpdate } from '../../mahojiSettings';
 
@@ -204,8 +204,8 @@ export async function barbAssaultGambleCommand(
 	);
 	const loot = new Bank().add(table.roll(quantity));
 	let str = `You spent ${(cost * quantity).toLocaleString()} Honour Points for ${quantity.toLocaleString()}x ${name} Gamble, and received...`;
+	str += displayCluesAndPets(user, loot);
 	if (loot.has('Pet Penance Queen')) {
-		str += petMessage(loot);
 		const amount = await countUsersWithItemInCl(itemID('Pet penance queen'), false);
 
 		globalClient.emit(

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -6,13 +6,12 @@ import { Bank } from 'oldschooljs';
 
 import { buildClueButtons } from '../../../lib/clues/clueUtils';
 import { BitField } from '../../../lib/constants';
-import { allPetsCL } from '../../../lib/data/CollectionsExport';
 import type { UnifiedOpenable } from '../../../lib/openables';
 import { allOpenables, getOpenableLoot } from '../../../lib/openables';
 import { makeComponents } from '../../../lib/util';
 import getOSItem, { getItem } from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
-import { petMessage } from '../../../lib/util/handleTripFinish';
+import { displayCluesAndPets } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 import { addToOpenablesScores, patronMsg, updateClientGPTrackSetting } from '../../mahojiSettings';
 
@@ -146,9 +145,9 @@ ${messages.join(', ')}`.trim(),
 		response.content =
 			'Due to opening so many things at once, you will have to download the attached text file to read the response.';
 	}
-	if (allPetsCL.some(p => loot?.has(p))) {
-		response.content += petMessage(loot);
-	}
+
+	response.content += displayCluesAndPets(user, loot);
+
 	return response;
 }
 


### PR DESCRIPTION
### Description:

Currently message for reaching 100 clues is never sent. Fixes that, and refactors to also put it in open command and barb assault gambles, which also give clues. Closes #6232.

### Changes:

- Add  `displayCluesAndPets` function that refactors message for receiving clues, showing clue stack and receiving pets. 
- Apply message in regular trip finishes and open and barb assault gamble commands.

### Other checks:

- [x] I have tested all my changes thoroughly.
