### PR TITLE
Update Mining Gloves cost + Add Soft Clay

### DIFF
--- a/data/osb/buyables.json
+++ b/data/osb/buyables.json
@@ -1295,7 +1295,7 @@
 	{
 		"name": "Expert mining gloves",
 		"item_cost": {
-			"21341": 60,
+			"21341": 40,
 			"21343": 1,
 			"21345": 1
 		},
@@ -2755,7 +2755,7 @@
 	{
 		"name": "Mining gloves",
 		"item_cost": {
-			"21341": 60
+			"21341": 40
 		},
 		"output_items": {
 			"21343": 1
@@ -3871,6 +3871,24 @@
 		}
 	},
 	{
+		"name": "Soft clay pack (golden nuggets)",
+		"output_items": {
+			"12009": 1
+		},
+		"item_cost": {
+			"12012": 10
+		}
+	},
+	{
+		"name": "Soft clay pack (minerals)",
+		"output_items": {
+			"12009": 1
+		},
+		"item_cost": {
+			"21341": 10
+		}
+	},
+	{
 		"name": "Spiny helmet",
 		"gp_cost": 65000,
 		"output_items": {
@@ -3947,7 +3965,7 @@
 	{
 		"name": "Superior mining gloves",
 		"item_cost": {
-			"21341": 120
+			"21341": 100
 		},
 		"output_items": {
 			"21345": 1

--- a/data/osb/openables.json
+++ b/data/osb/openables.json
@@ -3680,6 +3680,12 @@
 		]
 	},
 	{
+		"name": "Soft clay pack",
+		"id": 12009,
+		"opened_item": "Soft clay pack",
+		"all_items": ["Soft clay"]
+	},
+	{
 		"name": "Spoils of war",
 		"id": 25342,
 		"opened_item": "Spoils of war",

--- a/src/lib/data/buyables/mining.ts
+++ b/src/lib/data/buyables/mining.ts
@@ -42,13 +42,13 @@ export const miningBuyables: Buyable[] = [
 	{
 		name: 'Mining gloves',
 		itemCost: new Bank({
-			'Unidentified minerals': 60
+			'Unidentified minerals': 40
 		})
 	},
 	{
 		name: 'Superior mining gloves',
 		itemCost: new Bank({
-			'Unidentified minerals': 120
+			'Unidentified minerals': 100
 		})
 	},
 	{
@@ -56,7 +56,7 @@ export const miningBuyables: Buyable[] = [
 		itemCost: new Bank({
 			'Superior mining gloves': 1,
 			'Mining gloves': 1,
-			'Unidentified minerals': 60
+			'Unidentified minerals': 40
 		})
 	},
 	{
@@ -72,6 +72,24 @@ export const miningBuyables: Buyable[] = [
 		}),
 		itemCost: new Bank({
 			'Unidentified minerals': 20
+		})
+	},
+	{
+		name: 'Soft clay pack (minerals)',
+		outputItems: new Bank({
+			'Soft clay pack': 1
+		}),
+		itemCost: new Bank({
+			'Unidentified minerals': 10
+		})
+	},
+	{
+		name: 'Soft clay pack (golden nuggets)',
+		outputItems: new Bank({
+			'Soft clay pack': 1
+		}),
+		itemCost: new Bank({
+			'Golden nugget': 10
 		})
 	}
 ];

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -544,6 +544,14 @@ export const allOpenables: UnifiedOpenable[] = [
 		output: BaleOfFlax,
 		allItems: BaleOfFlax.allItems
 	},
+	{
+		name: 'Soft clay pack',
+		id: itemID('Soft clay pack'),
+		openedItem: Items.getOrThrow('Soft clay pack'),
+		aliases: ['soft clay pack', 'clay pack'],
+		output: new LootTable().add('Soft clay', 100),
+		allItems: resolveItems(['Soft clay'])
+	},
 	...clueOpenables,
 	...osjsOpenables,
 	...shadeChestOpenables


### PR DESCRIPTION
As per the update in May 2024, update the mining gloves costs and then add the soft clay packs that were never added

<img width="841" height="163" alt="image" src="https://github.com/user-attachments/assets/25218110-a19e-4a30-ad53-27810989e715" />

- [ ] I have tested all my changes thoroughly.
