### PR TITLE
Remove arrows from ammo in chompy hunting, tidy messages, use any Avas device in specialRemoveItems

### DIFF
--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -16,7 +16,7 @@ import type { CATier } from './combat_achievements/combatAchievements';
 import { CombatAchievements } from './combat_achievements/combatAchievements';
 import { BitField, projectiles } from './constants';
 import { bossCLItems } from './data/Collections';
-import { allPetIDs } from './data/CollectionsExport';
+import { allPetIDs, avasDevices } from './data/CollectionsExport';
 import { degradeableItems } from './degradeableItems';
 import type { GearSetup, UserFullGearSetup } from './gear/types';
 import { handleNewCLItems } from './handleNewCLItems';
@@ -541,7 +541,7 @@ Charge your items using ${mentionCommand(globalClient, 'minion', 'charge')}.`
 		const gearKey = options?.isInWilderness ? 'wildy' : 'range';
 		const realCost = bankToRemove.clone();
 		const rangeGear = this.gear[gearKey];
-		const hasAvas = rangeGear.hasEquipped("Ava's assembler");
+		const avasDevice = avasDevices.find(avas => rangeGear.hasEquipped(avas.item.id));
 		const updates: Prisma.UserUpdateArgs['data'] = {};
 
 		for (const [item, quantity] of bankToRemove.items()) {
@@ -576,10 +576,10 @@ Charge your items using ${mentionCommand(globalClient, 'minion', 'charge')}.`
 			const ammo = newRangeGear.ammo?.quantity;
 
 			const projectileCategory = Object.values(projectiles).find(i => i.items.includes(equippedAmmo));
-			if (hasAvas && projectileCategory?.savedByAvas) {
+			if (avasDevice && projectileCategory?.savedByAvas) {
 				const ammoCopy = ammoRemove[1];
 				for (let i = 0; i < ammoCopy; i++) {
-					if (percentChance(80)) {
+					if (percentChance(avasDevice.reduction)) {
 						ammoRemove[1]--;
 						realCost.remove(ammoRemove[0].id, 1);
 					}
@@ -598,10 +598,10 @@ Charge your items using ${mentionCommand(globalClient, 'minion', 'charge')}.`
 		}
 
 		if (dart) {
-			if (hasAvas) {
+			if (avasDevice) {
 				const copyDarts = dart?.[1];
 				for (let i = 0; i < copyDarts; i++) {
-					if (percentChance(80)) {
+					if (percentChance(avasDevice.reduction)) {
 						realCost.remove(dart[0].id, 1);
 						dart![1]--;
 					}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -333,6 +333,11 @@ export const projectiles = {
 		savedByAvas: true,
 		weapons: resolveItems(['Twisted bow'])
 	},
+	ogreArrow: {
+		items: resolveItems(['Ogre Arrow']),
+		savedByAvas: true,
+		weapons: resolveItems(['Ogre bow'])
+	},
 	bolt: {
 		items: resolveItems([
 			'Runite bolts',

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2266,3 +2266,9 @@ export const chompyHats = [
 	[getItemOrThrow('Chompy bird hat (expert ogre dragon archer)'), 3000],
 	[getItemOrThrow('Chompy bird hat (expert dragon archer)'), 4000]
 ] as const;
+
+export const avasDevices: { item: Item; reduction: number }[] = [
+	{ item: getOSItem("Ava's attractor"), reduction: 60 },
+	{ item: getOSItem("Ava's accumulator"), reduction: 72 },
+	{ item: getOSItem("Ava's assembler"), reduction: 80 }
+];

--- a/src/mahoji/lib/abstracted_commands/chompyHuntCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/chompyHuntCommand.ts
@@ -1,14 +1,13 @@
 import { formatDuration } from '@oldschoolgg/toolkit/util';
-import { Time, percentChance, reduceNumByPercent } from 'e';
+import { Time, percentChance } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { chompyHats } from '../../../lib/data/CollectionsExport';
+import { avasDevices, chompyHats } from '../../../lib/data/CollectionsExport';
 import { WesternProv, userhasDiaryTier } from '../../../lib/diaries';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
-import getOSItem from '../../../lib/util/getOSItem';
 
 const diaryBoosts = [
 	[WesternProv.elite, 100],
@@ -17,11 +16,6 @@ const diaryBoosts = [
 ] as const;
 
 const baseChompyPerHour = 100;
-
-const avas = [
-	[getOSItem("Ava's accumulator"), 72],
-	[getOSItem("Ava's assembler"), 80]
-] as const;
 
 export async function chompyHuntClaimCommand(user: MUser) {
 	const chompyScore = await getMinigameScore(user.id, 'big_chompy_bird_hunting');
@@ -44,7 +38,7 @@ export async function chompyHuntCommand(user: MUser, channelID: string) {
 	}
 
 	const rangeGear = user.gear.range;
-	if (!rangeGear.hasEquipped('Ogre bow')) {
+	if (!rangeGear.hasEquipped('Ogre bow') || !rangeGear.hasEquipped('Ogre arrow')) {
 		return 'You need an Ogre bow equipped in your range outfit, and Ogre arrows to hunt Chompy birds!';
 	}
 
@@ -68,21 +62,18 @@ export async function chompyHuntCommand(user: MUser, channelID: string) {
 		}
 	}
 
-	let arrowsNeeded = quantity;
-	for (const [ava, percent] of avas) {
-		if (rangeGear.hasEquipped(ava.name)) {
-			arrowsNeeded = Math.floor(reduceNumByPercent(arrowsNeeded, percent));
-			boosts.push(`${percent}% less arrows for ${ava.name}`);
-			break;
-		}
+	const avasDevice = avasDevices.find(avas => rangeGear.hasEquipped(avas.item.id));
+	if (avasDevice) {
+		boosts.push(`${avasDevice.reduction}% less arrows for ${avasDevice.item.name}`);
 	}
 
-	const cost = new Bank().add('Ogre arrow', arrowsNeeded);
-	if (!user.owns(cost)) {
-		return `You don't have enough Ogre arrow's to kill ${quantity}x Chompy birds, you need ${arrowsNeeded}.`;
+	const cost = new Bank().add('Ogre arrow', quantity);
+	const realCost = new Bank();
+	try {
+		realCost.add((await user.specialRemoveItems(cost)).realCost);
+	} catch (err: any) {
+		return `You cannot hunt chompy birds. ${err.message}`;
 	}
-
-	await transactItems({ userID: user.id, itemsToRemove: cost });
 
 	await addSubTaskToActivityTask<MinigameActivityTaskOptionsWithNoChanges>({
 		userID: user.id,
@@ -93,9 +84,9 @@ export async function chompyHuntCommand(user: MUser, channelID: string) {
 		minigameID: 'big_chompy_bird_hunting'
 	});
 
-	let str = `${user.minionName} is now hunting Big Chompy's! The trip will take ${formatDuration(
+	let str = `${user.minionName} is now hunting chompy birds! The trip will take ${formatDuration(
 		tripLength
-	)}. Removed ${cost} from your bank.`;
+	)}. Removing items: ${realCost}.`;
 
 	if (boosts.length > 0) {
 		str += `\n**Boosts:** ${boosts.join(', ')}.`;

--- a/src/tasks/minions/minigames/chompyHuntActivity.ts
+++ b/src/tasks/minions/minigames/chompyHuntActivity.ts
@@ -5,6 +5,7 @@ import { chompyHats } from '../../../lib/data/CollectionsExport';
 import { WesternProv, userhasDiaryTier } from '../../../lib/diaries';
 import { getMinigameEntity, incrementMinigameScore } from '../../../lib/settings/settings';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
+import { formatList } from '../../../lib/util';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 
 export const chompHuntTask: MinionTask = {
@@ -33,12 +34,11 @@ export const chompHuntTask: MinionTask = {
 			collectionLog: true,
 			itemsToAdd: loot
 		});
-		let str = `${user}, ${user.minionName} finished hunting Chompy Birds, they killed ${quantity}x Chompies. You have now have ${newScore} Chompies total. You received **${loot}**.`;
+		let str = `${user}, ${user.minionName} finished hunting ${quantity}x Chompy birds, you now have ${newScore} KC. You received ${loot}.`;
 
-		for (const [item, qty] of chompyHats) {
-			if (newScore >= qty && previousScore < qty) {
-				str += `\n\nCongratulations, you can now buy a ${item.name}!`;
-			}
+		const newHats = chompyHats.filter(hat => newScore >= hat[1] && previousScore < hat[1]);
+		if (newHats.length > 0) {
+			str += `\nYou can now claim the following chompy bird hats: **${formatList(newHats.map(hat => hat[0].name))}**!`;
 		}
 
 		handleTripFinish(user, channelID, str, undefined, data, loot);


### PR DESCRIPTION
### Description:

Chompy hunting currently required equipped ammo, but then removes ammo from bank. PR ensures arrows are removed from equipped ammo, and also adds support for any Avas device in `specialRemoveItems`. 

### Changes:

- Remove arrows from ammo in chompy hunting
- Tidy chompy hunt trip messages
- Allow any Avas device in 'specialRemoveItems'

### Other checks:

- [x] I have tested all my changes thoroughly.
