### PR TITLE
Superheat spells

### DIFF
--- a/data/osb/commands.json
+++ b/data/osb/commands.json
@@ -1,6 +1,6 @@
 {
-	"hash": "4e6b5f19ee746f8ca06542ac4d142529",
-	"date": "2026-02-20T07:19:34.772Z",
+	"hash": "f65934bd9069c076afa2035e57744b98",
+	"date": "2026-04-07T19:53:18.635Z",
 	"data": [
 		{
 			"name": "activities",
@@ -224,7 +224,7 @@
 		},
 		{
 			"name": "giveaway",
-			"desc": "Giveaway items from your ban to other players.",
+			"desc": "Giveaway items from your bank to other players.",
 			"examples": ["/giveaway items:10 trout, 5 coal time:1h"],
 			"subOptions": ["list", "start"]
 		},

--- a/data/osb/skills/magic-castables.json
+++ b/data/osb/skills/magic-castables.json
@@ -1259,6 +1259,147 @@
 		"craft_level": 61
 	},
 	{
+		"id": 2361,
+		"name": "Superheat Adamantite bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"449": 1,
+			"453": 6,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2361": 1
+		},
+		"ticks": 3,
+		"smithing_level": 70,
+		"smithing_xp": 37.5
+	},
+	{
+		"id": 2349,
+		"name": "Superheat Bronze bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"436": 1,
+			"438": 1,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2349": 1
+		},
+		"ticks": 3,
+		"smithing_level": 1,
+		"smithing_xp": 6.2
+	},
+	{
+		"id": 2357,
+		"name": "Superheat Gold bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"444": 1,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2357": 1
+		},
+		"ticks": 3,
+		"smithing_level": 40,
+		"smithing_xp": 22.5
+	},
+	{
+		"id": 2351,
+		"name": "Superheat Iron bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"440": 1,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2351": 1
+		},
+		"ticks": 3,
+		"smithing_level": 15,
+		"smithing_xp": 12.5
+	},
+	{
+		"id": 2359,
+		"name": "Superheat Mithril bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"447": 1,
+			"453": 4,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2359": 1
+		},
+		"ticks": 3,
+		"smithing_level": 50,
+		"smithing_xp": 30
+	},
+	{
+		"id": 2363,
+		"name": "Superheat Runite bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"451": 1,
+			"453": 8,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2363": 1
+		},
+		"ticks": 3,
+		"smithing_level": 85,
+		"smithing_xp": 50
+	},
+	{
+		"id": 2355,
+		"name": "Superheat Silver bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"442": 1,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2355": 1
+		},
+		"ticks": 3,
+		"smithing_level": 20,
+		"smithing_xp": 13.7
+	},
+	{
+		"id": 2353,
+		"name": "Superheat Steel bar",
+		"level": 43,
+		"xp": 53,
+		"input": {
+			"440": 1,
+			"453": 2,
+			"554": 4,
+			"561": 1
+		},
+		"output": {
+			"2353": 1
+		},
+		"ticks": 3,
+		"smithing_level": 30,
+		"smithing_xp": 17.5
+	},
+	{
 		"id": 2509,
 		"name": "Tan Black Dragon Leather",
 		"input": {

--- a/src/lib/skilling/skills/magic/castables.ts
+++ b/src/lib/skilling/skills/magic/castables.ts
@@ -15,6 +15,8 @@ export interface Castable {
 	agilityBoost?: number[][];
 	travelTime?: number;
 	prayerXp?: number;
+	smithingLevel?: number;
+	smithingXp?: number;
 }
 
 export const Castables: Castable[] = [
@@ -429,5 +431,126 @@ export const Castables: Castable[] = [
 		output: null,
 		ticks: 8,
 		prayerXp: 990
+	},
+	{
+		id: itemID('Bronze bar'),
+		name: 'Superheat Bronze bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Tin ore', 1).add('Copper ore', 1),
+		output: new Bank().add('Bronze bar', 1),
+		ticks: 3,
+		smithingLevel: 1,
+		smithingXp: 6.2
+	},
+	{
+		id: itemID('Iron bar'),
+		name: 'Superheat Iron bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Iron ore', 1),
+		output: new Bank().add('Iron bar', 1),
+		ticks: 3,
+		smithingLevel: 15,
+		smithingXp: 12.5
+	},
+	{
+		id: itemID('Silver bar'),
+		name: 'Superheat Silver bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Silver ore', 1),
+		output: new Bank().add('Silver bar', 1),
+		ticks: 3,
+		smithingLevel: 20,
+		smithingXp: 13.7
+	},
+	//{
+	//	id: itemID('Lead bar'),
+	//	name: 'Superheat Lead bar',
+	//	level: 43,
+	//	xp: 53,
+	//	input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Lead ore', 2),
+	//	output: new Bank().add('Lead bar', 1),
+	//	ticks: 3,
+	//	smithingLevel: 25,
+	//	smithingXp: 15.5
+	//},
+	{
+		id: itemID('Steel bar'),
+		name: 'Superheat Steel bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Iron ore', 1).add('Coal', 2),
+		output: new Bank().add('Steel bar', 1),
+		ticks: 3,
+		smithingLevel: 30,
+		smithingXp: 17.5
+	},
+	{
+		id: itemID('Gold bar'),
+		name: 'Superheat Gold bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Gold ore', 1),
+		output: new Bank().add('Gold bar', 1),
+		ticks: 3,
+		smithingLevel: 40,
+		smithingXp: 22.5
+	},
+	//{
+	//	id: itemID('Lovakite bar'),
+	//	name: 'Superheat Lovakite bar',
+	//	level: 43,
+	//	xp: 53,
+	//	input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Lovakite ore', 1).add('Coal', 2),
+	//	output: new Bank().add('Lovakite bar', 1),
+	//	ticks: 3,
+	//	smithingLevel: 45,
+	//	smithingXp: 20
+	//},
+	{
+		id: itemID('Mithril bar'),
+		name: 'Superheat Mithril bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Mithril ore', 1).add('Coal', 4),
+		output: new Bank().add('Mithril bar', 1),
+		ticks: 3,
+		smithingLevel: 50,
+		smithingXp: 30
+	},
+	{
+		id: itemID('Adamantite bar'),
+		name: 'Superheat Adamantite bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Adamantite ore', 1).add('Coal', 6),
+		output: new Bank().add('Adamantite bar', 1),
+		ticks: 3,
+		smithingLevel: 70,
+		smithingXp: 37.5
+	},
+	//{
+	//	id: itemID('Cupronickel bar'),
+	//	name: 'Superheat Cupronickel bar',
+	//	level: 43,
+	//	xp: 53,
+	//	input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Nickel ore', 1).add('Copper ore', 2),
+	//	output: new Bank().add('Cupronickel bar', 1),
+	//	ticks: 3,
+	//	smithingLevel: 74,
+	//	smithingXp: 42
+	//},
+	{
+		id: itemID('Runite bar'),
+		name: 'Superheat Runite bar',
+		level: 43,
+		xp: 53,
+		input: new Bank().add('Fire rune', 4).add('Nature rune', 1).add('Runite ore', 1).add('Coal', 8),
+		output: new Bank().add('Runite bar', 1),
+		ticks: 3,
+		smithingLevel: 85,
+		smithingXp: 50
 	}
 ];

--- a/src/mahoji/lib/abstracted_commands/castCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/castCommand.ts
@@ -1,4 +1,5 @@
 import { formatDuration, reduceNumByPercent, stringMatches, Time } from '@oldschoolgg/toolkit';
+import { itemID } from 'oldschooljs';
 
 import { Castables } from '@/lib/skilling/skills/magic/castables.js';
 import type { CastingActivityTaskOptions } from '@/lib/types/minions.js';
@@ -22,6 +23,10 @@ export async function castCommand(channelId: string, user: MUser, name: string, 
 
 	if (spell.craftLevel && user.skillsAsLevels.crafting < spell.craftLevel) {
 		return `${user.minionName} needs ${spell.craftLevel} Crafting to cast ${spell.name}.`;
+	}
+
+	if (spell.smithingLevel && user.skillsAsLevels.smithing < spell.smithingLevel) {
+		return `${user.minionName} needs ${spell.smithingLevel} Smithing to cast ${spell.name}.`;
 	}
 
 	if (spell.qpRequired && user.QP < spell.qpRequired) {
@@ -133,6 +138,19 @@ export async function castCommand(channelId: string, user: MUser, name: string, 
 		response += ` and** ${Math.round(
 			((spell.prayerXp * quantity) / (duration / Time.Minute)) * 60
 		).toLocaleString()} Prayer XP/Hr**`;
+	}
+
+	if (spell.smithingXp) {
+		let smithXp = spell.smithingXp;
+		let additionalInfo = '';
+		if (spell.id === itemID('Gold bar') && user.hasEquipped('Goldsmith gauntlets')) {
+			smithXp = 56.2;
+			additionalInfo = ' (Goldsmith gauntlet boost applied)';
+		}
+
+		response += ` and** ${Math.round(
+			((smithXp * quantity) / (duration / Time.Minute)) * 60
+		).toLocaleString()} Smithing XP/Hr**${additionalInfo}`;
 	}
 
 	if (boosts.length > 0) {

--- a/src/tasks/minions/castingActivity.ts
+++ b/src/tasks/minions/castingActivity.ts
@@ -1,3 +1,5 @@
+import { itemID } from 'oldschooljs';
+
 import { Castables } from '@/lib/skilling/skills/magic/castables.js';
 import type { CastingActivityTaskOptions } from '@/lib/types/minions.js';
 
@@ -39,6 +41,22 @@ export const castingTask: MinionTask = {
 			});
 		}
 
+		let smithXpReceived = 0;
+		let smithXpRes = '';
+		if (spell.smithingXp) {
+			if (spell.id === itemID('Gold bar') && user.hasEquipped('Goldsmith gauntlets')) {
+				smithXpReceived = 56.2 * quantity;
+			} else {
+				smithXpReceived = spell.smithingXp * quantity;
+			}
+
+			smithXpRes = await user.addXP({
+				skillName: 'smithing',
+				amount: smithXpReceived,
+				duration
+			});
+		}
+
 		const loot = spell.output?.clone().multiply(quantity);
 		if (loot) {
 			await user.transactItems({
@@ -49,7 +67,7 @@ export const castingTask: MinionTask = {
 
 		const str = `${user}, ${user.minionName} finished casting ${quantity}x ${spell.name}, you received ${
 			loot ?? 'no items'
-		}. ${xpRes} ${craftXpRes}${prayerXpRes}`;
+		}. ${xpRes} ${craftXpRes}${prayerXpRes}${smithXpRes}`;
 
 		handleTripFinish({ user, channelId, message: str, data, loot: loot ?? null });
 	}


### PR DESCRIPTION
### Description:
An alternative to smelting using Superheat spells.

### Changes:
* Added all Superheat spells (including Lead, Lovakite and Cupronickel, but commented them out at the moment - up to Cyr to decide since Lead and Cupronickel only came out with Sailing).
* Superheating with Goldsmith gauntlets equipped also provides its intended boost.

### Other checks:
- Possibly there's no need to keep Lovakite.
- [x] I have tested all my changes thoroughly inside test server (#jetta-testing-0).
