### PR TITLE
Fix: Remove ES2022 typings in oldschoolgg

### DIFF
--- a/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
+++ b/packages/oldschoolgg/src/components/pages/Account/MinionInfo.tsx
@@ -70,7 +70,7 @@ export function MinionInfo({ data }: { data: FullMinionData }) {
 		'Collection Log': Object.keys(data.collection_log_bank).length,
 		Sacrificed: `${data.total_sacrificed_value.toLocaleString()} GP`
 	};
-	const hasCurrentActivityData = Object.hasOwn(data, 'current_activity');
+	const hasCurrentActivityData = 'current_activity' in data;
 	const currentActivity = hasCurrentActivityData ? data.current_activity : undefined;
 	return (
 		<div className="flex items-center justify-center flex-col">


### PR DESCRIPTION
### Description:

`Object.hasOwn` doesn't exist for osgg

### Changes:



### Other checks:

- [x] I have tested all my changes thoroughly.
