### PR TITLE
Add back the ability to re-dye an item

### DIFF
--- a/src/mahoji/lib/abstracted_commands/useCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/useCommand.ts
@@ -7,6 +7,7 @@ import type { Item } from 'oldschooljs/dist/meta/types';
 import { divinationEnergies } from '../../../lib/bso/divination';
 import { BitField } from '../../../lib/constants';
 import { addToDoubleLootTimer } from '../../../lib/doubleLoot';
+import { allDyes, dyedItems } from '../../../lib/dyedItems';
 import { gearImages } from '../../../lib/gear/functions/generateGearImage';
 import { mysteriousStepData } from '../../../lib/mysteryTrail';
 import { makeScriptImage } from '../../../lib/scriptImages';
@@ -606,6 +607,23 @@ usables.push({
 		};
 	}
 });
+
+for (const group of dyedItems) {
+	for (const dyedVersion of group.dyedVersions) {
+		for (const dye of allDyes.filter(i => i !== dyedVersion.dye)) {
+			const resultingItem = group.dyedVersions.find(i => i.dye === dye);
+			if (!resultingItem) continue;
+			genericUsables.push({
+				items: [dyedVersion.item, dye],
+				cost: new Bank().add(dyedVersion.item.id).add(dye.id),
+				loot: new Bank().add(resultingItem.item.id),
+				response: () =>
+					`You used a ${dye.name} on your ${dyedVersion.item.name}, and received a ${resultingItem.item.name}.`,
+				addToCL: false
+			});
+		}
+	}
+}
 
 for (const genericU of genericUsables) {
 	usables.push({


### PR DESCRIPTION
### Description:
I removed this feature in https://github.com/oldschoolgg/oldschoolbot/pull/6352 thinking it was redundant to `/create` this feature is actually used to re-dye an item. ex. The user wants to change their `Drygore longsword (shadow)` into a `Drygore longsword (blood)`. This costs the user their Drygore longsword (shadow) and a blood dye in return for a Drygore longsword (blood) and doesn't add it to their cl.

### Changes:
- add back re-dye feature under `/use`

### Other checks:
- [X] I have tested all my changes thoroughly.
