### PR TITLE
Adjust Gnome loot table drops

### DIFF
--- a/packages/oldschooljs/src/simulation/monsters/low/g-m/Gnome.ts
+++ b/packages/oldschooljs/src/simulation/monsters/low/g-m/Gnome.ts
@@ -2,11 +2,12 @@ import LootTable from '@/structures/LootTable.js';
 import { SimpleMonster } from '@/structures/Monster.js';
 
 const GnomeTable = new LootTable({ limit: 128 })
-	.add('King worm', 1, 55)
-	.add('Coins', [1, 300], 30)
-	.add('Swamp toad', 1, 28)
+	.add('Arrow shaft', [2, 4], 56)
+	.add('Coins', 300, 30)
+	.add('Swamp toad', 1, 24)
 	.add('Gold ore', 1, 8)
 	.add('Earth rune', 1, 5)
+	.add('King worm', 1, 3)
 	.add('Fire orb', 1, 2)
 	.tertiary(150, 'Clue scroll (medium)')
 	.tertiary(108_718, 'Rocky');


### PR DESCRIPTION
Tweak Gnome monster loot: add Arrow shaft (2-4) as a common drop, change Coins to a fixed 300 instead of a 1-300 range, reduce Swamp toad drop weight from 28 to 24, and make King worm much rarer (weight 55 -> 3). Other drops and tertiary rewards unchanged.

Closes #6917