### PR TITLE
Enable transfering of banks by admin

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -647,6 +647,7 @@ enum economy_transaction_type {
   duel
   gri
   gift
+  admin
 }
 
 model EconomyTransaction {

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -4,9 +4,9 @@ import { promisify } from 'node:util';
 const rawExecAsync = promisify(execNonPromise);
 
 async function lintScript() {
+	await rawExecAsync('prettier --use-tabs --write "**/*.{yaml,yml,css,html}"');
 	await Promise.all([
 		rawExecAsync('biome check --write --diagnostic-level=error'),
-		rawExecAsync('prettier --use-tabs --write "**/*.{yaml,yml,css,html}"'),
 		rawExecAsync('prisma format --schema ./prisma/robochimp.prisma'),
 		rawExecAsync('prisma format --schema ./prisma/schema.prisma')
 	]);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -163,7 +163,8 @@ export enum BitField {
 	DisableDynamicTimestamp = 49,
 	WikiContributor = 50,
 	UnlimitedGiveaways = 51,
-	ServerSupport = 52
+	ServerSupport = 52,
+	Praetor = 53
 }
 
 export interface IBitFieldData {
@@ -293,7 +294,12 @@ export const BitFieldData: Record<BitField, IBitFieldData> = {
 	[BitField.ToggleAutoRummage]: { name: 'Auto Rummage Vale Offerings', protected: false, userConfigurable: true },
 	[BitField.WikiContributor]: { name: 'Wiki Contributor', protected: false, userConfigurable: false },
 	[BitField.UnlimitedGiveaways]: { name: 'Unlimited Giveaways', protected: false, userConfigurable: false },
-	[BitField.ServerSupport]: { name: 'Server Support', protected: true, userConfigurable: false }
+	[BitField.ServerSupport]: { name: 'Server Support', protected: true, userConfigurable: false },
+	[BitField.Praetor]: {
+		name: 'Praetor Access',
+		protected: true,
+		userConfigurable: false
+	}
 } as const;
 
 export const BadgesEnum = {

--- a/src/lib/user/BaseUser.ts
+++ b/src/lib/user/BaseUser.ts
@@ -366,6 +366,9 @@ export class BaseUser {
 	isMod(): boolean {
 		return this.bitfield.includes(BitField.Moderator);
 	}
+	isModPlus(): boolean {
+		return this.isMod() && this.bitfield.includes(BitField.Praetor);
+	}
 	isContributor(): boolean {
 		return this.bitfield.includes(BitField.Contributor);
 	}

--- a/src/mahoji/commands/rp.ts
+++ b/src/mahoji/commands/rp.ts
@@ -21,6 +21,7 @@ import { makeBankImage } from '@/lib/util/makeBankImage.js';
 import { migrateUser } from '@/lib/util/migrateUser.js';
 import { parseBank } from '@/lib/util/parseStringBank.js';
 import { refreshUserCache } from '@/lib/util/refreshCache.js';
+import { tradePlayerItems } from '@/lib/util/tradePlayerItems.js';
 import { insertUserEvent } from '@/lib/util/userEvents.js';
 import { gifs } from '@/mahoji/commands/admin.js';
 import { getUserInfo } from '@/mahoji/commands/minion.js';
@@ -273,6 +274,36 @@ export const rpCommand = defineCommand({
 				},
 				{
 					type: 'Subcommand',
+					name: 'transfer_bank',
+					description: "Transfer a user's bank into another account",
+					options: [
+						{
+							type: 'User',
+							name: 'source',
+							description: 'Source account to transfer items out of',
+							required: true
+						},
+						{
+							type: 'User',
+							name: 'target',
+							description: 'Target account to receive the transferred items',
+							required: true
+						},
+						{
+							type: 'Boolean',
+							name: 'untradeables',
+							description: 'Include untradeable items as well',
+							required: false
+						},
+						{
+							type: 'String',
+							name: 'reason',
+							description: 'The reason'
+						}
+					]
+				},
+				{
+					type: 'Subcommand',
 					name: 'list_trades',
 					description: 'Show trades between users',
 					options: [
@@ -416,6 +447,7 @@ export const rpCommand = defineCommand({
 	run: async ({ options, user: adminUser, interaction, guildId, rng }) => {
 		await interaction.defer();
 		const isAdmin = adminUser.isAdmin();
+		const isModPlus = adminUser.isModPlus();
 		const isMod = isAdmin || adminUser.isMod();
 		if (!guildId || (globalConfig.isProduction && guildId.toString() !== globalConfig.supportServerID)) {
 			return rng.pick(gifs);
@@ -680,6 +712,74 @@ Date: ${dateFm(date)}`;
 				return 'Done';
 			}
 			return result;
+		}
+
+		if (options.player?.transfer_bank) {
+			if (!isAdmin && !isModPlus) {
+				return rng.pick(gifs);
+			}
+
+			const { source, target, reason, untradeables = false } = options.player.transfer_bank;
+			if (untradeables && !isAdmin) {
+				return 'Only admins can transfer untradeables.';
+			}
+			if (source.user.id === target.user.id) {
+				return 'Target cannot be the same as the source!';
+			}
+
+			const sourceUser = await mUserFetch(source.user.id);
+			const targetUser = await mUserFetch(target.user.id);
+
+			if (!isAdmin && (isProtectedAccount(sourceUser) || isProtectedAccount(targetUser))) {
+				return 'Only admins can transfer banks to or from protected accounts.';
+			}
+
+			const itemsToTransfer = new Bank();
+			for (const [item, qty] of sourceUser.bank.items()) {
+				if (!untradeables && !itemIsTradeable(item.id, true)) continue;
+				itemsToTransfer.add(item.id, qty);
+			}
+			if (itemsToTransfer.length === 0) {
+				return `${sourceUser.logName} has no ${untradeables ? '' : 'tradeable '}items to transfer.`;
+			}
+
+			const transferPreview = itemsToTransfer.toString();
+			const transferPreviewDisplay =
+				transferPreview.length > 1500 ? `${transferPreview.slice(0, 1500)}...` : transferPreview;
+			await interaction.confirmation(
+				`Transfer ${transferPreviewDisplay} from \`${sourceUser.logName}\` to \`${targetUser.logName}\`${
+					untradeables ? ', including untradeables' : ''
+				}?`
+			);
+
+			const result = await tradePlayerItems(sourceUser, targetUser, itemsToTransfer, new Bank());
+			if (!result.success) {
+				return `Transfer failed because: ${result.message}`;
+			}
+
+			await prisma.economyTransaction.create({
+				data: {
+					guild_id: BigInt(guildId),
+					sender: BigInt(sourceUser.id),
+					recipient: BigInt(targetUser.id),
+					items_sent: itemsToTransfer.toJSON(),
+					items_received: undefined,
+					type: 'admin'
+				}
+			});
+
+			const fullTransfer = itemsToTransfer.toStringFull();
+			await globalClient.sendMessage(Channel.BotLogs, {
+				content: `${adminUser.logName} transferred ${transferPreview.slice(0, 500)} from ${sourceUser.logName} to ${
+					targetUser.logName
+				}${untradeables ? ' (including untradeables)' : ''}${reason ? `, for ${reason}` : ''}`,
+				files:
+					fullTransfer.length > 500
+						? [{ buffer: Buffer.from(fullTransfer), name: 'transfer_bank.txt' }]
+						: undefined
+			});
+
+			return `Transferred ${transferPreviewDisplay} from ${sourceUser.mention} to ${targetUser.mention}.`;
 		}
 		if (options.player?.list_trades) {
 			const baseSql =

--- a/src/mahoji/lib/abstracted_commands/ironmanCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/ironmanCommand.ts
@@ -136,6 +136,7 @@ After becoming an ironman:
 		BitField.PatronTier4,
 		BitField.PatronTier5,
 		BitField.Moderator,
+		BitField.Praetor,
 		BitField.BypassAgeRestriction,
 		BitField.HasPermanentEventBackgrounds,
 		BitField.HasPermanentTierOne,

--- a/tests/unit/MUser.test.ts
+++ b/tests/unit/MUser.test.ts
@@ -1,6 +1,7 @@
 import { Bank, convertLVLtoXP } from 'oldschooljs';
 import { describe, expect, test } from 'vitest';
 
+import { BitField } from '@/lib/constants.js';
 import { mockMUser } from './userutil.js';
 
 const testUser = mockMUser({
@@ -65,5 +66,22 @@ describe('MUser.test', () => {
 	test('cl', () => {
 		expect(testUser.cl.has('Coal')).toEqual(true);
 		expect(testUser.cl.length).toEqual(1);
+	});
+	test('isModPlus', () => {
+		expect(
+			mockMUser({
+				bitfield: [BitField.Moderator, BitField.Praetor]
+			}).isModPlus()
+		).toEqual(true);
+		expect(
+			mockMUser({
+				bitfield: [BitField.Praetor]
+			}).isModPlus()
+		).toEqual(false);
+		expect(
+			mockMUser({
+				bitfield: [BitField.Moderator]
+			}).isModPlus()
+		).toEqual(false);
 	});
 });


### PR DESCRIPTION
### Description:

- Adds rp player transfer_bank command to allow bank transfers
- Adds a Praetor bitfield that can be given to mods to let them take additional actions once they've been trained and experienced.

### Changes:

- When this is merged to BSO, untradeables option needs to be changed to 'supers' and will we'll have to use item.isSuperUntradeable instead of the standard untradeable.

### Other checks:

- [ ] I have tested all my changes thoroughly.
