### PR TITLE
Fix Daily claim issues for OSB & BSO

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -433,6 +433,6 @@ export const DEPRECATED_ACTIVITY_TYPES: activity_type_enum[] = [
 ];
 
 export const CONSTANTS = {
-	DAILY_COOLDOWN: Time.Hour * 12,
+	DAILY_COOLDOWN: BOT_TYPE === 'BSO' ? Time.Hour * 4 : Time.Hour * 12,
 	TEARS_OF_GUTHIX_CD: Time.Day * 7
 };

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -26,6 +26,7 @@ import {
 	makeTearsOfGuthixButton
 } from '@/lib/util/interactions.js';
 import { hasSkillReqs } from '@/lib/util/smallUtils.js';
+import { isUsersDailyReady } from '@/mahoji/lib/abstracted_commands/dailyCommand.js';
 import { canRunAutoContract } from '@/mahoji/lib/abstracted_commands/farmingContractCommand.js';
 import { handleTriggerShootingStar } from '@/mahoji/lib/abstracted_commands/shootingStarsCommand.js';
 import {
@@ -144,12 +145,11 @@ const tripFinishEffects: TripFinishEffect[] = [
 	{
 		name: 'Claim Daily Button',
 		requiredPerkTier: PerkTier.Two,
-		fn: async ({ user, components, lastDailyTimestamp }) => {
+		fn: async ({ user, components }) => {
 			if (user.bitfield.includes(BitField.DisableDailyButton)) return;
-			const last = Number(lastDailyTimestamp);
-			const ready = last <= 0 || Date.now() - last >= CONSTANTS.DAILY_COOLDOWN;
-
-			if (ready) {
+	
+			const { isReady } = await isUsersDailyReady(user);
+			if (isReady) {
 				components.push(makeClaimDailyButton());
 			}
 		}

--- a/src/mahoji/lib/abstracted_commands/dailyCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/dailyCommand.ts
@@ -1,7 +1,8 @@
 import { MathRNG, roll, shuffleArr } from '@oldschoolgg/rng';
-import { Emoji, formatDuration, isWeekend, Time, uniqueArr } from '@oldschoolgg/toolkit';
+import { Emoji, formatDuration, isWeekend, uniqueArr } from '@oldschoolgg/toolkit';
 
 import type { MessageBuilderClass } from '@/discord/MessageBuilder.js';
+import { CONSTANTS } from '@/lib/constants.js';
 import pets from '@/lib/data/pets.js';
 import { getRandomTriviaQuestions } from '@/lib/roboChimp.js';
 import dailyRoll from '@/lib/simulation/dailyTable.js';
@@ -14,8 +15,8 @@ export async function isUsersDailyReady(
 	const lastVoteDate = Number(stats.last_daily_timestamp);
 	const difference = currentDate - lastVoteDate;
 
-	if (difference < Time.Hour * 12) {
-		const duration = Date.now() - (lastVoteDate + Time.Hour * 12);
+	if (difference < CONSTANTS.DAILY_COOLDOWN) {
+		const duration = Date.now() - (lastVoteDate + CONSTANTS.DAILY_COOLDOWN);
 		return { isReady: false, durationUntilReady: duration };
 	}
 


### PR DESCRIPTION
### Description:
Aim to address the constant mismatches between BSO and OSB daily timers and buttons. This PR should prevent future issues of BSO getting the wrong timer when osb is merged into bso.

### Changes:
- use `BOT_TYPE` to assign 4hours for BSO and default to 12 hours.
- Simplify checking daily button for trip finishes.
- Use `CONSTANTS.DAILY_COOLDOWN` for checking if daily is available.

### Other checks:
- [ ] I have tested all my changes thoroughly.
