### PR TITLE
Fix bgcolor command

### DIFF
--- a/packages/toolkit/src/colors.ts
+++ b/packages/toolkit/src/colors.ts
@@ -1,5 +1,5 @@
 export function isValidHexColor(hex: string): boolean {
-	const isValid = hex.length === 7 && /^#([0-9A-F]{3}){1,2}$/i.test(hex);
+	const isValid = hex.length === 7 && /^#?([0-9A-F]{3}){1,2}$/i.test(hex);
 	return isValid;
 }
 


### PR DESCRIPTION
### Description:

- So the /confg bank bgcolor command technically works, but it throws an error everytime it 'works' and makes it look like it doesn't... This is because it's doing some weird shit, duplicating code in 2 different places, and Erasing the # in a function that immediately calls a function that dies without the #...... 
