### PR TITLE
Auto open passive implings

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -154,7 +154,8 @@ export enum BitField {
 
 	HasDeadeyeScroll = 45,
 	HasMysticVigourScroll = 46,
-	AllowPublicAPIDataRetrieval = 47
+	AllowPublicAPIDataRetrieval = 47,
+	AutoOpenPassiveImplings = 48
 }
 
 interface BitFieldData {
@@ -270,6 +271,11 @@ export const BitFieldData: Record<BitField, BitFieldData> = {
 	},
 	[BitField.AllowPublicAPIDataRetrieval]: {
 		name: 'Allow Public API Data Retrieval',
+		protected: false,
+		userConfigurable: true
+	},
+	[BitField.AutoOpenPassiveImplings]: {
+		name: 'Auto open passive implings',
 		protected: false,
 		userConfigurable: true
 	},

--- a/src/lib/implings.ts
+++ b/src/lib/implings.ts
@@ -1,5 +1,5 @@
 import { Time } from '@oldschoolgg/toolkit';
-import { Bank, LootTable, Openables } from 'oldschooljs';
+import { Bank, Implings, LootTable, Openables } from 'oldschooljs';
 
 import { activity_type_enum } from '@/prisma/main/enums.js';
 import type { ActivityTaskData } from '@/lib/types/minions.js';
@@ -101,6 +101,21 @@ const implingTableByWorldLocation = {
 	[WorldLocations.Priffdinas]: new LootTable({ limit: 155 }).add('Crystal impling jar', 1, 1),
 	[WorldLocations.World]: new LootTable().oneIn(85, defaultImpTable)
 };
+
+const implingLootTables = new Map<number, LootTable>();
+for (const impling of Implings) {
+	implingLootTables.set(impling.id, impling.table);
+}
+
+export function rollPassiveImplingLoot(bank: Bank) {
+	const loot = new Bank();
+	for (const [item, quantity] of bank.items()) {
+		const table = implingLootTables.get(item.id);
+		if (!table) continue;
+		loot.add(table.roll(quantity));
+	}
+	return loot;
+}
 
 export function handlePassiveImplings(user: MUser, data: ActivityTaskData) {
 	if (

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -73,6 +73,10 @@ const toggles: UserConfigToggle[] = [
 		bit: BitField.CleanHerbsFarming
 	},
 	{
+		name: 'Auto open passive implings',
+		bit: BitField.AutoOpenPassiveImplings
+	},
+	{
 		name: 'Lock Self From Gambling',
 		bit: BitField.SelfGamblingLocked,
 		canToggle: async (user, interaction) => {


### PR DESCRIPTION
- Added the AutoOpenPassiveImplings bitfield so passive implings can be auto-opened via a user-configurable toggle. 
- Surfaced the new toggle in the config command to let players enable or disable automatic passive impling openings. 
- Implemented passive impling jar auto-opening and loot rolling during trip completion, including collection log and openable score updates when the toggle is active. 

<img width="1159" height="110" alt="image" src="https://github.com/user-attachments/assets/526c23ad-dc75-406c-b43c-7e96fa18e9c7" />


- [ ] I have tested all my changes thoroughly.
