### PR TITLE
Improve /activities quest

### DIFF
--- a/src/lib/util/smallUtils.ts
+++ b/src/lib/util/smallUtils.ts
@@ -99,7 +99,13 @@ export function hasSkillReqsRaw(skills: SkillRequirements, requirements: SkillRe
 export function hasSkillReqs(user: MUser, reqs: Skills): [boolean, string | null] {
 	const hasReqs = hasSkillReqsRaw(user.skillsAsRequirements, reqs);
 	if (!hasReqs) {
-		return [false, formatSkillRequirements(reqs)];
+		const missingReqs = Object.fromEntries(
+			objectEntries(reqs).filter(([skillName, requiredLevel]) => {
+				const userLevel = user.skillsAsRequirements[skillName];
+				return !userLevel || userLevel < requiredLevel!;
+			})
+		) as SkillRequirements;
+		return [false, formatSkillRequirements(missingReqs)];
 	}
 	return [true, null];
 }

--- a/src/mahoji/commands/activities.ts
+++ b/src/mahoji/commands/activities.ts
@@ -170,13 +170,17 @@ export const activitiesCommand = defineCommand({
 					type: 'String',
 					name: 'name',
 					description: 'The name of the quest (optional).',
-					autocomplete: async ({ userId }: StringAutoComplete) => {
+					autocomplete: async ({ userId, value }: StringAutoComplete) => {
 						const user = await mUserFetch(userId);
+						const search = value.toLowerCase();
 						let list = quests
 							.filter(i => !user.user.finished_quest_ids.includes(i.id))
+							.filter(i => (!search ? true : i.name.toLowerCase().includes(search)))
 							.map(i => ({ name: i.name, value: i.name }));
 						if (list.length === 0) {
-							list = quests.map(i => ({ name: `${i.name} (completed)`, value: i.name }));
+							list = quests
+								.filter(i => (!search ? true : i.name.toLowerCase().includes(search)))
+								.map(i => ({ name: `${i.name} (completed)`, value: i.name }));
 						}
 						return list;
 					},


### PR DESCRIPTION
- Add text filtering to /activities quest autocomplete so quest suggestions match the user's typed input 
- Keep incomplete quests prioritised in autocomplete, with completed quests only used as the fallback list when no incomplete matches exist 
- Update quest skill requirement messaging to show only the skills the user is missing

- [x] I have tested all my changes thoroughly.
