### PR TITLE
Add more openables to the list that don't apply to Bingo

### DIFF
--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -109,6 +109,10 @@ const itemsThatDontAddToTempCL = resolveItems([
 	'Monkey crate',
 	'Magic crate',
 	'Chimpling jar',
+	'Mystery impling jar',
+	'Eternal impling jar',
+	'Infernal impling jar',
+	'Shrimpling',
 	...ClueTiers.flatMap(t => [t.id, t.scrollID])
 ]);
 


### PR DESCRIPTION
### Description:

Removes shrimplings, elder implings, and a few others from the list of openables that do not count towards bingo (or temp CL)
