### PR TITLE
Update global gear preset names in wiki and fix item render logic to exclude commands containing skill names

### DIFF
--- a/docs/src/content/docs/osb/Getting Started/gear.md
+++ b/docs/src/content/docs/osb/Getting Started/gear.md
@@ -62,7 +62,7 @@ Equip or unequip a pet, even during trips:
 
 These are built-in and don't count toward your preset limit:
 
-- Graceful
+- Graceful (Will equip any variant)
 - Clue_hunter
 - Construction (Carpenter's Outfit)
 - Thieving (Rogue Equipment)

--- a/docs/src/content/docs/osb/Getting Started/gear.md
+++ b/docs/src/content/docs/osb/Getting Started/gear.md
@@ -12,9 +12,7 @@ You can also save entire setups with gearpresets for quick re-equipping. (Some g
 
 ## Commands
 
-There are 4 main commands:  
-[[/gear equip]], [[/gear unequip]], [[/gear stats]], [[/gear pet]]
-
+There are 4 main commands: [[/gear equip]], [[/gear unequip]], [[/gear stats]] and [[/gear pet]].
 You can also type [[/gear]] to view them all.
 
 ### Gear Equip
@@ -65,17 +63,16 @@ Equip or unequip a pet, even during trips:
 These are built-in and don't count toward your preset limit:
 
 - Graceful
-- Carpenter
-- Rogue
 - Clue_hunter
-- Angler
-- Spirit_angler
-- Pyromancer
-- Prospector
-- Lumberjack
-- Farmer
-- Runecraft
-- Smith
+- Construction (Carpenter's Outfit)
+- Thieving (Rogue Equipment)
+- Fishing (Angler's or Spirit Angler's Outfit)
+- Firemaking (Pyromancer Outfit)
+- Mining (Prospector or Golden Prospector Kit)
+- Woodcutting (Lumberjack or Forestry Outfit)
+- Farming (Farmer's Outfit)
+- Runecraft (Raiments of the Eye)
+- Smithing (Smiths' uniform)
 
 ### Wildy Setup
 

--- a/docs/src/plugins/items.ts
+++ b/docs/src/plugins/items.ts
@@ -44,8 +44,8 @@ export function remarkItems(_options: any) {
 				} else if (imageExtensions.some(ext => content.endsWith(ext))) {
 					html = `<img src="/images/${content}" alt="${content}" />`;
 				} else if (
-					[...SkillsArray, 'divination', 'dungeoneering', 'invention', 'qp'].some(s =>
-						content.includes(`${s}`)
+					[...SkillsArray, 'divination', 'dungeoneering', 'invention', 'qp'].some(
+						s => content.includes(`${s}`) && !content.includes('/') // some commands contain names of skills
 					)
 				) {
 					const [skillName, level] = content.split(':');


### PR DESCRIPTION
Updates gear preset names based on #6135. Also fixes some bugged command formatting, e.g. `/gear equip gear_setup:Melee auto:melee_strength` gets matched to strength skill and wiki tries to turn it into an image.

### Description:

- Updates gear preset names
- Ensure skill matching does not apply for commands in `remarkItems`

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [x] I have tested all my changes thoroughly.
