### PR TITLE
Fix silent bot responses 'Slayer task assigned'

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -456,6 +456,7 @@ export async function interactionHook(interaction: Interaction) {
 				commandName: 'slayer',
 				args: { new_task: {} },
 				bypassInhibitors: true,
+				ephemeral: true,
 				...options
 			});
 		}

--- a/src/mahoji/lib/abstracted_commands/slayerTaskCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/slayerTaskCommand.ts
@@ -187,6 +187,7 @@ async function returnSuccess(channelID: string, user: MUser, content: string) {
 					args: { manage: { command: 'skip', new: true } },
 					bypassInhibitors: true,
 					interaction: selection,
+					ephemeral: true,
 					...options
 				});
 				return;
@@ -197,6 +198,7 @@ async function returnSuccess(channelID: string, user: MUser, content: string) {
 					args: { manage: { command: 'block', new: true } },
 					bypassInhibitors: true,
 					interaction: selection,
+					ephemeral: true,
 					...options
 				});
 			}


### PR DESCRIPTION
### Description:

Fixes 'Slayer task assigned' messages to be silent like they used to be, when responding to a button interaction.
I tried fully removing the message, but I think it makes the task messages too cramped. 

### Changes:

- Add necessary `ephemeral` flag to slayer interaction commands that return 'Slayer task assigned' message

### Other checks:

- [x] I have tested all my changes thoroughly.
