### PR TITLE
Add Targeted Patreon Sync

### DIFF
--- a/packages/robochimp/src/commands/tools.ts
+++ b/packages/robochimp/src/commands/tools.ts
@@ -34,7 +34,15 @@ export const toolsCommand = defineCommand({
 		{
 			type: 'Subcommand',
 			name: 'patreon_sync',
-			description: 'Patreon sync'
+			description: 'Patreon sync',
+			options: [
+				{
+					type: 'User',
+					name: 'user',
+					description: 'Only sync this user',
+					required: false
+				}
+			]
 		},
 		{
 			type: 'Subcommand',
@@ -49,11 +57,12 @@ export const toolsCommand = defineCommand({
 		if (!user.isSupport()) return 'Ook';
 
 		if (options.patreon_sync) {
-			const res = await patreonTask.run();
+			const targetUserID = options.patreon_sync.user?.user.id;
+			const res = await patreonTask.run(targetUserID);
 			if (res) {
 				console.log(res.join('\n').slice(0, 1950));
 			}
-			return 'Done.';
+			return targetUserID ? `Done. Synced <@${targetUserID}>.` : 'Done.';
 		}
 
 		if (!user.isMod()) return 'Ook';

--- a/packages/robochimp/src/lib/patreon.ts
+++ b/packages/robochimp/src/lib/patreon.ts
@@ -406,13 +406,14 @@ class PatreonTask {
 		return Promise.all(allUsers.map(u => this.validatePerks(u.id, tiers.find(t => t.number === 3)!, true)));
 	}
 
-	async run() {
+	async run(targetDiscordID?: string) {
 		if (!globalConfig.isProduction) {
 			console.log('Skipping patreon task run because not production');
 			return;
 		}
-		// Reset all users' perk tier to 0 if their group has inconsistent perk tiers.
-		await roboChimpClient.$queryRawUnsafe(`UPDATE "user"
+		// Full sync only: reset all users' perk tier to 0 if their group has inconsistent perk tiers.
+		if (!targetDiscordID) {
+			await roboChimpClient.$queryRawUnsafe(`UPDATE "user"
 SET perk_tier = 0
 WHERE user_group_id IN (
 SELECT u1.user_group_id
@@ -421,12 +422,26 @@ JOIN "user" u2 ON u1.user_group_id = u2.user_group_id
 WHERE u1.perk_tier <> u2.perk_tier
 AND u1.id <> u2.id
 );`);
-		await this.checkHasEverBeenPatron();
+			await this.checkHasEverBeenPatron();
+		}
 
 		const fetchedPatrons = await this.fetchPatrons();
 		const result = [];
+		const targetUser = targetDiscordID
+			? await roboChimpClient.user.findFirst({
+					where: { id: BigInt(targetDiscordID) }
+				})
+			: null;
 
 		for (const patron of fetchedPatrons) {
+			if (
+				targetDiscordID &&
+				patron.discordID !== targetDiscordID &&
+				!(targetUser?.patreon_id && targetUser.patreon_id === patron.patreonID)
+			) {
+				continue;
+			}
+
 			if (!patron.discordID) {
 				const backupUser = await roboChimpClient.user.findFirst({
 					where: {
@@ -434,6 +449,9 @@ AND u1.id <> u2.id
 					}
 				});
 				if (backupUser) {
+					if (targetDiscordID && backupUser.id.toString() !== targetDiscordID) {
+						continue;
+					}
 					result.push(
 						`Found a backup user for ${patron.patreonID}, setting their discord ID to ${backupUser.id}`
 					);
@@ -466,6 +484,7 @@ AND u1.id <> u2.id
 			// Only find the user if they don't already have the relevant perk tier.
 			const user = await globalClient.fetchRUser(patron.discordID);
 			if (!user) continue;
+			if (targetDiscordID && user.id.toString() !== targetDiscordID) continue;
 
 			const userIdentifier = `R[${user.id}]D[${patron.discordID}]P[${patron.patreonID}]`;
 
@@ -502,8 +521,10 @@ AND u1.id <> u2.id
 			await this.changeTier(user, tierTheyShouldHave);
 		}
 
-		result.push(await this.syncGithub());
-		result.push(await this.updateFreePerks());
+		if (!targetDiscordID) {
+			result.push(await this.syncGithub());
+			result.push(await this.updateFreePerks());
+		}
 		return result.flat(5).filter(notEmpty);
 	}
 

--- a/src/lib/perkTiers.ts
+++ b/src/lib/perkTiers.ts
@@ -32,48 +32,11 @@ function setHotCache(userId: string, tier: number) {
 }
 export function getPerkTierCached(userId: string) {
 	const tierCacheEntry = perkTierHotCache.get(userId);
-	if (!tierCacheEntry) return null;
-	if (tierCacheEntry.expires <= Date.now()) {
-		perkTierHotCache.delete(userId);
-		return null;
+	if (tierCacheEntry) {
+		return tierCacheEntry.tier;
 	}
-	return tierCacheEntry.tier;
+	return null;
 }
-
-export function clearPerkTierCached(userId: string) {
-	perkTierHotCache.delete(userId);
-}
-
-function isFreshCacheEntry(entry: PerkTierHotCacheEntry | undefined) {
-	return Boolean(entry && entry.expires > Date.now());
-}
-
-function tierMatchesRoboChimpCache(entry: PerkTierHotCacheEntry | undefined, roboChimpTier: number | null | undefined) {
-	if (!entry) return false;
-	if (roboChimpTier === null || roboChimpTier === undefined) return true;
-	return entry.tier === roboChimpTier;
-}
-
-async function getCachedRoboChimpTier(userId: string): Promise<number | null> {
-	const roboChimpCached = await Cache.getRoboChimpUser(userId);
-	if (!roboChimpCached) return null;
-	return roboChimpCached.perk_tier;
-}
-
-async function shouldUseHotCache(userId: string, entry: PerkTierHotCacheEntry | undefined): Promise<boolean> {
-	if (!isFreshCacheEntry(entry)) return false;
-	const roboChimpTier = await getCachedRoboChimpTier(userId);
-	if (!tierMatchesRoboChimpCache(entry, roboChimpTier)) {
-		clearPerkTierCached(userId);
-		return false;
-	}
-	return true;
-}
-
-async function getRoboChimpCachedUser(userId: string) {
-	return Cache.getRoboChimpUser(userId);
-}
-
 export async function getUsersPerkTier({
 	user,
 	guildId,
@@ -85,12 +48,15 @@ export async function getUsersPerkTier({
 	interaction?: MInteraction;
 	forceNoCache?: boolean;
 }): Promise<PerkTier | 0> {
-	const tierCacheEntry = perkTierHotCache.get(user.id);
-	const roboChimpCached = await getRoboChimpCachedUser(user.id);
-	if (!forceNoCache && (await shouldUseHotCache(user.id, tierCacheEntry))) {
-		return tierCacheEntry!.tier;
+	if (!forceNoCache) {
+		// We want a way to force a cache refresh
+		// Otherwise, we look for the a cached tier:
+		const tierCacheEntry = perkTierHotCache.get(user.id);
+		// If it's not expired, return it:
+		if (tierCacheEntry && tierCacheEntry.expires < Date.now()) {
+			return tierCacheEntry.tier;
+		}
 	}
-
 	const possibleGuildId = guildId ?? interaction?.guildId ?? null;
 	const eligibleTiers = [];
 	if (user.isMod()) {
@@ -119,6 +85,7 @@ export async function getUsersPerkTier({
 		eligibleTiers.push(PerkTier.Three);
 	}
 
+	const roboChimpCached = await Cache.getRoboChimpUser(user.id);
 	if (roboChimpCached) {
 		eligibleTiers.push(roboChimpCached.perk_tier);
 	}

--- a/src/lib/perkTiers.ts
+++ b/src/lib/perkTiers.ts
@@ -32,11 +32,48 @@ function setHotCache(userId: string, tier: number) {
 }
 export function getPerkTierCached(userId: string) {
 	const tierCacheEntry = perkTierHotCache.get(userId);
-	if (tierCacheEntry) {
-		return tierCacheEntry.tier;
+	if (!tierCacheEntry) return null;
+	if (tierCacheEntry.expires <= Date.now()) {
+		perkTierHotCache.delete(userId);
+		return null;
 	}
-	return null;
+	return tierCacheEntry.tier;
 }
+
+export function clearPerkTierCached(userId: string) {
+	perkTierHotCache.delete(userId);
+}
+
+function isFreshCacheEntry(entry: PerkTierHotCacheEntry | undefined) {
+	return Boolean(entry && entry.expires > Date.now());
+}
+
+function tierMatchesRoboChimpCache(entry: PerkTierHotCacheEntry | undefined, roboChimpTier: number | null | undefined) {
+	if (!entry) return false;
+	if (roboChimpTier === null || roboChimpTier === undefined) return true;
+	return entry.tier === roboChimpTier;
+}
+
+async function getCachedRoboChimpTier(userId: string): Promise<number | null> {
+	const roboChimpCached = await Cache.getRoboChimpUser(userId);
+	if (!roboChimpCached) return null;
+	return roboChimpCached.perk_tier;
+}
+
+async function shouldUseHotCache(userId: string, entry: PerkTierHotCacheEntry | undefined): Promise<boolean> {
+	if (!isFreshCacheEntry(entry)) return false;
+	const roboChimpTier = await getCachedRoboChimpTier(userId);
+	if (!tierMatchesRoboChimpCache(entry, roboChimpTier)) {
+		clearPerkTierCached(userId);
+		return false;
+	}
+	return true;
+}
+
+async function getRoboChimpCachedUser(userId: string) {
+	return Cache.getRoboChimpUser(userId);
+}
+
 export async function getUsersPerkTier({
 	user,
 	guildId,
@@ -48,15 +85,12 @@ export async function getUsersPerkTier({
 	interaction?: MInteraction;
 	forceNoCache?: boolean;
 }): Promise<PerkTier | 0> {
-	if (!forceNoCache) {
-		// We want a way to force a cache refresh
-		// Otherwise, we look for the a cached tier:
-		const tierCacheEntry = perkTierHotCache.get(user.id);
-		// If it's not expired, return it:
-		if (tierCacheEntry && tierCacheEntry.expires < Date.now()) {
-			return tierCacheEntry.tier;
-		}
+	const tierCacheEntry = perkTierHotCache.get(user.id);
+	const roboChimpCached = await getRoboChimpCachedUser(user.id);
+	if (!forceNoCache && (await shouldUseHotCache(user.id, tierCacheEntry))) {
+		return tierCacheEntry!.tier;
 	}
+
 	const possibleGuildId = guildId ?? interaction?.guildId ?? null;
 	const eligibleTiers = [];
 	if (user.isMod()) {
@@ -85,7 +119,6 @@ export async function getUsersPerkTier({
 		eligibleTiers.push(PerkTier.Three);
 	}
 
-	const roboChimpCached = await Cache.getRoboChimpUser(user.id);
 	if (roboChimpCached) {
 		eligibleTiers.push(roboChimpCached.perk_tier);
 	}


### PR DESCRIPTION
`/tools patreon_sync` now accepts an optional user field and runs a targeted sync for just that user, skipping the heavy sync.

I'm unable to test this personally 

- [ ] I have tested all my changes thoroughly.
