### PR TITLE
Puro Puro Repeat fix

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -535,21 +535,19 @@ const tripHandlers = {
 		commandName: 'activities',
 		args: (data: PuroPuroActivityTaskOptions) => {
 			const implingName =
-			data.implingTier === null
-					? null
-					: puroOptions.find(option => option.tier === data.implingTier)?.name;
+				data.implingTier === null ? null : puroOptions.find(option => option.tier === data.implingTier)?.name;
 
 			if (data.implingTier !== null && implingName === undefined) {
 				throw new Error(`Invalid impling tier: ${data.implingTier}`);
 			}
 
-	return {
-		puro_puro: {
-			impling: implingName,
-			dark_lure: data.darkLure
+			return {
+				puro_puro: {
+					impling: implingName,
+					dark_lure: data.darkLure
+				}
+			};
 		}
-	};
-}
 	},
 	[activity_type_enum.Questing]: {
 		commandName: 'activities',


### PR DESCRIPTION
Updates the stored-trip repeat handler so Puro-Puro activities translate the saved implingTier into the command’s impling string by importing and reusing the canonical puroOptions list, ensuring the repeated command receives both the impling choice and dark_lure flag.

- [ ] I have tested all my changes thoroughly.
