### PR TITLE
Fix stat requirements for Royal Titans

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -1438,7 +1438,8 @@ const killableBosses: KillableMonster[] = [
 					ring: 'Berserker ring (i)'
 				}).stats,
 				attack_ranged: -100,
-				defence_magic: -10,
+				attack_magic: -100,
+				defence_magic: -100,
 				prayer: -100,
 				defence_crush: 0,
 				defence_ranged: 0,


### PR DESCRIPTION
### Description:

Melee armour/gear tanks ranged+magic attack stats, and since melee armour isn't included in the generated gear, it creates an incorrectly high requirement for ranged+magic attack stats.

### Changes:

- Corrects this by setting a reasonable -100 requirement for ranged+magic, when Melee is the required attack style, and osrs loves to hit you with negative attack bonuses.

### Other checks:

- [ ] I have tested all my changes thoroughly.
