### PR TITLE
Fix crash in Bonanza activity return

### DIFF
--- a/src/lib/bso/tasks/bonanzaActivity.ts
+++ b/src/lib/bso/tasks/bonanzaActivity.ts
@@ -50,7 +50,7 @@ export const bonanzaTask: MinionTask = {
 		const averageLevel =
 			(user.skillsAsLevels.agility + user.skillsAsLevels.ranged + user.skillsAsLevels.thieving) / 3;
 
-		const tickets = rng.randInt(clamp(averageLevel / 2, { min: 1, max: 120 }), averageLevel);
+		const tickets = rng.randInt(Math.floor(clamp(averageLevel / 2, { min: 1, max: 120 })), Math.floor(averageLevel));
 		loot.add('Circus ticket', tickets);
 
 		const freeIgneTames = tames.filter(i => i.tame_activity.length === 0 && i.species_id === TameSpeciesID.Igne);


### PR DESCRIPTION
### Description:

- randInt() function needs to be passed 2 integers.

### Changes:

- Math.floor()'s both params passed to randInt()

### Other checks:

- [ ] I have tested all my changes thoroughly.
