### PR TITLE
Make Yeti a counted cl under PvM 

### DIFF
--- a/src/lib/bso/collection-log/main.ts
+++ b/src/lib/bso/collection-log/main.ts
@@ -185,6 +185,7 @@ export const queenBlackDragonCL = resolveItems([
 
 export const akumuCL = resolveItems(['Mini akumu', 'Nightmarish ashes', 'Cursed onyx', 'Demon statuette']);
 export const venatrixCL = resolveItems(['Baby venatrix', 'Venatrix eggs', 'Venatrix webbing', 'Spiders leg bottom']);
+export const yetiCL = resolveItems(['Raw yeti meat', 'Yeti hide', 'Frostclaw cape', 'Cold heart', 'Penguin egg']);
 
 export const gorajanWarriorOutfit = resolveItems([
 	'Gorajan warrior helmet',

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -27,7 +27,8 @@ import {
 	treeBeardCL,
 	vasaMagusCL,
 	venatrixCL,
-	vladDrakanCL
+	vladDrakanCL,
+	yetiCL
 } from '@/lib/bso/collection-log/main.js';
 import {
 	balthazarsBigBonanzaCL,
@@ -47,6 +48,7 @@ import { GrandmasterClueTable } from '@/lib/bso/grandmasterClue.js';
 import { keyCrates } from '@/lib/bso/keyCrates.js';
 import { kibbleCL } from '@/lib/bso/kibble.js';
 import { AkumuLootTable } from '@/lib/bso/monsters/bosses/Akumu.js';
+import { YetiLootTable } from '@/lib/bso/monsters/demi-bosses/Yeti.js';
 import { Ignecarus } from '@/lib/bso/monsters/bosses/Ignecarus.js';
 import { KalphiteKingMonster, kalphiteKingLootTable } from '@/lib/bso/monsters/bosses/KalphiteKing.js';
 import { KingGoldemar } from '@/lib/bso/monsters/bosses/KingGoldemar.js';
@@ -783,6 +785,12 @@ export const allCollectionLogs: ICollection = {
 				allItems: AkumuLootTable.allItems,
 				items: akumuCL,
 				fmtProg: kcProg(BSOMonsters.Akumu.id)
+			},
+			Yeti: {
+				alias: ['yeti'],
+				allItems: YetiLootTable.allItems,
+				items: yetiCL,
+				fmtProg: kcProg(BSOMonsters.Yeti.id)
 			},
 			Venatrix: {
 				alias: ['venatrix'],

--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -48,7 +48,6 @@ import { GrandmasterClueTable } from '@/lib/bso/grandmasterClue.js';
 import { keyCrates } from '@/lib/bso/keyCrates.js';
 import { kibbleCL } from '@/lib/bso/kibble.js';
 import { AkumuLootTable } from '@/lib/bso/monsters/bosses/Akumu.js';
-import { YetiLootTable } from '@/lib/bso/monsters/demi-bosses/Yeti.js';
 import { Ignecarus } from '@/lib/bso/monsters/bosses/Ignecarus.js';
 import { KalphiteKingMonster, kalphiteKingLootTable } from '@/lib/bso/monsters/bosses/KalphiteKing.js';
 import { KingGoldemar } from '@/lib/bso/monsters/bosses/KingGoldemar.js';
@@ -57,6 +56,7 @@ import { Naxxus, NaxxusLootTableFinishable } from '@/lib/bso/monsters/bosses/Nax
 import { VasaMagus } from '@/lib/bso/monsters/bosses/VasaMagus.js';
 import { VenatrixLootTable } from '@/lib/bso/monsters/bosses/Venatrix.js';
 import { BSOMonsters } from '@/lib/bso/monsters/customMonsters.js';
+import { YetiLootTable } from '@/lib/bso/monsters/demi-bosses/Yeti.js';
 import { NexMonster, nexLootTable } from '@/lib/bso/monsters/nex.js';
 import { cmbClothes } from '@/lib/bso/openables/cmb.js';
 import { PaintBoxTable } from '@/lib/bso/paintColors.js';

--- a/src/lib/growablePets.ts
+++ b/src/lib/growablePets.ts
@@ -119,4 +119,4 @@ export const handleGrowablePetGrowth: TripFinishEffect['fn'] = async ({ user, da
 
 export const growablePetsCL = growablePets
 	.flatMap(i => i.stages)
-	.filter(i => !resolveItems(['Magnabbit', 'Magnegg', 'Skip', 'Penguin egg']).includes(i));
+	.filter(i => !resolveItems(['Magnabbit', 'Magnegg']).includes(i));


### PR DESCRIPTION
### Description:
Poll from jonesxy: make yeti a counted cl and shown under the PvM cl tab
Poll from jonesxy: add penguin egg & Skip to growable cl

### Changes:

Make Yeti a counted cl under PvM and add penguin egg & Skip to the growable CL

### Other checks:

- [x ] I have tested all my changes thoroughly.
