### PR TITLE
Fix broken monster wiki links

### DIFF
--- a/docs/src/content/docs/osb/monsters.mdx
+++ b/docs/src/content/docs/osb/monsters.mdx
@@ -2230,7 +2230,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Duke Sucellus (Awakened)](https://oldschool.runescape.wiki/w/Duke%20Sucellus%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [Duke Sucellus (Awakened)](https://oldschool.runescape.wiki/w/Duke%20Sucellus)
 
 - You can send your minion to kill this monster using: [[/k name\:Duke Sucellus (Awakened)]]
 
@@ -4144,7 +4144,7 @@ Mage gear boosts, it is **required** to have atleast one of these:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Branda)](https://oldschool.runescape.wiki/w/Royal%20Titans%20(Branda))
+    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Branda)](https://oldschool.runescape.wiki/w/Royal%20Titans)
 
 - You can send your minion to kill this monster using: [[/k name\:Royal Titans (Branda)]]
 
@@ -4283,7 +4283,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Eldric)](https://oldschool.runescape.wiki/w/Royal%20Titans%20(Eldric))
+    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Eldric)](https://oldschool.runescape.wiki/w/Royal%20Titans)
 
 - You can send your minion to kill this monster using: [[/k name\:Royal Titans (Eldric)]]
 
@@ -4422,7 +4422,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Royal Titans (sacrifice)](https://oldschool.runescape.wiki/w/Royal%20Titans%20(sacrifice))
+    - You can view the drops for this monster on the osrs wiki: [Royal Titans (sacrifice)](https://oldschool.runescape.wiki/w/Royal%20Titans)
 
 - You can send your minion to kill this monster using: [[/k name\:Royal Titans (sacrifice)]]
 
@@ -5426,7 +5426,7 @@ Range gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [The Leviathan (Awakened)](https://oldschool.runescape.wiki/w/The%20Leviathan%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [The Leviathan (Awakened)](https://oldschool.runescape.wiki/w/The%20Leviathan)
 
 - You can send your minion to kill this monster using: [[/k name\:The Leviathan (Awakened)]]
 
@@ -5659,7 +5659,7 @@ Range gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [The Whisperer (Awakened)](https://oldschool.runescape.wiki/w/The%20Whisperer%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [The Whisperer (Awakened)](https://oldschool.runescape.wiki/w/The%20Whisperer)
 
 - You can send your minion to kill this monster using: [[/k name\:The Whisperer (Awakened)]]
 
@@ -6302,7 +6302,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Vardorvis (Awakened)](https://oldschool.runescape.wiki/w/Vardorvis%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [Vardorvis (Awakened)](https://oldschool.runescape.wiki/w/Vardorvis)
 
 - You can send your minion to kill this monster using: [[/k name\:Vardorvis (Awakened)]]
 

--- a/scripts/wiki/renderMonsters.ts
+++ b/scripts/wiki/renderMonsters.ts
@@ -12,6 +12,10 @@ function escapeItemName(str: string) {
 
 const name = (id: number) => escapeItemName(Items.itemNameFromId(id)!);
 
+function getOSRSWikiPageName(monsterName: string) {
+	return monsterName.replace(/\s+\([^)]*\)$/, '');
+}
+
 export function renderMonstersMarkdown() {
 	const markdown = new Markdown();
 
@@ -21,8 +25,9 @@ export function renderMonstersMarkdown() {
 
 		const infoTab = new Tab().setTitle('Information').setContent(() => {
 			const md = new Markdown();
+			const wikiName = getOSRSWikiPageName(monster.name);
 			md.addLine(
-				`- You can view the drops for this monster on the osrs wiki: [${monster.name}](https://oldschool.runescape.wiki/w/${encodeURIComponent(monster.name)})`
+				`- You can view the drops for this monster on the osrs wiki: [${monster.name}](https://oldschool.runescape.wiki/w/${encodeURIComponent(wikiName)})`
 			);
 			md.addLine(`- You can send your minion to kill this monster using: [[/k name:${monster.name}]]`);
 			md.addLine(`- You can check your KC using: [[/minion kc name:${monster.name}]]`);


### PR DESCRIPTION
Add stripping of trailing brackets from a monster name using a regex.
Use the stripped name when building the osrs wiki link.

- [ ] I have tested all my changes thoroughly.
