### PR TITLE
Remove BSO Duel tax

### DIFF
--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -21,7 +21,7 @@ async function handleFinishUpdates({
 	winner: MUser;
 	loser: MUser;
 }) {
-	const taxRate = BOT_TYPE === 'OSB' ? 0.95 : 0;
+	const taxRate = BOT_TYPE === 'OSB' ? 0.95 : 1;
 	const winningAmount = amount * 2;
 	const tax = winningAmount - Math.floor(winningAmount * taxRate);
 	const dividedAmount = tax / 1_000_000;


### PR DESCRIPTION
### Description:
Remove tax from bso `/gamble duel user:`

### Changes:
- Check `BOT_TYPE` for tax rate to keep the files in sync and prevent future mismatch.
- Tax was added to bso gamble contrary to an old news post so unsure if this was intentional or not https://discord.com/channels/342983479501389826/748492872428290158/792719678015143956.

### Other checks:
- [X] I have tested all my changes thoroughly.
