### PR TITLE
Adjust repeat trip filtering for farming activities

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -757,8 +757,10 @@ export async function fetchRepeatTrips(user: MUser): Promise<Activity[]> {
 	for (const trip of res) {
 		if (!taskCanBeRepeated(trip, user)) continue;
 		const data = ActivityManager.convertStoredActivityToFlatActivity(trip);
-		if (data.type === activity_type_enum.Farming && data.autoFarmed) {
-			continue;
+		if (data.type === activity_type_enum.Farming) {
+			if (!data.autoFarmed) {
+				continue;
+			}
 		}
 		if (!filtered.some(i => i.type === trip.type)) {
 			filtered.push(trip);


### PR DESCRIPTION
- include auto-farmed farming trips when building repeat buttons so the auto farm button can be repeated
- skip manual farming trips in repeat history to keep other activities available for quick repeat

- [ ] I have tested all my changes thoroughly.
