### PR TITLE
Some summer sweep up changes (and sarachnis)

### DIFF
--- a/data/osb/monsters.json
+++ b/data/osb/monsters.json
@@ -1,6 +1,6 @@
 {
-	"hash": "81de72ea9364b2872f3ff1f40878be7b",
-	"date": "2025-07-17T22:48:01.946Z",
+	"hash": "8e997cc218297b80ddc332acfb91c3b2",
+	"date": "2025-08-05T00:16:17.315Z",
 	"data": [
 		{
 			"id": 2,
@@ -4553,7 +4553,7 @@
 		{
 			"id": 8713,
 			"name": "Sarachnis",
-			"base_kill_time_ms": 141000,
+			"base_kill_time_ms": 91200,
 			"is_wildy": false,
 			"is_slayer_only": false,
 			"can_be_pked": false,
@@ -4578,6 +4578,7 @@
 					"Masori chaps (f)": 3
 				},
 				{
+					"Aranea boots": 10,
 					"Ring of stone": 10
 				}
 			],
@@ -5217,7 +5218,7 @@
 		{
 			"id": 14009,
 			"name": "The Hueycoatl",
-			"base_kill_time_ms": 480000,
+			"base_kill_time_ms": 360000,
 			"respawn_time_ms": 2000,
 			"is_wildy": false,
 			"is_slayer_only": false,

--- a/packages/oldschooljs/metadata.txt
+++ b/packages/oldschooljs/metadata.txt
@@ -4,14 +4,15 @@ Files in ./dist/cjs:
 	./dist/cjs/EItem.cjs: 333.84 KB 341,850 bytes
 	./dist/cjs/EMonster.cjs: 25.5 KB 26,114 bytes
 	./dist/cjs/gear/index.cjs: 1.77 KB 1,810 bytes
-	./dist/cjs/index.cjs: 864.83 KB 885,586 bytes
+	./dist/cjs/index.cjs: 864.83 KB 885,583 bytes
 	./dist/cjs/item_data-OPRFPN4I.json: 5.25 MB 5,509,046 bytes
 	./dist/cjs/monsters_data-5F625L5X.json: 363.54 KB 372,262 bytes
+	./dist/cjs/monsters_data-ZWSBZZS5.json: 363.54 KB 372,262 bytes
 	./dist/cjs/structures/Hiscores.cjs: 40.12 KB 41,084 bytes
 	./dist/cjs/structures/Wiki.cjs: 3.8 KB 3,889 bytes
 	./dist/cjs/util/util.cjs: 38.22 KB 39,137 bytes
 
-Total size: 7.01 MB
+Total size: 7.36 MB
 
 
 Files in ./dist/esm:
@@ -20,11 +21,12 @@ Files in ./dist/esm:
 	./dist/esm/EItem.mjs: 332.86 KB 340,850 bytes
 	./dist/esm/EMonster.mjs: 24.51 KB 25,099 bytes
 	./dist/esm/gear/index.mjs: 807 B 807 bytes
-	./dist/esm/index.mjs: 857.32 KB 877,892 bytes
+	./dist/esm/index.mjs: 857.31 KB 877,889 bytes
 	./dist/esm/item_data-OPRFPN4I.json: 5.25 MB 5,509,046 bytes
 	./dist/esm/monsters_data-5F625L5X.json: 363.54 KB 372,262 bytes
+	./dist/esm/monsters_data-ZWSBZZS5.json: 363.54 KB 372,262 bytes
 	./dist/esm/structures/Hiscores.mjs: 39.55 KB 40,496 bytes
 	./dist/esm/structures/Wiki.mjs: 2.23 KB 2,288 bytes
 	./dist/esm/util/util.mjs: 36.9 KB 37,788 bytes
 
-Total size: 6.99 MB
+Total size: 7.35 MB

--- a/packages/oldschooljs/src/data/monsters_data.json
+++ b/packages/oldschooljs/src/data/monsters_data.json
@@ -14362,7 +14362,7 @@
 	"12191": {
 		"members": true,
 		"combatLevel": 758,
-		"hitpoints": 440,
+		"hitpoints": 485,
 		"maxHit": 56,
 		"attackType": ["melee", "magic"],
 		"attackSpeed": 5,
@@ -14402,7 +14402,7 @@
 	"12192": {
 		"members": true,
 		"combatLevel": 758,
-		"hitpoints": 440,
+		"hitpoints": 485,
 		"maxHit": 56,
 		"attackType": ["melee", "magic"],
 		"attackSpeed": 5,

--- a/packages/oldschooljs/src/simulation/misc/Nightmare.ts
+++ b/packages/oldschooljs/src/simulation/misc/Nightmare.ts
@@ -126,7 +126,7 @@ const nonMvpTertiary = new LootTable()
 
 const phosaniTertiary = new LootTable()
 	.tertiary(35, 'Clue scroll (elite)')
-	.tertiary(100, 'Slepey tablet')
+	.tertiary(25, 'Slepey tablet')
 	.tertiary(200, 'Parasitic egg')
 	.tertiary(1400, 'Little nightmare')
 	.tertiary(4000, 'Jar of dreams');

--- a/packages/oldschooljs/src/simulation/monsters/bosses/TheHueycoatl.ts
+++ b/packages/oldschooljs/src/simulation/monsters/bosses/TheHueycoatl.ts
@@ -5,7 +5,7 @@ const TheHueycoatlTable = new LootTable()
 	.every('Big bones')
 	.tertiary(50, 'Clue scroll (hard)')
 	.tertiary(150, 'Tooth half of key (moon key)')
-	.tertiary(400 * 3.5, 'Huberte')
+	.tertiary(400 * 3, 'Huberte')
 
 	.oneIn(
 		18,

--- a/packages/oldschooljs/src/simulation/monsters/bosses/TheHueycoatl.ts
+++ b/packages/oldschooljs/src/simulation/monsters/bosses/TheHueycoatl.ts
@@ -8,11 +8,11 @@ const TheHueycoatlTable = new LootTable()
 	.tertiary(400 * 3.5, 'Huberte')
 
 	.oneIn(
-		23,
+		18,
 		new LootTable()
-			.add('Hueycoatl hide', [2, 3], 6)
-			.add('Tome of earth (empty)', 1, 3)
-			.add('Dragon hunter wand', 1, 1)
+			.add('Hueycoatl hide', 3, 63)
+			.add('Tome of earth (empty)', 1, 20)
+			.add('Dragon hunter wand', 1, 17)
 	)
 	.add('Rune mace', [1, 26], 3)
 	.add('Rune scimitar', [1, 20], 3)

--- a/src/lib/combat_achievements/elite.ts
+++ b/src/lib/combat_achievements/elite.ts
@@ -1697,7 +1697,7 @@ export const eliteCombatAchievements: CombatAchievement[] = [
 	{
 		id: 1147,
 		name: 'Duke Sucellus Speed-Trialist',
-		desc: 'Kill Duke Sucellus in less than 1:45 minutes without a slayer task.',
+		desc: 'Kill Duke Sucellus in less than 1:00 minutes without a slayer task.',
 		type: 'speed',
 		monster: 'Duke Sucellus',
 		rng: {

--- a/src/lib/combat_achievements/grandmaster.ts
+++ b/src/lib/combat_achievements/grandmaster.ts
@@ -405,7 +405,7 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 3030,
 		name: "Phosani's Speedrunner",
-		desc: "Defeat Phosani's Nightmare within 7:30 minutes.",
+		desc: "Defeat Phosani's Nightmare within 6 minutes.",
 		type: 'speed',
 		monster: "Phosani's Nightmare",
 		rng: {
@@ -1277,11 +1277,11 @@ export const grandmasterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 3108,
 		name: 'Duke Sucellus Speed-Runner',
-		desc: 'Kill Duke Sucellus in less than 1:25 minutes without a slayer task.',
+		desc: 'Kill Duke Sucellus in less than 40 seconds without a slayer task.',
 		type: 'speed',
 		monster: 'Duke Sucellus',
 		rng: {
-			chancePerKill: 150,
+			chancePerKill: 100,
 			hasChance: isCertainMonsterTrip(Monsters.DukeSucellus.id)
 		}
 	},

--- a/src/lib/combat_achievements/master.ts
+++ b/src/lib/combat_achievements/master.ts
@@ -717,7 +717,7 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2061,
 		name: "Phosani's Speedchaser",
-		desc: "Defeat Phosani's Nightmare within 9 minutes.",
+		desc: "Defeat Phosani's Nightmare within 7 minutes and 30 seconds.",
 		type: 'speed',
 		monster: "Phosani's Nightmare",
 		rng: {
@@ -1748,11 +1748,11 @@ export const masterCombatAchievements: CombatAchievement[] = [
 	{
 		id: 2153,
 		name: 'Duke Sucellus Speed-Chaser',
-		desc: 'Kill Duke Sucellus in less than 1:35 minutes without a slayer task.',
+		desc: 'Kill Duke Sucellus in less than 50 seconds without a slayer task.',
 		type: 'speed',
 		monster: 'Duke Sucellus',
 		rng: {
-			chancePerKill: 40,
+			chancePerKill: 30,
 			hasChance: isCertainMonsterTrip(Monsters.DukeSucellus.id)
 		}
 	},

--- a/src/lib/minions/data/killableMonsters/bosses/dt.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/dt.ts
@@ -39,7 +39,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 		id: Monsters.DukeSucellus.id,
 		name: Monsters.DukeSucellus.name,
 		aliases: Monsters.DukeSucellus.aliases,
-		timeToFinish: Time.Minute * 5.1,
+		timeToFinish: Time.Minute * 3.1,
 		table: Monsters.DukeSucellus,
 		notifyDrops: resolveItems(['Virtus robe top', 'Baron', 'Virtus robe bottom', 'Virtus mask']),
 		qpRequired: 100,
@@ -71,13 +71,13 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 			{
 				items: [
 					{ boostPercent: 5, itemID: itemID('Bellator ring') },
-					{ boostPercent: 5, itemID: itemID('Ultor ring') }
+					{ boostPercent: 3, itemID: itemID('Ultor ring') }
 				],
 				gearSetup: 'melee'
 			}
 		],
 
-		respawnTime: Time.Minute * 1.5,
+		respawnTime: Time.Minute * 0.5,
 		levelRequirements: {
 			prayer: 43,
 			hitpoints: 70
@@ -88,7 +88,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 			['Torva platelegs', 'Bandos tassets']
 		]),
 		defaultAttackStyles: [SkillsEnum.Attack],
-		combatXpMultiplier: 1.135,
+		combatXpMultiplier: 1.525,
 		healAmountNeeded: 45 * 20,
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],
@@ -143,7 +143,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 			{
 				items: [
 					{ boostPercent: 5, itemID: itemID('Bellator ring') },
-					{ boostPercent: 5, itemID: itemID('Ultor ring') }
+					{ boostPercent: 3, itemID: itemID('Ultor ring') }
 				],
 				gearSetup: 'melee'
 			}
@@ -160,7 +160,7 @@ export const desertTreasureKillableBosses: KillableMonster[] = [
 			['Torva platelegs', 'Bandos tassets']
 		]),
 		defaultAttackStyles: [SkillsEnum.Attack],
-		combatXpMultiplier: 1.135,
+		combatXpMultiplier: 1.525,
 		healAmountNeeded: 45 * 20 * 2.5,
 		attackStyleToUse: GearStat.AttackSlash,
 		attackStylesUsed: [GearStat.AttackSlash],

--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -768,7 +768,7 @@ const killableBosses: KillableMonster[] = [
 		id: Monsters.TheHueycoatl.id,
 		name: Monsters.TheHueycoatl.name,
 		aliases: Monsters.TheHueycoatl.aliases,
-		timeToFinish: Time.Minute * 8,
+		timeToFinish: Time.Minute * 6,
 		respawnTime: 2000,
 		table: Monsters.TheHueycoatl,
 		difficultyRating: 8,
@@ -784,7 +784,7 @@ const killableBosses: KillableMonster[] = [
 					{ boostPercent: 10, itemID: itemID('Dragon hunter lance') },
 					{ boostPercent: 9, itemID: itemID("Inquisitor's mace") },
 					{ boostPercent: 9, itemID: itemID('Soulreaper axe') },
-					{ boostPercent: 9, itemID: itemID('Abyssal bludgeon') }
+					{ boostPercent: 8, itemID: itemID('Abyssal bludgeon') }
 				],
 				gearSetup: 'melee',
 				required: false
@@ -819,7 +819,7 @@ const killableBosses: KillableMonster[] = [
 			},
 			{
 				items: resolveItems(["Inquisitor's hauberk", 'Torva platebody', 'Bandos chestplate']).map(id => ({
-					boostPercent: 2,
+					boostPercent: 3,
 					itemID: id
 				})),
 				gearSetup: 'melee',
@@ -827,7 +827,7 @@ const killableBosses: KillableMonster[] = [
 			},
 			{
 				items: resolveItems(["Inquisitor's plateskirt", 'Torva platelegs', 'Bandos tassets']).map(id => ({
-					boostPercent: 2,
+					boostPercent: 3,
 					itemID: id
 				})),
 				gearSetup: 'melee',
@@ -851,7 +851,7 @@ const killableBosses: KillableMonster[] = [
 				items: [
 					{
 						itemID: itemID('Scythe of vitur'),
-						boostPercent: 10
+						boostPercent: 25
 					}
 				]
 			}
@@ -889,6 +889,7 @@ const killableBosses: KillableMonster[] = [
 				defence_stab: 0
 			}
 		},
+		combatXpMultiplier: 1.4, // average multiplier weighted by HP on each phase
 		itemCost: [
 			{
 				itemCost: new Bank().add('Super restore(4)'),

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -229,7 +229,7 @@ const killableMonsters: KillableMonster[] = [
 		id: Monsters.Sarachnis.id,
 		name: Monsters.Sarachnis.name,
 		aliases: Monsters.Sarachnis.aliases,
-		timeToFinish: Time.Minute * 2.35,
+		timeToFinish: Time.Minute * 1.52,
 		table: Monsters.Sarachnis,
 		emoji: '<:Sraracha:608231007803670529>',
 		wildy: false,
@@ -255,6 +255,7 @@ const killableMonsters: KillableMonster[] = [
 			},
 			// Transformation ring
 			{
+				[itemID('Aranea boots')]: 10,
 				[itemID('Ring of stone')]: 10
 			}
 		],
@@ -321,7 +322,7 @@ export const NightmareMonster: KillableMonster = {
 	id: 9415,
 	name: 'The Nightmare',
 	aliases: ['nightmare', 'the nightmare'],
-	timeToFinish: Time.Minute * 25,
+	timeToFinish: Time.Minute * 20,
 	table: Monsters.GeneralGraardor,
 	emoji: '<:Little_nightmare:758149284952014928>',
 	wildy: false,
@@ -341,7 +342,7 @@ export const NightmareMonster: KillableMonster = {
 	]),
 	qpRequired: 10,
 	groupKillable: true,
-	respawnTime: Time.Minute * 1.5,
+	respawnTime: Time.Minute * 0.5,
 	levelRequirements: {
 		prayer: 43
 	},
@@ -357,12 +358,12 @@ export const NightmareMonster: KillableMonster = {
 		'Harmonised orb',
 		'Volatile orb'
 	]),
-	healAmountNeeded: 55 * 20,
+	healAmountNeeded: 40 * 20,
 	attackStyleToUse: GearStat.AttackCrush,
 	attackStylesUsed: [GearStat.AttackSlash],
 	minimumGearRequirements: {
 		melee: {
-			[GearStat.DefenceSlash]: 150,
+			[GearStat.DefenceSlash]: 100,
 			[GearStat.AttackCrush]: 80
 		}
 	},

--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -229,7 +229,7 @@ const killableMonsters: KillableMonster[] = [
 		id: Monsters.Sarachnis.id,
 		name: Monsters.Sarachnis.name,
 		aliases: Monsters.Sarachnis.aliases,
-		timeToFinish: Time.Minute * 1.52,
+		timeToFinish: Time.Minute * 1.63,
 		table: Monsters.Sarachnis,
 		emoji: '<:Sraracha:608231007803670529>',
 		wildy: false,

--- a/src/lib/skilling/skills/crafting/craftables/dragonhide.ts
+++ b/src/lib/skilling/skills/crafting/craftables/dragonhide.ts
@@ -151,7 +151,7 @@ const Dragonhide: Craftable[] = [
 	{
 		name: 'Hueycoatl hide body',
 		id: itemID('Hueycoatl hide body'),
-		level: 88,
+		level: 78,
 		xp: 285,
 		inputItems: new Bank().add('Hueycoatl hide', 3),
 		tickRate: 3.5
@@ -159,7 +159,7 @@ const Dragonhide: Craftable[] = [
 	{
 		name: 'Hueycoatl hide chaps',
 		id: itemID('Hueycoatl hide chaps'),
-		level: 87,
+		level: 77,
 		xp: 190,
 		inputItems: new Bank().add('Hueycoatl hide', 2),
 		tickRate: 3.5
@@ -167,7 +167,7 @@ const Dragonhide: Craftable[] = [
 	{
 		name: 'Hueycoatl hide coif',
 		id: itemID('Hueycoatl hide coif'),
-		level: 86,
+		level: 76,
 		xp: 190,
 		inputItems: new Bank().add('Hueycoatl hide', 2),
 		tickRate: 3.5
@@ -175,7 +175,7 @@ const Dragonhide: Craftable[] = [
 	{
 		name: 'Hueycoatl hide vambraces',
 		id: itemID('Hueycoatl hide vambraces'),
-		level: 86,
+		level: 76,
 		xp: 95,
 		inputItems: new Bank().add('Hueycoatl hide'),
 		tickRate: 3.5

--- a/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareCommand.ts
@@ -36,12 +36,7 @@ async function soloMessage(user: MUser, duration: number, quantity: number, isPh
 	return `${str} The trip will take approximately ${formatDuration(duration)}.`;
 }
 
-const inquisitorItems = resolveItems([
-	"Inquisitor's great helm",
-	"Inquisitor's hauberk",
-	"Inquisitor's plateskirt",
-	"Inquisitor's mace"
-]);
+const inquisitorItems = resolveItems(["Inquisitor's great helm", "Inquisitor's hauberk", "Inquisitor's plateskirt"]);
 
 const phosaniBISGear = new Gear({
 	head: "Inquisitor's great helm",
@@ -57,8 +52,8 @@ const phosaniBISGear = new Gear({
 	ammo: "Rada's blessing 4"
 });
 
-const shadowChargesPerKc = 70;
-const sangChargesPerKc = 85;
+const shadowChargesPerKc = 40;
+const sangChargesPerKc = 60;
 
 async function checkReqs(user: MUser, monster: KillableMonster, isPhosani: boolean): Promise<string | undefined> {
 	// Check the user has the requirements to kill The Nightmare
@@ -93,7 +88,14 @@ async function checkReqs(user: MUser, monster: KillableMonster, isPhosani: boole
 	}
 }
 
-function perUserCost(user: MUser, quantity: number, isPhosani: boolean, hasShadow: boolean, hasSang: boolean) {
+function perUserCost(
+	user: MUser,
+	quantity: number,
+	isPhosani: boolean,
+	hasShadow: boolean,
+	hasSang: boolean,
+	hasHarm: boolean
+) {
 	const cost = new Bank();
 	const tumCharges = shadowChargesPerKc * quantity;
 	const sangCharges = sangChargesPerKc * quantity;
@@ -111,15 +113,17 @@ function perUserCost(user: MUser, quantity: number, isPhosani: boolean, hasShado
 				'charge'
 			)}`;
 		}
+
 		cost.add('Super combat potion(4)', Math.max(1, Math.floor(quantity / 2)))
 			.add('Sanfew serum(4)', quantity)
 			.add('Super restore(4)', quantity);
 		if (hasShadow || hasSang) {
 			return cost;
+		} else if (hasHarm) {
+			cost.add('Fire rune', 10 * 70 * quantity)
+				.add('Air rune', 7 * 70 * quantity)
+				.add('Wrath rune', 70 * quantity);
 		}
-		cost.add('Fire rune', 10 * 70 * quantity)
-			.add('Air rune', 7 * 70 * quantity)
-			.add('Wrath rune', 70 * quantity);
 	}
 	if (!user.owns(cost)) {
 		return `${user} doesn't own ${cost}.`;
@@ -128,8 +132,10 @@ function perUserCost(user: MUser, quantity: number, isPhosani: boolean, hasShado
 }
 
 export async function nightmareCommand(user: MUser, channelID: string, name: string, qty: number | undefined) {
+	const hasMace = !!user.gear.melee.hasEquipped("Inquisitor's mace");
 	const hasShadow = !!user.gear.mage.hasEquipped("Tumeken's shadow");
 	const hasSang = !!user.gear.mage.hasEquipped('Sanguinesti staff');
+	const hasHarm = !!user.gear.mage.hasEquipped('Harmonised nightmare staff');
 	name = name.toLowerCase();
 	let isPhosani = false;
 	let type: 'solo' | 'mass' = 'solo';
@@ -155,7 +161,11 @@ export async function nightmareCommand(user: MUser, channelID: string, name: str
 	const meleeGear = user.gear.melee;
 
 	if (users.length === 1 && isPhosani) {
-		if (user.bitfield.includes(BitField.HasSlepeyTablet)) {
+		if (
+			user.bitfield.includes(BitField.HasSlepeyTablet) ||
+			user.bank.has('Slepey tablet') ||
+			user.cl.has('Slepey tablet')
+		) {
 			effectiveTime = reduceNumByPercent(effectiveTime, 15);
 			soloBoosts.push('15% for Slepey tablet');
 		}
@@ -170,11 +180,11 @@ export async function nightmareCommand(user: MUser, channelID: string, name: str
 
 	// Special inquisitor outfit damage boost
 	if (meleeGear.hasEquipped(inquisitorItems, true)) {
-		effectiveTime *= users.length === 1 ? 0.9 : 0.97;
+		effectiveTime *= users.length === 1 ? 0.9 : 0.95;
 	} else {
 		for (const inqItem of inquisitorItems) {
 			if (meleeGear.hasEquipped([inqItem])) {
-				effectiveTime *= users.length === 1 ? 0.98 : 0.995;
+				effectiveTime *= users.length === 1 ? 0.98 : 0.99;
 			}
 		}
 	}
@@ -206,24 +216,28 @@ export async function nightmareCommand(user: MUser, channelID: string, name: str
 		effectiveTime *= 0.96;
 	}
 	if (isPhosani) {
-		effectiveTime = reduceNumByPercent(effectiveTime, 31);
-		if (user.hasEquippedOrInBank('Dragon claws')) {
-			effectiveTime = reduceNumByPercent(effectiveTime, 3);
-			soloBoosts.push('3% for Dragon claws');
+		effectiveTime = reduceNumByPercent(effectiveTime, 30);
+		if (hasMace) {
+			effectiveTime = reduceNumByPercent(effectiveTime, 15);
+			soloBoosts.push("15% for Inquisitor's mace");
 		}
 		if (hasShadow) {
-			effectiveTime = reduceNumByPercent(effectiveTime, 6);
-			soloBoosts.push("6% for Tumeken's shadow");
+			effectiveTime = reduceNumByPercent(effectiveTime, 10);
+			soloBoosts.push("10% for Tumeken's shadow");
 		} else if (hasSang) {
-			effectiveTime = reduceNumByPercent(effectiveTime, 3);
-			soloBoosts.push('3% for Sanguinesti Staff');
+			effectiveTime = reduceNumByPercent(effectiveTime, 4);
+			soloBoosts.push('4% for Sanguinesti Staff');
 		} else if (user.hasEquippedOrInBank('Harmonised nightmare staff')) {
-			effectiveTime = reduceNumByPercent(effectiveTime, 3);
-			soloBoosts.push('3% for Harmonised nightmare staff');
+			effectiveTime = reduceNumByPercent(effectiveTime, 7);
+			soloBoosts.push('7% for Harmonised nightmare staff');
+		}
+		if (user.hasEquippedOrInBank('Voidwaker')) {
+			effectiveTime = reduceNumByPercent(effectiveTime, 5);
+			soloBoosts.push('5% for Voidwaker');
 		}
 		if (user.hasEquippedOrInBank('Elder maul')) {
-			effectiveTime = reduceNumByPercent(effectiveTime, 3);
-			soloBoosts.push('3% for Elder maul');
+			effectiveTime = reduceNumByPercent(effectiveTime, 2);
+			soloBoosts.push('2% for Elder maul');
 		}
 	}
 
@@ -240,7 +254,7 @@ export async function nightmareCommand(user: MUser, channelID: string, name: str
 	const totalCost = new Bank();
 	let soloFoodUsage: Bank | null = null;
 	const [healAmountNeeded] = calculateMonsterFood(NightmareMonster, user);
-	const cost = perUserCost(user, quantity, isPhosani, hasShadow, hasSang);
+	const cost = perUserCost(user, quantity, isPhosani, hasShadow, hasSang, hasHarm);
 	if (typeof cost === 'string') return cost;
 
 	const healingMod = isPhosani ? 1.5 : 1;

--- a/src/tasks/minions/minigames/nightmareActivity.ts
+++ b/src/tasks/minions/minigames/nightmareActivity.ts
@@ -56,7 +56,6 @@ export const nightmareTask: MinionTask = {
 		});
 
 		const { newKC } = await user.incrementKC(monsterID, kc);
-
 		const ownsOrUsedTablet =
 			user.bank.has('Slepey tablet') ||
 			(user.bitfield.includes(BitField.HasSlepeyTablet) && user.cl.has('Slepey Tablet'));
@@ -64,8 +63,11 @@ export const nightmareTask: MinionTask = {
 			if (ownsOrUsedTablet) {
 				userLoot.remove('Slepey tablet', userLoot.amount('Slepey tablet'));
 			}
-			if (!ownsOrUsedTablet && kc > 0 && newKC >= 100 && !userLoot.has('Slepey tablet')) {
-				userLoot.add('Slepey tablet');
+			if (!ownsOrUsedTablet && !userLoot.has('Slepey tablet')) {
+				// const { newKC } = await user.incrementKC(monsterID, kc);
+				if (newKC >= 25) {
+					userLoot.add('Slepey tablet');
+				}
 			}
 		}
 
@@ -113,10 +115,11 @@ export const nightmareTask: MinionTask = {
 			});
 
 			const kc = await user.getKC(monsterID);
+			const kcPerHour = (quantity / (duration / (1000 * 60 * 60))).toFixed(2);
 			handleTripFinish(
 				user,
 				channelID,
-				`${user}, ${user.minionName} finished killing ${quantity} ${monsterName}, you died ${deaths} times. Your ${monsterName} KC is now ${kc}. ${xpRes}`,
+				`${user}, ${user.minionName} finished killing ${quantity} ${monsterName} (${kcPerHour}/hr), you died ${deaths} times. Your ${monsterName} KC is now ${kc}. ${xpRes}`,
 				image.file.attachment,
 				data,
 				itemsAdded


### PR DESCRIPTION
### Description:

Phosani, Huey and Duke changes from [Summer Sweep Up: Combat](https://oldschool.runescape.wiki/w/Update:Summer_Sweep_Up:_Combat).
And Sarachnis because it is way off.
Still missing TOA, Nex, Bryo and Obor changes.

### Changes:

1. Phosani's P1 was removed
  - Nearly 11 kph now.
  - Changed spec from claws to voidwaker, bigger boost.
  - Slepey tablet drop rate adjusted to 1/25 with a guaranteed drop at 25+.

2. Huey
  - 22kph and scythe is now bis (8% better than dhl).
  -  Unique drop rate 1/23 -> 1/18, and weighting changes (wand more common).
  - Added bonus xp multiplier.
  - Huey hides now always drop as batch of 3 (and reduced craft req by 10 lvls).
 
3. Duke
  - 37 kph (leaving room for future oathplate boosts to bring it to the 39 we can currently get in OSRS).
  - Made CA speedruns a bit more likely (duke GM time was 1/150 but it was one of the easiest ones in the game even before oathplate, now it's free. Only changed it to 1/100 because not everyone has max gear)

4. Sarachnis
  - 75 kph.
  - Added boost for Aranea boots (same as ring of stone, just need either one in bank).


### Other checks:

- [x] I have tested all my changes thoroughly.
