### PR TITLE
Improve trade and pay clarity

### DIFF
--- a/packages/oldschooljs/src/structures/Bank.ts
+++ b/packages/oldschooljs/src/structures/Bank.ts
@@ -285,6 +285,17 @@ export default class Bank {
 			.join(', ');
 	}
 
+	public toStringFull(): string {
+		const items = this.items();
+		if (items.length === 0) {
+			return 'No items';
+		}
+		return items
+			.sort((a, b) => a[0].name.localeCompare(b[0].name))
+			.map(([item, qty]) => `${qty.toLocaleString()}x ${item?.name ?? 'Unknown item'}`)
+			.join(', ');
+	}
+
 	public get length(): number {
 		return this.map.size;
 	}

--- a/src/mahoji/commands/pay.ts
+++ b/src/mahoji/commands/pay.ts
@@ -1,7 +1,7 @@
 import { Events } from '@oldschoolgg/toolkit/constants';
 import type { CommandRunOptions, MahojiUserOption } from '@oldschoolgg/toolkit/util';
 import { ApplicationCommandOptionType } from 'discord.js';
-import { Bank, toKMB } from 'oldschooljs';
+import { Bank } from 'oldschooljs';
 
 import { BLACKLISTED_USERS } from '../../lib/blacklists';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
@@ -57,7 +57,7 @@ export const payCommand: OSBMahojiCommand = {
 				interaction,
 				`Are you sure you want to pay ${options.user.user.username}#${options.user.user.discriminator} (ID: ${
 					recipient.id
-				}) ${toKMB(amount)}?`
+				}) ${amount.toLocaleString()}?`
 			);
 		}
 

--- a/src/mahoji/commands/trade.ts
+++ b/src/mahoji/commands/trade.ts
@@ -19,6 +19,14 @@ import { filterOption } from '../lib/mahojiCommandOptions';
 import type { OSBMahojiCommand } from '../lib/util';
 import { addToGPTaxBalance, mahojiParseNumber } from '../mahojiSettings';
 
+function formatBankForDisplay(bank: Bank, maxLen: number): string {
+	const fullStr = bank.toStringFull();
+	if (fullStr.length > maxLen) {
+		return bank.toString(); // abbreviated with toKMB formatting
+	}
+	return fullStr;
+}
+
 export const tradeCommand: OSBMahojiCommand = {
 	name: 'trade',
 	description: 'Allows you to trade items with other players.',
@@ -116,13 +124,14 @@ export const tradeCommand: OSBMahojiCommand = {
 			return "You're trying to trade untradeable items.";
 		}
 
-		if (itemsSent.length === 0 && itemsReceived.length === 0) return "You can't make an empty trade.";
+		if (itemsSent.items().length === 0 && itemsReceived.items().length === 0)
+			return "You can't make an empty trade.";
 		if (!senderUser.owns(itemsSent)) return "You don't own those items.";
 
 		await handleMahojiConfirmation(
 			interaction,
-			`**${senderUser}** is giving: ${truncateString(itemsSent.toString(), 950)}
-**${recipientUser}** is giving: ${truncateString(itemsReceived.toString(), 950)}
+			`**${senderUser}** is giving: ${truncateString(formatBankForDisplay(itemsSent, 950), 950)}
+**${recipientUser}** is giving: ${truncateString(formatBankForDisplay(itemsReceived, 950), 950)}
 
 Both parties must click confirm to make the trade.`,
 			[recipientUser.id, senderUser.id]
@@ -158,9 +167,9 @@ Both parties must click confirm to make the trade.`,
 			await addToGPTaxBalance(senderUser.id, itemsSent.amount('Coins'));
 		}
 
-		return `${discrimName(senderAPIUser)} sold ${itemsSent} to ${discrimName(
+		return `${discrimName(senderAPIUser)} sold ${truncateString(formatBankForDisplay(itemsSent, 950), 950)} to ${discrimName(
 			recipientAPIUser
-		)} in return for ${itemsReceived}.
+		)} in return for ${truncateString(formatBankForDisplay(itemsReceived, 950), 950)}.
 
 You can now buy/sell items in the Grand Exchange: ${mentionCommand(globalClient, 'ge')}`;
 	}


### PR DESCRIPTION
A new Bank.toStringFull method outputs item quantities with comma formatting, and both /trade and /pay confirmations now show exact amounts.

Key changes include:
- Introduced toStringFull in the bank class to show comma-separated quantities without shortening
- /pay confirmation uses amount.toLocaleString() so large GP amounts display fully, replacing the prior toKMB format
- /trade confirmation strings use toStringFull() for both sent and received items, ensuring full quantities are displayed to each user, if this exceeds the character limit though, reverts back to the shortened way. 

- [x] I have tested all my changes thoroughly.
