### PR TITLE
Add Black swan to DC pets bank filter

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2276,6 +2276,8 @@ export const allPetIDs = [
 	...mumpkinMetamorphPets
 ];
 
+export { discontinuedCustomPetsCL };
+
 export const antiSantaOutfit = new Bank({
 	'Antisanta mask': 1,
 	'Antisanta jacket': 1,

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2276,8 +2276,6 @@ export const allPetIDs = [
 	...mumpkinMetamorphPets
 ];
 
-export { discontinuedCustomPetsCL };
-
 export const antiSantaOutfit = new Bank({
 	'Antisanta mask': 1,
 	'Antisanta jacket': 1,

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -1,4 +1,5 @@
 import { BSOItemGroups } from '@/lib/bso/bsoItemGroups.js';
+import { discontinuedCustomPetsCL } from '@/lib/bso/collection-log/main.js';
 import { GrandmasterClueTable } from '@/lib/bso/grandmasterClue.js';
 import { PartyhatTable } from '@/lib/bso/holidayItems.js';
 import { gods } from '@/lib/bso/minigames/divineDominion.js';
@@ -33,7 +34,6 @@ import {
 	cluesMasterRareCL,
 	cluesMediumCL,
 	cluesSharedCL,
-	discontinuedCustomPetsCL,
 	temporossCL,
 	wintertodtCL
 } from '@/lib/data/CollectionsExport.js';

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -33,6 +33,7 @@ import {
 	cluesMasterRareCL,
 	cluesMediumCL,
 	cluesSharedCL,
+	discontinuedCustomPetsCL,
 	temporossCL,
 	wintertodtCL
 } from '@/lib/data/CollectionsExport.js';
@@ -184,6 +185,8 @@ export const ores = resolveItems([
 	'Dwarven ore',
 	'Dark animica'
 ]);
+
+const dcPetsExtras = resolveItems(['Black swan']);
 
 const bars = resolveItems([
 	'Bronze bar',
@@ -961,6 +964,11 @@ export const baseFilters: Filterable[] = [
 		name: 'tmb',
 		aliases: ['tmb'],
 		items: () => tmbTable
+	},
+	{
+		name: 'DC Pets',
+		aliases: ['dc pets', 'dcpets', 'dcpet', 'dcp', 'discontinued custom pet', 'disc custom pet'],
+		items: () => [...discontinuedCustomPetsCL, ...dcPetsExtras]
 	},
 	{
 		name: 'Pets',

--- a/src/lib/data/filterables.ts
+++ b/src/lib/data/filterables.ts
@@ -966,7 +966,7 @@ export const baseFilters: Filterable[] = [
 		items: () => tmbTable
 	},
 	{
-		name: 'DC Pets',
+		name: 'Custom Pets (Discontinued)',
 		aliases: ['dc pets', 'dcpets', 'dcpet', 'dcp', 'discontinued custom pet', 'disc custom pet'],
 		items: () => [...discontinuedCustomPetsCL, ...dcPetsExtras]
 	},


### PR DESCRIPTION
Added a DC Pets bank filter that includes Black Swan without altering collection log entries

<img width="735" height="134" alt="image" src="https://github.com/user-attachments/assets/8911624e-40fe-4139-a749-fd957d738cf1" />


- [x] I have tested all my changes thoroughly.
