### PR TITLE
Fix loot message format in casket command

### DIFF
--- a/src/lib/workers/casket.worker.ts
+++ b/src/lib/workers/casket.worker.ts
@@ -24,11 +24,8 @@ export default async ({ clueTierID, quantity }: CasketWorkerArgs): Promise<[Item
 		}
 	}
 
-	const opened = `You opened ${quantity} ${clueTier.name} Clue Casket${quantity > 1 ? 's' : ''}${
-		mimicNumber > 0
-			? ` and defeated ${mimicNumber} 
-					mimic${mimicNumber > 1 ? 's' : ''}`
-			: ''
+	const opened = `Loot from ${quantity} ${clueTier.name} Casket${quantity > 1 ? 's' : ''}${
+		mimicNumber > 0 ? ` and ${mimicNumber} mimic${mimicNumber > 1 ? 's' : ''}` : ''
 	}`;
 
 	return [loot.toJSON(), opened];


### PR DESCRIPTION
### Description:

Currently the tabs before 'mimic' are included in the string, leading to a bunch of ???. Fixes this and shortens message so it fits in image.

### Changes:

Fix loot message format in casket command

### Other checks:

- [x] I have tested all my changes thoroughly.
