### PR TITLE
Add a way for test users to swap from instant trips

### DIFF
--- a/data/osb/commands.json
+++ b/data/osb/commands.json
@@ -1,6 +1,6 @@
 {
-	"hash": "4e6b5f19ee746f8ca06542ac4d142529",
-	"date": "2026-02-20T07:19:34.772Z",
+	"hash": "f65934bd9069c076afa2035e57744b98",
+	"date": "2026-04-14T08:56:11.227Z",
 	"data": [
 		{
 			"name": "activities",
@@ -224,7 +224,7 @@
 		},
 		{
 			"name": "giveaway",
-			"desc": "Giveaway items from your ban to other players.",
+			"desc": "Giveaway items from your bank to other players.",
 			"examples": ["/giveaway items:10 trout, 5 coal time:1h"],
 			"subOptions": ["list", "start"]
 		},

--- a/src/lib/ActivityManager.ts
+++ b/src/lib/ActivityManager.ts
@@ -1,7 +1,7 @@
 import { cryptoRng } from 'node-rng/crypto';
 
 import type { Activity, activity_type_enum } from '@/prisma/main.js';
-import { globalConfig } from '@/lib/constants.js';
+import { BitField, globalConfig } from '@/lib/constants.js';
 import { onMinionActivityFinish } from '@/lib/events.js';
 import { allTasks } from '@/lib/Task.js';
 import type { PrismaCompatibleJsonObject } from '@/lib/types/index.js';
@@ -72,9 +72,32 @@ class SActivityManager {
 	}
 
 	async processPendingActivities(): Promise<void> {
-		const activities: Activity[] = globalConfig.isProduction
+		let activities: Activity[] = globalConfig.isProduction
 			? await prisma.$queryRaw`SELECT * FROM activity WHERE completed = false AND finish_date < NOW() LIMIT 5;`
 			: await prisma.$queryRaw`SELECT * FROM activity WHERE completed = false;`;
+
+		if (!globalConfig.isProduction && activities.length > 0) {
+			const userIDs = [...new Set(activities.map(i => i.user_id.toString()))];
+			const users = await prisma.user.findMany({
+				where: {
+					id: {
+						in: userIDs
+					}
+				},
+				select: {
+					id: true,
+					bitfield: true
+				}
+			});
+			const usersWithNormalTripTimes = new Set(
+				users.filter(i => i.bitfield.includes(BitField.NormalTestBotTripTimes)).map(i => i.id)
+			);
+			const now = Date.now();
+			activities = activities.filter(
+				activity =>
+					activity.finish_date.getTime() < now || !usersWithNormalTripTimes.has(activity.user_id.toString())
+			);
+		}
 
 		if (activities.length > 0) {
 			await prisma.activity.updateMany({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -163,7 +163,8 @@ export enum BitField {
 	DisableDynamicTimestamp = 49,
 	WikiContributor = 50,
 	UnlimitedGiveaways = 51,
-	ServerSupport = 52
+	ServerSupport = 52,
+	NormalTestBotTripTimes = 53
 }
 
 export interface IBitFieldData {
@@ -293,7 +294,12 @@ export const BitFieldData: Record<BitField, IBitFieldData> = {
 	[BitField.ToggleAutoRummage]: { name: 'Auto Rummage Vale Offerings', protected: false, userConfigurable: true },
 	[BitField.WikiContributor]: { name: 'Wiki Contributor', protected: false, userConfigurable: false },
 	[BitField.UnlimitedGiveaways]: { name: 'Unlimited Giveaways', protected: false, userConfigurable: false },
-	[BitField.ServerSupport]: { name: 'Server Support', protected: true, userConfigurable: false }
+	[BitField.ServerSupport]: { name: 'Server Support', protected: true, userConfigurable: false },
+	[BitField.NormalTestBotTripTimes]: {
+		name: 'Normal Test Bot Trip Times',
+		protected: false,
+		userConfigurable: false
+	}
 } as const;
 
 export const BadgesEnum = {

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -11,7 +11,7 @@ import {
 } from '@/lib/bitFieldUtils.js';
 import { allStashUnitsFlat, allStashUnitTiers } from '@/lib/clues/stashUnits.js';
 import { CombatAchievements } from '@/lib/combat_achievements/combatAchievements.js';
-import { BitFieldData, globalConfig } from '@/lib/constants.js';
+import { BitField, BitFieldData, globalConfig } from '@/lib/constants.js';
 import { spiritAnglerOutfit } from '@/lib/data/CollectionsExport.js';
 import { COXMaxMageGear, COXMaxMeleeGear, COXMaxRangeGear } from '@/lib/data/cox.js';
 import { leaguesCreatables } from '@/lib/data/creatables/leagueCreatables.js';
@@ -554,6 +554,11 @@ export const testPotatoCommand = globalConfig.isProduction
 				},
 				{
 					type: 'Subcommand',
+					name: 'triptimes',
+					description: 'Toggle normal trip timing (instead of instant trips) on the test bot.'
+				},
+				{
+					type: 'Subcommand',
 					name: 'forcegrow',
 					description: 'Force a plant to grow.',
 					options: [
@@ -789,6 +794,15 @@ export const testPotatoCommand = globalConfig.isProduction
 						minion_ironman: !current
 					});
 					return `You now ${!current ? 'ARE' : 'ARE NOT'} an ironman.`;
+				}
+				if (options.triptimes) {
+					const nowEnabled = !user.bitfield.includes(BitField.NormalTestBotTripTimes);
+					await user.update({
+						bitfield: nowEnabled
+							? [...user.bitfield, BitField.NormalTestBotTripTimes]
+							: user.bitfield.filter(i => i !== BitField.NormalTestBotTripTimes)
+					});
+					return `Normal trip times are now ${nowEnabled ? 'enabled' : 'disabled'} for your test bot account.`;
 				}
 				if (options.wipe) {
 					const { thing } = options.wipe;


### PR DESCRIPTION
Adds a bitfield that can be toggled via testpotato, that users can swap to normal trip times rather than the instantly ending trips. Should help users test different things in future.

- [x] I have tested all my changes thoroughly.
