### PR TITLE
Add contract details to auto open seed pack response

### DIFF
--- a/src/mahoji/lib/abstracted_commands/farmingContractCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingContractCommand.ts
@@ -198,6 +198,14 @@ export async function autoContract(interaction: MInteraction, user: MUser): Prom
 		const contractResponse = await farmingContractCommand(user, bestContractTierCanDo);
 		const msg =
 			openResponse instanceof MessageBuilder ? openResponse : new MessageBuilder().setContent(openResponse);
+		const newContract = user.fetchFarmingContract();
+
+		if (newContract.hasContract && newContract.plantToGrow) {
+			msg.setContent(
+				`${msg.message.content}, your new farming contract is: ${toTitleCase(newContract.plantToGrow)}`
+			);
+		}
+
 		return msg.merge(contractResponse);
 	}
 


### PR DESCRIPTION
- append the newly assigned farming contract name to the auto open seed pack response
- keep the chat-head and buttons merged while ensuring the contract is visible in the text content

- [ ] I have tested all my changes thoroughly.
