### PR TITLE
Add lb ranks to website

### DIFF
--- a/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
+++ b/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
@@ -9,6 +9,16 @@ export function MinionInfo({ data }: { data: FullMinionData }) {
 		data.is_ironman && data.leaderboards.cl.ironman_rank
 			? ` (Ironman ${formatRank(data.leaderboards.cl.ironman_rank)})`
 			: '';
+	const masteryRank = formatRank(data.leaderboards.mastery_rank);
+	const masteryIronmanRank =
+		data.is_ironman && data.leaderboards.mastery_ironman_rank
+			? ` (Ironman ${formatRank(data.leaderboards.mastery_ironman_rank)})`
+			: '';
+	const skillsRank = formatRank(data.leaderboards.skills_rank);
+	const skillsIronmanRank =
+		data.is_ironman && data.leaderboards.skills_ironman_rank
+			? ` (Ironman ${formatRank(data.leaderboards.skills_ironman_rank)})`
+			: '';
 	const info = {
 		Ironman: data.is_ironman ? 'Yes' : 'No',
 		GP: data.gp.toLocaleString(),
@@ -17,8 +27,8 @@ export function MinionInfo({ data }: { data: FullMinionData }) {
 		'Collection Log': Object.keys(data.collection_log_bank).length,
 		Sacrificed: `${data.total_sacrificed_value.toLocaleString()} GP`,
 		'LB CL Overall': `${clRank}${clIronmanRank}`,
-		'LB Mastery': formatRank(data.leaderboards.mastery_rank),
-		'LB Skills': formatRank(data.leaderboards.skills_rank)
+		'LB Mastery': `${masteryRank}${masteryIronmanRank}`,
+		'LB Skills': `${skillsRank}${skillsIronmanRank}`
 	};
 	return (
 		<div className="flex items-center justify-center flex-col">

--- a/packages/robochimp/src/http/api-types.ts
+++ b/packages/robochimp/src/http/api-types.ts
@@ -23,7 +23,9 @@ export type FullMinionData = {
 			ironman_rank: number | null;
 		};
 		mastery_rank: number | null;
+		mastery_ironman_rank: number | null;
 		skills_rank: number | null;
+		skills_ironman_rank: number | null;
 	};
 
 	bank: ItemBank;


### PR DESCRIPTION
Expose live leaderboard positions on the oldschoolgg minion page for both osb and bso bots.
Show the user's collection log overall rank and ironman rank in brackets when applicable, plus mastery and skills ranks.

- [ ] I have tested all my changes thoroughly.
