### PR TITLE
Correct tainted essence extract quant/cost

### DIFF
--- a/data/bso/creatables.json
+++ b/data/bso/creatables.json
@@ -6660,10 +6660,10 @@
 		{
 			"name": "Mangled extract",
 			"items_created": {
-				"Mangled extract": 1
+				"Mangled extract": 5
 			},
 			"items_required": {
-				"Coins": 12000,
+				"Coins": 60000,
 				"Tainted essence chunk": 1
 			}
 		},
@@ -13183,10 +13183,10 @@
 		{
 			"name": "Scarred extract",
 			"items_created": {
-				"Scarred extract": 1
+				"Scarred extract": 5
 			},
 			"items_required": {
-				"Coins": 24000,
+				"Coins": 120000,
 				"Tainted essence chunk": 1
 			}
 		},
@@ -16920,10 +16920,10 @@
 		{
 			"name": "Warped extract",
 			"items_created": {
-				"Warped extract": 1
+				"Warped extract": 5
 			},
 			"items_required": {
-				"Coins": 1250,
+				"Coins": 6250,
 				"Tainted essence chunk": 1
 			}
 		},

--- a/data/osb/creatables.json
+++ b/data/osb/creatables.json
@@ -3839,10 +3839,10 @@
 		{
 			"name": "Mangled extract",
 			"items_created": {
-				"Mangled extract": 1
+				"Mangled extract": 5
 			},
 			"items_required": {
-				"Coins": 12000,
+				"Coins": 60000,
 				"Tainted essence chunk": 1
 			}
 		},
@@ -8535,10 +8535,10 @@
 		{
 			"name": "Scarred extract",
 			"items_created": {
-				"Scarred extract": 1
+				"Scarred extract": 5
 			},
 			"items_required": {
-				"Coins": 24000,
+				"Coins": 120000,
 				"Tainted essence chunk": 1
 			}
 		},
@@ -11263,10 +11263,10 @@
 		{
 			"name": "Warped extract",
 			"items_created": {
-				"Warped extract": 1
+				"Warped extract": 5
 			},
 			"items_required": {
-				"Coins": 1250,
+				"Coins": 6250,
 				"Tainted essence chunk": 1
 			}
 		},

--- a/src/lib/data/createables.ts
+++ b/src/lib/data/createables.ts
@@ -2601,10 +2601,10 @@ const Createables: Createable[] = [
 		name: 'Warped extract',
 		inputItems: new Bank({
 			'Tainted essence chunk': 1,
-			Coins: 1_250
+			Coins: 6_250
 		}),
 		outputItems: new Bank({
-			'Warped extract': 1
+			'Warped extract': 5
 		})
 	},
 	{
@@ -2621,20 +2621,20 @@ const Createables: Createable[] = [
 		name: 'Mangled extract',
 		inputItems: new Bank({
 			'Tainted essence chunk': 1,
-			Coins: 12_000
+			Coins: 60_000
 		}),
 		outputItems: new Bank({
-			'Mangled extract': 1
+			'Mangled extract': 5
 		})
 	},
 	{
 		name: 'Scarred extract',
 		inputItems: new Bank({
 			'Tainted essence chunk': 1,
-			Coins: 24_000
+			Coins: 120_000
 		}),
 		outputItems: new Bank({
-			'Scarred extract': 1
+			'Scarred extract': 5
 		})
 	},
 	{


### PR DESCRIPTION
### Description:

Corrected quantities on Tainted Essence Extracts based on osrs wiki https://oldschool.runescape.wiki/w/Tainted_essence_chunk

For an example: 
1 Tainted essence chunk + 60k gp = 5 Mangled extract.
Was previously 1 Tainted essence chunk + 12k gp = 1 Mangled extract. This made the gp cost make sense, but was 5x essence chunk requirement.

### Changes:

Updated in extract input/output cost in bso creatables, osb creatables, and creatables.

### Other checks:

- [ ] I have tested all my changes thoroughly.
