### PR TITLE
Improve Minion Kill Message

### DIFF
--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -2,6 +2,7 @@ import type { GearSetupType, PrimaryGearSetupType } from '@oldschoolgg/gear';
 import { MathRNG } from 'node-rng';
 import { Bank, type Item, Items, itemID, type Monster } from 'oldschooljs';
 
+import { BitField } from '@/lib/constants.js';
 import type { KillableMonster } from '@/lib/minions/types.js';
 import type { ChargeBank } from '@/lib/structures/Bank.js';
 import type { DegradeableItemColumns } from '@/lib/user/userTypes.js';
@@ -386,9 +387,12 @@ export async function degradeItem({
 		[degItem.settingsKey]: newCharges
 	});
 	assert(newCharges > 0);
+	const chargeMessage = `Your ${item.name} degraded by ${chargesToDegrade} charges`;
 	return {
 		chargesToDegrade: chargesToDegrade,
-		userMessage: `Your ${item.name} degraded by ${chargesToDegrade} charges, it has ${newCharges.toLocaleString()} charges remaining.`
+		userMessage: user.bitfield.includes(BitField.ShowDetailedInfo)
+			? `${chargeMessage}, it has ${newCharges.toLocaleString()} charges remaining.`
+			: chargeMessage
 	};
 }
 

--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -385,11 +385,10 @@ export async function degradeItem({
 	await user.update({
 		[degItem.settingsKey]: newCharges
 	});
-	const chargesAfter = user.user[degItem.settingsKey];
-	assert(typeof chargesAfter === 'number' && chargesAfter > 0);
+	assert(newCharges > 0);
 	return {
 		chargesToDegrade: chargesToDegrade,
-		userMessage: `Your ${item.name} degraded by ${chargesToDegrade} charges`
+		userMessage: `Your ${item.name} degraded by ${chargesToDegrade} charges, it has ${newCharges.toLocaleString()} charges remaining.`
 	};
 }
 

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -2,7 +2,7 @@ import { stringMatches } from '@oldschoolgg/toolkit';
 import { Monsters } from 'oldschooljs';
 
 import { colosseumCommand } from '@/lib/colosseum.js';
-import type { PvMMethod } from '@/lib/constants.js';
+import { BitField, type PvMMethod } from '@/lib/constants.js';
 import { trackLoot } from '@/lib/lootTrack.js';
 import { revenantMonsters } from '@/lib/minions/data/killableMonsters/revs.js';
 import type { MonsterActivityTaskOptions } from '@/lib/types/minions.js';
@@ -48,8 +48,8 @@ export async function minionKillCommand(
 
 	let monster = findMonster(name);
 
-	const matchedRevenantMonster = revenantMonsters.find(monster =>
-		monster.aliases.some(alias => stringMatches(alias, name))
+	const matchedRevenantMonster = revenantMonsters.find(revenantMonster =>
+		revenantMonster.aliases.some(alias => stringMatches(alias, name))
 	);
 	if (matchedRevenantMonster) {
 		monster = matchedRevenantMonster;
@@ -154,24 +154,33 @@ export async function minionKillCommand(
 		result.duration
 	)} to finish. Attack styles used: ${result.attackStyles.join(', ')}.`;
 
-	const messageLines: string[] = [];
-	if (result.messages.length > 0) {
-		messageLines.push(`**Boosts:** ${result.messages.join(', ')}`);
-	}
-	if (result.updateBank.chargeBank.length() > 0 && updateResult.message.length > 0) {
-		messageLines.push(`**Charges:** ${updateResult.message}`);
-	}
-	if (result.pkMessages.length > 0) {
-		messageLines.push(`**PK:** ${result.pkMessages.join(', ')}`);
-	}
-	if (result.food) {
-		messageLines.push(`**Food:** ${result.food.message}`);
-	}
-	if (totalCostExcludingFood.length > 0) {
-		messageLines.push(`**Item Cost:** ${totalCostExcludingFood}`);
-	}
-	if (messageLines.length > 0) {
-		response += `\n\n${messageLines.join('\n')}`;
+	if (user.bitfield.includes(BitField.ShowDetailedInfo)) {
+		const messageLines: string[] = [];
+		if (result.messages.length > 0) {
+			messageLines.push(`**Boosts:** ${result.messages.join(', ')}`);
+		}
+		if (result.updateBank.chargeBank.length() > 0 && updateResult.message.length > 0) {
+			messageLines.push(`**Charges:** ${updateResult.message}`);
+		}
+		if (result.pkMessages.length > 0) {
+			messageLines.push(`**PK:** ${result.pkMessages.join(', ')}`);
+		}
+		if (result.food) {
+			messageLines.push(`**Food:** ${result.food.message}`);
+		}
+		if (totalCostExcludingFood.length > 0) {
+			messageLines.push(`**Item Cost:** ${totalCostExcludingFood}`);
+		}
+		if (messageLines.length > 0) {
+			response += `\n\n${messageLines.join('\n')}`;
+		}
+	} else {
+		const messageLines = [...result.messages];
+		if (updateResult.message.length > 0) messageLines.push(updateResult.message);
+		if (updateResult.totalCost.length > 0) messageLines.push(`Removing items: ${updateResult.totalCost}`);
+		if (messageLines.length > 0) {
+			response += `\n\n${messageLines.join(', ')}`;
+		}
 	}
 
 	return response;

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -110,11 +110,8 @@ export async function minionKillCommand(
 		return updateResult;
 	}
 
-	if (updateResult.message.length > 0) result.messages.push(updateResult.message);
-
-	if (updateResult.totalCost.length > 0) {
-		result.messages.push(`Removing items: ${updateResult.totalCost}`);
-	}
+	const totalCostExcludingFood = updateResult.totalCost.clone();
+	if (result.food) totalCostExcludingFood.remove(result.food.itemCost);
 
 	if (result.updateBank.itemCostBank.length > 0) {
 		await ClientSettings.updateBankSetting('economyStats_PVMCost', result.updateBank.itemCostBank);
@@ -157,8 +154,24 @@ export async function minionKillCommand(
 		result.duration
 	)} to finish. Attack styles used: ${result.attackStyles.join(', ')}.`;
 
+	const messageLines: string[] = [];
 	if (result.messages.length > 0) {
-		response += `\n\n${result.messages.join(', ')}`;
+		messageLines.push(`**Boosts:** ${result.messages.join(', ')}`);
+	}
+	if (result.updateBank.chargeBank.length() > 0 && updateResult.message.length > 0) {
+		messageLines.push(`**Charges:** ${updateResult.message}`);
+	}
+	if (result.pkMessages.length > 0) {
+		messageLines.push(`**PK:** ${result.pkMessages.join(', ')}`);
+	}
+	if (result.food) {
+		messageLines.push(`**Food:** ${result.food.message}`);
+	}
+	if (totalCostExcludingFood.length > 0) {
+		messageLines.push(`**Item Cost:** ${totalCostExcludingFood}`);
+	}
+	if (messageLines.length > 0) {
+		response += `\n\n${messageLines.join('\n')}`;
 	}
 
 	return response;

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -24,6 +24,7 @@ import {
 } from '@/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.js';
 import {
 	CombatMethodOptionsSchema,
+	FoodResultSchema,
 	speedCalculations
 } from '@/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.js';
 
@@ -35,6 +36,8 @@ const newMinionKillReturnSchema = z.object({
 	attackStyles: z.array(z.enum(['attack', 'strength', 'defence', 'magic', 'ranged'])),
 	currentTaskOptions: CombatMethodOptionsSchema,
 	messages: z.array(z.string()),
+	pkMessages: z.array(z.string()),
+	food: FoodResultSchema.optional(),
 	updateBank: z.instanceof(UpdateBank)
 });
 
@@ -245,8 +248,13 @@ export function newMinionKillCommand(args: MinionKillOptions): string | MinionKi
 				duration = increaseNumByPercent(duration, boostResult.percentageIncrease);
 			}
 			if (boostResult.charges) speedDurationResult.updateBank.chargeBank.add(boostResult.charges);
+			if (boostResult.food) {
+				speedDurationResult.updateBank.itemCostBank.add(boostResult.food.itemCost);
+				speedDurationResult.food = boostResult.food;
+			}
 			if (boostResult.itemCost) speedDurationResult.updateBank.itemCostBank.add(boostResult.itemCost);
 			if (boostResult.message) speedDurationResult.messages.push(boostResult.message);
+			if (boostResult.pkMessage) speedDurationResult.pkMessages.push(boostResult.pkMessage);
 		}
 	}
 	duration = Math.ceil(duration);
@@ -262,6 +270,8 @@ export function newMinionKillCommand(args: MinionKillOptions): string | MinionKi
 		attackStyles,
 		currentTaskOptions: speedDurationResult.currentTaskOptions,
 		messages: speedDurationResult.messages,
+		pkMessages: speedDurationResult.pkMessages,
+		food: speedDurationResult.food,
 		updateBank: speedDurationResult.updateBank
 	});
 

--- a/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
@@ -17,7 +17,15 @@ const noFoodBoost = Math.floor(Math.max(...Eatables.map(eatable => eatable.pvmBo
 // Runs after we know the quantity/duration/etc
 type PostBoostEffectReturn = Pick<
 	BoostResult,
-	'percentageReduction' | 'percentageIncrease' | 'message' | 'charges' | 'changes' | 'itemCost'
+	| 'percentageReduction'
+	| 'percentageIncrease'
+	| 'message'
+	| 'pkMessage'
+	| 'food'
+	| 'charges'
+	| 'changes'
+	| 'itemCost'
+	| 'confirmation'
 >;
 export type PostBoostEffect = {
 	description: string;
@@ -38,7 +46,7 @@ export const postBoostEffects: PostBoostEffect[] = [
 					message: `${noFoodBoost}% for no food`
 				};
 			}
-			const [healAmountNeeded] = calculateMonsterFoodRaw(gearBank, monster);
+			const [healAmountNeeded, foodInfo] = calculateMonsterFoodRaw(gearBank, monster);
 
 			let gearToCheck: GearSetupType = convertAttackStyleToGearSetup(monster.attackStyleToUse);
 			if (isInWilderness) gearToCheck = 'wildy';
@@ -95,7 +103,14 @@ export const postBoostEffects: PostBoostEffect[] = [
 			}
 
 			results.push({
-				itemCost: foodRemoveResult.foodToRemove
+				food: {
+					message: [
+						foodInfo,
+						...foodRemoveResult.reductions,
+						`Removed ${foodRemoveResult.foodToRemove}`
+					].join(', '),
+					itemCost: foodRemoveResult.foodToRemove
+				}
 			});
 			return results;
 		}
@@ -165,7 +180,7 @@ export const postBoostEffects: PostBoostEffect[] = [
 			}
 
 			return {
-				message: messages.join(', '),
+				pkMessage: messages.join(', '),
 				confirmation: confirmationString,
 				itemCost: antiPKSupplies,
 				changes: {

--- a/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
@@ -61,6 +61,11 @@ export type BoostResult = {
 	percentageIncrease?: number;
 	percentageReduction?: number;
 	message?: string;
+	pkMessage?: string;
+	food?: {
+		message: string;
+		itemCost: Bank;
+	};
 	consumables?: Consumable[];
 	itemCost?: Bank;
 	charges?: ChargeBank;

--- a/src/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.ts
@@ -36,12 +36,19 @@ export const CombatMethodOptionsSchema = z.object({
 	isInWilderness: z.boolean().optional()
 });
 
+export const FoodResultSchema = z.object({
+	message: z.string(),
+	itemCost: z.instanceof(Bank)
+});
+
 const schema = z.object({
 	timeToFinish: z.number().int().positive(),
 	messages: z.array(z.string()),
+	pkMessages: z.array(z.string()),
 	currentTaskOptions: CombatMethodOptionsSchema,
 	finalQuantity: z.number().int().positive().min(1),
 	confirmations: z.array(z.string()),
+	food: FoodResultSchema.optional(),
 	updateBank: z.instanceof(UpdateBank)
 });
 
@@ -155,9 +162,11 @@ export function speedCalculations(args: Omit<BoostArgs, 'currentTaskOptions'>) {
 	const result = schema.parse({
 		timeToFinish,
 		messages,
+		pkMessages: [],
 		currentTaskOptions,
 		finalQuantity: consumablesCost.finalQuantity,
 		confirmations,
+		food: undefined,
 		updateBank
 	});
 

--- a/tests/integration/pvm/pvm.test.ts
+++ b/tests/integration/pvm/pvm.test.ts
@@ -243,6 +243,28 @@ describe('PVM', async () => {
 		expect(result.commandResult).toContain('15.00% for stats');
 	});
 
+	it('should show PK messages separately from boosts', async () => {
+		const user = await client.mockUser({
+			bank: new Bank()
+				.add('Saradomin brew(4)', 10)
+				.add('Super restore(4)', 10)
+				.add('Cooked karambwan', 10)
+				.add('Revenant cave teleport', 10),
+			maxed: true
+		});
+		await user.equip('wildy', resolveItems(['Abyssal bludgeon']));
+		const result = await user.runCmdAndTrip(minionKCommand, {
+			name: 'revenant imp',
+			quantity: 1,
+			wilderness: true
+		});
+
+		expect(result.commandResult).toContain('**Boosts:**');
+		expect(result.commandResult).toContain('**PK:**');
+		expect(result.commandResult).toContain('potential pkers');
+		expect(result.commandResult).not.toContain('**Boosts:** Your minion brought some supplies');
+	});
+
 	it('should only use 1 skotizo totem', async () => {
 		const user = await client.mockUser({
 			bank: new Bank().add('Dark totem', 100),

--- a/tests/integration/pvm/pvm.test.ts
+++ b/tests/integration/pvm/pvm.test.ts
@@ -2,6 +2,7 @@ import { calcPerHour } from '@oldschoolgg/toolkit';
 import { Bank, convertLVLtoXP, EItem, EMonster, itemID, Monsters, resolveItems } from 'oldschooljs';
 import { describe, expect, it, test } from 'vitest';
 
+import { BitField } from '@/lib/constants.js';
 import { CombatCannonItemBank } from '@/lib/minions/data/combatConstants.js';
 import { getPOHObject } from '@/lib/poh/index.js';
 import { Gear } from '@/lib/structures/Gear.js';
@@ -243,7 +244,7 @@ describe('PVM', async () => {
 		expect(result.commandResult).toContain('15.00% for stats');
 	});
 
-	it('should show PK messages separately from boosts', async () => {
+	it('should only show PK messages with detailed info enabled', async () => {
 		const user = await client.mockUser({
 			bank: new Bank()
 				.add('Saradomin brew(4)', 10)
@@ -259,10 +260,23 @@ describe('PVM', async () => {
 			wilderness: true
 		});
 
-		expect(result.commandResult).toContain('**Boosts:**');
-		expect(result.commandResult).toContain('**PK:**');
-		expect(result.commandResult).toContain('potential pkers');
+		expect(result.commandResult).not.toContain('**Boosts:**');
+		expect(result.commandResult).not.toContain('**PK:**');
+		expect(result.commandResult).not.toContain('potential pkers');
 		expect(result.commandResult).not.toContain('**Boosts:** Your minion brought some supplies');
+		expect(result.commandResult).toContain('Removing items:');
+
+		await user.update({ bitfield: { push: BitField.ShowDetailedInfo } });
+		const detailedResult = await user.runCmdAndTrip(minionKCommand, {
+			name: 'revenant imp',
+			quantity: 1,
+			wilderness: true
+		});
+
+		expect(detailedResult.commandResult).toContain('**Boosts:**');
+		expect(detailedResult.commandResult).toContain('**PK:**');
+		expect(detailedResult.commandResult).toContain('potential pkers');
+		expect(detailedResult.commandResult).not.toContain('**Boosts:** Your minion brought some supplies');
 	});
 
 	it('should only use 1 skotizo totem', async () => {
@@ -431,6 +445,8 @@ describe('PVM', async () => {
 		const res = await user.kill(EMonster.ARAXXOR);
 		expect(res.commandResult).toContain('is now killing');
 		expect(res.commandResult).toContain('25% for Scythe of vitur');
+		expect(res.commandResult).toContain('Your Scythe of vitur degraded by');
+		expect(res.commandResult).not.toContain('charges remaining');
 		const perHourWithScythe = calcPerHour(res.activityResult!.q, res.activityResult!.duration);
 
 		expect(perHourWithScythe).toBeGreaterThan(perHourWithoutScythe);


### PR DESCRIPTION
Adds headings for boosts, charges, pk, food and item costs

Adds back all the details we had about food reduction 2 years ago

Adds charges remaining to charge boost message

- [x] I have tested all my changes thoroughly.
