### PR TITLE
Royal titans stat requirements and zcb boost

### DIFF
--- a/src/lib/minions/data/killableMonsters/bosses/misc.ts
+++ b/src/lib/minions/data/killableMonsters/bosses/misc.ts
@@ -1129,7 +1129,8 @@ const killableBosses: KillableMonster[] = [
 				[itemID('Giantsoul amulet')]: 13
 			},
 			{
-				[itemID('Dragon claws')]: 6,
+				[itemID('Zaryte crossbow')]: 6,
+				[itemID('Dragon claws')]: 5,
 				[itemID('Burning claws')]: 3
 			}
 		],
@@ -1167,12 +1168,17 @@ const killableBosses: KillableMonster[] = [
 					feet: 'Dragon boots',
 					ring: 'Berserker ring (i)'
 				}).stats,
-				defence_magic: 0,
-				prayer: 0,
+				attack_ranged: -100,
+				attack_magic: -100,
+				defence_magic: -100,
+				prayer: -100,
 				defence_crush: 0,
 				defence_ranged: 0,
 				defence_slash: 0,
 				defence_stab: 0
+			},
+			mage: {
+				[GearStat.AttackMagic]: 70
 			}
 		},
 		specialLoot: ({ loot, user }) => {
@@ -1266,7 +1272,8 @@ const killableBosses: KillableMonster[] = [
 				[itemID('Giantsoul amulet')]: 13
 			},
 			{
-				[itemID('Dragon claws')]: 6,
+				[itemID('Zaryte crossbow')]: 6,
+				[itemID('Dragon claws')]: 5,
 				[itemID('Burning claws')]: 3
 			}
 		],
@@ -1304,12 +1311,17 @@ const killableBosses: KillableMonster[] = [
 					feet: 'Dragon boots',
 					ring: 'Berserker ring (i)'
 				}).stats,
-				defence_magic: 0,
-				prayer: 0,
+				attack_ranged: -100,
+				attack_magic: -100,
+				defence_magic: -100,
+				prayer: -100,
 				defence_crush: 0,
 				defence_ranged: 0,
 				defence_slash: 0,
 				defence_stab: 0
+			},
+			mage: {
+				[GearStat.AttackMagic]: 70
 			}
 		},
 		specialLoot: ({ loot, user }) => {
@@ -1399,7 +1411,8 @@ const killableBosses: KillableMonster[] = [
 				[itemID('Giantsoul amulet')]: 13
 			},
 			{
-				[itemID('Dragon claws')]: 6,
+				[itemID('Zaryte crossbow')]: 6,
+				[itemID('Dragon claws')]: 5,
 				[itemID('Burning claws')]: 3
 			}
 		],
@@ -1445,6 +1458,9 @@ const killableBosses: KillableMonster[] = [
 				defence_ranged: 0,
 				defence_slash: 0,
 				defence_stab: 0
+			},
+			mage: {
+				[GearStat.AttackMagic]: 70
 			}
 		}
 	}


### PR DESCRIPTION
### Description:

Previous stat reqs fix PR only fixed it for the sacrifice option, this fixes it for Branda and Eldric too, and some other requested changes.

### Changes:

- Added a +70 magic attack req in mage gear.
- Zcb is now bis spec boost over claws.

### Other checks:

- [x] I have tested all my changes thoroughly.
