### PR TITLE
Nex Nihil Shard Droprate

### DIFF
--- a/src/lib/simulation/misc.ts
+++ b/src/lib/simulation/misc.ts
@@ -217,5 +217,6 @@ const NexNonUniqueBaseTable = new LootTable()
 
 export const NexNonUniqueTable = new LootTable()
 	.every(NexNonUniqueBaseTable, 2)
-	.oneIn(25, 'Nihil shard', [1, 20])
+	.oneIn(16.4, 'Nihil shard', [80, 85])
+	.oneIn(26.13, 'Nihil shard', [85, 95])
 	.oneIn(100, 'Rune sword');


### PR DESCRIPTION


### Description:

Updated droprate and quantity of nihil shards on NexNonUniqueTable to match OSRS rates.

### Changes:

Replaced current tertiary 1/25 drop of 1-20 nihil shards with 2 separate tertiary drops with rates and quantities matching the confirmed droprates of nihil shards from OSRS Nex (as confirmed by Mod Ash)

### Other checks:

- [x ] I have tested all my changes thoroughly.
- Method of having 2 tertiary nihil shard drops gives possibility of both drops in one kill (different behavior from OSRS) but this does not affect expected average