### PR TITLE
Adds /bso spawnlamp to Robochimp, along with osb + bso prize banks to be claimed

### DIFF
--- a/packages/robochimp/package.json
+++ b/packages/robochimp/package.json
@@ -11,9 +11,9 @@
 		"test:types": "tsc -p src --noEmit",
 		"test:unit": "vitest run --config vitest.unit.config.mts",
 		"devsss": "pnpm fetch-schema && pnpm build && pnpm test",
-		"gen": "concurrently \"npx prisma generate --schema prisma/bso_schema.prisma\" \"npx prisma generate --schema prisma/osb_schema.prisma\" \"npx prisma generate --schema prisma/robochimp_schema.prisma\"",
+		"gen": "concurrently \"pnpm exec prisma generate --schema prisma/bso_schema.prisma\" \"pnpm exec prisma generate --schema prisma/osb_schema.prisma\" \"pnpm exec prisma generate --schema prisma/robochimp_schema.prisma\"",
 		"fetch-schema": "tsx ./scripts/fetchSchema.ts",
-		"dbpush": "npx prisma db push --schema=./prisma/robochimp_schema.prisma",
+		"dbpush": "pnpm exec prisma db push --schema=./prisma/robochimp_schema.prisma",
 		"seed": "tsx --tsconfig=./src/tsconfig.json ./src/scripts/seed.ts"
 	},
 	"dependencies": {

--- a/packages/robochimp/prisma/robochimp_schema.prisma
+++ b/packages/robochimp/prisma/robochimp_schema.prisma
@@ -56,6 +56,8 @@ model User {
   bso_cl_percent  Float?
   osb_mastery     Float?
   bso_mastery     Float?
+  osb_prize_bank  Json   @default("{}") @db.JsonB
+  bso_prize_bank  Json   @default("{}") @db.JsonB
 
   store_bitfield Int[]
 

--- a/packages/robochimp/src/commands/allCommands.ts
+++ b/packages/robochimp/src/commands/allCommands.ts
@@ -1,4 +1,5 @@
 import { blacklistCommand } from '@/commands/blacklist.js';
+import { bsoCommand } from '@/commands/bso.js';
 import { linkCommand } from '@/commands/link.js';
 import { pingableRolesCommand } from '@/commands/pingableroles.js';
 import { reactCommand } from '@/commands/react.js';
@@ -8,6 +9,7 @@ import { triviaCommand } from '@/commands/trivia.js';
 
 export const allCommands: AnyCommand[] = [
 	blacklistCommand,
+	bsoCommand,
 	pingableRolesCommand,
 	reactCommand,
 	tagCommand,

--- a/packages/robochimp/src/commands/bso.ts
+++ b/packages/robochimp/src/commands/bso.ts
@@ -1,0 +1,110 @@
+import { userMention } from '@oldschoolgg/discord';
+import { SimpleTable, Time } from '@oldschoolgg/toolkit';
+import { convertLVLtoXP, type ItemBank } from 'oldschooljs';
+
+const LampTable = new SimpleTable<number>()
+	.add(6796, 40)
+	.add(21_642, 30)
+	.add(23_516, 20)
+	.add(22_320, 5)
+	.add(11_157, 1);
+
+const lampMap: Record<number, string> = {
+	6796: 'Tiny lamp',
+	21642: 'Small lamp',
+	23516: 'Medium lamp',
+	22320: 'Large lamp',
+	11157: 'Huge lamp'
+};
+
+function randInt(min: number, max: number) {
+	return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function generateXPLevelQuestion() {
+	const level = randInt(1, 120);
+	const xp = randInt(convertLVLtoXP(level), convertLVLtoXP(level + 1) - 1);
+
+	return {
+		question: `What level would you be at with ${xp.toLocaleString()} XP?`,
+		answer: level.toString(),
+		explainAnswer: `${xp.toLocaleString()} is level ${level}!`
+	};
+}
+
+export const bsoCommand = defineCommand({
+	name: 'bso',
+	description: 'BSO-specific Robochimp commands.',
+	options: [
+		{
+			type: 'Subcommand',
+			name: 'spawnlamp',
+			description: 'Spawn a BSO lamp question.'
+		}
+	],
+	run: async ({ options, user, interaction }) => {
+		if (!options.spawnlamp) return 'Invalid command.';
+
+		await interaction.defer();
+
+		// if (globalConfig.isProduction && interaction.guildId !== globalConfig.supportServerID) {
+		// 	return 'You can only use this command in the support server.';
+		// }
+		// const [lampIsReady, reason] = user.isAdmin() ? [true, ''] : await spawnLampIsReady(user, interaction.channelId);
+		// if (!lampIsReady && reason) return reason;
+		//
+		// const group = await findGroupOfUser(user.id);
+		// await prisma.user.updateMany({
+		// 	where: {
+		// 		id: {
+		// 			in: group
+		// 		}
+		// 	},
+		// 	data: {
+		// 		lastSpawnLamp: Date.now()
+		// 	}
+		// });
+
+		if (!user.isAdmin()) {
+			return 'Only admins can use this command.';
+		}
+
+		const { answer, question, explainAnswer } = generateXPLevelQuestion();
+		const createdMessage = await interaction.replyWithResponse({
+			content: `${userMention(user.id.toString())} spawned a Lamp: ${question}`,
+			withResponse: true
+		});
+		const messages = await globalClient.awaitMessages({
+			channelId: interaction.channelId,
+			time: Time.Minute,
+			filter: m => m.content === answer
+		});
+
+		if (!messages[0]) {
+			const content = `Nobody got it. ${explainAnswer}`;
+			await globalClient.editMessage(interaction.channelId, createdMessage!.message_id, { content });
+			return { content };
+		}
+
+		const winner = await globalClient.fetchRUser(messages[0].author.id);
+		const winningItemId = LampTable.rollOrThrow();
+		const lootName = lampMap[winningItemId] ?? `item ${winningItemId}`;
+		const bsoPrizeBank: ItemBank = { ...winner.bsoPrizeBank };
+		const itemKey = winningItemId.toString();
+		bsoPrizeBank[itemKey] = bsoPrizeBank[itemKey] ? ++bsoPrizeBank[itemKey] : 1;
+		await winner.update({
+			bso_prize_bank: bsoPrizeBank
+		});
+
+		const content = `${winner.mention} got it, and won **1x ${lootName}**! ${explainAnswer}`;
+		await globalClient.editMessage(interaction.channelId, createdMessage!.message_id, { content });
+
+		if (lootName === 'Large lamp' || lootName === 'Huge lamp') {
+			await globalClient.sendMessage(interaction.channelId, {
+				content: `Wow! <@${winner.id.toString()}> just won a 1x ${lootName}!`
+			});
+		}
+
+		return { content };
+	}
+});

--- a/packages/robochimp/src/commands/bso.ts
+++ b/packages/robochimp/src/commands/bso.ts
@@ -2,12 +2,7 @@ import { userMention } from '@oldschoolgg/discord';
 import { SimpleTable, Time } from '@oldschoolgg/toolkit';
 import { convertLVLtoXP, type ItemBank } from 'oldschooljs';
 
-const LampTable = new SimpleTable<number>()
-	.add(6796, 40)
-	.add(21_642, 30)
-	.add(23_516, 20)
-	.add(22_320, 5)
-	.add(11_157, 1);
+const LampTable = new SimpleTable<number>().add(6796, 40).add(21_642, 30).add(23_516, 20).add(22_320, 5).add(11_157, 1);
 
 const lampMap: Record<number, string> = {
 	6796: 'Tiny lamp',

--- a/packages/robochimp/src/discord/RoboChimpBotClient.ts
+++ b/packages/robochimp/src/discord/RoboChimpBotClient.ts
@@ -1,4 +1,11 @@
-import { type APIApplication, type APIUser, DiscordClient, type DiscordClientOptions } from '@oldschoolgg/discord';
+import {
+	type APIApplication,
+	type APIUser,
+	DiscordClient,
+	type DiscordClientOptions,
+	type GatewayMessageCreateDispatchData
+} from '@oldschoolgg/discord';
+import { Time } from '@oldschoolgg/toolkit';
 import { RedisKeys } from '@oldschoolgg/util';
 import type { DiscordUser } from '@prisma/robochimp';
 import { DiscordSnowflake } from '@sapphire/snowflake';
@@ -61,6 +68,53 @@ export class RoboChimpBotClient extends DiscordClient {
 
 	mentionCommand(name: string, subCommand?: string, subSubCommand?: string) {
 		return mentionCommand(name, subCommand, subSubCommand);
+	}
+
+	async awaitMessages({
+		channelId,
+		max = 1,
+		time = Time.Second * 30,
+		errors = [],
+		filter = () => true
+	}: {
+		channelId: string;
+		max?: number;
+		time?: number;
+		errors?: string[];
+		filter?: (msg: GatewayMessageCreateDispatchData) => boolean;
+	}): Promise<GatewayMessageCreateDispatchData[]> {
+		return new Promise((resolve, reject) => {
+			const collected: GatewayMessageCreateDispatchData[] = [];
+			let timeoutId: NodeJS.Timeout;
+
+			const messageHandler = (msg: GatewayMessageCreateDispatchData) => {
+				if (msg.channel_id !== channelId) return;
+				if (!filter(msg)) return;
+
+				collected.push(msg);
+
+				if (collected.length >= max) {
+					cleanup();
+					resolve(collected);
+				}
+			};
+
+			const cleanup = () => {
+				this.off('rawMessageCreate', messageHandler);
+				if (timeoutId) clearTimeout(timeoutId);
+			};
+
+			timeoutId = setTimeout(() => {
+				cleanup();
+				if (errors.includes('time')) {
+					reject(new Error('Time limit exceeded'));
+				} else {
+					resolve(collected);
+				}
+			}, time);
+
+			this.on('rawMessageCreate', messageHandler);
+		});
 	}
 
 	async handleReadyEvent({ application }: { application: APIApplication }) {

--- a/packages/robochimp/src/structures/RUser.ts
+++ b/packages/robochimp/src/structures/RUser.ts
@@ -1,6 +1,7 @@
 import { userMention } from '@oldschoolgg/discord';
 import { RedisKeys } from '@oldschoolgg/util';
 import type { Prisma, User } from '@prisma/robochimp';
+import type { ItemBank } from 'oldschooljs';
 
 import { redis } from '@/lib/redis.js';
 import { Bits, type PatronTier, tiers } from '@/util.js';
@@ -121,6 +122,14 @@ export class RUser {
 
 	get bsoMastery(): number {
 		return this._user.bso_mastery ?? 0;
+	}
+
+	get osbPrizeBank(): ItemBank {
+		return (this._user.osb_prize_bank as ItemBank | null) ?? {};
+	}
+
+	get bsoPrizeBank(): ItemBank {
+		return (this._user.bso_prize_bank as ItemBank | null) ?? {};
 	}
 
 	globalMastery(): number {

--- a/prisma/robochimp.prisma
+++ b/prisma/robochimp.prisma
@@ -55,6 +55,8 @@ model User {
   bso_cl_percent  Float?
   osb_mastery     Float?
   bso_mastery     Float?
+  osb_prize_bank  Json    @default("{}") @db.JsonB
+  bso_prize_bank  Json    @default("{}") @db.JsonB
 
   store_bitfield Int[]
 

--- a/src/mahoji/commands/claim.ts
+++ b/src/mahoji/commands/claim.ts
@@ -1,7 +1,7 @@
 import { CollectionLog } from '@oldschoolgg/collectionlog';
 import { dateFm } from '@oldschoolgg/discord';
 import { stringMatches } from '@oldschoolgg/toolkit';
-import { Bank, Items } from 'oldschooljs';
+import { Bank, type ItemBank, Items } from 'oldschooljs';
 
 import { BitField, BOT_TYPE, BSO_MAX_TOTAL_LEVEL, Channel } from '@/lib/constants.js';
 import { calcCLDetails } from '@/lib/data/Collections.js';
@@ -10,6 +10,43 @@ import { getReclaimableItemsOfUser } from '@/lib/reclaimableItems.js';
 import { roboChimpUserFetch } from '@/lib/roboChimp.js';
 
 const claimables = [
+	{
+		name: 'Robochimp BSO Prize Bank',
+		hasRequirement: async (user: MUser): Promise<true | string> => {
+			const roboChimpUser = await roboChimpUserFetch(user.id);
+			const prizeBank = new Bank((roboChimpUser.osb_prize_bank as ItemBank | null) ?? {});
+			if (prizeBank.length === 0) {
+				return 'You have nothing in your Robochimp OSB Prize Bank.';
+			}
+			return true;
+		},
+		action: async (user: MUser, interaction: MInteraction) => {
+			const roboChimpUser = await roboChimpUserFetch(user.id);
+			const prizeBank = new Bank((roboChimpUser.osb_prize_bank as ItemBank | null) ?? {});
+			if (prizeBank.length === 0) {
+				return 'You have nothing in your Robochimp OSB Prize Bank.';
+			}
+			await interaction.confirmation(
+				`Your Robochimp OSB Prize Bank contains: ${prizeBank.toString()}\n\nDo you want to claim it?`
+			);
+			await roboChimpClient.user.update({
+				where: {
+					id: BigInt(user.id)
+				},
+				data: {
+					osb_prize_bank: {}
+				}
+			});
+			await user.transactItems({ itemsToAdd: prizeBank, collectionLog: false });
+			return new MessageBuilder()
+				.setContent(`Claimed your Robochimp OSB Prize Bank: ${prizeBank}.`)
+				.addBankImage({
+					bank: prizeBank,
+					title: 'Robochimp OSB Prize Bank Claimed',
+					user
+				});
+		}
+	},
 	{
 		name: 'Free T1 Perks',
 		hasRequirement: async (user: MUser): Promise<true | string> => {
@@ -125,7 +162,7 @@ export const claimCommand = defineCommand({
 			}
 		}
 	],
-	run: async ({ options, user }) => {
+	run: async ({ options, user, interaction }) => {
 		const claimable = claimables.find(i => stringMatches(i.name, options.name));
 		if (!claimable) {
 			const reclaimableData = await getReclaimableItemsOfUser(user);
@@ -152,7 +189,7 @@ ${dateFm(new Date(rawData.date))}`;
 			}
 		}
 
-		const result = await claimable.action(user);
+		const result = await claimable.action(user, interaction);
 		return result;
 	}
 });


### PR DESCRIPTION
### Spawnlamp

- Admins can use /bso spawnlamp on Robochimp so that players don't have to reply to the bot for every guess.
- If it works out well, the real BSO spawnlamp will be fully migrated to robochimp, so everyone can use it.

### Changes:

- Adds `bso_prize_bank` and `osb_prize_bank` to Robochimp schema
- Add's "Claim Robochimp Prize Bank" to `/claim`  (osb prize bank isn't populated by anything yet)
- This will obviously have to be changed to BSO Prize bank on the bso Branch.
- Updates packages/robochimp/package.json to avoid using `npx` and use `pnpm exec` instead because of upcoming npm changes that could break npx.

### Other checks:

- [ ] I have tested all my changes thoroughly.
