### PR TITLE
BSO - Fix Canvas test errors

### DIFF
--- a/src/lib/canvas/OSRSCanvas.ts
+++ b/src/lib/canvas/OSRSCanvas.ts
@@ -391,7 +391,8 @@ export class OSRSCanvas {
 		let customImage: Image | null = null;
 
 		if (user && show_paints !== false) {
-			if (show_paints === true || !user.bitfield.includes(BitField.DisablePaints)) {
+			const hasDisablePaintsBit = user.bitfield?.includes?.(BitField.DisablePaints) ?? false;
+			if (show_paints === true || !hasDisablePaintsBit) {
 				customImage = await applyCustomItemEffects(user, itemID);
 			}
 		}


### PR DESCRIPTION
Updated OSRSCanvas.ts to safely handle user.bitfield being undefined before calling .includes(...).

This change allows pnpm dev to pass successfully

- [x] I have tested all my changes thoroughly.
