### PR TITLE
Allow barraging jellies in wildy

### DIFF
--- a/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/autoSlayCommand.ts
@@ -330,7 +330,7 @@ const WildyAutoSlayMaxEfficiencyTable: AutoslayLink[] = [
 		monsterID: Monsters.Jelly.id,
 		efficientName: Monsters.Jelly.name,
 		efficientMonster: Monsters.Jelly.id,
-		efficientMethod: ['barrage', 'cannon']
+		efficientMethod: 'barrage'
 	},
 	{
 		monsterID: Monsters.LesserDemon.id,

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -132,8 +132,10 @@ export function newMinionKillCommand(args: MinionKillOptions) {
 
 	const isBurstingOrBarraging = combatMethods.includes('burst') || combatMethods.includes('barrage');
 	if (isBurstingOrBarraging && !monster.canBarrage) {
-		if (isKillingJelly && !isInWilderness) {
-			return `${monster.name} can only be barraged or burst in the wilderness.`;
+		if (isKillingJelly) {
+			if (!isInWilderness) {
+				return `${monster.name} can only be barraged or burst in the wilderness.`;
+			}
 		} else {
 			return `${monster.name} cannot be barraged or burst.`;
 		}

--- a/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
@@ -1,5 +1,5 @@
 import { calcWhatPercent, sumArr } from 'e';
-import { Bank, type Item, type Monster } from 'oldschooljs';
+import { Bank, type Item, type Monster, Monsters } from 'oldschooljs';
 
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 import { MonsterAttribute } from 'oldschooljs/dist/meta/monsterData';
@@ -315,8 +315,9 @@ export const mainBoostEffects: (Boost | Boost[])[] = [
 		run: ({ monster, attackStyles, combatMethods, isOnTask, isInWilderness, gearBank }) => {
 			const isBarraging = combatMethods.includes('barrage');
 			const isBursting = combatMethods.includes('burst');
+			const canBarrageMonster = monster.canBarrage || (monster.id === Monsters.Jelly.id && isInWilderness);
 
-			if (!isBarraging && !isBursting) return null;
+			if (!canBarrageMonster || (!isBarraging && !isBursting)) return null;
 
 			let newAttackStyles = [...attackStyles];
 			if (!newAttackStyles.includes(SkillsEnum.Magic)) {
@@ -327,7 +328,7 @@ export const mainBoostEffects: (Boost | Boost[])[] = [
 			}
 
 			const { virtusBoost } = calculateVirtusBoost({ isInWilderness, gearBank, isOnTask });
-			if (isBarraging && attackStyles.includes(SkillsEnum.Magic) && monster.canBarrage) {
+			if (isBarraging && attackStyles.includes(SkillsEnum.Magic)) {
 				return {
 					percentageReduction: boostIceBarrage + virtusBoost,
 					consumables: [iceBarrageConsumables],
@@ -339,7 +340,7 @@ export const mainBoostEffects: (Boost | Boost[])[] = [
 				};
 			}
 
-			if (isBursting && attackStyles.includes(SkillsEnum.Magic) && monster.canBarrage) {
+			if (isBursting && attackStyles.includes(SkillsEnum.Magic)) {
 				return {
 					percentageReduction: boostIceBurst + virtusBoost,
 					consumables: [iceBurstConsumables],


### PR DESCRIPTION
### Description:

This PR allows barraging jellies in wildy. Fixes the logic that gave incorrect 'Jelly cannot be barraged or burst' message, and adds exception to burst/barrage boost to allow jellies in wildy. Removes cannon from Jelly EHP because at the moment they can't be cannoned. 

### Changes:

- Fixes the logic that gave incorrect 'jellies cannot be burst or barraged' message
- Adds exception to burst/barrage boost to allow jellies in wildy
- Removes cannon from Jelly EHP

### Other checks:

- [x] I have tested all my changes thoroughly.
