### PR TITLE
greatly improve BSO ToA wiki

### DIFF
--- a/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/chambers-of-xeric.md
@@ -6,30 +6,32 @@ See the [OSB wiki](https://wiki.oldschool.gg/osb/raids/cox/) for general info.
 
 ### Boosts
 
-The following items give a boost to your combat score. Only the highest available boost from each line will be applied.
+The following items grant a speed boost in Chambers of Xeric (CoX).  
+Only the highest applicable boost from each group will be applied.
 
-All boosts work from the bank unless otherwise specified. Gorajan armour does not affect gear score.
+Unless stated otherwise, items can be either equipped or in your bank to count toward the boost.
 
-- Twisted bow (7%) **OR** Bow of faerdhinen (c) (6%) **OR** Dragon hunter crossbow (5%)
-- Dragon warhammer (3%) **OR** Bandos godsword (2.5%)
-- Drygore rapier (8%)\* **OR** Dragon hunter lance (3%) **OR** Abyssal tentacle (2%)
-- Offhand drygore rapier (4%)\*
-- Void staff (8%)\*\* Sanguinesti staff (7%)
-- Chincannon (60% speed boost at cost of raid loot)\*\*\*
+> Note:  
+> - Items marked with (equipped) must be equipped in the correct gear setup  
+> - Items marked with (charged) must have enough charges to be used
 
-\* Must be equipped in melee setup
+---
 
-\*\* Must be equipped in mage setup
-
-\*\*\* Must be equipped in range setup
+- Twisted bow (7%) **OR** Bow of faerdhinen (c) (6%) **OR** Dragon hunter crossbow (5%)  
+- Dragon warhammer (3%) **OR** Bandos godsword (2.5%) **OR** Bandos godsword (or) (2.5%)  
+- Drygore rapier (8%) (equipped, melee) **OR** Dragon hunter lance (3%) **OR** Abyssal tentacle (2%) (charged)  
+- Offhand spidergore rapier (6.5%) (equipped, melee) **OR** Offhand drygore rapier (4%) (equipped, melee)  
+- Void staff (9%) (equipped, mage, charged) **OR** Tumeken's shadow (8%) (charged) **OR** Sanguinesti staff (7%) (charged)  
+- Chincannon (60% speed boost, must be equipped in range setup; destroys all loot, including teammates' loot)  
 
 #### Degradeable item info
 
-| Item              | Charges used per raid |
-| ----------------- | --------------------- |
-| Abyssal Tentacle  | 200                   |
-| Void Staff        | 15                    |
-| Sanguinesti Staff | 150                   |
+| Item                 | Charges used per raid |
+|----------------------|------------------------|
+| Abyssal tentacle     | 200                    |
+| Void staff           | 15                     |
+| Sanguinesti staff    | 150                    |
+| Tumeken's shadow     | 130                    |
 
 ### Reference Setups
 
@@ -41,16 +43,16 @@ See [How does 'BiS gear' work?](https://wiki.oldschool.gg/bso/monsters/raids/rea
 
 ## Supplies
 
-**Stamina potion(4) - Solo = 2, Mass = 1**
+For teams for 2+, here are the supply costs of brews, restores, and stamina potions:
 
-**Saradomin brew(4) - At 0 KC 7, scaling to 1** with higher kc.
+| Killcount (KC) | Saradomin brews (4) | Super restores (4) | Stamina potions (4) |
+| -------------- | ------------------- | ------------------ | ------------------- |
+| 0              | 7                   | 2                  | 1                   |
+| 30             | 6                   | 2                  | 1                   |
+| 60             | 5                   | 1                  | 1                   |
+| 90             | 4                   | 1                  | 1                   |
+| 120            | 3                   | 1                  | 1                   |
+| 150            | 2                   | 1                  | 1                   |
+| 180+           | 1                   | 1                  | 1                   |
 
-**Super restore(4) - At 2 Kc 2, scaling to 1** with higher kc. (1/3 of brews needed rounded down)
-
-Saradomin brew calculation :\
-Max(1, 8 - Max(1, Ceiling((KC+1)/30)))\
-Where Max means the highest number - this just ensures you always need at least 1\
-Ceiling is rounding up to the nearest whole number, i.e. 5.78 = 6, 2.01 = 3\
-Examples:\
-50 KC: 8-ceiling(50+1)/30) = 8-ceiling(1.7) = 8-2 = 6\
-500 KC: 8-ceiling(500+1)/30) = max(1, 8-(ceiling(16.7)) = max(1,-9) = 1
+Solos always require 1 extra Saradomin brew and 1 extra stamina potion compared to teams.

--- a/docs/src/content/docs/bso/Monsters/Raids/tombs-of-amascut-toa.md
+++ b/docs/src/content/docs/bso/Monsters/Raids/tombs-of-amascut-toa.md
@@ -2,34 +2,117 @@
 title: "Tombs of Amascut (ToA)"
 ---
 
-See the [OSB wiki ](https://wiki.oldschool.gg/osb/raids/toa)for general info.
+See the [OSB wiki](https://wiki.oldschool.gg/osb/raids/toa) for general info.
 
 ## Boosts
 
-Boosts are different in BSO to the OSB version, they are as followed:
+Boosts and best-in-slot gear differ between BSO and OSB. With higher kc, your death chance will reduce and your speed boost will increase. The maximum death chance reduction is received at 250+ **attempts** (not KC) and the maximum speed boost will be received at 350+ **attempts** (not KC).
 
-- Void staff (50%) (Equipped in Mage)
-- Bandos godsword (2%) (Works from bank)
-- Hellfire bow (4%) (Equipped in Range)
-- Zaryte crossbow (9%) or Dragon claws (6%) (Works from bank)
-- Chincannon (60% speed boost at cost of raid loot)\*
+### Gear Score
 
-\* Must be equipped in range setup
+Gear score affects both death chance and speed boost:
 
-## Reference Setups
+- Max speed boost from gear score: +15%
+- If **any** gear setup (melee, range, or mage) is below 90%, you receive a **+10% death-chance penalty**
+- Full speed boost is reached at **93.1%** gear score (due to rounding). A gear score above 93.1% (e.g. 100%) adds no further benefit in any way.
+- Gorajan sets grant **no special bonus** over Torva/Pernix/Virtus. Only the stats matter.
+- Blowpipe dart type grants **no bonus in any way**; use Adamant or Rune darts to save costs
 
-See [How does 'BiS gear' work?](https://wiki.oldschool.gg/bso/monsters/raids/readme/#how-does-bis-gear-work) for an explanation on gear setups.
+### Speed-Boost Items
 
-### Melee
+Unless noted, these work from your bank:
 
-<figure><figcaption>Ghrazi Rapier is better for Invocations under 300</figcaption></figure>
+- Bandos Godsword (+2%)
+- Zaryte Crossbow (+9%) **OR** Dragon Claws (+6%)
+- Osmumten’s Fang (+15%) **OR** Ghrazi Rapier (+6%)
+- Void Staff — **special 50%** time reduction (must be equipped in mage setup)
+- Hellfire Bow (+4%) (must be equipped in range setup)
+- Chincannon — **special 60%** time reduction, but **destroys all loot for teammates** (must be equipped in range)
 
-### Range
+### Notes on Speed Boosts
 
-<figure><figcaption>Ava's assembler can be replaced with Master Range cape, Combatant's cape</figcaption></figure>
+- Osmumten’s Fang is BiS at invocation 300+. Below 300, the order is reversed, and Ghrazi Rapier becomes BiS at +15%.
+- Due to the way boosts are calculated, Void Staff and Chincannon boosts are significantly stronger than all other boosts. Void Staff’s effective boost is >8x all other boosts combined (excluding Chincannon).
+- In teams of 3+, the **slowest player’s boost is ignored** (see Team Size Boosts section).
 
-Note: You need to equip enough arrows to use (150 per raid, usage is reduced by Ava's effect). If using a Hellfire bow you need to use Hellfire arrows, Twisted bow can use Adamant, Rune, Amethyst, Dragon or Hellfire arrows, Bow of Faedhinen (c) does not require arrows
+## Team Size Boosts
 
-### Mage
+| Party Size | Speed Boost (%) |
+|:----------:|:---------------:|
+| 1 (Solo)   | 0%              |
+| 2          | 10%             |
+| 3          | 15%             |
+| 4          | 20%             |
+| 5 – 8      | 25%             |
 
-<figure><figcaption>Cape can be replaced with any imbued cape or vasa cloak, a Magic master cape will not give 100%</figcaption></figure>
+> In parties of 3+, the player with the lowest boost is ignored. This is to encourage carrying new players, which allows the team to obtain a higher over team size speed boost, without suffering from the new players' lack of attempts/kc.
+
+## Consumable supply requirements (darts, arrows, potions)
+
+* ~150 darts + 150 scales from blowpipe (reduced by Ava’s device)
+* ~150 arrows (if not using a zero-arrow weapon; reduced by Ava’s device)
+	* Hellfire Bow: must use Hellfire Arrows  
+	* Twisted Bow: must use Adamant arrows or better (the type of arrow has a small impact on gear score)
+	* Bow of Faerdhinen (c): no arrows consumed. Use Barbarian Assault arrows for BiS stats
+	* Chincannon: consumes Explosive material and consumes arrows (the type of arrow has a small impact on gear score)
+* 1× Sanfew Serum (or Serpentine Helm equipped in Melee with 600 charges/hr)
+* 1× Ranging Potion
+* 1× Super Combat Potion
+* Super restores and Saradomin brews, based on your KC according to the table below
+
+| KC Range | Brews Needed | Restores Needed |
+|:--------:|:------------:|:---------------:|
+| < 2      | 8            | 5               |
+| 2 – 4    | 8            | 4               |
+| 5 – 50   | 5 – 8        | 2               |
+| ≥ 96     | 1            | 2               |
+
+## Max Gear Setups
+
+> Gear scores of at least 93.1% deliver the same boosts as 100%. Below are “100% reference” setups. There is no benefit to exceeding the max.
+
+#### Melee (100%)
+
+- Full Gorajan Warrior (or Torva)
+- Brawler’s Hook Necklace
+- TzKal Cape
+- Osmumten’s Fang (Ghrazi Rapier if invocation 1-299)
+- Avernic Defender or equivalent
+- Ignis Ring (i)
+
+> Offhand Spidergore weapons provide less defenses than Avernic Defender, and therefore are **NOT** recommended.
+> A Osmumten’s Fang (or) **WILL NOT** receive the +15% boost, and is therefore **NOT** recommended. Note that you **CANNOT** revert it at this time.
+
+#### Range (100%)
+
+- Full Gorajan Archer (or Pernix)
+- Farsight Snapshot Necklace
+- Ava’s Assembler or equivalent
+- Hellfire Bow + Hellfire Arrows
+- Ring of Piercing (i)
+
+> Tidal Collector (i) is superior and therefore recommended, but not always required for 100%.
+> Master Range/Combatant’s Cape offers more defense, but less offense than Ava's Assembler, and therefore will likely reduce your gear score
+
+#### Mage (100%)
+
+- Full Gorajan Occult (or Virtus)
+- Arcane Blast Necklace
+- Imbued Saradomin Cape
+- Void Staff
+- Abyssal Tome
+- (no ring)
+
+> Vasa Cloak is superior, and therefore recommended, but not always required for 100%.
+> A ring is recommended, but not always required for 100%.
+
+### Strategy
+
+* Since a gear score of 93.1% or higher grants full boost, you may wish to sacrifice a small amount of gear score to save on costs:
+  * Melee: Equip Serpentine Helm (600 charges/hr) instead of a Sanfew Serum.
+  * Range: Use Bow of Faerdhinen (c) + Barbarian Assault arrow to avoid arrow consumption (at max gear score/stats, you will be missing out on approximately 0.25% overall boost from not using a Hellfire Bow).
+  * Since darts don't affect death chance or speed boost, you are recommended to use adamant darts or rune darts to save on cost. There is no benefit to using dragon darts.
+* Theoretically, assuming max gear and 350+ attempts, 450 invocations should give the highest rate of uniques per hour.
+* At early attempts/kc, you are recommended to mass in chincannons at level 150 invocation, so that you can make progression towards the total 2000 normal/expert KC Icthlarin's shroud (tier 5).
+
+


### PR DESCRIPTION
- Clearly state death chance and speed boost max (250/350).
- Clearly state massive Void Staff speed reduction vs. small Hellfire Bow reduction.
- Add easy to read chart for brew/restore consumption
- Remove incorrect information about Ranged master cape vs. Ava's
- Add BiS gear reference
- Add slowest player removed section
- Explain gear score rounding mechanic
