### PR TITLE
Fix flaky PerkTier in Minion Status

### DIFF
--- a/src/lib/perkTiers.ts
+++ b/src/lib/perkTiers.ts
@@ -36,23 +36,8 @@ export function getPerkTierCached(userId: string) {
 	}
 	return null;
 }
-export async function getUsersPerkTier({
-	user,
-	forceNoCache
-}: {
-	user: MUser;
-	forceNoCache?: boolean;
-}): Promise<PerkTier | 0> {
-	if (!forceNoCache) {
-		// We want a way to force a cache refresh
-		// Otherwise, we look for a cached tier:
-		const tierCacheEntry = perkTierHotCache.get(user.id);
-		// If it's not expired, return it:
-		if (tierCacheEntry && tierCacheEntry.expires > Date.now()) {
-			return tierCacheEntry.tier;
-		}
-	}
 
+export function getUserPerkTierFromBitfield(user: MUser): PerkTier | 0 {
 	const eligibleTiers = [];
 	if (user.isContributor() || user.isModOrAdmin()) {
 		eligibleTiers.push(PerkTier.Four);
@@ -82,18 +67,39 @@ export async function getUsersPerkTier({
 		eligibleTiers.push(PerkTier.Three);
 	}
 
+	if (
+		bitfield.includes(BitField.PatronTier1) ||
+		bitfield.includes(BitField.HasPermanentTierOne) ||
+		bitfield.includes(BitField.BothBotsMaxedFreeTierOnePerks)
+	) {
+		eligibleTiers.push(PerkTier.Two);
+	}
+
+	return Math.max(...eligibleTiers, 0);
+}
+
+export async function getUsersPerkTier({
+	user,
+	forceNoCache
+}: {
+	user: MUser;
+	forceNoCache?: boolean;
+}): Promise<PerkTier | 0> {
+	if (!forceNoCache) {
+		// We want a way to force a cache refresh
+		// Otherwise, we look for a cached tier:
+		const tierCacheEntry = perkTierHotCache.get(user.id);
+		// If it's not expired, return it:
+		if (tierCacheEntry && tierCacheEntry.expires > Date.now()) {
+			return tierCacheEntry.tier;
+		}
+	}
+
+	const eligibleTiers = [getUserPerkTierFromBitfield(user)];
+
 	const roboChimpCached = await Cache.getRoboChimpUser(user.id);
 	if (roboChimpCached) {
 		eligibleTiers.push(roboChimpCached.perk_tier);
-	}
-
-	// Why bother looking for the member if it doesn't help get a higher tier
-	if (
-		user.bitfield.includes(BitField.PatronTier1) ||
-		user.bitfield.includes(BitField.HasPermanentTierOne) ||
-		user.bitfield.includes(BitField.BothBotsMaxedFreeTierOnePerks)
-	) {
-		eligibleTiers.push(PerkTier.Two);
 	}
 	// Server boosting perk has been eliminated
 

--- a/src/lib/user/MUser.ts
+++ b/src/lib/user/MUser.ts
@@ -43,7 +43,7 @@ import type { AttackStyles } from '@/lib/minions/functions/index.js';
 import type { RemoveFoodFromUserParams } from '@/lib/minions/functions/removeFoodFromUser.js';
 import removeFoodFromUser from '@/lib/minions/functions/removeFoodFromUser.js';
 import type { AddXpParams, ClueBank, KillableMonster } from '@/lib/minions/types.js';
-import { getPerkTierCached, getUsersPerkTier } from '@/lib/perkTiers.js';
+import { getPerkTierCached, getUserPerkTierFromBitfield, getUsersPerkTier } from '@/lib/perkTiers.js';
 import { roboChimpUserFetchCached } from '@/lib/roboChimp.js';
 import { type MinigameName, type MinigameScore, Minigames } from '@/lib/settings/minigames.js';
 import { Farming } from '@/lib/skilling/skills/farming/index.js';
@@ -163,7 +163,7 @@ export class MUserClass extends BaseUser {
 	}
 
 	get perkTier() {
-		return getPerkTierCached(this.id) ?? 0;
+		return getPerkTierCached(this.id) ?? getUserPerkTierFromBitfield(this);
 	}
 	get perkTierIsCached(): boolean {
 		return getPerkTierCached(this.id) !== null;

--- a/tests/unit/MUser.test.ts
+++ b/tests/unit/MUser.test.ts
@@ -1,6 +1,7 @@
 import { Bank, convertLVLtoXP } from 'oldschooljs';
 import { describe, expect, test } from 'vitest';
 
+import { BitField, PerkTier } from '@/lib/constants.js';
 import { mockMUser } from './userutil.js';
 
 const testUser = mockMUser({
@@ -65,5 +66,16 @@ describe('MUser.test', () => {
 	test('cl', () => {
 		expect(testUser.cl.has('Coal')).toEqual(true);
 		expect(testUser.cl.length).toEqual(1);
+	});
+	test('perkTier derives from user bitfield when hot cache is cold', () => {
+		expect(mockMUser({ id: 'perk-tier-none' }).perkTier).toEqual(0);
+		expect(mockMUser({ id: 'perk-tier-t1', bitfield: [BitField.PatronTier1] }).perkTier).toEqual(PerkTier.Two);
+		expect(mockMUser({ id: 'perk-tier-t3', bitfield: [BitField.PatronTier3] }).perkTier).toEqual(PerkTier.Four);
+		expect(
+			mockMUser({
+				id: 'perk-tier-free-t1',
+				bitfield: [BitField.BothBotsMaxedFreeTierOnePerks]
+			}).perkTier
+		).toEqual(PerkTier.Two);
 	});
 });


### PR DESCRIPTION
Move perk-tier derivation from user bitfield into a new getUserPerkTierFromBitfield helper and simplify getUsersPerkTier to reuse it. Update MUser.perkTier to fall back to the bitfield-derived tier when the hot cache is cold. Adjust logic to compute eligible tiers consistently and preserve roboChimp lookup in getUsersPerkTier. Add unit tests and necessary imports to validate perk tier derivation from the user's bitfield.

Utilised AI to fix this issue

- [ ] I have tested all my changes thoroughly.
