### PR TITLE
Fix Bonus loot emoji for box openings

### DIFF
--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -170,7 +170,7 @@ async function finalizeOpening({
 		}
 		smokeyMsg =
 			bonuses.length > 0
-				? `${hasOcto ? '<:Octo:1227526833776492554>' : Emoji.Smokey} Bonus Rolls: ${bonuses.join(', ')}`
+				? `${hasSmokey ? Emoji.Smokey : '<:Octo:1227526833776492554>'} Bonus Rolls: ${bonuses.join(', ')}`
 				: null;
 	}
 	if (smokeyMsg) messages.push(smokeyMsg);


### PR DESCRIPTION
### Description: 
Fix the emoji that shows for bonus loot when opening boxes.

### Changes:
- Switch around the logic to always show the correct emoji for which pet is giving bonus loot.

### Other checks:
- [X] I have tested all my changes thoroughly.
