### PR TITLE
Fix CA boost impact on clue tables

### DIFF
--- a/packages/oldschooljs/src/structures/LootTable.ts
+++ b/packages/oldschooljs/src/structures/LootTable.ts
@@ -212,7 +212,7 @@ export default class LootTable {
 					if (!change) return i;
 					return {
 						...i,
-						chance: Math.floor(reduceNumByPercent(i.chance, change))
+						chance: Math.max(1, Math.floor(reduceNumByPercent(i.chance, change)))
 					};
 				})
 			: this.tertiaryItems;

--- a/packages/oldschooljs/src/structures/LootTable.ts
+++ b/packages/oldschooljs/src/structures/LootTable.ts
@@ -212,7 +212,7 @@ export default class LootTable {
 					if (!change) return i;
 					return {
 						...i,
-						chance: Math.ceil(reduceNumByPercent(i.chance, change))
+						chance: Math.floor(reduceNumByPercent(i.chance, change))
 					};
 				})
 			: this.tertiaryItems;
@@ -232,31 +232,35 @@ export default class LootTable {
 
 		outerLoop: for (let i = 0; i < quantity; i++) {
 			for (let j = 0; j < this.everyItems.length; j++) {
-				this.addResultToLoot(this.everyItems[j], loot);
+				this.addResultToLoot(this.everyItems[j], loot, options.tertiaryItemPercentageChanges);
 			}
 
 			for (let j = 0; j < effectiveTertiaryItems.length; j++) {
 				if (roll(effectiveTertiaryItems[j].chance)) {
-					this.addResultToLoot(effectiveTertiaryItems[j], loot);
+					this.addResultToLoot(effectiveTertiaryItems[j], loot, options.tertiaryItemPercentageChanges);
 				}
 			}
 
 			for (let j = 0; j < this.oneInItems.length; j++) {
 				if (roll(this.oneInItems[j].chance)) {
-					this.addResultToLoot(this.oneInItems[j], loot);
+					this.addResultToLoot(this.oneInItems[j], loot, options.tertiaryItemPercentageChanges);
 					continue outerLoop;
 				}
 			}
 
 			if (this.cachedOptimizedTable) {
-				this.addResultToLoot(this.table[randArrItem(this.cachedOptimizedTable)], loot);
+				this.addResultToLoot(
+					this.table[randArrItem(this.cachedOptimizedTable)],
+					loot,
+					options.tertiaryItemPercentageChanges
+				);
 			} else {
 				const randomWeight = randFloat(0, limit);
 				let weight = 0;
 				for (let i = 0; i < this.table.length; i++) {
 					weight += this.table[i].weight!;
 					if (randomWeight <= weight) {
-						this.addResultToLoot(this.table[i], loot);
+						this.addResultToLoot(this.table[i], loot, options.tertiaryItemPercentageChanges);
 						break;
 					}
 				}
@@ -269,7 +273,11 @@ export default class LootTable {
 		return null;
 	}
 
-	private addResultToLoot(result: LootTableItem, loot: Bank): void {
+	private addResultToLoot(
+		result: LootTableItem,
+		loot: Bank,
+		tertiaryItemPercentageChanges?: Map<string, number>
+	): void {
 		if (typeof result?.item === 'number') {
 			loot.addItem(result.item, this.determineQuantity(result.quantity));
 			return;
@@ -277,8 +285,9 @@ export default class LootTable {
 
 		if (result?.item instanceof LootTable) {
 			const qty = this.determineQuantity(result.quantity);
-			if (result.options?.multiply) loot.add(result.item.roll(1).multiply(qty));
-			else result.item.roll(qty, { targetBank: loot });
+			if (result.options?.multiply)
+				loot.add(result.item.roll(1, { tertiaryItemPercentageChanges }).multiply(qty));
+			else result.item.roll(qty, { targetBank: loot, tertiaryItemPercentageChanges });
 			return;
 		}
 	}


### PR DESCRIPTION
### Description:

This PR addresses incorrect application of `tertiaryItemPercentageChanges` boosts, primarily from CAs boosting clues. The tertiary odds are rounded up when they should be rounded down, e.g. elite clue for [skotizo](https://oldschool.runescape.wiki/w/Skotizo#cite_ref-3) should go to 1/4, and tertiary odds aren't boosted when in any sub-table for osjs monster, e.g. [artio](https://github.com/oldschoolgg/oldschoolbot/blob/master/packages/oldschooljs/src/simulation/monsters/bosses/wildy/Artio.ts).

Closes #6307.

### Changes:

- Update `effectiveTertiaryItems` to round tertiary odds up, rather than down in `LootTable.roll`
- Add `tertiaryItemPercentageChanges` to all sub table rolls within `LootTable.roll`

### Other checks:

- [x] I have tested all my changes thoroughly.
