### PR TITLE
QoL MegaDuck fixes

### DIFF
--- a/src/mahoji/commands/megaduck.ts
+++ b/src/mahoji/commands/megaduck.ts
@@ -148,15 +148,6 @@ export const megaDuckCommand: OSBMahojiCommand = {
 			resetCooldown(user, 'megaduck');
 			return message;
 		};
-		const defaultWithoutCooldown = () => {
-			resetCooldown(user, 'megaduck');
-			return {
-				content: `${user} Mega duck is at ${location.x}x ${location.y}y. You've moved it ${
-					location.usersParticipated[user.id] ?? 0
-				} times. ${topFeeders(Object.entries(location.usersParticipated))}`,
-				files: [{ attachment: image, name: 'megaduck.png' }]
-			};
-		};
 
 		const guild = guildID ? globalClient.guilds.cache.get(guildID.toString()) : null;
 		if (!guild) return withoutCooldown('You can only run this in a guild.');
@@ -199,7 +190,13 @@ export const megaDuckCommand: OSBMahojiCommand = {
 
 		const { image } = await makeImage(location);
 		if (!direction) {
-			return defaultWithoutCooldown();
+			resetCooldown(user, 'megaduck');
+			return {
+				content: `${user} Mega duck is at ${location.x}x ${location.y}y. You've moved it ${
+					location.usersParticipated[user.id] ?? 0
+				} times. ${topFeeders(Object.entries(location.usersParticipated))}`,
+				files: [{ attachment: image, name: 'megaduck.png' }]
+			};
 		}
 
 		const cost = new Bank().add('Breadcrumbs');


### PR DESCRIPTION
### Description:

Adds some nice QoL fixes for MegaDuck

### Changes:

- Reduces cooldown from 30 => 20 seconds
- Resets cooldown in more cases: 'Cannot move' and 'No direction' (check)
- Allows bot admins (aka Cyr) to reset the duck in the oldschool.gg discord so I don't have to do it manually anymore.

### Other checks:

- [ ] I have tested all my changes thoroughly.
