### PR TITLE
Fix dry streak items causing an error

### DIFF
--- a/src/mahoji/commands/tools.ts
+++ b/src/mahoji/commands/tools.ts
@@ -796,7 +796,7 @@ for (const openable of allOpenables) {
 }
 
 async function dryStreakCommand(sourceName: string, itemName: string, ironmanOnly: boolean) {
-	const item = Items.get(itemName);
+	const item = Items.getItem(itemName);
 	if (!item) return 'Invalid item.';
 	const entity = dryStreakEntities.find(
 		e =>


### PR DESCRIPTION
### Description:
Fix drystreak items from showing as invalid.

### Changes:
- update `Items.get` to `Items.getItem`

### Other checks:
- [X] I have tested all my changes thoroughly.
