### PR TITLE
Make polls silent responses, and update ephemeral handling in deferInteraction

### DIFF
--- a/src/lib/util/interactionReply.ts
+++ b/src/lib/util/interactionReply.ts
@@ -9,7 +9,7 @@ import type {
 	RepliableInteraction,
 	StringSelectMenuInteraction
 } from 'discord.js';
-import { DiscordAPIError } from 'discord.js';
+import { DiscordAPIError, MessageFlags } from 'discord.js';
 
 import { SILENT_ERROR } from '../constants';
 import { logErrorForInteraction } from './logError';
@@ -51,7 +51,9 @@ export async function deferInteraction(
 	if (!interaction.deferred && !wasDeferred.has(interaction.id)) {
 		wasDeferred.add(interaction.id);
 		try {
-			await interaction.deferReply({ ephemeral });
+			const options: { flags?: number } = {};
+			if (ephemeral) options.flags = MessageFlags.Ephemeral;
+			await interaction.deferReply(options);
 		} catch (err) {
 			logErrorForInteraction(err, interaction);
 		}

--- a/src/mahoji/commands/poll.ts
+++ b/src/mahoji/commands/poll.ts
@@ -19,7 +19,7 @@ export const pollCommand: OSBMahojiCommand = {
 	run: async ({ interaction, options, user, channelID }: CommandRunOptions<{ question: string }>) => {
 		const channel = globalClient.channels.cache.get(channelID.toString());
 		if (!channelIsSendable(channel)) return { ephemeral: true, content: 'Invalid channel.' };
-		await deferInteraction(interaction);
+		await deferInteraction(interaction, true);
 		try {
 			const message = await channel.send({
 				content: `**Poll from ${user.username}:** ${options.question}`,


### PR DESCRIPTION
### Description:

Switches the "Poll created. Users can click on the two reactions to vote." message to silent response. Apparently `ephemeral = true` is deprecated in discord.js and needs to be replaced with `flags = MessageFlags.Ephemeral`, updates this for `deferInteraction`.

### Changes:

- Switches the "Poll created. Users can click on the two reactions to vote." message to silent response.
- Changes `deferInteraction` to use `flags = MessageFlags.Ephemeral`, when `ephemeral` is `true`.

### Other checks:

- [x] I have tested all my changes thoroughly.
