### PR TITLE
Ensure infinity robes are equipable using /gear item

### DIFF
--- a/src/lib/util/parseStringBank.ts
+++ b/src/lib/util/parseStringBank.ts
@@ -16,7 +16,7 @@ export function parseQuantityAndItem(str = '', inputBank?: Bank): [Item[], numbe
 	const split = str.split(' ');
 
 	// If we're passed 2 numbers in a row, e.g. '1 1 coal', remove that number and recurse back.
-	if (!Number.isNaN(Number(split[1])) && split.length > 2) {
+	if (!Number.isNaN(Number(split[1])) && split[1].toLowerCase() !== 'infinity' && split.length > 2) {
 		split.splice(1, 1);
 		return parseQuantityAndItem(split.join(' '));
 	}


### PR DESCRIPTION
### Description:

Currently parser catches 'infinity' as a number when trying to equip infinity robes by name and bugs out. 
PR fixes this by adding in an exception for this case, so it always assumes 'infinity' is part of the item name.

### Changes:

- Exclude 'infinity' from the quantity check in `parseQuantityAndItem`

### Other checks:

- [x] I have tested all my changes thoroughly.
