### PR TITLE
Make global timeout 2.5 minutes for now

### DIFF
--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -54,7 +54,7 @@ async function makePrismaClient() {
 		adapter,
 		transactionOptions: {
 			maxWait: 15_000,
-			timeout: 15_000
+			timeout: 250_000
 		}
 	});
 	prismaClient.$on('query', e => {


### PR DESCRIPTION
### Description:

This should have been pushed to OSB, sorry

### Changes:

- Increase the Prisma $transaction timeout to 2.5 minutes, needed especially for migrate user, though we should try to figure out how to do it on a per command basis. My original try failed.

### Other checks:

- [x] I have tested all my changes thoroughly.
