### PR TITLE
Update Elven Crystal Chest and Crystal implings

### DIFF
--- a/packages/oldschooljs/src/simulation/openables/ElvenCrystalChest.ts
+++ b/packages/oldschooljs/src/simulation/openables/ElvenCrystalChest.ts
@@ -20,7 +20,7 @@ const coinsKeyHalfTable = new LootTable()
 /* Rune armor roll */
 const runeArmorTable = new LootTable()
 	.every('Uncut dragonstone')
-	.every('Crystal shard', [4, 6])
+	.every('Crystal shard', [7, 9])
 	.add('Rune platelegs', 1, 1)
 	.add('Rune plateskirt', 1, 1);
 
@@ -56,7 +56,7 @@ const ElvenCrystalChestTable = new LootTable()
 		itemTupleToTable([
 			['Uncut dragonstone', 1],
 			['Coins', [30_000, 50_000]],
-			["Crystal shard", [13, 19]]
+			['Crystal shard', [13, 19]]
 		]),
 		1,
 		20
@@ -64,7 +64,7 @@ const ElvenCrystalChestTable = new LootTable()
 	.add(
 		itemTupleToTable([
 			['Uncut dragonstone', 1],
-			["Crystal shard", [25, 35]]
+			['Crystal shard', [25, 35]]
 		]),
 		1,
 		17
@@ -117,7 +117,7 @@ const ElvenCrystalChestTable = new LootTable()
 	.add(
 		itemTupleToTable([
 			['Uncut dragonstone', 1],
-			["Crystal acorn", [4, 6]]
+			['Crystal acorn', [4, 6]]
 		]),
 		1,
 		7

--- a/packages/oldschooljs/src/simulation/openables/ElvenCrystalChest.ts
+++ b/packages/oldschooljs/src/simulation/openables/ElvenCrystalChest.ts
@@ -56,7 +56,7 @@ const ElvenCrystalChestTable = new LootTable()
 		itemTupleToTable([
 			['Uncut dragonstone', 1],
 			['Coins', [30_000, 50_000]],
-			['Crystal shard', [8, 13]]
+			["Crystal shard", [13, 19]]
 		]),
 		1,
 		20
@@ -64,7 +64,7 @@ const ElvenCrystalChestTable = new LootTable()
 	.add(
 		itemTupleToTable([
 			['Uncut dragonstone', 1],
-			['Crystal shard', [20, 30]]
+			["Crystal shard", [25, 35]]
 		]),
 		1,
 		17
@@ -117,7 +117,7 @@ const ElvenCrystalChestTable = new LootTable()
 	.add(
 		itemTupleToTable([
 			['Uncut dragonstone', 1],
-			['Crystal acorn', [1, 2]]
+			["Crystal acorn", [4, 6]]
 		]),
 		1,
 		7

--- a/packages/oldschooljs/src/simulation/openables/Implings.ts
+++ b/packages/oldschooljs/src/simulation/openables/Implings.ts
@@ -260,7 +260,7 @@ export const CrystalImpling = new SimpleOpenable({
 	table: new LootTable()
 		.add('Amulet of power', [5, 7])
 		.add('Crystal acorn')
-		.add("Crystal shard", [30, 40])
+		.add('Crystal shard', [30, 40])
 		.add('Dragonstone amulet')
 		.add('Dragonstone', 2)
 		.add('Ruby bolt tips', [50, 125])

--- a/packages/oldschooljs/src/simulation/openables/Implings.ts
+++ b/packages/oldschooljs/src/simulation/openables/Implings.ts
@@ -260,7 +260,7 @@ export const CrystalImpling = new SimpleOpenable({
 	table: new LootTable()
 		.add('Amulet of power', [5, 7])
 		.add('Crystal acorn')
-		.add('Crystal shard', [5, 10])
+		.add("Crystal shard", [30, 40])
 		.add('Dragonstone amulet')
 		.add('Dragonstone', 2)
 		.add('Ruby bolt tips', [50, 125])


### PR DESCRIPTION
### Description:

These were updated ages ago in [poll 82](https://oldschool.runescape.wiki/w/Update:Araxxor_CAs,_Poll_82_Updates_%26_More!#Crystal_Shard_Rates_Buff) but my PR on OSJS was never merged.

### Changes:

-Elven Crystal Chest: Buffed the quantity of Acorns to 4-6 and quantity of Shards by ~50%.
-Crystal Impling: 30-40 Shards, up from 5-10.

### Other checks:

- [x] I have tested all my changes thoroughly.
