### PR TITLE
Refresh diary completion from live stats

### DIFF
--- a/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/achievementDiaryCommand.ts
@@ -112,7 +112,9 @@ export async function claimAchievementDiaryCommand(user: MUser, diaryName: strin
 		d => stringMatches(d.name, diaryName) || d.alias?.some(a => stringMatches(a, diaryName))
 	);
 
-	await user.syncCompletedAchievementDiaries().catch(console.error);
+	const [stats, minigameScores] = await Promise.all([user.fetchMStats(), user.fetchMinigames()]);
+
+	await user.syncCompletedAchievementDiaries({ stats, minigameScores }).catch(console.error);
 
 	if (!diary) {
 		return `These are the achievement diaries you can claim: ${diaries.map(d => d.name).join(', ')}.`;
@@ -120,7 +122,6 @@ export async function claimAchievementDiaryCommand(user: MUser, diaryName: strin
 
 	const allItems = user.allItemsOwned;
 	const { cl } = user;
-	const [stats, minigameScores] = await Promise.all([user.fetchMStats(), user.fetchMinigames()]);
 
 	for (const tier of ['easy', 'medium', 'hard', 'elite'] as const) {
 		const diaryTier = diary[tier];


### PR DESCRIPTION
Ensures a user’s completed_achievement_diaries array is always updated from live stats and minigame scores. Previously it only synced once, causing stale diary tiers (e.g. Western Provinces elite) and incorrect boosts.

- [ ] I have tested all my changes thoroughly.
