### PR TITLE
Fix grand exchange buy offer progress bar

### DIFF
--- a/src/lib/canvas/geImage.ts
+++ b/src/lib/canvas/geImage.ts
@@ -100,7 +100,10 @@ class GeImageGeneratorSingleton {
 
 		const maxWidth = progressShadowImage.width;
 		ctx.fillStyle = OSRSCanvas.COLORS.ORANGE;
-		let percentFullfilled = calcWhatPercent(listing.total_quantity - listing.quantity_remaining, listing.total_quantity);
+		let percentFullfilled = calcWhatPercent(
+			listing.total_quantity - listing.quantity_remaining,
+			listing.total_quantity
+		);
 		if (listing.type === 'Sell') {
 			percentFullfilled = 100 - percentFullfilled;
 		}


### PR DESCRIPTION
### Description:
- Fix grand exchange buy offers from showing a full green bar if nothing has been bought yet.

### Changes:
- correct the equation for `percentFullfilled` 

### Other checks:
- [X] I have tested all my changes thoroughly.

Visual of the issue: 
<img width="613" height="513" alt="Discord_83LdDAhurv" src="https://github.com/user-attachments/assets/1a81f6c8-fcff-4a31-b15b-ba9c4b3e2afc" />
