### PR TITLE
Add "click to copy" for OSB commands on wiki

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -46,6 +46,10 @@ export default defineConfig({
 					content: `if (window.location.href.includes('/bso/')) {
 window.onload = () => document.body.classList.add('bso-theme');
 }`
+				},
+				{
+					tag: 'script',
+					attrs: { src: '/scripts/copyCommand.js', defer: true }
 				}
 			],
 			editLink: {

--- a/docs/public/scripts/copyCommand.js
+++ b/docs/public/scripts/copyCommand.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Store original text if not already stored - else double clicking will override original text
         if (!btn.hasAttribute('data-original-text')) {
             btn.setAttribute('data-original-text', btn.textContent);
+            btn.style.width = btn.offsetWidth + 'px';
         }
         const original = btn.getAttribute('data-original-text');
 

--- a/docs/public/scripts/copyCommand.js
+++ b/docs/public/scripts/copyCommand.js
@@ -1,0 +1,26 @@
+let copyTimeout;
+document.addEventListener('DOMContentLoaded', () => {
+    document.body.addEventListener('click', function (e) {
+        const btn = e.target.closest('.discord_command_copy');
+        if (!btn) return;
+        const command = btn.getAttribute('data-command');
+        if (!command) return;
+
+        // Store original text if not already stored - else double clicking will override original text
+        if (!btn.hasAttribute('data-original-text')) {
+            btn.setAttribute('data-original-text', btn.textContent);
+        }
+        const original = btn.getAttribute('data-original-text');
+
+        navigator.clipboard.writeText(command).then(() => {
+            btn.classList.add('copied');
+            btn.textContent = 'Copied!';
+            if (btn.copyTimeout) clearTimeout(btn.copyTimeout);
+            btn.copyTimeout = setTimeout(() => {
+                btn.classList.remove('copied');
+                btn.textContent = original;
+                btn.copyTimeout = null;
+            }, 1200);
+        });
+    });
+});

--- a/docs/public/scripts/copyCommand.js
+++ b/docs/public/scripts/copyCommand.js
@@ -21,6 +21,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 btn.textContent = original;
                 btn.copyTimeout = null;
             }, 1200);
+        }).catch(() => {
+            btn.classList.add('copied');
+            btn.textContent = 'Failed to copy!';
+            if (btn.copyTimeout) clearTimeout(btn.copyTimeout);
+            btn.copyTimeout = setTimeout(() => {
+                btn.classList.remove('copied');
+                btn.textContent = original;
+                btn.copyTimeout = null;
+            }, 2000);
         });
     });
 });

--- a/docs/src/plugins/items.ts
+++ b/docs/src/plugins/items.ts
@@ -71,7 +71,7 @@ ${author?.avatar ? `<img class="contributor_avatar" src="${author.avatar}" />` :
 					if (!cmd) {
 						console.warn(`Could not find command with name: ${match.slice(1)}`);
 					}
-					html = `<span class="discord_command">${content}</span>`;
+					html = `<button class="discord_command_copy" data-command="${content}" type="button" aria-label="Copy command">${content}</button>`;
 				} else if (content.includes('...')) {
 					const githubIcon = `<svg aria-hidden="true" class="github_icon" width="17" height="17" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.8 23.38c.6.12.83-.26.83-.57L9 21.07c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.08-.74.09-.73.09-.73 1.2.09 1.83 1.24 1.83 1.24 1.08 1.83 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.64 1.66.24 2.88.12 3.18a4.65 4.65 0 0 1 1.23 3.22c0 4.61-2.8 5.63-5.48 5.92.42.36.81 1.1.81 2.22l-.01 3.29c0 .31.2.69.82.57A12 12 0 0 0 12 .3Z"></path></svg>`;
 					html = `<div class="github_link">${githubIcon}<a target="_blank" href="https://github.com/oldschoolgg/oldschoolbot/compare/${content}">Commits</a></div>`;

--- a/docs/src/styles/main.css
+++ b/docs/src/styles/main.css
@@ -425,18 +425,29 @@ ol + ol li blockquote {
 	text-decoration: none !important;
 }
 
-.discord_command {
+.discord_command_copy {
 	background-color: #4e538f;
 	width: max-content;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	align-content: center;
 	padding: 0px 5px;
 	font-size: 13px;
 	color: white;
+	border-radius: 6px;
+	cursor: pointer;
+	transition: background 0.2s;
+	margin: 0 2px;
 }
 
+.discord_command_copy:hover {
+	background: #6a6fcf;
+}
+
+.discord_command_copy.copied {
+	background: #3cb371;
+}
 sl-sidebar-state-persist > ul > li:nth-child(2) > details > summary,
 sl-sidebar-state-persist > ul > li:nth-child(3) > details > summary {
 	text-align: center;
@@ -476,7 +487,7 @@ sl-sidebar-state-persist > ul > li:nth-child(3) > details > summary > svg {
 }
 
 .osrs_item,
-.discord_command {
+.discord_command_copy {
 	display: inline-flex;
 	align-items: center;
 	vertical-align: middle;
@@ -491,7 +502,7 @@ sl-sidebar-state-persist > ul > li:nth-child(3) > details > summary > svg {
 }
 
 .osrs_item_name,
-.discord_command {
+.discord_command_copy {
 	font-size: 0.9em;
 	text-align: center;
 	white-space: nowrap;


### PR DESCRIPTION
### Description:

Adds functionality to copy command text to clipboard when you click on formatted commands in wiki. The copy script is currently in js, I don't know if it should be rewritten in ts or not to match backend style.
There's no visual indicator that commands can be copied, but they appear as buttons and should catch on pretty fast. 

### Changes:

- Add copy command functionality to OSB command formatting
- Change css of formatting so commands look/ feel like a button 

### Other checks:

- [x] I have tested all my changes thoroughly.
