### PR TITLE
Increase prisma transaction timeout for migrate user

### DIFF
--- a/src/lib/util/migrateUser.ts
+++ b/src/lib/util/migrateUser.ts
@@ -210,12 +210,10 @@ export async function migrateUser(_source: string | MUser, _dest: string | MUser
 	transactions.push(prisma.$queryRawUnsafe(updateUsers));
 
 	try {
-		await prisma.$transaction(
-			transactions,
-			{
-				timeout: 300_000, // 2 minutes
-				maxWait: 30_000
-			});
+		await prisma.$transaction(transactions, {
+			timeout: 300_000, // 5 minutes
+			maxWait: 30_000
+		});
 	} catch (err: unknown) {
 		Logging.logError(err as Error);
 		throw new UserError('Error migrating user. Sorry about that!');
@@ -243,12 +241,10 @@ export async function migrateUser(_source: string | MUser, _dest: string | MUser
 			})
 		);
 		try {
-			await roboChimpClient.$transaction(
-				robochimpTx,
-				{
-					timeout: 300_000, // 2 minutes
-					maxWait: 30_000
-				});
+			await roboChimpClient.$transaction(robochimpTx, {
+				timeout: 300_000, // 5 minutes
+				maxWait: 30_000
+			});
 		} catch (_err: unknown) {
 			const err = _err as Error;
 			err.message += ' - User already migrated! Robochimp migration failed!';


### PR DESCRIPTION
### Description:

Migrate user command fails because the timeout is too short. Increase to 5 minutes

### Changes:

- Increases prisma tx timeout to 5 minutes for this command.

### Other checks:

- [ ] I have tested all my changes thoroughly.
