### PR TITLE
Fix team cape stash bug

### DIFF
--- a/src/lib/clues/stashUnits.ts
+++ b/src/lib/clues/stashUnits.ts
@@ -192,7 +192,7 @@ export const mediumStashes: StashUnitTier = {
 		{
 			id: 35,
 			desc: 'Castle Wars bank',
-			items: deepResolveItems(['Ruby amulet', 'Mithril scimitar', ...ItemGroups.teamCapes])
+			items: deepResolveItems(['Ruby amulet', 'Mithril scimitar', ItemGroups.teamCapes])
 		},
 		{
 			id: 36,
@@ -261,7 +261,7 @@ export const mediumStashes: StashUnitTier = {
 		{
 			id: 47,
 			desc: 'Barbarian Outpost obstacle course (centre)',
-			items: deepResolveItems(['Steel platebody', 'Maple shortbow', ...ItemGroups.teamCapes])
+			items: deepResolveItems(['Steel platebody', 'Maple shortbow', ItemGroups.teamCapes])
 		},
 		{
 			id: 48,


### PR DESCRIPTION
### Description:
Fix stash units 35 & 47 from requiring all 50 team capes. 

Users can also do `/tools stash_units unfill unit: 35` & `/tools stash_units unfill unit: 47` then `/tools stash_units fill_all` if they want to get all their team capes back.

### Changes:
Fix ItemGroups.teamCapes

### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/6499