### PR TITLE
Make Tears of Guthix reset at 00:00 UTC

### DIFF
--- a/packages/toolkit/src/util/misc.ts
+++ b/packages/toolkit/src/util/misc.ts
@@ -88,6 +88,16 @@ export function getInterval(intervalHours: number) {
 	};
 }
 
+export function getNextUTCReset(lastPlayedUnix: number, cd: number) {
+	const coolDownEnd = new Date(lastPlayedUnix + cd);
+
+	const nextUTCReset = new Date(
+		Date.UTC(coolDownEnd.getUTCFullYear(), coolDownEnd.getUTCMonth(), coolDownEnd.getUTCDate(), 0, 0, 0, 0)
+	);
+
+	return nextUTCReset.getTime();
+}
+
 export function objHasAnyPropInCommon(obj: object, other: object): boolean {
 	for (const key of Object.keys(obj)) {
 		if (key in other) return true;

--- a/packages/toolkit/src/util/misc.ts
+++ b/packages/toolkit/src/util/misc.ts
@@ -88,8 +88,8 @@ export function getInterval(intervalHours: number) {
 	};
 }
 
-export function getNextUTCReset(lastPlayedUnix: number, cd: number) {
-	const coolDownEnd = new Date(lastPlayedUnix + cd);
+export function getNextUTCReset(last_timeStamp: number, cd: number) {
+	const coolDownEnd = new Date(last_timeStamp + cd);
 
 	const nextUTCReset = new Date(
 		Date.UTC(coolDownEnd.getUTCFullYear(), coolDownEnd.getUTCMonth(), coolDownEnd.getUTCDate(), 0, 0, 0, 0)

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -7,6 +7,7 @@ import { Time, isFunction, roll } from 'e';
 import { LRUCache } from 'lru-cache';
 import { type ItemBank, Items, toKMB } from 'oldschooljs';
 
+import { dateFm, getNextUTCReset } from '@oldschoolgg/toolkit/util';
 import { minionStatusCommand } from '../mahoji/lib/abstracted_commands/minionStatusCommand';
 import { untrustedGuildSettingsCache } from './cache.js';
 import { Channel, globalConfig } from './constants';
@@ -14,7 +15,6 @@ import pets from './data/pets';
 import { logError } from './util/logError';
 import { makeBankImage } from './util/makeBankImage';
 import { minionStatsEmbed } from './util/minionStatsEmbed';
-import { dateFm, getNextUTCReset } from '@oldschoolgg/toolkit/util';
 
 const rareRolesSrc: [string, number, string][] = [
 	['670211706907000842', 250, 'Bronze'],
@@ -114,7 +114,7 @@ Type \`/tools user mypets\` to see your pets.`);
 const mentionText = `<@${globalConfig.clientID}>`;
 const mentionRegex = new RegExp(`^(\\s*<@&?[0-9]+>)*\\s*<@${globalConfig.clientID}>\\s*(<@&?[0-9]+>\\s*)*$`);
 
-export const tears_of_guthix_cd = Time.Day * 7
+export const tears_of_guthix_cd = Time.Day * 7;
 
 const cooldownTimers: {
 	name: string;

--- a/src/mahoji/lib/abstracted_commands/tearsOfGuthixCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/tearsOfGuthixCommand.ts
@@ -51,15 +51,12 @@ function getTearsOfGuthixMissingSkillMessage(user: MUser): string | null {
 
 export async function tearsOfGuthixCommand(user: MUser, channelID: string) {
 	if (user.minionIsBusy) return `${user.minionName} is busy.`;
-	const currentDate = Date.now();
-
 	const currentStats = await user.fetchStats({ last_tears_of_guthix_timestamp: true });
-
 	const lastPlayedDate = Number(currentStats.last_tears_of_guthix_timestamp);
 	const nextReset = getNextUTCReset(lastPlayedDate, tears_of_guthix_cd);
 
 	// If they have already claimed a ToG in the past 7days
-	if (currentDate < nextReset) {
+	if (Date.now() < nextReset) {
 		return `**${Emoji.Snake} Juna says...** You can drink from the Tears of Guthix in ${dateFm(new Date(nextReset))}`;
 	}
 

--- a/src/mahoji/lib/abstracted_commands/tearsOfGuthixCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/tearsOfGuthixCommand.ts
@@ -1,7 +1,8 @@
 import { Emoji } from '@oldschoolgg/toolkit/constants';
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { dateFm, formatDuration, getNextUTCReset } from '@oldschoolgg/toolkit/util';
 import { Time, notEmpty, objectEntries } from 'e';
 
+import { tears_of_guthix_cd } from '@/lib/events';
 import { formatSkillRequirements } from '@/lib/util/smallUtils.js';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
@@ -55,12 +56,11 @@ export async function tearsOfGuthixCommand(user: MUser, channelID: string) {
 	const currentStats = await user.fetchStats({ last_tears_of_guthix_timestamp: true });
 
 	const lastPlayedDate = Number(currentStats.last_tears_of_guthix_timestamp);
-	const difference = currentDate - lastPlayedDate;
+	const nextReset = getNextUTCReset(lastPlayedDate, tears_of_guthix_cd);
 
 	// If they have already claimed a ToG in the past 7days
-	if (difference < Time.Day * 7) {
-		const duration = formatDuration(Date.now() - (lastPlayedDate + Time.Day * 7));
-		return `**${Emoji.Snake} Juna says...** You can drink from the Tears of Guthix in ${duration}.`;
+	if (currentDate < nextReset) {
+		return `**${Emoji.Snake} Juna says...** You can drink from the Tears of Guthix in ${dateFm(new Date(nextReset))}`;
 	}
 
 	// 43 QP for the quest


### PR DESCRIPTION
### Description:
Make Tears of Guthix reset at 00:00 UTC. This will also work with the BSO specific minigames that have weekly cooldowns. 

### Changes:
- Tears of guthix now resets at 00:00 UTC like ingame.
- add `getNextUTCReset` to handle the appropriate date and time. 
  - will be used for BSO weekly D&D aswell.

### Other checks:
- [X] I have tested all my changes thoroughly.
closes: https://github.com/oldschoolgg/oldschoolbot/issues/5724
