### PR TITLE
Fix Halloween card tracking for first card chance

### DIFF
--- a/src/lib/bso/halloween.ts
+++ b/src/lib/bso/halloween.ts
@@ -137,7 +137,6 @@ export async function halloweenTicker() {
 
 export const HalloweenEvent2025 = {
 	ALL_CARD_IDS: [
-		BSOItem.HALLOWEEN_CANDY,
 		BSOItem.WITCH_CARD,
 		BSOItem.GHOST_CARD,
 		BSOItem.VAMPIRE_CARD,


### PR DESCRIPTION
Remove the halloween_candy from the card_ids so people get the correct drop rate on first card

- [ ] I have tested all my changes thoroughly.
