### PR TITLE
Add bird nest (egg) to /collect

### DIFF
--- a/data/osb/all-obtainable-items.json
+++ b/data/osb/all-obtainable-items.json
@@ -531,6 +531,7 @@
 	"Binding necklace",
 	"Bird house",
 	"Bird nest",
+	"Bird nest (egg)",
 	"Birthday present",
 	"Black 2h sword",
 	"Black axe",

--- a/data/osb/openables.json
+++ b/data/osb/openables.json
@@ -81,6 +81,12 @@
 		]
 	},
 	{
+		"name": "Bird nest (egg)",
+		"id": 5071,
+		"opened_item": "Bird nest (egg)",
+		"all_items": ["Bird nest", "Blue bird egg", "Green bird egg", "Red bird egg"]
+	},
+	{
 		"name": "Birthday present",
 		"id": 11918,
 		"opened_item": "Birthday present",

--- a/src/lib/data/itemAliases.ts
+++ b/src/lib/data/itemAliases.ts
@@ -202,6 +202,9 @@ setItemAlias(25_842, 'Orange sraracha');
 setItemAlias(25_843, 'Blue sraracha');
 setItemAlias(12_654, 'Airborne kalphite princess');
 
+// Green egg nest used for /collect
+setItemAlias(5071, 'Bird nest (egg)');
+
 // Kittens
 setItemAlias(1555, 'Grey and black kitten');
 setItemAlias(1556, 'White kitten');

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -43,7 +43,7 @@ import {
 import { ClueTiers } from '@/lib/clues/clueTiers.js';
 import { cluesRaresCL } from '@/lib/data/CollectionsExport.js';
 import { shadeChestOpenables } from '@/lib/shadesKeys.js';
-import { nestTable } from '@/lib/simulation/birdsNest.js';
+import { birdsNestID, eggNest, nestTable } from '@/lib/simulation/birdsNest.js';
 import {
 	BagFullOfGemsTable,
 	BuildersSupplyCrateTable,
@@ -339,6 +339,14 @@ const osjsOpenables: UnifiedOpenable[] = [
 		aliases: ['bird nest', 'nest'],
 		output: nestTable,
 		allItems: nestTable.allItems
+	},
+	{
+		name: 'Bird nest (egg)',
+		id: 5071,
+		openedItem: Items.getOrThrow(5071),
+		aliases: ['bird nest (egg)'],
+		output: new LootTable().every(birdsNestID).add(eggNest),
+		allItems: resolveItems([birdsNestID, ...eggNest.allItems])
 	},
 	{
 		name: 'Amylase pack',

--- a/src/mahoji/lib/collectables.ts
+++ b/src/mahoji/lib/collectables.ts
@@ -141,5 +141,12 @@ export const collectables: Collectable[] = [
 		},
 		duration: 10 * Time.Minute,
 		qpRequired: 100
+	},
+	// Simulates hunting god bird eggs on W444 with a scouting cc
+	{
+		item: Items.getOrThrow('Bird nest (egg)'),
+		quantity: 4,
+		duration: 30 * Time.Minute,
+		qpRequired: 205
 	}
 ];


### PR DESCRIPTION
### Description:
Add a way to collect bird nest (egg), similar to in game methods utilizing ent events and forestry world 444.
- Full write up/discussion: https://discord.com/channels/342983479501389826/1409573445326471329/1409573445326471329

### Changes:
- Add item 5071 (green egg nest) for the item received with `/collect` at 8/hr
- Add 5071 to openables.

### Other checks:
- [X] I have tested all my changes thoroughly.
