### PR TITLE
Remove cantHaveItems restriction from Master clue creation

### DIFF
--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -1544,9 +1544,6 @@ const Createables: Createable[] = [
 		},
 		outputItems: {
 			[itemID('Clue scroll (master)')]: 1
-		},
-		cantHaveItems: {
-			[itemID('Clue scroll (master)')]: 1
 		}
 	},
 	{

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -4932,9 +4932,7 @@ exports[`OSB Creatables 1`] = `
     },
   },
   {
-    "cantHaveItems": {
-      "19835": 1,
-    },
+    "cantHaveItems": undefined,
     "inputItems": {
       "12073": 1,
       "2677": 1,


### PR DESCRIPTION
Now that clue scrolls can be stacked up to 100, the old restriction preventing users from creating a Master clue if they already had one is obsolete.

This PR removes the `cantHaveItems` check from the Master clue creation recipe. Since the input requires four clues (easy, medium, hard, elite) and only outputs one Master clue, there is no risk of exceeding the clue cap through this method.

Closes #6347

- [x] I have tested all my changes thoroughly.
