### PR TITLE
Fix player cache refresh showing old usernames

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -32,13 +32,16 @@ function createUsernameWithBadges(user: Pick<User, 'username' | 'badges' | 'mini
 	return `${badges ? `${badges} ` : ''}${user.username}`;
 }
 
-export async function fetchUsernameAndCache(_id: string | bigint): Promise<string> {
+export async function fetchUsernameAndCache(
+	_id: string | bigint,
+	options: { refreshDiscordUser?: boolean } = {}
+): Promise<string> {
 	const id = _id.toString();
 
 	if (!isValidDiscordSnowflake(id)) {
 		throw new Error(`Invalid userID: ${id}`);
 	}
-	const cached = await Cache._getBadgedUsernameRaw(id);
+	const cached = options.refreshDiscordUser ? null : await Cache._getBadgedUsernameRaw(id);
 	if (cached) return cached;
 	let user = await prisma.user.upsert({
 		where: {
@@ -55,8 +58,8 @@ export async function fetchUsernameAndCache(_id: string | bigint): Promise<strin
 		update: {}
 	});
 
-	// If no username available, fetch it
-	if (!user?.username && !process.env.TEST) {
+	// If no username is available, or this is an explicit cache refresh, fetch it.
+	if ((!user?.username || options.refreshDiscordUser) && !process.env.TEST) {
 		const djsUser = await globalClient.fetchUser(id).catch(() => null);
 		if (djsUser) {
 			user = await prisma.user.update({

--- a/src/lib/util/refreshCache.ts
+++ b/src/lib/util/refreshCache.ts
@@ -1,7 +1,7 @@
 import { isValidDiscordSnowflake } from '@oldschoolgg/util';
 
 import { roboChimpUserFetch } from '@/lib/roboChimp.js';
-import { getIdFromMention } from '@/lib/util.js';
+import { fetchUsernameAndCache, getIdFromMention } from '@/lib/util.js';
 
 export async function refreshUserCache({
 	user,
@@ -28,8 +28,10 @@ export async function refreshUserCache({
 	};
 	await Promise.all([
 		refreshUser.fetchPerkTier({ forceNoCache: true }),
+		fetchUsernameAndCache(refreshUser.id, { refreshDiscordUser: true }),
 		updateGuildMember(refreshUser.id),
 		roboChimpUserFetch(refreshUser.id)
 	]);
+	await refreshUser.sync();
 	return `${refreshUser}'s Caches updated successfully!`;
 }


### PR DESCRIPTION
This fixes an issue where refreshing a player’s cache could still leave their old Discord username showing in bot responses, bank images, and player info.

When a refresh is run, the bot now fetches the latest Discord username, updates the stored player record, refreshes the cached display name, and then uses the updated player data straight away. This means renamed users should display correctly after cache refresh.

Tested with type checks, linting, and unit tests.

Utilised AI to fix this issue.

- [x] I have tested all my changes thoroughly.
