### PR TITLE
Use UTC for weekend boost

### DIFF
--- a/packages/toolkit/src/util/datetime.ts
+++ b/packages/toolkit/src/util/datetime.ts
@@ -14,8 +14,8 @@ export function isAtleastThisOld(date: Date | number, expectedAgeInMS: number): 
 }
 
 export function isWeekend(): boolean {
-	const currentDate = new Date(Date.now() - Time.Hour * 6);
-	return [6, 0].includes(currentDate.getDay());
+	const currentDate = new Date();
+	return [6, 0].includes(currentDate.getUTCDay());
 }
 
 export function calcPerHour(value: number, duration: number): number {


### PR DESCRIPTION
Ensures the weekend boost uses the correct UTC timing and no longer depends on server local time.

- [x] I have tested all my changes thoroughly.
