### PR TITLE
Split item costs into required and optional on wiki

### DIFF
--- a/docs/src/content/docs/osb/monsters.mdx
+++ b/docs/src/content/docs/osb/monsters.mdx
@@ -153,7 +153,7 @@ These boosts are from having the right object built in your POH.
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Anti-venom+(4)]] or [[Anti-venom(4)]] or [[Antidote++(4)]]
 
@@ -236,11 +236,13 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Super restore(4)]] or [[Prayer potion(4)]]
 
-- [[Super combat potion(4)]]
+**Optional Items**
+
+- [[Super combat potion(4)]] (7% boost)
 
 </TabItem>
 <TabItem label="Requirements">
@@ -369,7 +371,7 @@ Melee gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Extended anti-venom+(4)]] or [[Anti-venom+(4)]]
 
@@ -381,7 +383,9 @@ Melee gear boosts:
 
 - [[Anglerfish]]
 
-- [[Spider cave teleport]]
+**Optional Items**
+
+- [[Spider cave teleport]] (10% boost)
 
 </TabItem>
 <TabItem label="Requirements">
@@ -518,7 +522,7 @@ Melee gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Blighted ancient ice sack]] or [[Blood rune]] [[Death rune]] [[Water rune]] or [[Stamina potion(4)]]
 
@@ -926,7 +930,7 @@ Range gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Mossy key]]
 
@@ -956,7 +960,7 @@ Range gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Blighted ancient ice sack]] or [[Blood rune]] [[Death rune]] [[Water rune]] or [[Stamina potion(4)]]
 
@@ -1259,9 +1263,9 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Optional Items**
 
-- [[Key master teleport]]
+- [[Key master teleport]] (10% boost)
 
 </TabItem>
 <TabItem label="Requirements">
@@ -2193,7 +2197,7 @@ Melee gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Awakener's orb]]
 
@@ -2336,7 +2340,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Raw cave eel]] [[Giant frog legs]]
 
@@ -2490,7 +2494,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - No Food Needed
 
-**Item Cost**
+**Required Items**
 
 - [[Prayer potion(4)]]
 
@@ -2792,7 +2796,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Anti-venom+(4)]] or [[Anti-venom(4)]] or [[Antidote++(4)]]
 
@@ -2867,7 +2871,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Raw jubbly]] [[Raw lobster]]
 
@@ -3629,7 +3633,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Eye of newt]] [[Feather]]
 
@@ -3726,7 +3730,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Giant key]]
 
@@ -3897,7 +3901,7 @@ Mage gear boosts, it is **required** to have atleast one of these:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Stamina potion(4)]] [[Ruby dragon bolts (e)]]
 
@@ -4167,7 +4171,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Dark totem]]
 
@@ -4210,7 +4214,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Red spiders' eggs]] [[Raw sardine]]
 
@@ -4309,7 +4313,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Bronze knife]] or [[Iron knife]] or [[Steel knife]] or [[Black knife]] or [[Mithril knife]] or [[Adamant knife]] or [[Rune knife]] or [[Dragon knife]] or [[Rune knife(p++)]] or [[Chinchompa]] or [[Red chinchompa]] or [[Black chinchompa]]
 
@@ -4446,7 +4450,7 @@ Wildy gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Raw swordfish]] [[Raw chicken]]
 
@@ -4543,7 +4547,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Super restore(4)]] or [[Prayer potion(4)]]
 
@@ -4794,7 +4798,7 @@ Range gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Awakener's orb]]
 
@@ -5023,7 +5027,7 @@ Range gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Awakener's orb]]
 
@@ -5232,9 +5236,9 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Optional Items**
 
-- [[Guthixian temple teleport]]
+- [[Guthixian temple teleport]] (10% boost)
 
 </TabItem>
 <TabItem label="Requirements">
@@ -5403,7 +5407,7 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Cowhide]] [[Unicorn horn]]
 
@@ -5662,7 +5666,7 @@ Melee gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Awakener's orb]]
 
@@ -5764,7 +5768,7 @@ Melee gear boosts, it is **required** to have atleast one of these:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Required Items**
 
 - [[Bronze knife]] or [[Iron knife]] or [[Steel knife]] or [[Black knife]] or [[Mithril knife]] or [[Adamant knife]] or [[Rune knife]] or [[Dragon knife]] or [[Rune knife(p++)]] or [[Chinchompa]] or [[Red chinchompa]] or [[Black chinchompa]]
 
@@ -6282,11 +6286,13 @@ You can have one of the following boosts:
 <TabItem label="Costs">
     - No Food Needed
 
-**Item Cost**
+**Required Items**
 
 - [[Blighted super restore(4)]] or [[Super restore(4)]] or [[Prayer potion(4)]]
 
-- [[Burning amulet(5)]]
+**Optional Items**
+
+- [[Burning amulet(5)]] (25% boost)
 
 </TabItem>
 <TabItem label="Requirements">
@@ -6333,9 +6339,9 @@ Wildy gear boosts:
 <TabItem label="Costs">
     - Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. 
 
-**Item Cost**
+**Optional Items**
 
-- [[Zul-andra teleport]]
+- [[Zul-andra teleport]] (10% boost)
 
 </TabItem>
 <TabItem label="Requirements">

--- a/scripts/wiki.ts
+++ b/scripts/wiki.ts
@@ -91,12 +91,26 @@ async function renderMonstersMarkdown() {
 				`- ${monster.healAmountNeeded ? `Requires food in your bank to kill, the amount needed is heavily reduced based on your gear/experience. ${monster.minimumHealAmount ? `You must have/use food that heals atleast ${monster.healAmountNeeded}HP` : ''}` : 'No Food Needed'}`
 			);
 			if (monster.itemCost) {
-				md.addLine('**Item Cost**');
-				for (const consumable of Array.isArray(monster.itemCost) ? monster.itemCost : [monster.itemCost]) {
-					const allConsumables = [consumable, ...[consumable.alternativeConsumables ?? []]].flat();
-					md.addLine(
-						`- ${allConsumables.map(c => `${c.itemCost.itemIDs.map(id => `[[${name(id)}]]`).join(' ')}`).join(' or ')}`
-					);
+				const itemCostArray = Array.isArray(monster.itemCost) ? monster.itemCost : [monster.itemCost];
+				const requiredItems = itemCostArray.filter(ic => !ic.optional);
+				const optionalItems = itemCostArray.filter(ic => ic.optional);
+				if (requiredItems.length > 0) {
+					md.addLine('**Required Items**');
+					for (const consumable of requiredItems) {
+						const allConsumables = [consumable, ...[consumable.alternativeConsumables ?? []]].flat();
+						md.addLine(
+							`- ${allConsumables.map(c => `${c.itemCost.itemIDs.map(id => `[[${name(id)}]]`).join(' ')}`).join(' or ')}`
+						);
+					}
+				}
+				if (optionalItems.length > 0) {
+					md.addLine('**Optional Items**');
+					for (const consumable of optionalItems) {
+						const allConsumables = [consumable, ...[consumable.alternativeConsumables ?? []]].flat();
+						md.addLine(
+							`- ${allConsumables.map(c => `${c.itemCost.itemIDs.map(id => `[[${name(id)}]]`).join(' ')}`).join(' or ')} (${consumable.boostPercent ?? 0}% boost)`
+						);
+					}
 				}
 			}
 


### PR DESCRIPTION
### Description:

Split item costs into required and optional on wiki. Closes #6367.

### Changes:

- Split item costs into required and optional on wiki
- Add boosts for optional items

### Other checks:

- [x] I have tested all my changes thoroughly.
