### PR TITLE
Add Warped Sceptre boosts and requirements for Kraken, Zulrah, Rex and Barrows

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -97,7 +97,7 @@ const killableBosses: KillableMonster[] = [
 				[itemID('Pegasian boots')]: 4
 			},
 			{
-				[itemID("Iban's staff")]: 1,
+				[itemID('Warped sceptre (uncharged)')]: 1,
 				[itemID('Trident of the seas')]: 2,
 				[itemID('Trident of the swamp')]: 3,
 				[itemID('Sanguinesti staff')]: 4,

--- a/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
+++ b/src/lib/minions/data/killableMonsters/chaeldarMonsters.ts
@@ -276,6 +276,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		difficultyRating: 5,
 		itemsRequired: deepResolveItems([
 			[
+				'Warped sceptre (uncharged)',
 				'Trident of the seas',
 				'Trident of the seas (full)',
 				'Uncharged trident',
@@ -288,6 +289,7 @@ export const chaeldarMonsters: KillableMonster[] = [
 		notifyDrops: resolveItems(['Jar of sand', 'Pet kraken']),
 		itemInBankBoosts: [
 			{
+				[itemID('Warped sceptre (uncharged)')]: 3,
 				[itemID('Uncharged trident')]: 5,
 				[itemID('Trident of the seas')]: 5,
 				[itemID('Trident of the seas (full)')]: 8,

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -53,6 +53,7 @@ const killableMonsters: KillableMonster[] = [
 			{ [itemID('Barrows gloves')]: 2 },
 			{
 				[itemID("Iban's staff")]: 5,
+				[itemID('Warped sceptre (uncharged)')]: 6,
 				[itemID('Harmonised nightmare staff')]: 7,
 				[itemID("Tumeken's shadow")]: 10
 			},
@@ -136,6 +137,7 @@ const killableMonsters: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID("Iban's staff")]: 3,
+				[itemID('Warped sceptre (uncharged)')]: 4,
 				[itemID('Harmonised nightmare staff')]: 5
 			},
 			{


### PR DESCRIPTION
### Description:

Add Warped Sceptre boosts and requirements for Kraken, Zulrah, Rex and Barrows. Places it above Ibans, below trident. Also adds sceptre as a requirement for kraken, to fix issue of getting kraken boss task but being unable to kill it without trident.

### Changes:

- Add Warped Sceptre boosts and requirements for Kraken, Zulrah, Rex and Barrows

### Other checks:

- [x] I have tested all my changes thoroughly.
