### PR TITLE
Add creatables to top collector role

### DIFF
--- a/src/lib/rolesTask.ts
+++ b/src/lib/rolesTask.ts
@@ -40,7 +40,8 @@ const CLS_THAT_GET_ROLE = [
 	'slayer',
 	'other',
 	'custom',
-	'overall'
+	'overall',
+	'creatables'
 ];
 
 for (const cl of CLS_THAT_GET_ROLE) {


### PR DESCRIPTION
### Description:
Creatables collection log isn't easy due to 3rd age felling axe, pets, rares, etc. This adds creatables to the collection logs that can receive top collector role. 

### Changes:
- add 'creatables' to CLS_THAT_GET_ROLE for top collector role.

### Other checks:
- [X] I have tested all my changes thoroughly.
