### PR TITLE
Fix wildy PK logic

### DIFF
--- a/src/lib/util/calcWildyPkChance.ts
+++ b/src/lib/util/calcWildyPkChance.ts
@@ -49,10 +49,10 @@ export function calcWildyPKChance(
 	const evasionReduction = randomVariation(calcPercentOfNum(scaledExp, maxReductionPercent), 10);
 
 	const tripMinutes = Math.round(duration / Time.Minute);
-	let pkCount = 0;
+	let pkEncounters = 0;
 	for (let i = 0; i < tripMinutes; i++) {
 		if (percentChance(pkChance)) {
-			pkCount++;
+			pkEncounters++;
 		}
 	}
 
@@ -102,8 +102,8 @@ export function calcWildyPKChance(
 	deathChance = reduceNumByPercent(deathChance, evasionReduction);
 
 	deathChance = Math.min(Math.max(0, deathChance), 100);
-	if (pkCount > 0) {
-		for (let i = 0; i < pkCount; i++) {
+	if (pkEncounters > 0) {
+		for (let i = 0; i < pkEncounters; i++) {
 			if (percentChance(deathChance)) {
 				died = true;
 				break;
@@ -123,5 +123,5 @@ export function calcWildyPKChance(
 		wildyMultiMultiplier === 1 ? ' no' : ''
 	} multi)`;
 
-	return { pkCount, died, chanceString, currentPeak };
+	return { pkEncounters, died, chanceString, currentPeak };
 }

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -124,7 +124,7 @@ export async function minionKillCommand(
 		});
 	}
 
-	const { bob, usingCannon, cannonMulti, chinning, hasWildySupplies } = result.currentTaskOptions;
+	const { bob, usingCannon, cannonMulti, chinning, died, pkEncounters, hasWildySupplies } = result.currentTaskOptions;
 	await addSubTaskToActivityTask<MonsterActivityTaskOptions>({
 		mi: monster.id,
 		userID: user.id,
@@ -137,6 +137,8 @@ export async function minionKillCommand(
 		cannonMulti: !cannonMulti ? undefined : cannonMulti,
 		chinning: !chinning ? undefined : chinning,
 		bob: !bob ? undefined : bob,
+		died,
+		pkEncounters,
 		hasWildySupplies,
 		isInWilderness: result.isInWilderness === true ? true : undefined,
 		attackStyles: result.attackStyles,

--- a/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
@@ -144,7 +144,7 @@ export const postBoostEffects: PostBoostEffect[] = [
 					'Your minion brought some supplies to survive potential pkers. (Handed back after trip if lucky)'
 				);
 			}
-			const { pkCount, died, chanceString } = calcWildyPKChance(
+			const { pkEncounters, died, chanceString } = calcWildyPKChance(
 				currentPeak,
 				gearBank,
 				monster,
@@ -161,9 +161,10 @@ export const postBoostEffects: PostBoostEffect[] = [
 			return {
 				message: messages.join(', '),
 				confirmation: confirmationString,
+				itemCost: antiPKSupplies,
 				changes: {
-					pkEncounters: pkCount,
-					died: died,
+					pkEncounters,
+					died,
 					hasWildySupplies
 				}
 			};


### PR DESCRIPTION
### Description:

Fixes wildy PK logic

### Changes:

- Add anti-PK supplies as item cost so they are removed on trip send
- Add pk info to monster activity data so it can be applied on trip return 

### Other checks:

- [x] I have tested all my changes thoroughly.
