### PR TITLE
Disable Passive Trip End Triggers on TestUser

### DIFF
--- a/data/osb/commands.json
+++ b/data/osb/commands.json
@@ -1,6 +1,6 @@
 {
-	"hash": "4e6b5f19ee746f8ca06542ac4d142529",
-	"date": "2026-02-20T07:19:34.772Z",
+	"hash": "f65934bd9069c076afa2035e57744b98",
+	"date": "2026-05-08T09:02:38.284Z",
 	"data": [
 		{
 			"name": "activities",
@@ -224,7 +224,7 @@
 		},
 		{
 			"name": "giveaway",
-			"desc": "Giveaway items from your ban to other players.",
+			"desc": "Giveaway items from your bank to other players.",
 			"examples": ["/giveaway items:10 trout, 5 coal time:1h"],
 			"subOptions": ["list", "start"]
 		},

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -159,7 +159,8 @@ export enum BitField {
 	HasMysticVigourScroll = 46,
 	AllowPublicAPIDataRetrieval = 47,
 	ToggleAutoRummage = 48,
-	DisableDynamicTimestamp = 49
+	DisableDynamicTimestamp = 49,
+	DisabledPassiveImplings = 50
 }
 
 interface BitFieldData {
@@ -280,6 +281,11 @@ export const BitFieldData: Record<BitField, BitFieldData> = {
 	},
 	[BitField.DisableDynamicTimestamp]: {
 		name: 'Disable Dynamic Minion Return Time',
+		protected: false,
+		userConfigurable: true
+	},
+	[BitField.DisabledPassiveImplings]: {
+		name: 'Disabled Passive Implings',
 		protected: false,
 		userConfigurable: true
 	},

--- a/src/lib/implings.ts
+++ b/src/lib/implings.ts
@@ -17,6 +17,7 @@ import {
 } from 'oldschooljs';
 
 import { activity_type_enum } from '@/prisma/main/enums.js';
+import { BitField } from '@/lib/constants.js';
 import type { ActivityTaskData } from '@/lib/types/minions.js';
 import activityInArea, { WorldLocations } from '@/lib/util/activityInArea.js';
 
@@ -87,6 +88,7 @@ const implingTableByWorldLocation = {
 };
 
 export function handlePassiveImplings(user: MUser, data: ActivityTaskData) {
+	if (user.bitfield.includes(BitField.DisabledPassiveImplings)) return null;
 	if (
 		[
 			'FightCaves',

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -43,6 +43,10 @@ const toggles: UserConfigToggle[] = [
 		bit: BitField.DisabledRandomEvents
 	},
 	{
+		name: 'Disable Passive Implings',
+		bit: BitField.DisabledPassiveImplings
+	},
+	{
 		name: 'Small Bank Images',
 		bit: BitField.AlwaysSmallBank
 	},

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -123,8 +123,9 @@ async function favFoodConfig(
 	}
 	const currentFavorites = user.user.favorite_food;
 	const item = Items.getItem(itemToAdd ?? itemToRemove);
-	const currentItems = `Your current favorite food is: ${currentFavorites.length === 0 ? 'None' : currentFavorites.map(i => Items.itemNameFromId(i)).join(', ')
-		}.`;
+	const currentItems = `Your current favorite food is: ${
+		currentFavorites.length === 0 ? 'None' : currentFavorites.map(i => Items.itemNameFromId(i)).join(', ')
+	}.`;
 	if (!item) return currentItems;
 	if (!Eatables.some(i => i.id === item.id)) return "That's not a valid item.";
 
@@ -153,13 +154,14 @@ async function favItemConfig(
 	}
 	const currentFavorites = user.user.favoriteItems;
 	const item = Items.getItem(itemToAdd ?? itemToRemove);
-	const currentItems = `Your current favorite items are: ${currentFavorites.length === 0
+	const currentItems = `Your current favorite items are: ${
+		currentFavorites.length === 0
 			? 'None'
 			: currentFavorites
-				.map(i => Items.itemNameFromId(i))
-				.join(', ')
-				.slice(0, 1500)
-		}.`;
+					.map(i => Items.itemNameFromId(i))
+					.join(', ')
+					.slice(0, 1500)
+	}.`;
 
 	if (!item) return currentItems;
 	if (itemToAdd) {
@@ -264,8 +266,9 @@ async function favBhSeedsConfig(
 		}
 	}
 
-	const currentItems = `Your current favorite items are: ${currentFavorites.length === 0 ? 'None' : currentFavorites.map(i => Items.itemNameFromId(i)).join(', ')
-		}.`;
+	const currentItems = `Your current favorite items are: ${
+		currentFavorites.length === 0 ? 'None' : currentFavorites.map(i => Items.itemNameFromId(i)).join(', ')
+	}.`;
 	return currentItems;
 }
 

--- a/tests/test-utils/mockUser.ts
+++ b/tests/test-utils/mockUser.ts
@@ -10,6 +10,7 @@ import type { GearSetupType, Prisma, User, UserStats } from '@/prisma/main.js';
 import { rawCommandHandlerInner } from '@/discord/commandHandler.js';
 import { MessageBuilderClass } from '@/discord/MessageBuilder.js';
 import type { PvMMethod } from '@/lib/constants.js';
+import { BitField } from '@/lib/constants.js';
 import type { DegradeableItem } from '@/lib/degradeableItems.js';
 import { type SkillNameType, SkillsArray } from '@/lib/skilling/types.js';
 import { slayerMasters } from '@/lib/slayer/slayerMasters.js';
@@ -363,6 +364,7 @@ export async function mockUser(
 export async function createTestUser(_bank?: Bank, userData: Partial<Prisma.UserCreateInput> = {}) {
 	const id = userData.id ?? mockedId();
 	userData.username ??= `TestUser`;
+	userData.bitfield ??= [BitField.DisabledRandomEvents];
 
 	const bank = _bank ? _bank.clone() : null;
 	let GP = userData.GP ? Number(userData.GP) : undefined;

--- a/tests/test-utils/mockUser.ts
+++ b/tests/test-utils/mockUser.ts
@@ -364,7 +364,7 @@ export async function mockUser(
 export async function createTestUser(_bank?: Bank, userData: Partial<Prisma.UserCreateInput> = {}) {
 	const id = userData.id ?? mockedId();
 	userData.username ??= `TestUser`;
-	userData.bitfield ??= [BitField.DisabledRandomEvents];
+	userData.bitfield ??= [BitField.DisabledRandomEvents, BitField.DisabledPassiveImplings];
 
 	const bank = _bank ? _bank.clone() : null;
 	let GP = userData.GP ? Number(userData.GP) : undefined;


### PR DESCRIPTION
createTestUser now defaults all test users to BitField.DisabledRandomEvents and Bitfield.DisabledPassiveImplings

Some tests such as the hunter.test was rolling random events/implings which was failing the tests. This should stop that from happening.

If a specific test needs random events/implings enabled, we can pass an explicit override.

I also had to add the bitfield for disabling passive implings, if this needs moving to its own pr let me know

- [x] I have tested all my changes thoroughly.
