### PR TITLE
Track gambling profit and loss by date

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -664,6 +664,19 @@ model EconomyTransaction {
   @@map("economy_transaction")
 }
 
+model GamblingTransaction {
+  id            Int      @id @default(autoincrement())
+  user_id       BigInt
+  date          DateTime @default(now())
+  type          String   @db.VarChar(32)
+  amount_staked BigInt
+  pnl           BigInt
+
+  @@index([user_id, date])
+  @@index([type, date])
+  @@map("gambling_transaction")
+}
+
 model StashUnit {
   stash_id        Int
   user_id         BigInt

--- a/src/lib/util/gambling.ts
+++ b/src/lib/util/gambling.ts
@@ -1,0 +1,18 @@
+export type GamblingTransactionType = 'dice' | 'duel' | 'hot_cold' | 'lucky_pick' | 'slots';
+
+export async function trackGamblingTransaction({
+	userID,
+	type,
+	amountStaked,
+	pnl
+}: {
+	userID: string;
+	type: GamblingTransactionType;
+	amountStaked: number;
+	pnl: number;
+}) {
+	await prisma.$executeRaw`
+INSERT INTO gambling_transaction (user_id, type, amount_staked, pnl)
+VALUES (${BigInt(userID)}, ${type}, ${BigInt(amountStaked)}, ${BigInt(Math.trunc(pnl))});
+`;
+}

--- a/src/mahoji/lib/abstracted_commands/diceCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/diceCommand.ts
@@ -1,5 +1,6 @@
 import { Bank, toKMB } from 'oldschooljs';
 
+import { trackGamblingTransaction } from '@/lib/util/gambling.js';
 import { mahojiParseNumber } from '@/mahoji/mahojiSettings.js';
 
 export async function diceCommand(rng: RNGProvider, user: MUser, interaction: MInteraction, diceamount?: string) {
@@ -29,6 +30,12 @@ export async function diceCommand(rng: RNGProvider, user: MUser, interaction: MI
 	const won = roll >= 55;
 	const amountToAdd = won ? amount : -amount;
 
+	await trackGamblingTransaction({
+		userID: user.id,
+		type: 'dice',
+		amountStaked: amount,
+		pnl: amountToAdd
+	});
 	await ClientSettings.updateClientGPTrackSetting('gp_dice', amountToAdd);
 	await user.updateGPTrackSetting('gp_dice', amountToAdd);
 

--- a/src/mahoji/lib/abstracted_commands/duelCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/duelCommand.ts
@@ -3,6 +3,7 @@ import { Bank, toKMB } from 'oldschooljs';
 
 import { BOT_TYPE } from '@/lib/constants.js';
 import { MUserClass } from '@/lib/user/MUser.js';
+import { trackGamblingTransaction } from '@/lib/util/gambling.js';
 import { mahojiParseNumber } from '@/mahoji/mahojiSettings.js';
 
 async function checkBal(user: MUser, amount: number) {
@@ -46,15 +47,29 @@ async function handleFinishUpdates({
 	const loot = new Bank().add('Coins', amountGPWinnerReceives);
 	await winner.addItemsToBank({ items: loot, collectionLog: false });
 
-	await prisma.economyTransaction.create({
-		data: {
-			guild_id: guildId ? BigInt(guildId) : null,
-			sender: BigInt(loser.id),
-			recipient: BigInt(winner.id),
-			items_sent: new Bank().add('Coins').toJSON(),
-			type: 'duel'
-		}
-	});
+	await Promise.all([
+		prisma.economyTransaction.create({
+			data: {
+				guild_id: guildId ? BigInt(guildId) : null,
+				sender: BigInt(loser.id),
+				recipient: BigInt(winner.id),
+				items_sent: new Bank().add('Coins').toJSON(),
+				type: 'duel'
+			}
+		}),
+		trackGamblingTransaction({
+			userID: winner.id,
+			type: 'duel',
+			amountStaked: amount,
+			pnl: amountGPWinnerReceives - amount
+		}),
+		trackGamblingTransaction({
+			userID: loser.id,
+			type: 'duel',
+			amountStaked: amount,
+			pnl: -amount
+		})
+	]);
 	return {
 		amountGPWinnerReceives,
 		taxPaid: tax

--- a/src/mahoji/lib/abstracted_commands/hotColdCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/hotColdCommand.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder } from '@oldschoolgg/discord';
 import { LootTable, resolveItems, toKMB } from 'oldschooljs';
 
+import { trackGamblingTransaction } from '@/lib/util/gambling.js';
 import { mahojiParseNumber } from '@/mahoji/mahojiSettings.js';
 
 export const flowerTable = new LootTable()
@@ -78,6 +79,12 @@ ${explanation}`
 				decrement: amountWon
 			}
 		});
+		await trackGamblingTransaction({
+			userID: user.id,
+			type: 'hot_cold',
+			amountStaked: amount,
+			pnl: amountWon
+		});
 		embed
 			.setDescription(
 				`You rolled a special flower, and received 5x of your bet! You received ${toKMB(amountWon)}`
@@ -112,6 +119,12 @@ ${explanation}`
 				increment: amount
 			}
 		});
+		await trackGamblingTransaction({
+			userID: user.id,
+			type: 'hot_cold',
+			amountStaked: amount,
+			pnl: amount
+		});
 		embed.setDescription(`You **won** ${toKMB(amountWon)}!`).setColor(6_875_960);
 		return response;
 	}
@@ -119,6 +132,12 @@ ${explanation}`
 		gp_hotcold: {
 			decrement: amount
 		}
+	});
+	await trackGamblingTransaction({
+		userID: user.id,
+		type: 'hot_cold',
+		amountStaked: amount,
+		pnl: -amount
 	});
 
 	embed.setDescription(`You lost ${toKMB(amount)}.`).setColor(15_417_396);

--- a/src/mahoji/lib/abstracted_commands/luckyPickCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/luckyPickCommand.ts
@@ -3,6 +3,7 @@ import { Bank, toKMB } from 'oldschooljs';
 import { chunk } from 'remeda';
 
 import { EmojiId } from '@/lib/data/emojis.js';
+import { trackGamblingTransaction } from '@/lib/util/gambling.js';
 import { mahojiParseNumber } from '@/mahoji/mahojiSettings.js';
 
 const buttons: Button[] = [
@@ -157,6 +158,12 @@ export async function luckyPickCommand(
 	if (amountReceived > 0) {
 		await user.addItemsToBank({ items: new Bank().add('Coins', amountReceived) });
 	}
+	await trackGamblingTransaction({
+		userID: user.id,
+		type: 'lucky_pick',
+		amountStaked: amount,
+		pnl: amountReceived - amount
+	});
 	await ClientSettings.updateClientGPTrackSetting('gp_luckypick', amountReceived - amount);
 	await user.updateGPTrackSetting('gp_luckypick', amountReceived - amount);
 	const content =

--- a/src/mahoji/lib/abstracted_commands/slotsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/slotsCommand.ts
@@ -3,6 +3,7 @@ import { SimpleTable, sleep } from '@oldschoolgg/toolkit';
 import { Bank, toKMB } from 'oldschooljs';
 import { chunk } from 'remeda';
 
+import { trackGamblingTransaction } from '@/lib/util/gambling.js';
 import { mahojiParseNumber } from '@/mahoji/mahojiSettings.js';
 
 interface Button {
@@ -147,6 +148,12 @@ ${buttonsData.map(b => `${b.name}: ${b.mod(1)}x`).join('\n')}`;
 			: `You won ${toKMB(amountReceived)}!`;
 
 	await user.transactItems({ itemsToAdd: new Bank().add('Coins', amountReceived), collectionLog: false });
+	await trackGamblingTransaction({
+		userID: user.id,
+		type: 'slots',
+		amountStaked: amount,
+		pnl: amountReceived - amount
+	});
 	await ClientSettings.updateClientGPTrackSetting('gp_slots', amountReceived - amount);
 	await user.updateGPTrackSetting('gp_slots', amountReceived - amount);
 


### PR DESCRIPTION
Starts saving gambling wins and losses with dates, so the bot can later show gambling profit or loss over time instead of only lifetime totals. This covers dice, slots, lucky pick, hot/cold, and duels.

- [ ] I have tested all my changes thoroughly.
