### PR TITLE
Update Jewellery Invention list

### DIFF
--- a/data/bso/disassembly.json
+++ b/data/bso/disassembly.json
@@ -2250,6 +2250,10 @@
 				"lvl": 22
 			},
 			{
+				"item": "Tiara",
+				"lvl": 23
+			},
+			{
 				"item": ["Bracelet of clay", "Sapphire bracelet"],
 				"lvl": 23
 			},

--- a/src/lib/bso/skills/invention/groups/Jewellery.ts
+++ b/src/lib/bso/skills/invention/groups/Jewellery.ts
@@ -42,8 +42,8 @@ export const Jewellery: DisassemblySourceGroup = {
 			].map(i),
 			lvl: 22
 		},
-
 		{ item: ['Opal bracelet', 'Expeditious bracelet'].map(i), lvl: 22 },
+		{ item: i('Tiara'), lvl: 23 },
 		{ item: ['Sapphire bracelet', 'Bracelet of clay'].map(i), lvl: 23 },
 		{ item: ['Sapphire amulet (u)', 'Sapphire amulet', 'Amulet of magic'].map(i), lvl: 24 },
 		{


### PR DESCRIPTION
### Description:
Update Jewellery Invention list

### Changes:
- add more options for jewellery such as charge and unstrung variants
- combine any related items, such as: dragonstone amulet (u), dragon stone amulet, variants of glory etc
- add some missing jewellery
- move Archers ring, Seers ring, Berserker ring, Warrior ring, Ring of coins to lvl 80.

### Other checks:
- [X] I have tested all my changes thoroughly.
