### PR TITLE
Add Dodgy necklace

### DIFF
--- a/data/osb/skills/thieving-stealabes.json
+++ b/data/osb/skills/thieving-stealabes.json
@@ -20,6 +20,7 @@
 		"slope": 0.76776,
 		"intercept": 18.13176,
 		"custom_tick_rate": 2.5,
+		"blackjacking": true,
 		"pet_chance": 257211
 	},
 	{
@@ -261,6 +262,7 @@
 		"slope": 0.65485,
 		"intercept": 29.30985,
 		"custom_tick_rate": 2.5,
+		"blackjacking": true,
 		"pet_chance": 257211
 	},
 	{

--- a/packages/robochimp/prisma/bso_schema.prisma
+++ b/packages/robochimp/prisma/bso_schema.prisma
@@ -441,6 +441,7 @@ model User {
   blood_essence_charges  Int @default(0)
   trident_charges        Int @default(0)
   venator_bow_charges    Int @default(0)
+  dodgy_necklace_charges Int @default(0)
 
   scythe_of_vitur_charges Int @default(0)
 

--- a/packages/robochimp/prisma/osb_schema.prisma
+++ b/packages/robochimp/prisma/osb_schema.prisma
@@ -387,6 +387,7 @@ model User {
   blood_essence_charges  Int @default(0)
   trident_charges        Int @default(0)
   venator_bow_charges    Int @default(0)
+  dodgy_necklace_charges Int @default(0)
 
   scythe_of_vitur_charges Int @default(0)
 

--- a/packages/robochimp/src/http/api-types.ts
+++ b/packages/robochimp/src/http/api-types.ts
@@ -59,6 +59,7 @@ export type FullMinionData = {
 		blood_essence: number;
 		trident: number;
 		venator_bow: number;
+		dodgy_necklace: number;
 		scythe_of_vitur: number;
 	};
 

--- a/packages/robochimp/src/lib/fullMinionData.ts
+++ b/packages/robochimp/src/lib/fullMinionData.ts
@@ -120,6 +120,7 @@ export async function fetchFullMinionData(bot: IBotType, targetUserId: string): 
 			blood_essence: botUser.blood_essence_charges,
 			trident: botUser.trident_charges,
 			venator_bow: botUser.venator_bow_charges,
+			dodgy_necklace: botUser.dodgy_necklace_charges,
 			scythe_of_vitur: botUser.scythe_of_vitur_charges
 		},
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -385,6 +385,7 @@ model User {
   blood_essence_charges  Int @default(0)
   trident_charges        Int @default(0)
   venator_bow_charges    Int @default(0)
+  dodgy_necklace_charges Int @default(0)
 
   scythe_of_vitur_charges Int @default(0)
 

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -225,6 +225,19 @@ export const degradeableItems: DegradeableItem[] = [
 		unchargedItem: Items.getOrThrow('Venator bow (uncharged)'),
 		convertOnCharge: true,
 		emoji: ''
+	},
+	{
+		item: Items.getOrThrow('Dodgy necklace'),
+		settingsKey: 'dodgy_necklace_charges',
+		itemsToRefundOnBreak: new Bank().freeze(),
+		refundVariants: [],
+		setup: 'skilling',
+		aliases: ['dodgy', 'dodgy neck'],
+		chargeInput: {
+			cost: new Bank().freeze(),
+			charges: 10
+		},
+		emoji: ''
 	}
 ];
 

--- a/src/lib/minions/functions/degradeableItemsCommand.ts
+++ b/src/lib/minions/functions/degradeableItemsCommand.ts
@@ -17,10 +17,23 @@ export async function degradeableItemsCommand(
 		return `Use \`/minion charge item: [${degradeableItems.map(i => i.item.name).join('|')}] amount:[1-100,000]\`
 ${degradeableItems
 	.map(i => {
-		const charges = user.user[i.settingsKey];
+		const charges =
+			i.settingsKey === 'dodgy_necklace_charges' &&
+			user.user.dodgy_necklace_charges === 0 &&
+			user.hasEquippedOrInBank('Dodgy necklace')
+				? 10
+				: user.user[i.settingsKey];
 		return `${i.item.name}: ${charges.toLocaleString()} charges`;
 	})
 	.join('\n')}`;
+	}
+
+	if (item.settingsKey === 'dodgy_necklace_charges') {
+		const charges =
+			user.user.dodgy_necklace_charges === 0 && user.hasEquippedOrInBank('Dodgy necklace')
+				? 10
+				: user.user.dodgy_necklace_charges;
+		return `Dodgy necklace charges are added when you enchant Opal necklaces. Your Dodgy necklaces currently have ${charges.toLocaleString()} charges.`;
 	}
 
 	const cost = item.chargeInput.cost.clone().multiply(number);

--- a/src/lib/skilling/skills/thieving/stealables.ts
+++ b/src/lib/skilling/skills/thieving/stealables.ts
@@ -48,6 +48,7 @@ export interface Stealable {
 	slope?: number;
 	intercept?: number;
 	customTickRate?: number;
+	blackjacking?: boolean;
 }
 
 const stalls: Stealable[] = [
@@ -529,6 +530,7 @@ const pickpocketables: Stealable[] = [
 		slope: 0.767_76,
 		intercept: 18.131_76,
 		customTickRate: 2.5,
+		blackjacking: true,
 		petChance: 257_211
 	},
 	{
@@ -602,6 +604,7 @@ const pickpocketables: Stealable[] = [
 		slope: 0.654_85,
 		intercept: 29.309_85,
 		customTickRate: 2.5,
+		blackjacking: true,
 		petChance: 257_211
 	},
 	{

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -259,6 +259,8 @@ export interface PickpocketActivityTaskOptions extends ActivityTaskOptions {
 	xpReceived: number;
 	successfulQuantity: number;
 	damageTaken: number;
+	dodgyNecklaceChargesUsed?: number;
+	dodgyNecklaceChargesRemaining?: number;
 }
 
 export interface BuryingActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/user/userTypes.ts
+++ b/src/lib/user/userTypes.ts
@@ -32,7 +32,8 @@ export type DegradeableItemColumns =
 	| 'blood_essence_charges'
 	| 'trident_charges'
 	| 'scythe_of_vitur_charges'
-	| 'venator_bow_charges';
+	| 'venator_bow_charges'
+	| 'dodgy_necklace_charges';
 
 export type Exact<A, B> = A extends B ? (B extends A ? A : never) : never;
 

--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -1,6 +1,8 @@
 import { bold } from '@oldschoolgg/discord';
 import { formatDuration, stringMatches, UserError } from '@oldschoolgg/toolkit';
+import { Items } from 'oldschooljs';
 
+import { degradeItem } from '@/lib/degradeableItems.js';
 import { quests } from '@/lib/minions/data/quests.js';
 import removeFoodFromUser from '@/lib/minions/functions/removeFoodFromUser.js';
 import { Thieving } from '@/lib/skilling/skills/thieving/index.js';
@@ -118,6 +120,9 @@ export const stealCommand = defineCommand({
 		let successfulQuantity = 0;
 		let xpReceived = 0;
 		let damageTaken = 0;
+		let dodgyNecklaceChargesUsed = 0;
+		let dodgyNecklaceChargesRemaining: number | undefined;
+		let dodgyNecklaceMessage = '';
 
 		let str = `${user.minionName} is now going to ${
 			stealable.type === 'pickpockable' ? 'pickpocket' : 'steal from'
@@ -129,17 +134,39 @@ export const stealCommand = defineCommand({
 				boosts.push('+10% chance of success from Ardougne Hard diary');
 			}
 
-			[successfulQuantity, damageTaken, xpReceived] = calcLootXPPickpocketing(
+			[successfulQuantity, damageTaken, xpReceived, , dodgyNecklaceChargesUsed] = calcLootXPPickpocketing(
 				user.skillsAsLevels.thieving,
 				stealable,
 				quantity,
 				user.hasEquipped(['Thieving cape', 'Thieving cape(t)']),
 				hasArdyHard,
-				rng
+				rng,
+				user.gear.skilling.hasEquipped('Dodgy necklace') && !stealable.blackjacking
+					? user.user.dodgy_necklace_charges || 10
+					: 0
 			);
 
 			if (user.hasEquipped(['Thieving cape', 'Thieving cape(t)'])) {
 				boosts.push('+10% chance of success from Thieving cape');
+			}
+
+			if (dodgyNecklaceChargesUsed > 0) {
+				if (user.user.dodgy_necklace_charges === 0) {
+					await user.update({ dodgy_necklace_charges: 10 });
+				}
+
+				const degradationResult = await degradeItem({
+					item: Items.getOrThrow('Dodgy necklace'),
+					chargesToDegrade: dodgyNecklaceChargesUsed,
+					user
+				});
+
+				boosts.push(`Dodgy necklace is helping you steal`);
+
+				if (degradationResult.userMessage.includes('ran out of charges')) {
+					dodgyNecklaceMessage = ' Your Dodgy necklace used its last charge and crumbled to dust';
+				}
+				dodgyNecklaceChargesRemaining = user.user.dodgy_necklace_charges;
 			}
 
 			if (Thieving.rogueOutfitPercentBonus(user) > 0) {
@@ -166,7 +193,7 @@ export const stealCommand = defineCommand({
 			const foodRemoved = removeFoodResult.foodRemoved;
 
 			await ClientSettings.updateBankSetting('economyStats_thievingCost', foodRemoved);
-			str += ` Removed ${foodRemoved}.`;
+			str += ` Removed ${foodRemoved}.${dodgyNecklaceMessage}`;
 		} else {
 			// Up to 5% fail chance, random
 			successfulQuantity = Math.floor((quantity * rng.randInt(95, 100)) / 100);
@@ -182,7 +209,9 @@ export const stealCommand = defineCommand({
 			type: 'Pickpocket',
 			damageTaken,
 			successfulQuantity,
-			xpReceived
+			xpReceived,
+			dodgyNecklaceChargesUsed,
+			dodgyNecklaceChargesRemaining
 		});
 
 		if (boosts.length > 0) {

--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -123,6 +123,10 @@ export const stealCommand = defineCommand({
 		let dodgyNecklaceChargesUsed = 0;
 		let dodgyNecklaceChargesRemaining: number | undefined;
 		let dodgyNecklaceMessage = '';
+		const isUsingDodgyNecklace =
+			stealable.type === 'pickpockable' &&
+			user.gear.skilling.hasEquipped('Dodgy necklace') &&
+			!stealable.blackjacking;
 
 		let str = `${user.minionName} is now going to ${
 			stealable.type === 'pickpockable' ? 'pickpocket' : 'steal from'
@@ -141,32 +145,15 @@ export const stealCommand = defineCommand({
 				user.hasEquipped(['Thieving cape', 'Thieving cape(t)']),
 				hasArdyHard,
 				rng,
-				user.gear.skilling.hasEquipped('Dodgy necklace') && !stealable.blackjacking
-					? user.user.dodgy_necklace_charges || 10
-					: 0
+				isUsingDodgyNecklace ? user.user.dodgy_necklace_charges || 10 : 0
 			);
 
 			if (user.hasEquipped(['Thieving cape', 'Thieving cape(t)'])) {
 				boosts.push('+10% chance of success from Thieving cape');
 			}
 
-			if (dodgyNecklaceChargesUsed > 0) {
-				if (user.user.dodgy_necklace_charges === 0) {
-					await user.update({ dodgy_necklace_charges: 10 });
-				}
-
-				const degradationResult = await degradeItem({
-					item: Items.getOrThrow('Dodgy necklace'),
-					chargesToDegrade: dodgyNecklaceChargesUsed,
-					user
-				});
-
-				boosts.push(`Dodgy necklace is helping you steal`);
-
-				if (degradationResult.userMessage.includes('ran out of charges')) {
-					dodgyNecklaceMessage = ' Your Dodgy necklace used its last charge and crumbled to dust';
-				}
-				dodgyNecklaceChargesRemaining = user.user.dodgy_necklace_charges;
+			if (isUsingDodgyNecklace) {
+				boosts.push('Dodgy necklace equipped');
 			}
 
 			if (Thieving.rogueOutfitPercentBonus(user) > 0) {
@@ -191,6 +178,23 @@ export const stealCommand = defineCommand({
 				throw err;
 			}
 			const foodRemoved = removeFoodResult.foodRemoved;
+
+			if (dodgyNecklaceChargesUsed > 0) {
+				if (user.user.dodgy_necklace_charges === 0) {
+					await user.update({ dodgy_necklace_charges: 10 });
+				}
+
+				const degradationResult = await degradeItem({
+					item: Items.getOrThrow('Dodgy necklace'),
+					chargesToDegrade: dodgyNecklaceChargesUsed,
+					user
+				});
+
+				if (degradationResult.userMessage.includes('ran out of charges')) {
+					dodgyNecklaceMessage = ' Your Dodgy necklace used its last charge and crumbled to dust';
+				}
+				dodgyNecklaceChargesRemaining = user.user.dodgy_necklace_charges;
+			}
 
 			await ClientSettings.updateBankSetting('economyStats_thievingCost', foodRemoved);
 			str += ` Removed ${foodRemoved}.${dodgyNecklaceMessage}`;

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -1003,6 +1003,7 @@ export const testPotatoCommand = globalConfig.isProduction
 							celestial_ring_charges: 10000,
 							scythe_of_vitur_charges: 10000,
 							venator_bow_charges: 10000,
+							dodgy_necklace_charges: 10000,
 							blowpipe: {
 								scales: 100000,
 								dartQuantity: 100000,

--- a/src/tasks/minions/enchantingActivity.ts
+++ b/src/tasks/minions/enchantingActivity.ts
@@ -16,12 +16,36 @@ export const enchantingTask: MinionTask = {
 		});
 
 		const loot = enchantable.output.clone().multiply(quantity);
+		let str = `${user}, ${user.minionName} finished enchanting ${quantity}x ${enchantable.name}, you received ${loot}. ${xpRes}`;
+
+		if (loot.has('Dodgy necklace')) {
+			const existingDodgyNecklaceCharges =
+				user.user.dodgy_necklace_charges || (user.hasEquippedOrInBank('Dodgy necklace') ? 10 : 0);
+			const dodgyNecklaceChargesAdded = loot.amount('Dodgy necklace') * 10;
+			const itemsToAdd = user.hasEquippedOrInBank('Dodgy necklace')
+				? loot.clone().remove('Dodgy necklace', loot.amount('Dodgy necklace'))
+				: loot.clone().remove('Dodgy necklace', loot.amount('Dodgy necklace')).add('Dodgy necklace');
+
+			await user.transactItems({
+				collectionLog: true,
+				itemsToAdd,
+				otherUpdates: {
+					dodgy_necklace_charges: existingDodgyNecklaceCharges + dodgyNecklaceChargesAdded
+				}
+			});
+
+			str = `${user}, ${user.minionName} finished enchanting ${quantity}x ${enchantable.name}, adding ${dodgyNecklaceChargesAdded.toLocaleString()} charges to your Dodgy necklace. It now has ${(
+				existingDodgyNecklaceCharges + dodgyNecklaceChargesAdded
+			).toLocaleString()} charges. ${xpRes}`;
+
+			handleTripFinish({ user, channelId, message: str, data, loot: itemsToAdd });
+			return;
+		}
+
 		await user.transactItems({
 			collectionLog: true,
 			itemsToAdd: loot
 		});
-
-		const str = `${user}, ${user.minionName} finished enchanting ${quantity}x ${enchantable.name}, you received ${loot}. ${xpRes}`;
 
 		handleTripFinish({ user, channelId, message: str, data, loot });
 	}

--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -13,12 +13,14 @@ export function calcLootXPPickpocketing(
 	quantity: number,
 	hasThievingCape: boolean,
 	hasDiary: boolean,
-	rng: { percentChance: (percent: number) => boolean }
-): [number, number, number, number] {
+	rng: { percentChance: (percent: number) => boolean },
+	dodgyNecklaceCharges = 0
+): [number, number, number, number, number] {
 	let xpReceived = 0;
 
 	let successful = 0;
 	let damageTaken = 0;
+	let dodgyNecklaceChargesUsed = 0;
 	// Pickpocketing takes 2 ticks
 	const timeToPickpocket = (npc.customTickRate ?? 2.05) * 0.6;
 	// For future Ardougne Diary and Thieving cape
@@ -29,6 +31,10 @@ export function calcLootXPPickpocketing(
 
 	for (let i = 0; i < quantity; i++) {
 		if (!rng.percentChance(chanceOfSuccess)) {
+			if (dodgyNecklaceChargesUsed < dodgyNecklaceCharges && rng.percentChance(25)) {
+				dodgyNecklaceChargesUsed++;
+				continue;
+			}
 			// The minion has just been stunned, and cant pickpocket for a few ticks, therefore
 			// they also miss out on the next few pickpockets depending on stun time. And take damage
 			damageTaken += npc.stunDamage!;
@@ -40,7 +46,7 @@ export function calcLootXPPickpocketing(
 		xpReceived += npc.xp;
 	}
 
-	return [successful, damageTaken, xpReceived, chanceOfSuccess];
+	return [successful, damageTaken, xpReceived, chanceOfSuccess, dodgyNecklaceChargesUsed];
 }
 
 export const pickpocketTask: MinionTask = {
@@ -111,7 +117,15 @@ export const pickpocketTask: MinionTask = {
 			obj.type === 'pickpockable' ? 'pickpocketing' : 'stealing'
 		} from ${obj.name} ${successfulQuantity}x times, due to failures you missed out on ${
 			quantity - successfulQuantity
-		}x ${obj.type === 'pickpockable' ? 'pickpockets' : 'steals'}. ${xpRes}`;
+		}x ${obj.type === 'pickpockable' ? 'pickpockets' : 'steals'}. ${xpRes}.`;
+
+		if (data.dodgyNecklaceChargesUsed && typeof data.dodgyNecklaceChargesRemaining === 'number') {
+			str += `\nYour Dodgy necklace prevented ${data.dodgyNecklaceChargesUsed} stun${
+				data.dodgyNecklaceChargesUsed === 1 ? '' : 's'
+			} and has ${data.dodgyNecklaceChargesRemaining.toLocaleString()} charge${
+				data.dodgyNecklaceChargesRemaining === 1 ? '' : 's'
+			} remaining.`;
+		}
 
 		str += `\n${
 			obj.type === 'pickpockable'

--- a/tests/unit/thieving.test.ts
+++ b/tests/unit/thieving.test.ts
@@ -1,6 +1,7 @@
-import { describe, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { stealables } from '@/lib/skilling/skills/thieving/stealables.js';
+import { calcLootXPPickpocketing } from '@/tasks/minions/pickpocketActivity.js';
 
 describe('Thieving', () => {
 	test('All stealables should have a table', () => {
@@ -9,5 +10,42 @@ describe('Thieving', () => {
 				throw new Error(`No table for ${entity.name}.`);
 			}
 		}
+	});
+
+	test('Dodgy necklace prevents pickpocket stun and damage while consuming charges', () => {
+		const man = stealables.find(entity => entity.name === 'Man')!;
+		const [, damageTaken, , , dodgyChargesUsed] = calcLootXPPickpocketing(
+			1,
+			man,
+			10,
+			false,
+			false,
+			{ percentChance: percent => percent === 25 },
+			10
+		);
+
+		expect(damageTaken).toBe(0);
+		expect(dodgyChargesUsed).toBe(10);
+	});
+
+	test('Dodgy necklace only prevents failures while it has charges', () => {
+		const man = stealables.find(entity => entity.name === 'Man')!;
+		const [, damageTaken, , , dodgyChargesUsed] = calcLootXPPickpocketing(
+			1,
+			man,
+			10,
+			false,
+			false,
+			{ percentChance: percent => percent === 25 },
+			3
+		);
+
+		expect(dodgyChargesUsed).toBe(3);
+		expect(damageTaken).toBe(2);
+	});
+
+	test('blackjacking pickpocketables are marked to ignore Dodgy necklace', () => {
+		expect(stealables.find(entity => entity.name === 'Menaphite Thug')?.blackjacking).toBe(true);
+		expect(stealables.find(entity => entity.name === 'Bearded Pollnivnian Bandit')?.blackjacking).toBe(true);
 	});
 });


### PR DESCRIPTION
A Dodgy necklace stores charges on the player the same as how the blood fury works.

Works while equipped in skilling for normal pickpocketing, and has a chance to prevent stun and damage when a pickpocket fails. Each successful prevention uses a charge, and the necklace crumbles when the last charge is used.

Blackjacking is excluded, and thieving trip finish messages now show Dodgy necklace charge usage and remaining charges when applicable.

- [x] I have tested all my changes thoroughly.
