### PR TITLE
Fix Admin can use disabled commands

### DIFF
--- a/src/mahoji/lib/inhibitors.ts
+++ b/src/mahoji/lib/inhibitors.ts
@@ -90,7 +90,7 @@ const inhibitors: Inhibitor[] = [
 		name: 'disabled',
 		run: ({ command, guild, userID }) => {
 			if (
-				globalConfig.adminUserIDs.includes(userID) &&
+				!globalConfig.adminUserIDs.includes(userID) &&
 				(command.attributes?.enabled === false || DISABLED_COMMANDS.has(command.name))
 			) {
 				return { content: 'This command is globally disabled.' };


### PR DESCRIPTION
### Description:

Disabled commands were only affecting admins instead of the other way around

### Changes:

Adds negation to the admin check

### Other checks:

- [ ] I have tested all my changes thoroughly.
