### PR TITLE
Fix Rabbit on OSB

### DIFF
--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -295,7 +295,12 @@ const killableMonsters: KillableMonster[] = [
 				[GearStat.AttackRanged]: 20 + 33 + 10 + 94 + 8
 			}
 		},
-		itemCost: { itemCost: new Bank().add('Stamina potion(4)', 5).add('Ruby dragon bolts (e)', 100), qtyPerKill: 1 }
+		projectileUsage: {
+			required: true,
+			requiredItems: resolveItems(['Ruby dragon bolts (e)']),
+			calculateQuantity: ({ quantity }) => quantity * 100
+		},
+		itemCost: { itemCost: new Bank().add('Stamina potion(4)', 5), qtyPerKill: 1 }
 	},
 	{
 		id: Monsters.DerangedArchaeologist.id,

--- a/src/lib/minions/types.ts
+++ b/src/lib/minions/types.ts
@@ -115,6 +115,7 @@ export interface KillableMonster {
 	}[];
 	projectileUsage?: {
 		required: boolean;
+		requiredItems?: number[];
 		calculateQuantity: (opts: { quantity: number }) => number;
 	};
 	equippedItemBoosts?: {

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -50,8 +50,8 @@ export async function minionKillCommand(
 
 	let monster = findMonster(name);
 
-	const matchedRevenantMonster = revenantMonsters.find(monster =>
-		monster.aliases.some(alias => stringMatches(alias, name))
+	const matchedRevenantMonster = revenantMonsters.find(revenantMonster =>
+		revenantMonster.aliases.some(alias => stringMatches(alias, name))
 	);
 	if (matchedRevenantMonster) {
 		monster = matchedRevenantMonster;
@@ -81,6 +81,7 @@ export async function minionKillCommand(
 		kcForBonus = kcs.BRANDA + kcs.ELDRIC + kcs.ROYAL_TITANS;
 	}
 
+	const maxTripLength = await user.calcMaxTripLength('MonsterKilling');
 	const result = newMinionKillCommand({
 		gearBank: user.gearBank,
 		attackStyles: user.getAttackStyles(),
@@ -89,7 +90,7 @@ export async function minionKillCommand(
 		isTryingToUseWildy: wilderness ?? false,
 		monsterKC: kcForBonus,
 		inputPVMMethod: method,
-		maxTripLength: await user.calcMaxTripLength('MonsterKilling'),
+		maxTripLength: monster.id === Monsters.PriffRabbit.id ? maxTripLength * 2 : maxTripLength,
 		pkEvasionExperience,
 		poh: await getPOH(user.id),
 		inputQuantity,

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -201,6 +201,14 @@ export function newMinionKillCommand(args: MinionKillOptions): string | MinionKi
 
 		const projectilesNeeded = usingBowfa ? 0 : monster.projectileUsage.calculateQuantity({ quantity });
 		if (rangeCheck.ammo) {
+			if (
+				monster.projectileUsage.requiredItems &&
+				!monster.projectileUsage.requiredItems.includes(rangeCheck.ammo.item)
+			) {
+				return `You need ${monster.projectileUsage.requiredItems
+					.map(id => Items.itemNameFromId(id))
+					.join(' or ')} equipped as your range ammo to kill ${monster.name}.`;
+			}
 			speedDurationResult.updateBank.itemCostBank.add(rangeCheck.ammo.item, projectilesNeeded);
 			if (projectilesNeeded > rangeCheck.ammo.quantity) {
 				return `You need ${projectilesNeeded.toLocaleString()}x ${Items.itemNameFromId(

--- a/tests/integration/pvm/pvm.test.ts
+++ b/tests/integration/pvm/pvm.test.ts
@@ -92,6 +92,34 @@ describe('PVM', async () => {
 		expect(user.bank.amount('Anti-venom+(4)')).toEqual(0);
 	});
 
+	it('should start Rabbit trips when requirements are met', async () => {
+		const user = await client.mockUser({
+			bank: new Bank().add('Anglerfish', 1000).add('Ruby dragon bolts (e)', 1000).add('Stamina potion(4)', 50),
+			QP: 300,
+			rangeGear: resolveItems([
+				'Zaryte crossbow',
+				'Masori body (f)',
+				'Masori chaps (f)',
+				'Masori mask (f)',
+				'Zaryte vambraces',
+				'Pegasian boots',
+				'Necklace of anguish'
+			])
+		});
+		await user.max();
+		await user.setAttackStyle(['ranged']);
+		expect(await user.runCommand(minionKCommand, { name: 'Rabbit', quantity: 1 })).toContain(
+			"Your range gear isn't right: You have no ammo equipped."
+		);
+		const rangeGear = user.gear.range;
+		rangeGear.equip('Ruby dragon bolts (e)', 1000);
+		await user.updateGear([{ setup: 'range', gear: rangeGear.raw() }]);
+		const result = await user.kill(EMonster.RABBIT, { quantity: 5 });
+		expect(result.commandResult).toContain('is now killing 1x Rabbit');
+		expect(user.bank.amount('Stamina potion(4)')).toEqual(45);
+		expect(user.gear.range.get('ammo')!.quantity).toEqual(900);
+	});
+
 	it('shouldnt let you barrage bloodvelds', async () => {
 		const user = await client.mockUser({
 			slayerLevel: 70,

--- a/tests/unit/getItemCostFromConsumables.test.ts
+++ b/tests/unit/getItemCostFromConsumables.test.ts
@@ -10,7 +10,6 @@ describe('getItemCostFromConsumables', () => {
 	test('getItemCostFromConsumables', () => {
 		const gearBank = makeGearBank();
 		gearBank.bank.add('Stamina potion(4)', 100);
-		gearBank.bank.add('Ruby dragon bolts (e)', 1000);
 
 		const monster = killableMonsters.find(m => m.name === 'Rabbit')!;
 		for (const inputQuantity of [1, 2, 5, 100]) {
@@ -23,7 +22,6 @@ describe('getItemCostFromConsumables', () => {
 				slayerKillsRemaining: null
 			});
 			expect(consumablesCost.itemCost!.amount('Stamina potion(4)')).toEqual(1 * 5);
-			expect(consumablesCost.itemCost!.amount('Ruby dragon bolts (e)')).toEqual(1 * 100);
 			expect(consumablesCost.finalQuantity).toEqual(1);
 		}
 
@@ -50,7 +48,7 @@ describe('getItemCostFromConsumables', () => {
 		const monster = killableMonsters.find(m => m.id === Monsters.AlchemicalHydra.id)!;
 
 		const consumablesCost2 = getItemCostFromConsumables({
-			consumableCosts: [monster.itemCost as any],
+			consumableCosts: Array.isArray(monster.itemCost) ? monster.itemCost : [monster.itemCost!],
 			gearBank: gearBank,
 			inputQuantity: 5,
 			timeToFinish: monster.timeToFinish,


### PR DESCRIPTION
Make ruby dragon bolts (e) need to be equipped.
Alter maxTripLength in minionKill and apply a Priff Rabbit-specific doubling so non-patrons can kill without erroring. 
Fix a variable rename in the revenant monster lookup. 
Update tests: add an integration test for Rabbit trips and adjust unit tests to reflect the new projectile handling and itemCost shape.

- [x] I have tested all my changes thoroughly.
