### PR TITLE
Ensure wildy slayer monsters can only be killed on task

### DIFF
--- a/src/lib/slayer/slayerUtil.ts
+++ b/src/lib/slayer/slayerUtil.ts
@@ -18,6 +18,13 @@ import { SlayerRewardsShop, SlayerTaskUnlocksEnum } from './slayerUnlocks';
 import { bossTasks, wildernessBossTasks } from './tasks/bossTasks';
 import type { AssignableSlayerTask, SlayerMaster } from './types';
 
+export const wildySlayerOnlyMonsters = [
+	Monsters.DustDevil,
+	Monsters.GreaterNechryael,
+	Monsters.AbyssalDemon,
+	Monsters.Jelly
+];
+
 export enum SlayerMasterEnum {
 	Reserved = 0,
 	Turael = 1,
@@ -170,7 +177,7 @@ function userCanUseTask(user: MUser, task: AssignableSlayerTask, master: SlayerM
 	)
 		return false;
 	if (
-		(lmon === 'dust devil' || lmon === 'greater nechryael' || lmon === 'abyssal demon' || lmon === 'jelly') &&
+		wildySlayerOnlyMonsters.some(m => m.id === task.monster.id) &&
 		lmast === 'krystilia' &&
 		!myUnlocks.includes(SlayerTaskUnlocksEnum.IWildyMoreSlayer)
 	)

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -16,7 +16,11 @@ import {
 } from '../../../../lib/minions/functions';
 import type { KillableMonster } from '../../../../lib/minions/types';
 import type { SlayerTaskUnlocksEnum } from '../../../../lib/slayer/slayerUnlocks';
-import { type CurrentSlayerInfo, determineCombatBoosts } from '../../../../lib/slayer/slayerUtil';
+import {
+	type CurrentSlayerInfo,
+	determineCombatBoosts,
+	wildySlayerOnlyMonsters
+} from '../../../../lib/slayer/slayerUtil';
 import type { GearBank } from '../../../../lib/structures/GearBank';
 import { UpdateBank } from '../../../../lib/structures/UpdateBank';
 import type { Peak } from '../../../../lib/tickers';
@@ -90,6 +94,10 @@ export function newMinionKillCommand(args: MinionKillOptions) {
 
 	if (!monster.wildy && isInWilderness) {
 		return `You can't kill ${monster.name} in the wilderness.`;
+	}
+
+	if (wildySlayerOnlyMonsters.some(m => m.id === monster.id) && isInWilderness && !isOnTask) {
+		return `${monster.name} can only be killed in the wilderness when on a slayer task.`;
 	}
 
 	const matchedRevenantMonster = revenantMonsters.find(m => m.id === monster.id);


### PR DESCRIPTION
### Description:

Prevents abyssal demons, dust devils, nechs or jellies being killable in wildy unless on slayer task, just like in game. 

### Changes:

- Ensure wildy slayer monsters can only be killed on task

### Other checks:

- [x] I have tested all my changes thoroughly.
