### PR TITLE
Divine Dominion qol

### DIFF
--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -7,6 +7,7 @@ import { MediumClueTable } from 'oldschooljs/dist/simulation/clues/Medium';
 
 import { uniqueArr } from 'e';
 import { Lampables } from '../../mahoji/lib/abstracted_commands/lampCommand';
+import { gods } from '../bso/divineDominion';
 import { tmbTable, umbTable } from '../bsoOpenables';
 import { customItems } from '../customItems/util';
 import { type DisassembleFlag, disassembleFlagMaterials, materialTypes } from '../invention';
@@ -1067,5 +1068,14 @@ for (const type of materialTypes) {
 		name: `${type}-material`,
 		aliases: [type],
 		items: () => items
+	});
+}
+
+for (const god of gods) {
+	const name = `${god.name} Divine Dominion God Items`;
+	filterableTypes.push({
+		name,
+		aliases: [name.toLowerCase()],
+		items: () => god.godItems
 	});
 }

--- a/src/mahoji/commands/bsominigames.ts
+++ b/src/mahoji/commands/bsominigames.ts
@@ -15,7 +15,7 @@ import { joinGuthixianCache } from '../../lib/bso/guthixianCache';
 import { type TuraelsTrialsMethod, TuraelsTrialsMethods, turaelsTrialsStartCommand } from '../../lib/bso/turaelsTrials';
 import { fishingLocations } from '../../lib/fishingContest';
 import type { MaterialType } from '../../lib/invention';
-import { itemNameFromID } from '../../lib/util';
+import { Bank, type ItemBank, itemNameFromID } from '../../lib/util';
 import { bonanzaCommand } from '../lib/abstracted_commands/bonanzaCommand';
 import {
 	fishingContestStartCommand,
@@ -31,8 +31,9 @@ import {
 } from '../lib/abstracted_commands/odsCommand';
 import { stealingCreationCommand } from '../lib/abstracted_commands/stealingCreation';
 import { tinkeringWorkshopCommand } from '../lib/abstracted_commands/tinkeringWorkshopCommand';
-import { itemOption, ownedMaterialOption } from '../lib/mahojiCommandOptions';
+import { itemOption, ownedItemOption, ownedMaterialOption } from '../lib/mahojiCommandOptions';
 import type { OSBMahojiCommand } from '../lib/util';
+import { mahojiUsersSettingsFetch } from '../mahojiSettings';
 
 export const bsoMinigamesCommand: OSBMahojiCommand = {
 	name: 'bsominigames',
@@ -245,7 +246,24 @@ export const bsoMinigamesCommand: OSBMahojiCommand = {
 					name: 'sacrifice_god_item',
 					description: 'Sacrifice godly items.',
 					options: [
-						itemOption(item => allGodlyItems.includes(item.id)),
+						{
+							name: 'item',
+							type: ApplicationCommandOptionType.String,
+							description: 'The godly item to sacrifice.',
+							required: true,
+							autocomplete: async (value, { id }) => {
+								const raw = await mahojiUsersSettingsFetch(id, { bank: true });
+								const bank = new Bank(raw.bank as ItemBank);
+
+								return bank
+									.items()
+									.filter(i => allGodlyItems.includes(i[0].id))
+									.filter(i =>
+										!value ? true : i[0].name.toLowerCase().includes(value.toLowerCase())
+									)
+									.map(i => ({ name: `${i[0].name} (${i[1]}x Owned)`, value: i[0].name }));
+							}
+						},
 						{
 							type: ApplicationCommandOptionType.Integer,
 							name: 'quantity',

--- a/src/mahoji/commands/bsominigames.ts
+++ b/src/mahoji/commands/bsominigames.ts
@@ -31,7 +31,7 @@ import {
 } from '../lib/abstracted_commands/odsCommand';
 import { stealingCreationCommand } from '../lib/abstracted_commands/stealingCreation';
 import { tinkeringWorkshopCommand } from '../lib/abstracted_commands/tinkeringWorkshopCommand';
-import { itemOption, ownedItemOption, ownedMaterialOption } from '../lib/mahojiCommandOptions';
+import { ownedMaterialOption } from '../lib/mahojiCommandOptions';
 import type { OSBMahojiCommand } from '../lib/util';
 import { mahojiUsersSettingsFetch } from '../mahojiSettings';
 


### PR DESCRIPTION
### Description:
Add some qol features to divine dominion minigame.

### Changes:
- Show the items owned when doing `/bsominigames divine_dominion sacrifice_god_item item:`
- Add filters for all god items for their respective gods.

### Other checks:
- [X] I have tested all my changes thoroughly.

Some Screenshots:
![Discord_peNnSeB3E3](https://github.com/user-attachments/assets/7eb4ecfe-58e1-423a-a981-4adcf2f98d72)
![Discord_0HjPS2qsd7](https://github.com/user-attachments/assets/24d7e559-a705-4a29-b9ba-14dee780474b)
![Discord_4cqhDzRYWL](https://github.com/user-attachments/assets/e6f69cc7-5f48-4077-9607-2f141c8427f7)
