### PR TITLE
Add Karambwan Shop Cook + Drop method

### DIFF
--- a/docs/src/content/docs/osb/Skills/cooking.md
+++ b/docs/src/content/docs/osb/Skills/cooking.md
@@ -27,3 +27,5 @@ The first 3 things listed below will allow for increased cooking rates due to le
 - Hosidius Range
 - Elite Kourend & Kebos diary
 - 92 Cooking allows for Karambwans to be '1-ticked'
+
+At 92 Cooking, you can also use [[/cook name\:Karambwan Shop Cook + Drop]] to buy raw karambwans from a shop, cook them, and drop the cooked karambwans for around 450k-480k Cooking XP/hr. This costs 133 GP per raw karambwan and gives no items.

--- a/src/lib/skilling/skills/cooking/cooking.ts
+++ b/src/lib/skilling/skills/cooking/cooking.ts
@@ -297,6 +297,14 @@ export const Cookables: Cookable[] = [
 	}
 ];
 
+export const KarambwanShopCookDropMethod = {
+	name: 'Karambwan Shop Cook + Drop',
+	aliases: ['karambwan shop', 'karambwan shop cook', 'karambwan shop cook drop', 'shop karambwan', 'shop karambwans'],
+	level: 92,
+	gpCost: 133,
+	quantityPerHour: 2450
+} as const;
+
 const Cooking = defineSkill({
 	aliases: ['cooking', 'cook'],
 	Cookables,

--- a/src/lib/skilling/skills/cooking/cooking.ts
+++ b/src/lib/skilling/skills/cooking/cooking.ts
@@ -3,6 +3,11 @@ import { itemID } from 'oldschooljs';
 
 import { type Cookable, defineSkill } from '@/lib/skilling/types.js';
 
+export enum CookingMethodEnum {
+	Default = 0,
+	KarambwanShop = 1
+}
+
 export const Cookables: Cookable[] = [
 	{
 		level: 1,
@@ -297,13 +302,16 @@ export const Cookables: Cookable[] = [
 	}
 ];
 
-export const KarambwanShopCookDropMethod = {
-	name: 'Karambwan Shop Cook + Drop',
-	aliases: ['karambwan shop', 'karambwan shop cook', 'karambwan shop cook drop', 'shop karambwan', 'shop karambwans'],
-	level: 92,
-	gpCost: 133,
-	quantityPerHour: 2450
-} as const;
+export const CookingMethods = [
+	{
+		type: CookingMethodEnum.KarambwanShop,
+		name: 'Karambwan Shop Cook + Drop',
+		aliases: ['karambwan shop', 'karambwan shop cook', 'karambwan shop cook drop'],
+		level: 92,
+		gpCost: 133,
+		quantityPerHour: 2450
+	}
+] as const;
 
 const Cooking = defineSkill({
 	aliases: ['cooking', 'cook'],

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -124,6 +124,7 @@ export interface CookingActivityTaskOptions extends ActivityTaskOptions {
 	type: 'Cooking';
 	cookableID: number;
 	quantity: number;
+	method?: 'KarambwanShopCookDrop';
 }
 
 export interface ConstructionActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -6,6 +6,7 @@ import type { SlayerActivityConstants } from '@/lib/minions/data/combatConstants
 import type { AttackStyles } from '@/lib/minions/functions/index.js';
 import type { MinigameName } from '@/lib/settings/minigames.js';
 import type { UnderwaterAgilityThievingTrainingSkill } from '@/lib/skilling/skills/agility.js';
+import type { CookingMethodEnum } from '@/lib/skilling/skills/cooking/cooking.js';
 import type { IPatchData } from '@/lib/skilling/skills/farming/utils/types.js';
 import type { SharkLureQuantity } from '@/lib/skilling/skills/fishing/fishingUtil.js';
 import type { TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
@@ -124,7 +125,7 @@ export interface CookingActivityTaskOptions extends ActivityTaskOptions {
 	type: 'Cooking';
 	cookableID: number;
 	quantity: number;
-	method?: 'KarambwanShopCookDrop';
+	method?: CookingMethodEnum;
 }
 
 export interface ConstructionActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -145,7 +145,13 @@ export function minionStatus(user: MUser, currentTask: ActivityTaskData | null, 
 		case 'Cooking': {
 			const data = currentTask as CookingActivityTaskOptions;
 
-			const cookable = Cooking.Cookables.find(cookable => cookable.id === data.cookableID);
+			if (data.method === 'KarambwanShopCookDrop') {
+				return `${name} is currently buying, cooking and dropping ${data.quantity}x karambwans. ${formattedDuration} Your ${
+					Emoji.Cooking
+				} Cooking level is ${user.skillsAsLevels.cooking}`;
+			}
+
+			const cookable = Cooking.Cookables.find(item => item.id === data.cookableID);
 
 			return `${name} is currently cooking ${data.quantity}x ${cookable?.name}. ${formattedDuration} Your ${
 				Emoji.Cooking

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -9,7 +9,7 @@ import { Planks } from '@/lib/minions/data/planks.js';
 import { quests } from '@/lib/minions/data/quests.js';
 import Agility from '@/lib/skilling/skills/agility.js';
 import Constructables from '@/lib/skilling/skills/construction/constructables.js';
-import Cooking from '@/lib/skilling/skills/cooking/cooking.js';
+import Cooking, { CookingMethodEnum } from '@/lib/skilling/skills/cooking/cooking.js';
 import ForestryRations from '@/lib/skilling/skills/cooking/forestersRations.js';
 import { LeapingFish } from '@/lib/skilling/skills/cooking/leapingFish.js';
 import Crafting from '@/lib/skilling/skills/crafting/index.js';
@@ -145,7 +145,7 @@ export function minionStatus(user: MUser, currentTask: ActivityTaskData | null, 
 		case 'Cooking': {
 			const data = currentTask as CookingActivityTaskOptions;
 
-			if (data.method === 'KarambwanShopCookDrop') {
+			if (data.method === CookingMethodEnum.KarambwanShop) {
 				return `${name} is currently buying, cooking and dropping ${data.quantity}x karambwans. ${formattedDuration} Your ${
 					Emoji.Cooking
 				} Cooking level is ${user.skillsAsLevels.cooking}`;

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -299,7 +299,10 @@ const tripHandlers: {
 	[activity_type_enum.Cooking]: {
 		commandName: 'cook',
 		args: (data: CookingActivityTaskOptions) => ({
-			name: Items.itemNameFromId(data.cookableID),
+			name:
+				data.method === 'KarambwanShopCookDrop'
+					? 'Karambwan Shop Cook + Drop'
+					: Items.itemNameFromId(data.cookableID),
 			quantity: data.quantity
 		})
 	},

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -11,6 +11,7 @@ import { SlayerActivityConstants } from '@/lib/minions/data/combatConstants.js';
 import { autocompleteMonsters } from '@/lib/minions/data/killableMonsters/index.js';
 import { runCommand } from '@/lib/settings/settings.js';
 import { courses } from '@/lib/skilling/skills/agility.js';
+import { CookingMethodEnum } from '@/lib/skilling/skills/cooking/cooking.js';
 import {
 	ensureValidStoredFishingTripIdentifier,
 	FISHING_REWORK_MESSAGE,
@@ -300,7 +301,7 @@ const tripHandlers: {
 		commandName: 'cook',
 		args: (data: CookingActivityTaskOptions) => ({
 			name:
-				data.method === 'KarambwanShopCookDrop'
+				data.method === CookingMethodEnum.KarambwanShop
 					? 'Karambwan Shop Cook + Drop'
 					: Items.itemNameFromId(data.cookableID),
 			quantity: data.quantity

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -114,11 +114,12 @@ export const cookCommand = defineCommand({
 				method: 'KarambwanShopCookDrop'
 			});
 
-			return `${user.minionName
-				} is now buying, cooking and dropping ${quantity.toLocaleString()}x karambwans, it'll take around ${formatTripDuration(
-					user,
-					duration
-				)} to finish. This cost ${totalCost}.`;
+			return `${
+				user.minionName
+			} is now buying, cooking and dropping ${quantity.toLocaleString()}x karambwans, it'll take around ${formatTripDuration(
+				user,
+				duration
+			)} to finish. This cost ${totalCost}.`;
 		}
 
 		const cookable = Cooking.Cookables.find(

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -1,7 +1,7 @@
 import { formatDuration, stringMatches, Time } from '@oldschoolgg/toolkit';
-import { Bank, itemID } from 'oldschooljs';
+import { Bank, EItem, itemID } from 'oldschooljs';
 
-import Cooking, { Cookables } from '@/lib/skilling/skills/cooking/cooking.js';
+import Cooking, { Cookables, KarambwanShopCookDropMethod } from '@/lib/skilling/skills/cooking/cooking.js';
 import ForestryRations from '@/lib/skilling/skills/cooking/forestersRations.js';
 import { LeapingFish } from '@/lib/skilling/skills/cooking/leapingFish.js';
 import type { CookingActivityTaskOptions } from '@/lib/types/minions.js';
@@ -26,6 +26,7 @@ export const cookCommand = defineCommand({
 			autocomplete: async ({ value }: StringAutoComplete) => {
 				return [
 					...Cookables.map(i => i.name),
+					KarambwanShopCookDropMethod.name,
 					...LeapingFish.map(i => i.item.name),
 					...ForestryRations.map(i => i.name)
 				]
@@ -67,16 +68,69 @@ export const cookCommand = defineCommand({
 			return forestersRationCommand({ user, channelId, name, quantity });
 		}
 
+		const isKarambwanShopCookDrop =
+			stringMatches(KarambwanShopCookDropMethod.name, name) ||
+			KarambwanShopCookDropMethod.aliases.some(alias => stringMatches(alias, name));
+
+		if (isKarambwanShopCookDrop) {
+			if (user.skillLevel('cooking') < KarambwanShopCookDropMethod.level) {
+				return `${user.minionName} needs ${KarambwanShopCookDropMethod.level} Cooking to do ${KarambwanShopCookDropMethod.name}.`;
+			}
+
+			const timeToCookSingleCookable = Time.Hour / KarambwanShopCookDropMethod.quantityPerHour;
+			const maxTripLength = await user.calcMaxTripLength('Cooking');
+			if (!quantity) {
+				quantity = Math.floor(maxTripLength / timeToCookSingleCookable);
+				quantity = Math.min(quantity, Math.floor(Number(user.GP) / KarambwanShopCookDropMethod.gpCost));
+			}
+			if (quantity < 1) {
+				return `You need at least ${KarambwanShopCookDropMethod.gpCost.toLocaleString()} GP to buy Raw karambwan.`;
+			}
+
+			const duration = quantity * timeToCookSingleCookable;
+			if (duration > maxTripLength) {
+				return `${user.minionName} can't go on trips longer than ${formatDuration(
+					maxTripLength
+				)} minutes, try a lower quantity. The highest amount of karambwans you can cook and drop is ${Math.floor(
+					maxTripLength / timeToCookSingleCookable
+				)}.`;
+			}
+
+			const totalCost = new Bank().add('Coins', quantity * KarambwanShopCookDropMethod.gpCost);
+			if (!user.owns(totalCost)) {
+				return `You need ${totalCost} to buy ${quantity.toLocaleString()}x Raw karambwan.`;
+			}
+
+			await user.removeItemsFromBank(totalCost);
+			await ClientSettings.updateBankSetting('buy_cost_bank', totalCost);
+
+			await ActivityManager.startTrip<CookingActivityTaskOptions>({
+				cookableID: EItem.COOKED_KARAMBWAN,
+				userID: user.id,
+				channelId,
+				quantity,
+				duration,
+				type: 'Cooking',
+				method: 'KarambwanShopCookDrop'
+			});
+
+			return `${user.minionName
+				} is now buying, cooking and dropping ${quantity.toLocaleString()}x karambwans, it'll take around ${formatTripDuration(
+					user,
+					duration
+				)} to finish. This cost ${totalCost}.`;
+		}
+
 		const cookable = Cooking.Cookables.find(
-			cookable =>
-				stringMatches(cookable.name, options.name) ||
-				cookable.alias?.some(alias => stringMatches(alias, options.name))
+			item =>
+				stringMatches(item.name, options.name) || item.alias?.some(alias => stringMatches(alias, options.name))
 		);
 
 		if (!cookable) {
-			return `Thats not a valid item to cook. Valid cookables are ${Cooking.Cookables.map(
-				cookable => cookable.name
-			).join(', ')}.`;
+			return `Thats not a valid item to cook. Valid cookables are ${[
+				KarambwanShopCookDropMethod.name,
+				...Cooking.Cookables.map(item => item.name)
+			].join(', ')}.`;
 		}
 
 		if (user.skillLevel('cooking') < cookable.level) {

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -1,7 +1,7 @@
 import { formatDuration, stringMatches, Time } from '@oldschoolgg/toolkit';
 import { Bank, EItem, itemID } from 'oldschooljs';
 
-import Cooking, { Cookables, KarambwanShopCookDropMethod } from '@/lib/skilling/skills/cooking/cooking.js';
+import Cooking, { Cookables, CookingMethodEnum, CookingMethods } from '@/lib/skilling/skills/cooking/cooking.js';
 import ForestryRations from '@/lib/skilling/skills/cooking/forestersRations.js';
 import { LeapingFish } from '@/lib/skilling/skills/cooking/leapingFish.js';
 import type { CookingActivityTaskOptions } from '@/lib/types/minions.js';
@@ -26,7 +26,7 @@ export const cookCommand = defineCommand({
 			autocomplete: async ({ value }: StringAutoComplete) => {
 				return [
 					...Cookables.map(i => i.name),
-					KarambwanShopCookDropMethod.name,
+					...CookingMethods.map(i => i.name),
 					...LeapingFish.map(i => i.item.name),
 					...ForestryRations.map(i => i.name)
 				]
@@ -68,23 +68,23 @@ export const cookCommand = defineCommand({
 			return forestersRationCommand({ user, channelId, name, quantity });
 		}
 
-		const isKarambwanShopCookDrop =
-			stringMatches(KarambwanShopCookDropMethod.name, name) ||
-			KarambwanShopCookDropMethod.aliases.some(alias => stringMatches(alias, name));
+		const cookingMethod = CookingMethods.find(
+			method => stringMatches(method.name, name) || method.aliases.some(alias => stringMatches(alias, name))
+		);
 
-		if (isKarambwanShopCookDrop) {
-			if (user.skillLevel('cooking') < KarambwanShopCookDropMethod.level) {
-				return `${user.minionName} needs ${KarambwanShopCookDropMethod.level} Cooking to do ${KarambwanShopCookDropMethod.name}.`;
+		if (cookingMethod?.type === CookingMethodEnum.KarambwanShop) {
+			if (user.skillLevel('cooking') < cookingMethod.level) {
+				return `${user.minionName} needs ${cookingMethod.level} Cooking to do ${cookingMethod.name}.`;
 			}
 
-			const timeToCookSingleCookable = Time.Hour / KarambwanShopCookDropMethod.quantityPerHour;
+			const timeToCookSingleCookable = Time.Hour / cookingMethod.quantityPerHour;
 			const maxTripLength = await user.calcMaxTripLength('Cooking');
 			if (!quantity) {
 				quantity = Math.floor(maxTripLength / timeToCookSingleCookable);
-				quantity = Math.min(quantity, Math.floor(Number(user.GP) / KarambwanShopCookDropMethod.gpCost));
+				quantity = Math.min(quantity, Math.floor(Number(user.GP) / cookingMethod.gpCost));
 			}
 			if (quantity < 1) {
-				return `You need at least ${KarambwanShopCookDropMethod.gpCost.toLocaleString()} GP to buy Raw karambwan.`;
+				return `You need at least ${cookingMethod.gpCost.toLocaleString()} GP to buy Raw karambwan.`;
 			}
 
 			const duration = quantity * timeToCookSingleCookable;
@@ -96,7 +96,7 @@ export const cookCommand = defineCommand({
 				)}.`;
 			}
 
-			const totalCost = new Bank().add('Coins', quantity * KarambwanShopCookDropMethod.gpCost);
+			const totalCost = new Bank().add('Coins', quantity * cookingMethod.gpCost);
 			if (!user.owns(totalCost)) {
 				return `You need ${totalCost} to buy ${quantity.toLocaleString()}x Raw karambwan.`;
 			}
@@ -111,7 +111,7 @@ export const cookCommand = defineCommand({
 				quantity,
 				duration,
 				type: 'Cooking',
-				method: 'KarambwanShopCookDrop'
+				method: cookingMethod.type
 			});
 
 			return `${
@@ -129,7 +129,7 @@ export const cookCommand = defineCommand({
 
 		if (!cookable) {
 			return `Thats not a valid item to cook. Valid cookables are ${[
-				KarambwanShopCookDropMethod.name,
+				...CookingMethods.map(method => method.name),
 				...Cooking.Cookables.map(item => item.name)
 			].join(', ')}.`;
 		}

--- a/src/tasks/minions/cookingActivity.ts
+++ b/src/tasks/minions/cookingActivity.ts
@@ -1,4 +1,4 @@
-import { Bank } from 'oldschooljs';
+import { Bank, EItem } from 'oldschooljs';
 
 import { calcBurntCookables } from '@/lib/skilling/functions/calcBurntCookables.js';
 import Cooking from '@/lib/skilling/skills/cooking/cooking.js';
@@ -7,9 +7,33 @@ import type { CookingActivityTaskOptions } from '@/lib/types/minions.js';
 export const cookingTask: MinionTask = {
 	type: 'Cooking',
 	async run(data: CookingActivityTaskOptions, { user, handleTripFinish, rng }) {
-		const { cookableID, quantity, channelId, duration } = data;
+		const { cookableID, quantity, channelId, duration, method } = data;
 
-		const cookable = Cooking.Cookables.find(cookable => cookable.id === cookableID)!;
+		const cookable = Cooking.Cookables.find(item => item.id === cookableID)!;
+
+		if (method === 'KarambwanShopCookDrop') {
+			const rawKarambwans = new Bank().add(EItem.RAW_KARAMBWAN, quantity);
+			const cookedKarambwans = new Bank().add(EItem.COOKED_KARAMBWAN, quantity);
+			const xpReceived = quantity * cookable.xp;
+
+			const xpRes = await user.addXP({
+				skillName: 'cooking',
+				amount: xpReceived,
+				duration
+			});
+
+			await Promise.all([
+				ClientSettings.updateBankSetting('buy_loot_bank', rawKarambwans),
+				ClientSettings.updateBankSetting('dropped_items', cookedKarambwans),
+				user.addItemsToCollectionLog({ itemsToAdd: rawKarambwans.clone().add(cookedKarambwans) })
+			]);
+
+			const str = `${user}, ${user.minionName} finished buying, cooking and dropping ${quantity.toLocaleString()}x karambwans. ${xpRes}\nYou received: nothing, as the cooked karambwans were dropped.`;
+			const loot = new Bank();
+
+			handleTripFinish({ user, channelId, message: str, data, loot });
+			return;
+		}
 
 		let burnedAmount = 0;
 		let stopBurningLvl = 0;

--- a/src/tasks/minions/cookingActivity.ts
+++ b/src/tasks/minions/cookingActivity.ts
@@ -1,7 +1,7 @@
 import { Bank, EItem } from 'oldschooljs';
 
 import { calcBurntCookables } from '@/lib/skilling/functions/calcBurntCookables.js';
-import Cooking from '@/lib/skilling/skills/cooking/cooking.js';
+import Cooking, { CookingMethodEnum } from '@/lib/skilling/skills/cooking/cooking.js';
 import type { CookingActivityTaskOptions } from '@/lib/types/minions.js';
 
 export const cookingTask: MinionTask = {
@@ -11,7 +11,7 @@ export const cookingTask: MinionTask = {
 
 		const cookable = Cooking.Cookables.find(item => item.id === cookableID)!;
 
-		if (method === 'KarambwanShopCookDrop') {
+		if (method === CookingMethodEnum.KarambwanShop) {
 			const rawKarambwans = new Bank().add(EItem.RAW_KARAMBWAN, quantity);
 			const cookedKarambwans = new Bank().add(EItem.COOKED_KARAMBWAN, quantity);
 			const xpReceived = quantity * cookable.xp;


### PR DESCRIPTION
Introduce a new Cooking method that buys raw karambwans from a shop, cooks them, and drops the cooked karambwans for Cooking XP.

Key changes:
- Add KarambwanShopCookDropMethod to cooking skill (level 92, 133 GP per raw, ~2450 qty/hr).
- Extend CookingActivityTaskOptions type with optional method flag.
- Handle KarambwanShopCookDrop in minion status output and repeatStoredTrip naming.
- Implement command handling in cook command: validation (level, GP, max trip length), purchase (remove coins, record buy cost), start trip with method, and user feedback.
- Update cooking activity task to process the method: grant XP, record bought raw and dropped cooked karambwans to client settings, update collection log, and finish trip with no loot returned.
- Update docs to advertise the new command/strategy and expected XP/hr.

This enables users to run an automated buy-cook-drop flow for karambwans, ensuring proper cost checks, trip duration limits, and bookkeeping (buy cost, bought loot, dropped items, collection log).

- [x] I have tested all my changes thoroughly.
