### PR TITLE
Preserve user-specified minutes when repeating underwater trips

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -63,6 +63,8 @@ export interface ActivityTaskOptionsWithQuantity extends ActivityTaskOptions {
 	quantity: number;
 	// iQty is 'input quantity.' This is the number specified at command time, so we can accurately repeat such trips.
 	iQty?: number;
+	// Optional number of minutes specified by the user when minutes are the primary input.
+	minutes?: number;
 }
 
 export interface ShootingStarsOptions extends ActivityTaskOptions {
@@ -533,6 +535,7 @@ export interface UnderwaterAgilityThievingTaskOptions extends ActivityTaskOption
 	trainingSkill: UnderwaterAgilityThievingTrainingSkill;
 	quantity: number;
 	noStams: boolean;
+	minutes?: number;
 }
 
 export interface PuroPuroActivityTaskOptions extends MinigameActivityTaskOptions {

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -712,7 +712,7 @@ const tripHandlers: {
 			underwater: {
 				agility_thieving: {
 					training_skill: data.trainingSkill,
-					minutes: Math.floor(data.duration / Time.Minute),
+					minutes: data.minutes ?? Math.max(1, Math.floor(data.duration / Time.Minute)),
 					no_stams: data.noStams
 				}
 			}
@@ -722,7 +722,9 @@ const tripHandlers: {
 		commandName: 'activities',
 		args: (data: ActivityTaskOptionsWithQuantity) => ({
 			underwater: {
-				drift_net_fishing: { minutes: Math.floor(data.duration / Time.Minute) }
+				drift_net_fishing: {
+					minutes: data.minutes ?? Math.max(1, Math.floor(data.duration / Time.Minute))
+				}
 			}
 		})
 	},

--- a/src/mahoji/lib/abstracted_commands/driftNetCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/driftNetCommand.ts
@@ -77,6 +77,7 @@ export async function driftNetCommand(
 		userID: user.id,
 		channelId,
 		quantity,
+		minutes,
 		duration,
 		type: 'DriftNet'
 	});

--- a/src/mahoji/lib/abstracted_commands/underwaterCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/underwaterCommand.ts
@@ -80,6 +80,7 @@ export async function underwaterAgilityThievingCommand(
 		channelId,
 		trainingSkill,
 		quantity,
+		minutes,
 		duration,
 		noStams,
 		type: 'UnderwaterAgilityThieving'


### PR DESCRIPTION
This PR makes drift net fishing and underwater agility/thieving repeats use the original minutes the user chose, instead of recalculating from duration each time. 

If no explicit minutes were stored, repeats now derive minutes by flooring the duration and enforcing a minimum of 1 minute to avoid zero-length trips.

This change is to stop the trips slowly go shorter and shorter from the varience e.g. 30mins then 28mins then 27mins then 25mins etc

- [x] I have tested all my changes thoroughly.
