### PR TITLE
Add Quiver to Similar Item for Assembler

### DIFF
--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -193,7 +193,14 @@ const source: [string, (string | number)[]][] = [
 	["Ava's accumulator", ['Accumulator max cape']],
 	[
 		"Ava's assembler",
-		['Assembler max cape', 'Assembler max cape (l)', 'Masori assembler', 'Masori assembler max cape', "Blessed dizana's quiver", "Dizana's max cape" ]
+		[
+			'Assembler max cape',
+			'Assembler max cape (l)',
+			'Masori assembler',
+			'Masori assembler max cape',
+			"Blessed dizana's quiver",
+			"Dizana's max cape"
+		]
 	],
 	["Blessed dizana's quiver", ["Dizana's max cape"]],
 	['Mythical cape', ['Mythical max cape']],

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -193,7 +193,7 @@ const source: [string, (string | number)[]][] = [
 	["Ava's accumulator", ['Accumulator max cape']],
 	[
 		"Ava's assembler",
-		['Assembler max cape', 'Assembler max cape (l)', 'Masori assembler', 'Masori assembler max cape']
+		['Assembler max cape', 'Assembler max cape (l)', 'Masori assembler', 'Masori assembler max cape', "Blessed dizana's quiver", "Dizana's max cape" ]
 	],
 	["Blessed dizana's quiver", ["Dizana's max cape"]],
 	['Mythical cape', ['Mythical max cape']],


### PR DESCRIPTION


### Description:

Adds the quiver and max cape variant to the similar items for Ava's Assembler so that it can be used for the ammo saving effect or places where assembler is strictly required.

### Changes:

Added Blessed Dizana's Quiver and Dizana's max cape to the similar items list under the Ava's Assembler.

### Other checks:

- [ ] I have tested all my changes thoroughly.
