### PR TITLE
Fetch updated user data when displaying clues and pets for open command

### DIFF
--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -146,7 +146,7 @@ ${messages.join(', ')}`.trim(),
 			'Due to opening so many things at once, you will have to download the attached text file to read the response.';
 	}
 
-	response.content += displayCluesAndPets(await mUserFetch(user.id), loot); //Need to fetch new user to get updated bank.
+	response.content += displayCluesAndPets(await mUserFetch(user.id), loot);
 
 	return response;
 }

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -146,7 +146,7 @@ ${messages.join(', ')}`.trim(),
 			'Due to opening so many things at once, you will have to download the attached text file to read the response.';
 	}
 
-	response.content += displayCluesAndPets(user, loot);
+	response.content += displayCluesAndPets(await mUserFetch(user.id), loot); //Need to fetch new user to get updated bank.
 
 	return response;
 }


### PR DESCRIPTION
### Description:

Currently `user` isn't updated in `/open` command so when checking clue stack, it uses old bank before loot transaction. 

Fixes this by inputting updated `user` into `displayCluesAndPets`.

### Changes:

- Fetch updated user data when displaying clues and pets for open command

### Other checks:

- [x] I have tested all my changes thoroughly.
