### PR TITLE
Farming fixes

### DIFF
--- a/src/mahoji/commands/farming.ts
+++ b/src/mahoji/commands/farming.ts
@@ -464,6 +464,7 @@ export const farmingCommand = defineCommand({
 			return farmingPlantCommand({
 				user,
 				interaction,
+				channelId,
 				plantName: options.plant.plant_name,
 				quantity: options.plant.quantity ?? null,
 				autoFarmed: false,
@@ -474,7 +475,8 @@ export const farmingCommand = defineCommand({
 			return harvestCommand({
 				user: user,
 				seedType: options.harvest.patch_name,
-				interaction
+				interaction,
+				channelId
 			});
 		}
 		if (options.tithe_farm) {

--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -17,11 +17,13 @@ import { formatTripDuration } from '@/lib/util/minionUtils.js';
 export async function harvestCommand({
 	user,
 	seedType,
-	interaction
+	interaction,
+	channelId = interaction.channelId
 }: {
 	user: MUser;
 	seedType: string;
 	interaction: MInteraction;
+	channelId?: string;
 }) {
 	if (await user.minionIsBusy()) {
 		return 'Your minion must not be busy to use this command.';
@@ -90,7 +92,7 @@ It'll take around ${formatTripDuration(user, duration)} to finish.${formatFarmin
 		plantsName: patch.lastPlanted,
 		patchType: patches[patch.patchName],
 		userID: user.id,
-		channelId: interaction.channelId,
+		channelId,
 		upgradeType,
 		duration,
 		quantity: patch.lastQuantity,
@@ -106,6 +108,7 @@ It'll take around ${formatTripDuration(user, duration)} to finish.${formatFarmin
 export async function farmingPlantCommand({
 	user,
 	interaction,
+	channelId = interaction.channelId,
 	plantName,
 	quantity,
 	autoFarmed,
@@ -113,6 +116,7 @@ export async function farmingPlantCommand({
 }: {
 	user: MUser;
 	interaction: MInteraction;
+	channelId?: string;
 	plantName: string;
 	quantity: number | null;
 	autoFarmed: boolean;
@@ -218,7 +222,7 @@ export async function farmingPlantCommand({
 		plantsName: plant.name,
 		patchType: patches[plant.seedType],
 		userID: user.id,
-		channelId: interaction.channelId,
+		channelId,
 		quantity,
 		upgradeType,
 		payment: didPay,

--- a/src/tasks/minions/farmingStep.ts
+++ b/src/tasks/minions/farmingStep.ts
@@ -862,7 +862,7 @@ export async function executeFarmingStep({
 			? xpBreakdownParts.join(', ').replace(/, ([^,]*)$/, ', and $1')
 			: xpBreakdownParts[0];
 	infoStr.push(
-		`${plantingStr}harvesting ${patchType.lastQuantity}x ${plantToHarvest.name}.${payStr}\n\nYou received ${xpBreakdown}. In total: ${xpRes}. ${
+		`${user}, ${plantingStr}harvesting ${patchType.lastQuantity}x ${plantToHarvest.name}.${payStr}\n\nYou received ${xpBreakdown}. In total: ${xpRes}. ${
 			woodcuttingOutcome.woodcuttingOccurred ? wcXP : ''
 		}`
 	);

--- a/tests/unit/farmingStep.test.ts
+++ b/tests/unit/farmingStep.test.ts
@@ -85,6 +85,7 @@ describe('farmingStep tree fee handling', () => {
 		});
 
 		expect(result).not.toBeNull();
+		expect(result?.message).toContain(`${user}`);
 		expect(removeItemsFromBankSpy).not.toHaveBeenCalled();
 		expect(addItemsToBankSpy).toHaveBeenCalledTimes(1);
 		const refundArg = addItemsToBankSpy.mock.calls[0]?.[0] as { items: Bank } | undefined;


### PR DESCRIPTION
Adds back the mention to normal harvest/plant trips
Adds channelID in to ensure it sends the farming task returns

- [ ] I have tested all my changes thoroughly.
