### PR TITLE
Update wiki docs for Sepulchre, Woodcutting and Runecrafting 

### DIFF
--- a/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
+++ b/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
@@ -6,6 +6,17 @@ The Hallowed Sepulchre is an agility minigame where you can unlock the Dark Grac
 
 To start the Sepulchre, use [[/minigames sepulchre start]].
 
+### Fletching while Running
+
+You can fletch specific "zero-time" items during each lap by specifying the
+`fletching:` option when starting a run:
+
+- `[[/minigames sepulchre start fletching\:Rune dart]]`
+
+This works with darts, arrows, bolts, broad arrows, broad bolts, amethyst broad
+bolts, tipped bolts, tipped dragon bolts and javelins. The necessary materials
+are removed from your bank and do not extend the trip duration.
+
 ## Requirements
 
 - Any set of Graceful - **MUST BE EQUIPPED IN THE SKILLING SETUP**

--- a/docs/src/content/docs/osb/Skills/fletching.md
+++ b/docs/src/content/docs/osb/Skills/fletching.md
@@ -14,3 +14,17 @@ You can train Fletching with the [[/fletch]] command. To see all the items you c
 1. [[/fletch name\:Adamant dart]] until 81
 1. [[/fletch name\:Rune dart]] until 95
 1. [[/fletch name\:Dragon dart]] until 99
+
+### Fletching at the Hallowed Sepulchre
+
+You can fletch certain "zero-time" items while completing laps of the Hallowed
+Sepulchre. Start a run with the `fletching:` option and specify the item ID you
+wish to fletch:
+
+- `[[/minigames sepulchre start fletching\:Rune dart]]`
+
+The following items can be fletched this way without increasing trip duration:
+Broad arrows, Broad bolts, Amethyst broad bolts, all types of darts, arrows,
+bolts, tipped bolts and javelins. The required items are removed from your bank
+at the start of the trip and your minion will fletch as many as possible while
+running the Sepulchre.

--- a/docs/src/content/docs/osb/Skills/runecrafting.md
+++ b/docs/src/content/docs/osb/Skills/runecrafting.md
@@ -4,6 +4,10 @@ title: "Runecrafting"
 
 You can train Runecrafting using [[/runecraft]].
 
+Runecrafting can also be trained at the [Guardians of the Rift](/osb/activities/guardians-of-the-rift) minigame using `[/minigames gotr start]`.
+When equipped in the skilling setup, the **Raiments of the eye** outfit grants up to **60%** extra runes during the minigame and while regular runecrafting.
+An **Abyssal lantern** can be purchased with Abyssal pearls to further boost barrier repairs and mined fragments based on your Firemaking level.
+
 ## Boosts
 
 There are several boosts available which apply to all runes except blood and soul runes. You can view the boosts for blood and soul runes on the [Dark Altar page](https://wiki.oldschool.gg/skills/runecrafting/dark-altar). The true blood altar uses the same boosts as regular runecrafting.

--- a/docs/src/content/docs/osb/Skills/woodcutting/README.md
+++ b/docs/src/content/docs/osb/Skills/woodcutting/README.md
@@ -22,6 +22,7 @@ If you have at least 60 Woodcutting, and the tree you are attempting to chop is 
 Using this filter when chopping logs allows your minion to reach much higher xp rates, at the expense of not receiving any logs from your trip. For ironmen, it may be beneficial to chop normally so they can use the logs for early firemaking or construction levels. You will still receive bird nests and their contents when powerchopping.
 
 After level 92, your minion magically learns how to tick manipulate, allowing rates of up to 200k xp/h powerchopping Teak logs.
+To use the 1.5 tick method you must chop the trees planted in Farming patches. Teak trees require [[woodcutting:92]] and [[farming:35]], while Mahogany trees require [[woodcutting:92]] and [[farming:55]]. Forestry events must be disabled for this method.
 
 ## Lumberjack Outfit
 


### PR DESCRIPTION
**Summary**
- document zero-time fletching at the Hallowed Sepulchre
- mention Sepulchre fletching in the fletching skill guide
- expand woodcutting powerchopping section with 1.5 tick method details
- note Guardians of the Rift training and rewards in runecrafting guide
