### PR TITLE
Fix runecraft skill formatting in wiki

### DIFF
--- a/docs/src/content/docs/bso/Monsters/Bosses/vasa-magus.md
+++ b/docs/src/content/docs/bso/Monsters/Bosses/vasa-magus.md
@@ -43,7 +43,7 @@ Use the best possible mage gear. Virtus is the best option besides Gorajan Occul
 
 - **Voidling:** Pet that alchs items from your favorite alchs list while on trips. Works faster with a Magic Master Cape.
 - **Tattered Robes of Vasa:** Used to craft a Vasa Cloak, the BiS mage cape
-  - Requires [[runecrafting:105]], [[crafting:105]], 1 Imbued Mage Arena Cape, 1 Abyssal Cape, and 1 Tattered Robes of Vasa  
+  - Requires [[runecraft:105]], [[crafting:105]], 1 Imbued Mage Arena Cape, 1 Abyssal Cape, and 1 Tattered Robes of Vasa  
     → [[/create item\:vasa cloak]]
 - **Magical Artifact:** Alchs for 50M
 - **Jar of Magic:** Has no use

--- a/docs/src/content/docs/osb/Skills/runecrafting.md
+++ b/docs/src/content/docs/osb/Skills/runecrafting.md
@@ -20,11 +20,11 @@ You can create Runecrafting pouches using [[/create]]. Similarly to in-game, hig
 
 | **Pouch**      | **Rc'ing Lvl Required To Use**        |
 | -------------- | ------------------------------------- |
-| Small Pouch    | [[runecrafting:1]]                    |
-| Medium Pouch   | [[runecrafting:25]]                   |
-| Large Pouch    | [[runecrafting:50]]                   |
-| Giant Pouch    | [[runecrafting:75]]                   |
-| Colossal Pouch | [[runecrafting:85]] + [[crafting:56]] |
+| Small Pouch    | [[runecraft:1]]                    |
+| Medium Pouch   | [[runecraft:25]]                   |
+| Large Pouch    | [[runecraft:50]]                   |
+| Giant Pouch    | [[runecraft:75]]                   |
+| Colossal Pouch | [[runecraft:85]] + [[crafting:56]] |
 
 - Requires an Abyssal needle and one of each lower tier pouch to create.
 
@@ -32,20 +32,20 @@ You can create Runecrafting pouches using [[/create]]. Similarly to in-game, hig
 
 | **Rune** | **Required Level**  |
 | -------- | ------------------- |
-| Air      | [[runecrafting:1]]  |
-| Mind     | [[runecrafting:2]]  |
-| Water    | [[runecrafting:5]]  |
-| Earth    | [[runecrafting:9]]  |
-| Fire     | [[runecrafting:14]] |
-| Body     | [[runecrafting:20]] |
-| Cosmic   | [[runecrafting:27]] |
-| Chaos    | [[runecrafting:35]] |
-| Astral   | [[runecrafting:40]] |
-| Nature   | [[runecrafting:44]] |
-| Law      | [[runecrafting:54]] |
-| Death    | [[runecrafting:65]] |
-| Blood    | [[runecrafting:77]] |
-| Wrath    | [[runecrafting:95]] |
+| Air      | [[runecraft:1]]  |
+| Mind     | [[runecraft:2]]  |
+| Water    | [[runecraft:5]]  |
+| Earth    | [[runecraft:9]]  |
+| Fire     | [[runecraft:14]] |
+| Body     | [[runecraft:20]] |
+| Cosmic   | [[runecraft:27]] |
+| Chaos    | [[runecraft:35]] |
+| Astral   | [[runecraft:40]] |
+| Nature   | [[runecraft:44]] |
+| Law      | [[runecraft:54]] |
+| Death    | [[runecraft:65]] |
+| Blood    | [[runecraft:77]] |
+| Wrath    | [[runecraft:95]] |
 
 - Blood runes crafted using the true blood altar also require the stats for Sins of the Father quest:
   - [[woodcutting:62]]
@@ -72,12 +72,12 @@ It's recommended to equip a staff in your skilling setup to provide infinite run
 
 | **Rune** | **Required Level**  |
 | -------- | ------------------- |
-| Mist     | [[runecrafting:6]]  |
-| Dust     | [[runecrafting:10]] |
-| Mud      | [[runecrafting:13]] |
-| Smoke    | [[runecrafting:15]] |
-| Steam    | [[runecrafting:19]] |
-| Lava     | [[runecrafting:23]] |
+| Mist     | [[runecraft:6]]  |
+| Dust     | [[runecraft:10]] |
+| Mud      | [[runecraft:13]] |
+| Smoke    | [[runecraft:15]] |
+| Steam    | [[runecraft:19]] |
+| Lava     | [[runecraft:23]] |
 
 ## Tiaras
 
@@ -93,8 +93,8 @@ Blood runes and Soul runes can be crafted at the Dark Altar using [[/runecraft]]
 
 - [[mining:38]]
 - [[crafting:38]]
-- [[runecrafting:77]] for Bloods
-- [[runecrafting:90]] for Souls
+- [[runecraft:77]] for Bloods
+- [[runecraft:90]] for Souls
 - [[agility:73]] highly recommended
 
 ### Boosts
@@ -106,13 +106,13 @@ Blood runes and Soul runes can be crafted at the Dark Altar using [[/runecraft]]
 
 ## Fastest Route to 99:
 
-[[/runecraft rune\:Air Rune quantity\:103]] (until [[runecrafting:6]])  
-[[/runecraft rune\:Mist Rune quantity\:76]] (until [[runecrafting:10]])  
-[[/runecraft rune\:Dust Rune quantity\:75]] (until [[runecrafting:13]])  
-[[/runecraft rune\:Mud Rune quantity\:61]] (until [[runecrafting:15]])  
-[[/runecraft rune\:Smoke Rune quantity\:164]] (until [[runecrafting:19]])  
-[[/runecraft rune\:Steam Rune quantity\:232]] (until [[runecrafting:23]])  
-[[/runecraft rune\:Lava Rune]] (repeat until [[runecrafting:99]])
+[[/runecraft rune\:Air Rune quantity\:103]] (until [[runecraft:6]])  
+[[/runecraft rune\:Mist Rune quantity\:76]] (until [[runecraft:10]])  
+[[/runecraft rune\:Dust Rune quantity\:75]] (until [[runecraft:13]])  
+[[/runecraft rune\:Mud Rune quantity\:61]] (until [[runecraft:15]])  
+[[/runecraft rune\:Smoke Rune quantity\:164]] (until [[runecraft:19]])  
+[[/runecraft rune\:Steam Rune quantity\:232]] (until [[runecraft:23]])  
+[[/runecraft rune\:Lava Rune]] (repeat until [[runecraft:99]])
 
 **Materials Needed:**  
 1,241,520 Pure essence and 1000–2000 Binding necklaces  
@@ -132,8 +132,8 @@ This assumes you have a staff providing infinite fire runes in your skilling set
 [[/runecraft rune\:Earth Rune quantity\:176]]  
 [[/runecraft rune\:Fire Rune quantity\:338]]  
 [[/runecraft rune\:Body Rune quantity\:4368]]  
-[[/runecraft rune\:Astral Rune]] – to [[runecrafting:77]]  
-[[/runecraft rune\:Blood Rune]] – to [[runecrafting:90]] (or 99)  
+[[/runecraft rune\:Astral Rune]] – to [[runecraft:77]]  
+[[/runecraft rune\:Blood Rune]] – to [[runecraft:90]] (or 99)  
 [[/runecraft rune\:Soul Rune]] – to whatever; this is best XP/hr at the Dark Altar!
 
 **Materials Needed:** 170,382 Pure essence


### PR DESCRIPTION
### Description:

Currently formatting of runecrafting skill breaks. Skill lookups uses `SkillsArray`, which has 'runecraft', so use that instead.

### Changes:

- Rename `runecrafting` to `runecraft` where skill formatting is used in wiki

### Other checks:

- [x] I have tested all my changes thoroughly.
