### PR TITLE
Add off-task slayer unlock

### DIFF
--- a/src/lib/slayer/slayerUnlocks.ts
+++ b/src/lib/slayer/slayerUnlocks.ts
@@ -75,7 +75,8 @@ export enum SlayerTaskUnlocksEnum {
 	Revenenenenenants = 201,
 	EyeSeeYou = 202,
 	MoreEyesThanSense = 203,
-	WarpedReality = 204
+	WarpedReality = 204,
+	OffTaskSlayer = 205
 }
 
 export const SlayerRewardsShop: SlayerTaskUnlocks[] = [
@@ -599,6 +600,14 @@ export const SlayerRewardsShop: SlayerTaskUnlocks[] = [
 		slayerPointCost: 60,
 		canBeRemoved: true,
 		aliases: ['warped reality']
+	},
+	{
+		id: SlayerTaskUnlocksEnum.OffTaskSlayer,
+		name: 'Off-task Slayer',
+		desc: 'Allows you to kill slayer-only monsters off task (slayer helm boosts still require a task).',
+		slayerPointCost: 5000,
+		canBeRemoved: true,
+		aliases: ['off task slayer', 'off-task slayer', 'taskless slayer']
 	}
 ];
 

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -16,7 +16,7 @@ import { type AttackStyles, getAttackStylesContext } from '@/lib/minions/functio
 import { resolveAttackStyles } from '@/lib/minions/functions/resolveAttackStyles.js';
 import type { KillableMonster } from '@/lib/minions/types.js';
 import { wildySlayerOnlyMonsters } from '@/lib/slayer/constants.js';
-import type { SlayerTaskUnlocksEnum } from '@/lib/slayer/slayerUnlocks.js';
+import { SlayerTaskUnlocksEnum } from '@/lib/slayer/slayerUnlocks.js';
 import { type CurrentSlayerInfo, determineCombatBoosts } from '@/lib/slayer/slayerUtil.js';
 import type { GearBank } from '@/lib/structures/GearBank.js';
 import { UpdateBank } from '@/lib/structures/UpdateBank.js';
@@ -84,7 +84,9 @@ export function newMinionKillCommand(args: MinionKillOptions): string | MinionKi
 		currentSlayerTask.currentTask !== null &&
 		currentSlayerTask.assignedTask.monsters.includes(monster.id);
 
-	if (monster.slayerOnly && !isOnTask) {
+	const canKillOffTask = slayerUnlocks.includes(SlayerTaskUnlocksEnum.OffTaskSlayer);
+
+	if (monster.slayerOnly && !isOnTask && !canKillOffTask) {
 		return `You can't kill ${monster.name}, because you're not on a slayer task.`;
 	}
 

--- a/tests/unit/snapshots/slayerUnlocks.snapshot.json
+++ b/tests/unit/snapshots/slayerUnlocks.snapshot.json
@@ -56,5 +56,6 @@
 	"Revenenenenenants": 201,
 	"EyeSeeYou": 202,
 	"MoreEyesThanSense": 203,
-	"WarpedReality": 204
+	"WarpedReality": 204,
+	"OffTaskSlayer": 205
 }


### PR DESCRIPTION
Introduce a purchasable unlock to allow killing OSRS slayer-only monsters off task for users who want to farm bosses like Cerb, Sire, Araxxor, etc., without a slayer task.
Keep existing behaviour for slayer boosts so they still require being on a slayer task.
Ensure kill validation respects the new unlock while preserving wilderness and wildy-only restrictions.

- Add `OffTaskSlayer` to `SlayerTaskUnlocksEnum` and include a new `SlayerRewardsShop` entry named `Off-task Slayer` with `slayerPointCost: 5000` and aliases. 
- Update `newMinionKillCommand` to allow `monster.slayerOnly` kills when `slayerUnlocks` includes `SlayerTaskUnlocksEnum.OffTaskSlayer`. 
- Keep other checks intact such as `wildySlayerOnlyMonsters`, wilderness-only rules, and boost/method restrictions. 

<img width="1277" height="154" alt="image" src="https://github.com/user-attachments/assets/56d1829a-51f2-422a-99a0-801ab28d00e5" />

- [x] I have tested all my changes thoroughly.
