### PR TITLE
Correct logic for tears of guthix button

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -36,6 +36,8 @@ import {
 } from './interactions';
 import { hasSkillReqs } from './smallUtils';
 import { sendToChannelID } from './webhook';
+import { getNextUTCReset } from 'packages/toolkit/dist/util';
+import { TEARS_OF_GUTHIX_CD } from '../events';
 
 const collectors = new Map<string, MessageCollector>();
 
@@ -189,8 +191,9 @@ export async function handleTripFinish(
 
 		// Tears of Guthix start button if ready
 		if (!user.bitfield.includes(BitField.DisableTearsOfGuthixButton)) {
-			const last = Number(last_tears_of_guthix_timestamp);
-			const ready = last <= 0 || Date.now() - last >= Time.Day * 7;
+			const lastPlayedDate = Number(last_tears_of_guthix_timestamp);
+			const nextReset = getNextUTCReset(lastPlayedDate, TEARS_OF_GUTHIX_CD);
+			const ready = nextReset < Date.now();
 			const meetsSkillReqs = hasSkillReqs(user, tearsOfGuthixSkillReqs)[0];
 			const meetsIronmanReqs = user.user.minion_ironman ? hasSkillReqs(user, tearsOfGuthixIronmanReqs)[0] : true;
 


### PR DESCRIPTION
### Description:
Correct the logic for the tears of guthix button on trip finishes to align with https://github.com/oldschoolgg/oldschoolbot/commit/58d9f769264b9ec5e3af5ef9c9802532bbd7ecbc

### Changes:
- use `getNextUTCReset` to check if tears of guthix is ready and to add button to trip finish

### Other checks:
- [X] I have tested all my changes thoroughly.
