### PR TITLE
Add Moondash boost to replant farming trips

### DIFF
--- a/packages/oldschooljs/test/Items.test.ts
+++ b/packages/oldschooljs/test/Items.test.ts
@@ -76,69 +76,61 @@ describe('Items', () => {
 		checkItems();
 	});
 
-	test.concurrent(
-		'Fetching Item by ID',
-		async () => {
-			const [tbow, superStr, dragonDagger, coins] = [
-				Items.get(20_997),
-				Items.get(2440),
-				Items.getItem('Dragon dagger(p++)'),
-				Items.getItem('Coins')
-			];
+	test.concurrent('Fetching Item by ID', async () => {
+		const [tbow, superStr, dragonDagger, coins] = [
+			Items.get(20_997),
+			Items.get(2440),
+			Items.getItem('Dragon dagger(p++)'),
+			Items.getItem('Coins')
+		];
 
-			if (!tbow) throw new Error('Missing item.');
-			expect(tbow.id).toBe(20_997);
-			expect(tbow.name).toBe('Twisted bow');
-			expect(tbow.price).toBeGreaterThan(800_000_000);
+		if (!tbow) throw new Error('Missing item.');
+		expect(tbow.id).toBe(20_997);
+		expect(tbow.name).toBe('Twisted bow');
+		expect(tbow.price).toBeGreaterThan(800_000_000);
 
-			if (!superStr) throw new Error('Missing item.');
-			expect(superStr.id).toBe(2440);
+		if (!superStr) throw new Error('Missing item.');
+		expect(superStr.id).toBe(2440);
 
-			if (!dragonDagger) throw new Error('Missing item.');
-			expect(dragonDagger.id).toBe(5698);
-			expect(dragonDagger.name).toBe('Dragon dagger(p++)');
-			expect(dragonDagger.price).toBeLessThan(26_000);
+		if (!dragonDagger) throw new Error('Missing item.');
+		expect(dragonDagger.id).toBe(5698);
+		expect(dragonDagger.name).toBe('Dragon dagger(p++)');
+		expect(dragonDagger.price).toBeLessThan(26_000);
 
-			if (!coins) throw new Error('Missing item.');
-			expect(coins.id).toBe(995);
-			expect(coins.price).toEqual(1);
-			expect(Items.getItem('Snowy knight')!.price).toEqual(0);
+		if (!coins) throw new Error('Missing item.');
+		expect(coins.id).toBe(995);
+		expect(coins.price).toEqual(1);
+		expect(Items.getItem('Snowy knight')!.price).toEqual(0);
 
-			expect(Items.getItem('Vial of blood')!.id).toEqual(22_446);
-		},
-		60_000
-	);
+		expect(Items.getItem('Vial of blood')!.id).toEqual(22_446);
+	}, 60_000);
 
-	test.concurrent(
-		'Equipment',
-		async () => {
-			const tbow = Items.getItem('Twisted bow')!;
-			expect(tbow.equipment!.attack_ranged).toEqual(70);
-			expect(tbow.equipment!.defence_crush).toEqual(0);
-			expect(tbow.equipment!.slot).toEqual(EquipmentSlot.TwoHanded);
-			expect(tbow.wiki_name).toEqual('Twisted bow');
-			expect(tbow.equipable_weapon).toEqual(true);
+	test.concurrent('Equipment', async () => {
+		const tbow = Items.getItem('Twisted bow')!;
+		expect(tbow.equipment!.attack_ranged).toEqual(70);
+		expect(tbow.equipment!.defence_crush).toEqual(0);
+		expect(tbow.equipment!.slot).toEqual(EquipmentSlot.TwoHanded);
+		expect(tbow.wiki_name).toEqual('Twisted bow');
+		expect(tbow.equipable_weapon).toEqual(true);
 
-			const anglerHat = Items.getItem('Angler hat')!;
-			expect(anglerHat.equipment!.slot).toEqual(EquipmentSlot.Head);
-			expect(anglerHat.equipable).toEqual(true);
-			expect(anglerHat.equipable_by_player).toEqual(true);
-			expect(anglerHat.equipable_weapon).toEqual(undefined);
-			expect(anglerHat.equipment!.attack_ranged).toEqual(0);
+		const anglerHat = Items.getItem('Angler hat')!;
+		expect(anglerHat.equipment!.slot).toEqual(EquipmentSlot.Head);
+		expect(anglerHat.equipable).toEqual(true);
+		expect(anglerHat.equipable_by_player).toEqual(true);
+		expect(anglerHat.equipable_weapon).toEqual(undefined);
+		expect(anglerHat.equipment!.attack_ranged).toEqual(0);
 
-			const scep = Items.get(26_950);
-			expect(scep).toEqual(undefined);
+		const scep = Items.get(26_950);
+		expect(scep).toEqual(undefined);
 
-			const scep2 = Items.getItem("Pharaoh's sceptre")!;
-			expect(scep2.name).toEqual("Pharaoh's sceptre");
-			expect(scep2.id).toEqual(9044);
-			expect(scep2.equipable_by_player).toEqual(true);
-			expect(scep2.equipable_weapon).toEqual(true);
-			expect(scep2.equipable).toEqual(true);
-			expect(scep2.equipment?.slot).toEqual(EquipmentSlot.Weapon);
-		},
-		60_000
-	);
+		const scep2 = Items.getItem("Pharaoh's sceptre")!;
+		expect(scep2.name).toEqual("Pharaoh's sceptre");
+		expect(scep2.id).toEqual(9044);
+		expect(scep2.equipable_by_player).toEqual(true);
+		expect(scep2.equipable_weapon).toEqual(true);
+		expect(scep2.equipable).toEqual(true);
+		expect(scep2.equipment?.slot).toEqual(EquipmentSlot.Weapon);
+	}, 60_000);
 });
 
 test('modifyItem', () => {

--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -213,6 +213,11 @@ export async function farmingPlantCommand({
 		duration *= 0.9;
 	}
 
+	if (user.bitfield.includes(BitField.HasMoondashCharm)) {
+		boostStr.push('25% faster for Moondash charm');
+		duration = reduceNumByPercent(duration, 25);
+	}
+
 	if (user.hasDiary('ardougne.hard')) {
 		boostStr.push(`4% time for Ardougne Hard diary`);
 		duration *= 0.96;


### PR DESCRIPTION
### Description:

apply the Moondash charm speed boost when farming replant trips

- [ ] I have tested all my changes thoroughly.
