### PR TITLE
Patched /steal to surface a food error

### DIFF
--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -1,5 +1,5 @@
 import { bold } from '@oldschoolgg/discord';
-import { formatDuration, stringMatches } from '@oldschoolgg/toolkit';
+import { formatDuration, stringMatches, UserError } from '@oldschoolgg/toolkit';
 
 import { quests } from '@/lib/minions/data/quests.js';
 import removeFoodFromUser from '@/lib/minions/functions/removeFoodFromUser.js';
@@ -147,13 +147,22 @@ export const stealCommand = defineCommand({
 				);
 			}
 
-			const { foodRemoved } = await removeFoodFromUser({
-				user,
-				totalHealingNeeded: damageTaken,
-				healPerAction: Math.ceil(damageTaken / quantity),
-				activityName: 'Pickpocketing',
-				attackStylesUsed: []
-			});
+			let removeFoodResult: Awaited<ReturnType<typeof removeFoodFromUser>>;
+			try {
+				removeFoodResult = await removeFoodFromUser({
+					user,
+					totalHealingNeeded: damageTaken,
+					healPerAction: Math.ceil(damageTaken / quantity),
+					activityName: 'Pickpocketing',
+					attackStylesUsed: []
+				});
+			} catch (err: unknown) {
+				if (err instanceof UserError) {
+					return err.message;
+				}
+				throw err;
+			}
+			const foodRemoved = removeFoodResult.foodRemoved;
 
 			await ClientSettings.updateBankSetting('economyStats_thievingCost', foodRemoved);
 			str += ` Removed ${foodRemoved}.`;


### PR DESCRIPTION
/steal name:man with no food now returns the specific “not enough food / need X HP” message from removeFoodFromUser, instead of An error occurred while running this command.

- [x] I have tested all my changes thoroughly.
