### PR TITLE
Add Yeti to PvM collection log

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -210,8 +210,8 @@ import {
 	vladDrakanCL,
 	volcanicMineCL,
 	vorkathCL,
-	yetiCL,
 	wintertodtCL,
+	yetiCL,
 	zalcanoCL,
 	zulrahCL
 } from './CollectionsExport';

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -210,6 +210,7 @@ import {
 	vladDrakanCL,
 	volcanicMineCL,
 	vorkathCL,
+	yetiCL,
 	wintertodtCL,
 	zalcanoCL,
 	zulrahCL
@@ -748,6 +749,12 @@ export const allCollectionLogs: ICollection = {
 				allItems: BSOMonsters.Treebeard.table.allItems,
 				items: treeBeardCL,
 				fmtProg: kcProg(BSOMonsters.Treebeard.id)
+			},
+			Yeti: {
+				alias: BSOMonsters.Yeti.aliases,
+				allItems: BSOMonsters.Yeti.table.allItems,
+				items: yetiCL,
+				fmtProg: kcProg(BSOMonsters.Yeti.id)
 			},
 			'Sea Kraken': {
 				alias: BSOMonsters.SeaKraken.aliases,

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2466,13 +2466,7 @@ export const kalphiteKingCL = resolveItems([
 
 export const ignecarusCL = resolveItems(['Ignecarus scales', 'Ignecarus dragonclaw', 'Dragon egg', 'Ignis ring']);
 
-export const yetiCL = resolveItems([
-        'Raw yeti meat',
-        'Yeti hide',
-        'Frostclaw cape',
-        'Cold heart',
-        'Penguin egg'
-]);
+export const yetiCL = resolveItems(['Raw yeti meat', 'Yeti hide', 'Frostclaw cape', 'Cold heart', 'Penguin egg']);
 
 export const treeBeardCL = resolveItems([
 	// Tangleroot pets

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2466,6 +2466,14 @@ export const kalphiteKingCL = resolveItems([
 
 export const ignecarusCL = resolveItems(['Ignecarus scales', 'Ignecarus dragonclaw', 'Dragon egg', 'Ignis ring']);
 
+export const yetiCL = resolveItems([
+        'Raw yeti meat',
+        'Yeti hide',
+        'Frostclaw cape',
+        'Cold heart',
+        'Penguin egg'
+]);
+
 export const treeBeardCL = resolveItems([
 	// Tangleroot pets
 	20_661,

--- a/tests/unit/snapshots/clsnapshots.test.ts.snap
+++ b/tests/unit/snapshots/clsnapshots.test.ts.snap
@@ -199,6 +199,7 @@ Vladimir Drakan (8)
 Volcanic Mine (4)
 Vorkath (6)
 Wintertodt (11)
+Yeti (5)
 Zalcano (4)
 Zulrah (11)"
 `;
@@ -780,6 +781,7 @@ Cockatrice mask
 Cockatrice slayer helm
 Coconut parasol
 Cogsworth
+Cold heart
 Colossal blade
 Colossal wyrm teleport scroll
 Commander boots
@@ -1046,6 +1048,7 @@ Fresh crab shell
 Frog slippers
 Frog token
 Frostbite
+Frostclaw cape
 Frozen cache
 Frozen key
 Frozen tablet
@@ -1660,6 +1663,7 @@ Peky
 Penance gloves
 Penance skirt
 Pendant of ates (inert)
+Penguin egg
 Penguin mask
 Perfect chitin
 Pernix body (broken)
@@ -1741,6 +1745,7 @@ Ranger hat
 Rangers' tights
 Rangers' tunic
 Raven
+Raw yeti meat
 Rebirth portent
 Red beret
 Red boater
@@ -2248,6 +2253,7 @@ Xeric's sentinel
 Xeric's talisman (inert)
 Xeric's warrior
 Yellow dark bow paint
+Yeti hide
 Yew comp bow
 Youngllef
 Zak


### PR DESCRIPTION
- add a `yetiCL` collection definition covering the unique loot from Yeti
- register Yeti under the PvM collection log so its drops count toward the tab

<img width="606" height="100" alt="image" src="https://github.com/user-attachments/assets/b89a4e1b-c7a0-45b5-ab2e-5b6523a3fb50" />

- [ ] I have tested all my changes thoroughly.
