### PR TITLE
Update BSO CoX wiki page: boosts, supplies, and item charges

### DIFF
--- a/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
@@ -6,30 +6,32 @@ See the [OSB wiki](https://wiki.oldschool.gg/osb/raids/cox/) for general info.
 
 ### Boosts
 
-The following items give a boost to your combat score. Only the highest available boost from each line will be applied.
+The following items grant a speed boost in Chambers of Xeric (CoX).  
+Only the highest applicable boost from each group will be applied.
 
-All boosts work from the bank unless otherwise specified. Gorajan armour does not affect gear score.
+Unless stated otherwise, items can be either equipped or in your bank to count toward the boost.
 
-- Twisted bow (7%) **OR** Bow of faerdhinen (c) (6%) **OR** Dragon hunter crossbow (5%)
-- Dragon warhammer (3%) **OR** Bandos godsword (2.5%)
-- Drygore rapier (8%)\* **OR** Dragon hunter lance (3%) **OR** Abyssal tentacle (2%)
-- Offhand drygore rapier (4%)\*
-- Void staff (8%)\*\* Sanguinesti staff (7%)
-- Chincannon (60% speed boost at cost of raid loot)\*\*\*
+> Note:  
+> - Items marked with (equipped) must be equipped in the correct gear setup  
+> - Items marked with (charged) must have enough charges to be used
 
-\* Must be equipped in melee setup
+---
 
-\*\* Must be equipped in mage setup
-
-\*\*\* Must be equipped in range setup
+- Twisted bow (7%) **OR** Bow of faerdhinen (c) (6%) **OR** Dragon hunter crossbow (5%)  
+- Dragon warhammer (3%) **OR** Bandos godsword (2.5%) **OR** Bandos godsword (or) (2.5%)  
+- Drygore rapier (8%) (equipped, melee) **OR** Dragon hunter lance (3%) **OR** Abyssal tentacle (2%) (charged)  
+- Offhand spidergore rapier (6.5%) (equipped, melee) **OR** Offhand drygore rapier (4%) (equipped, melee)  
+- Void staff (9%) (equipped, mage, charged) **OR** Tumeken's shadow (8%) (charged) **OR** Sanguinesti staff (7%) (charged)  
+- Chincannon (60% speed boost, must be equipped in range setup; destroys all loot, including teammates' loot)  
 
 #### Degradeable item info
 
-| Item              | Charges used per raid |
-| ----------------- | --------------------- |
-| Abyssal Tentacle  | 200                   |
-| Void Staff        | 15                    |
-| Sanguinesti Staff | 150                   |
+| Item                 | Charges used per raid |
+|----------------------|------------------------|
+| Abyssal tentacle     | 200                    |
+| Void staff           | 15                     |
+| Sanguinesti staff    | 150                    |
+| Tumeken's shadow     | 130                    |
 
 ### Reference Setups
 
@@ -41,16 +43,16 @@ See [How does 'BiS gear' work?](https://wiki.oldschool.gg/bso/monsters/raids/rea
 
 ## Supplies
 
-**Stamina potion(4) - Solo = 2, Mass = 1**
+For teams for 2+, here are the supply costs of brews, restores, and stamina potions:
 
-**Saradomin brew(4) - At 0 KC 7, scaling to 1** with higher kc.
+| Killcount (KC) | Saradomin brews (4) | Super restores (4) | Stamina potions (4) |
+| -------------- | ------------------- | ------------------ | ------------------- |
+| 0              | 7                   | 2                  | 1                   |
+| 30             | 6                   | 2                  | 1                   |
+| 60             | 5                   | 1                  | 1                   |
+| 90             | 4                   | 1                  | 1                   |
+| 120            | 3                   | 1                  | 1                   |
+| 150            | 2                   | 1                  | 1                   |
+| 180+           | 1                   | 1                  | 1                   |
 
-**Super restore(4) - At 2 Kc 2, scaling to 1** with higher kc. (1/3 of brews needed rounded down)
-
-Saradomin brew calculation :\
-Max(1, 8 - Max(1, Ceiling((KC+1)/30)))\
-Where Max means the highest number - this just ensures you always need at least 1\
-Ceiling is rounding up to the nearest whole number, i.e. 5.78 = 6, 2.01 = 3\
-Examples:\
-50 KC: 8-ceiling(50+1)/30) = 8-ceiling(1.7) = 8-2 = 6\
-500 KC: 8-ceiling(500+1)/30) = max(1, 8-(ceiling(16.7)) = max(1,-9) = 1
+Solos always require 1 extra Saradomin brew and 1 extra stamina potion compared to teams.


### PR DESCRIPTION
This PR updates the Chambers of Xeric wiki page to reflect the current BSO implementation:

- Updated item boost list (Void staff to 9%, added Tumeken's shadow)
- Added Bandos godsword (or) and offhand spidergore rapier
- Clarified (equipped) and (charged) item rules
- Added full table of degradable item charges
- Rewrote supply section with KC-based table and solo note