### PR TITLE
Fix mass content on website Activity

### DIFF
--- a/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
+++ b/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
@@ -70,7 +70,8 @@ export function MinionInfo({ data }: { data: FullMinionData }) {
 		'Collection Log': Object.keys(data.collection_log_bank).length,
 		Sacrificed: `${data.total_sacrificed_value.toLocaleString()} GP`
 	};
-	const currentActivity = data.current_activity;
+	const hasCurrentActivityData = Object.prototype.hasOwnProperty.call(data, 'current_activity');
+	const currentActivity = hasCurrentActivityData ? data.current_activity : undefined;
 	return (
 		<div className="flex items-center justify-center flex-col">
 			<div className="flex items-center flex-col mb-4">
@@ -98,19 +99,29 @@ export function MinionInfo({ data }: { data: FullMinionData }) {
 				<p className="text-center font-semibold mb-2 text-white">Current Activity</p>
 				<div className="flex justify-between">
 					<span className="font-extrabold text-white">Activity:</span>
-					<span className="text-gray-300">{currentActivity?.name ?? 'Idle'}</span>
+					<span className="text-gray-300">
+						{hasCurrentActivityData ? (currentActivity?.name ?? 'Idle') : 'Unavailable'}
+					</span>
 				</div>
 				<div className="flex justify-between">
 					<span className="font-extrabold text-white">Started:</span>
-					<span className="text-gray-300">{formatTimestamp(currentActivity?.started_at ?? null)}</span>
+					<span className="text-gray-300">
+						{hasCurrentActivityData ? formatTimestamp(currentActivity?.started_at ?? null) : '—'}
+					</span>
 				</div>
 				<div className="flex justify-between">
 					<span className="font-extrabold text-white">Ends:</span>
-					<span className="text-gray-300">{formatTimestamp(currentActivity?.finishes_at ?? null)}</span>
+					<span className="text-gray-300">
+						{hasCurrentActivityData ? formatTimestamp(currentActivity?.finishes_at ?? null) : '—'}
+					</span>
 				</div>
 				<div className="flex justify-between">
 					<span className="font-extrabold text-white">Countdown:</span>
-					<ActivityCountdown finishesAt={currentActivity?.finishes_at ?? null} />
+					{hasCurrentActivityData ? (
+						<ActivityCountdown finishesAt={currentActivity?.finishes_at ?? null} />
+					) : (
+						<span className="text-gray-300">—</span>
+					)}
 				</div>
 			</div>
 			<BankImage sort="name" title="Bank" bank={data.bank} />

--- a/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
+++ b/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
@@ -70,7 +70,7 @@ export function MinionInfo({ data }: { data: FullMinionData }) {
 		'Collection Log': Object.keys(data.collection_log_bank).length,
 		Sacrificed: `${data.total_sacrificed_value.toLocaleString()} GP`
 	};
-	const hasCurrentActivityData = Object.prototype.hasOwnProperty.call(data, 'current_activity');
+	const hasCurrentActivityData = Object.hasOwn(data, 'current_activity');
 	const currentActivity = hasCurrentActivityData ? data.current_activity : undefined;
 	return (
 		<div className="flex items-center justify-center flex-col">

--- a/packages/robochimp/prisma/bso_schema.prisma
+++ b/packages/robochimp/prisma/bso_schema.prisma
@@ -21,6 +21,7 @@ model Activity {
   type           activity_type_enum
   channel_id     BigInt?
   data           Json?              @db.JsonB
+  all_user_ids   BigInt[]           @default([])
   pinnedTrip     PinnedTrip[]
 
   @@index([user_id, finish_date])

--- a/packages/robochimp/prisma/osb_schema.prisma
+++ b/packages/robochimp/prisma/osb_schema.prisma
@@ -21,6 +21,7 @@ model Activity {
   type           activity_type_enum
   channel_id     BigInt?
   data           Json?              @db.JsonB
+  all_user_ids   BigInt[]           @default([])
   pinnedTrip     PinnedTrip[]
 
   @@index([user_id, finish_date])

--- a/packages/robochimp/src/http/api-types.ts
+++ b/packages/robochimp/src/http/api-types.ts
@@ -83,7 +83,7 @@ export type FullMinionData = {
 		combat_options: number[];
 	};
 
-	current_activity: {
+	current_activity?: {
 		name: string;
 		started_at: string;
 		finishes_at: string;

--- a/packages/robochimp/src/lib/fullMinionData.ts
+++ b/packages/robochimp/src/lib/fullMinionData.ts
@@ -40,14 +40,32 @@ export async function fetchFullMinionData(bot: IBotType, targetUserId: string): 
 		bot === 'osb'
 			? await osbClient.activity.findFirst({
 					where: {
-						user_id: BigInt(targetUserId),
+						OR: [
+							{
+								user_id: BigInt(targetUserId)
+							},
+							{
+								all_user_ids: {
+									has: BigInt(targetUserId)
+								}
+							}
+						],
 						completed: false
 					},
 					orderBy: { finish_date: 'desc' }
 				})
 			: await bsoClient.activity.findFirst({
 					where: {
-						user_id: BigInt(targetUserId),
+						OR: [
+							{
+								user_id: BigInt(targetUserId)
+							},
+							{
+								all_user_ids: {
+									has: BigInt(targetUserId)
+								}
+							}
+						],
 						completed: false
 					},
 					orderBy: { finish_date: 'desc' }


### PR DESCRIPTION
- Introduce a new BigInt[] field all_user_ids (default []) to the Activity model in both bso_schema.prisma and osb_schema.prisma. 
- Update fetchFullMinionData to include an OR condition so it finds the most recent incomplete activity where either user_id equals the target or all_user_ids contains the target user id. 
- This ensures activities involving multiple participants are tracked and returned for any member.


- [ ] I have tested all my changes thoroughly.
