### PR TITLE
Allow monkey tame to repeat tansmute candy

### DIFF
--- a/src/lib/bso/tames/tameTasks.ts
+++ b/src/lib/bso/tames/tameTasks.ts
@@ -479,6 +479,12 @@ export async function repeatTameTrip({
 					};
 					break;
 				}
+				case 6: {
+					args = {
+						transmute_candy: Items.getOrThrow(data.itemID).name
+					};
+					break;
+				}
 			}
 			return runCommand({
 				commandName: 'tames',


### PR DESCRIPTION
I'm unable to get my test bot working properly to test, but this should fix the repeat trip for monkey tame using the transmute candy spell

- [ ] I have tested all my changes thoroughly.
