### PR TITLE
Fix bso leaderboards

### DIFF
--- a/packages/oldschooljs/test/Items.test.ts
+++ b/packages/oldschooljs/test/Items.test.ts
@@ -76,69 +76,61 @@ describe('Items', () => {
 		checkItems();
 	});
 
-	test.concurrent(
-		'Fetching Item by ID',
-		async () => {
-			const [tbow, superStr, dragonDagger, coins] = [
-				Items.get(20_997),
-				Items.get(2440),
-				Items.getItem('Dragon dagger(p++)'),
-				Items.getItem('Coins')
-			];
+	test.concurrent('Fetching Item by ID', async () => {
+		const [tbow, superStr, dragonDagger, coins] = [
+			Items.get(20_997),
+			Items.get(2440),
+			Items.getItem('Dragon dagger(p++)'),
+			Items.getItem('Coins')
+		];
 
-			if (!tbow) throw new Error('Missing item.');
-			expect(tbow.id).toBe(20_997);
-			expect(tbow.name).toBe('Twisted bow');
-			expect(tbow.price).toBeGreaterThan(800_000_000);
+		if (!tbow) throw new Error('Missing item.');
+		expect(tbow.id).toBe(20_997);
+		expect(tbow.name).toBe('Twisted bow');
+		expect(tbow.price).toBeGreaterThan(800_000_000);
 
-			if (!superStr) throw new Error('Missing item.');
-			expect(superStr.id).toBe(2440);
+		if (!superStr) throw new Error('Missing item.');
+		expect(superStr.id).toBe(2440);
 
-			if (!dragonDagger) throw new Error('Missing item.');
-			expect(dragonDagger.id).toBe(5698);
-			expect(dragonDagger.name).toBe('Dragon dagger(p++)');
-			expect(dragonDagger.price).toBeLessThan(26_000);
+		if (!dragonDagger) throw new Error('Missing item.');
+		expect(dragonDagger.id).toBe(5698);
+		expect(dragonDagger.name).toBe('Dragon dagger(p++)');
+		expect(dragonDagger.price).toBeLessThan(26_000);
 
-			if (!coins) throw new Error('Missing item.');
-			expect(coins.id).toBe(995);
-			expect(coins.price).toEqual(1);
-			expect(Items.getItem('Snowy knight')!.price).toEqual(0);
+		if (!coins) throw new Error('Missing item.');
+		expect(coins.id).toBe(995);
+		expect(coins.price).toEqual(1);
+		expect(Items.getItem('Snowy knight')!.price).toEqual(0);
 
-			expect(Items.getItem('Vial of blood')!.id).toEqual(22_446);
-		},
-		60_000
-	);
+		expect(Items.getItem('Vial of blood')!.id).toEqual(22_446);
+	}, 60_000);
 
-	test.concurrent(
-		'Equipment',
-		async () => {
-			const tbow = Items.getItem('Twisted bow')!;
-			expect(tbow.equipment!.attack_ranged).toEqual(70);
-			expect(tbow.equipment!.defence_crush).toEqual(0);
-			expect(tbow.equipment!.slot).toEqual(EquipmentSlot.TwoHanded);
-			expect(tbow.wiki_name).toEqual('Twisted bow');
-			expect(tbow.equipable_weapon).toEqual(true);
+	test.concurrent('Equipment', async () => {
+		const tbow = Items.getItem('Twisted bow')!;
+		expect(tbow.equipment!.attack_ranged).toEqual(70);
+		expect(tbow.equipment!.defence_crush).toEqual(0);
+		expect(tbow.equipment!.slot).toEqual(EquipmentSlot.TwoHanded);
+		expect(tbow.wiki_name).toEqual('Twisted bow');
+		expect(tbow.equipable_weapon).toEqual(true);
 
-			const anglerHat = Items.getItem('Angler hat')!;
-			expect(anglerHat.equipment!.slot).toEqual(EquipmentSlot.Head);
-			expect(anglerHat.equipable).toEqual(true);
-			expect(anglerHat.equipable_by_player).toEqual(true);
-			expect(anglerHat.equipable_weapon).toEqual(undefined);
-			expect(anglerHat.equipment!.attack_ranged).toEqual(0);
+		const anglerHat = Items.getItem('Angler hat')!;
+		expect(anglerHat.equipment!.slot).toEqual(EquipmentSlot.Head);
+		expect(anglerHat.equipable).toEqual(true);
+		expect(anglerHat.equipable_by_player).toEqual(true);
+		expect(anglerHat.equipable_weapon).toEqual(undefined);
+		expect(anglerHat.equipment!.attack_ranged).toEqual(0);
 
-			const scep = Items.get(26_950);
-			expect(scep).toEqual(undefined);
+		const scep = Items.get(26_950);
+		expect(scep).toEqual(undefined);
 
-			const scep2 = Items.getItem("Pharaoh's sceptre")!;
-			expect(scep2.name).toEqual("Pharaoh's sceptre");
-			expect(scep2.id).toEqual(9044);
-			expect(scep2.equipable_by_player).toEqual(true);
-			expect(scep2.equipable_weapon).toEqual(true);
-			expect(scep2.equipable).toEqual(true);
-			expect(scep2.equipment?.slot).toEqual(EquipmentSlot.Weapon);
-		},
-		60_000
-	);
+		const scep2 = Items.getItem("Pharaoh's sceptre")!;
+		expect(scep2.name).toEqual("Pharaoh's sceptre");
+		expect(scep2.id).toEqual(9044);
+		expect(scep2.equipable_by_player).toEqual(true);
+		expect(scep2.equipable_weapon).toEqual(true);
+		expect(scep2.equipable).toEqual(true);
+		expect(scep2.equipment?.slot).toEqual(EquipmentSlot.Weapon);
+	}, 60_000);
 });
 
 test('modifyItem', () => {

--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -1,3 +1,6 @@
+import { bsoItemContractDonationGivenLb, bsoItemContractLb } from '@/lib/bso/leaderboards/itemContractsLb.js';
+import { bsoTamesHatchedLb } from '@/lib/bso/leaderboards/tamesHatchedLb.js';
+
 import { calcWhatPercent, formatDuration, stringMatches, toTitleCase } from '@oldschoolgg/toolkit';
 import { convertXPtoLVL } from 'oldschooljs';
 
@@ -956,6 +959,22 @@ export const leaderboardCommand = defineCommand({
 
 		if (options.cl) {
 			return clLb(interaction, options.cl.cl, Boolean(options.cl.ironmen_only), Boolean(options.cl.tames));
+		}
+
+		if (options.item_contract_streak) {
+			return bsoItemContractLb(interaction, Boolean(options.item_contract_streak.ironmen_only));
+		}
+
+		if (options.tames_hatched) {
+			return bsoTamesHatchedLb(interaction, Boolean(options.tames_hatched.ironmen_only));
+		}
+
+		if (options.total_ic_donation_given) {
+			return bsoItemContractDonationGivenLb(interaction, true);
+		}
+
+		if (options.unique_ic_donation_given) {
+			return bsoItemContractDonationGivenLb(interaction, false);
 		}
 
 		if (options.clues) {


### PR DESCRIPTION
- connect item contract, donation, and tames hatched leaderboards to the /lb command
- format Items.test.ts to satisfy linting

- [ ] I have tested all my changes thoroughly.
