### PR TITLE
Add xmas version of sungod axe as a similar item

### DIFF
--- a/src/lib/bso/commands/kkCommand.ts
+++ b/src/lib/bso/commands/kkCommand.ts
@@ -182,7 +182,7 @@ export async function kkCommand(
 			msgs.push(`${percent}% boost for TzKal cape`);
 		}
 
-		if (user.owns('Axe of the high sungod')) {
+		if (user.hasEquippedOrInBank('Axe of the high sungod')) {
 			const percent = 10;
 			effectiveTime = reduceNumByPercent(effectiveTime, percent);
 			msgs.push(`${percent}% boost for Axe of the high sungod`);

--- a/src/lib/data/similarItems.ts
+++ b/src/lib/data/similarItems.ts
@@ -415,6 +415,7 @@ const source: [string, (string | number)[]][] = [
 	['Ring of suffering (i)', ['Ring of suffering (ri)']],
 	['Amulet of rancour', ['Amulet of rancour (s)']],
 	['Skull sceptre', ['Skull sceptre (i)']],
+	['Axe of the high sungod', ['Axe of the high sungod (xmas)']],
 
 	// Tame gear
 	['Abyssal jibwings', ['Abyssal jibwings (e)']],


### PR DESCRIPTION
### Description:
Add Axe of the high sungod (xmas) as a similar item to Axe of the high sungod. Allows users to get the same boosts with the dyed version as they would the base item at various monsters.

### Changes:
- Updated similarItems.ts
- Update kkComand.ts to check for similar axe item.

### Other checks:
- [X] I have tested all my changes thoroughly.
