### PR TITLE
Fetch updated user info in displayCluesAndPets

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -107,7 +107,8 @@ const tripFinishEffects: TripFinishEffect[] = [
 	}
 ];
 
-export function displayCluesAndPets(user: MUser, loot: Bank | null | undefined) {
+export async function displayCluesAndPets(userID: string, loot: Bank | null | undefined) {
+	const user = await mUserFetch(userID);
 	let ret = '';
 	const clueReceived = loot ? ClueTiers.filter(tier => loot.amount(tier.scrollID) > 0) : [];
 	if (clueReceived.length > 0) {
@@ -182,7 +183,7 @@ export async function handleTripFinish(
 		message.content += `\n**Messages:** ${messages.join(', ')}`;
 	}
 
-	message.content += displayCluesAndPets(user, loot);
+	message.content += await displayCluesAndPets(user.id, loot);
 
 	const existingCollector = collectors.get(user.id);
 

--- a/src/mahoji/lib/abstracted_commands/barbAssault.ts
+++ b/src/mahoji/lib/abstracted_commands/barbAssault.ts
@@ -204,7 +204,7 @@ export async function barbAssaultGambleCommand(
 	);
 	const loot = new Bank().add(table.roll(quantity));
 	let str = `You spent ${(cost * quantity).toLocaleString()} Honour Points for ${quantity.toLocaleString()}x ${name} Gamble, and received...`;
-	str += displayCluesAndPets(user, loot);
+	str += await displayCluesAndPets(user.id, loot);
 	if (loot.has('Pet Penance Queen')) {
 		const amount = await countUsersWithItemInCl(itemID('Pet penance queen'), false);
 

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -166,7 +166,7 @@ ${messages.join(', ')}`.trim(),
 			'Due to opening so many things at once, you will have to download the attached text file to read the response.';
 	}
 
-	response.content += displayCluesAndPets(await mUserFetch(user.id), loot);
+	response.content += await displayCluesAndPets(user.id, loot);
 
 	return response;
 }


### PR DESCRIPTION
### Description:

Found another instance where user isn't updated after transacting items (`/steal`).

PR covers all cases by inputting user id and fetching fresh user.

### Changes:

- Fetch updated user info in `displayCluesAndPets`

### Other checks:

- [x] I have tested all my changes thoroughly.
