### PR TITLE
Remove Firemaking level check in pyre log creation

### DIFF
--- a/src/mahoji/lib/abstracted_commands/shadesOfMortonCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shadesOfMortonCommand.ts
@@ -432,11 +432,6 @@ export async function shadesOfMortonCreatePyreLogsCommand(
 	const pyreLog = shadesLogs.find(l => l.normalLog.id === recipe.log.id);
 	if (!pyreLog) return 'Could not find pyre log data.';
 
-	const userStats = user.skillsAsLevels;
-	if (userStats.firemaking < pyreLog.fmLevel) {
-		return `You need ${pyreLog.fmLevel} Firemaking to create ${recipe.pyreLogs.name}.`;
-	}
-
 	const logsOwned = user.bank.amount(recipe.log.id);
 	const sacredOilOwned = user.bank.amount(sacredOilItem.id);
 


### PR DESCRIPTION
Remove the inline Firemaking level validation from shadesOfMortonCreatePyreLogsCommand. As per the wiki you don't need the firemaking level to create the logs.

https://oldschool.runescape.wiki/w/Money_making_guide/Making_redwood_pyre_logs

- [ ] I have tested all my changes thoroughly.
