### PR TITLE
Tob fake mass auto host

### DIFF
--- a/docs/src/content/docs/osb/Raids/tob.mdx
+++ b/docs/src/content/docs/osb/Raids/tob.mdx
@@ -29,6 +29,16 @@ You can see your KC, attempts and death chances using [[/raid tob stats]]
 
 ---
 
+## Masses
+
+Normal ToB masses require at least 2 real users, and ToB duos require 150 KC. Users cannot manually host fake-host ToB masses.
+
+The official server runs automatic learner ToB masses on the hour, with a 5 minute join timer. These masses use 1 maxed fake host, letting learners start a ToB mass even if only 1 real user joins. The fake host is included in the team for raid time, deaths, wipe chance and purple recipient rolls, but does not receive loot in a real bank. Regular loot, XP, KC and attempt mechanics are otherwise the same as normal ToB.
+
+Real users below 150 ToB KC are eligible for purples in fake-host masses. Real users with 150 or more ToB KC can still join fake-host masses and receive regular loot, XP, KC and attempts, but they cannot receive a purple from that fake-host mass.
+
+---
+
 ## Boosts
 
 ### Gear Score

--- a/packages/discord/src/client/DiscordClient.ts
+++ b/packages/discord/src/client/DiscordClient.ts
@@ -257,8 +257,9 @@ export class DiscordClient extends AsyncEventEmitter<DiscordClientEventsMap> imp
 
 	async editMessage(channelId: string, messageId: string, body: SendableMessage): Promise<void> {
 		const route = Routes.channelMessage(channelId, messageId);
+		const { message } = await this.sendableMsgToApiCreate(body);
 		await this.rest.patch(route, {
-			body
+			body: message
 		});
 	}
 

--- a/src/lib/data/tob.ts
+++ b/src/lib/data/tob.ts
@@ -43,6 +43,9 @@ export const TOBRooms: TOBRoom[] = [
 	}
 ];
 
+export const FAKE_TOB_HOST_ID = 'fake_tob_mass_host';
+export const TOB_FAKE_MASS_PURPLE_KC_CUTOFF = 150;
+
 interface TOBDeaths {
 	/**
 	 * An array, where each item is the index of the room they died in.
@@ -358,7 +361,7 @@ interface ParsedTeamMember {
 	deaths: number[];
 	wipeDeaths: number[];
 }
-interface TobTeam {
+export interface TobTeam {
 	user: MUser;
 	gear: { melee: Gear; range: Gear; mage: Gear };
 	bank: Bank;

--- a/src/lib/simulation/tob.ts
+++ b/src/lib/simulation/tob.ts
@@ -21,6 +21,7 @@ interface TheatreOfBloodOptions {
 	 * The members of the raid team, 1-5 people.
 	 */
 	team: readonly TeamMember[];
+	uniqueEligibleUserIDs?: readonly string[];
 	rng: RNGProvider;
 }
 
@@ -132,7 +133,7 @@ class TheatreOfBloodClass {
 		return table.roll();
 	}
 
-	public complete({ team, rng, hardMode }: TheatreOfBloodOptions) {
+	public complete({ team, rng, hardMode, uniqueEligibleUserIDs }: TheatreOfBloodOptions) {
 		assert(team.length >= 1 || team.length <= 5, 'TOB team must have 1-5 members');
 
 		const maxPointsPerPerson = 22;
@@ -153,8 +154,12 @@ class TheatreOfBloodClass {
 
 		const percentBaseChanceOfUnique = (hardMode ? 13 : 11) * (teamPoints / maxPointsTeamCanGet);
 
-		const purpleReceived = rng.percentChance(percentBaseChanceOfUnique);
-		const purpleRecipient = purpleReceived ? this.uniqueDecide(parsedTeam) : null;
+		const eligibleTeam =
+			uniqueEligibleUserIDs === undefined
+				? parsedTeam
+				: parsedTeam.filter(member => uniqueEligibleUserIDs.includes(member.id));
+		const purpleReceived = eligibleTeam.length > 0 && rng.percentChance(percentBaseChanceOfUnique);
+		const purpleRecipient = purpleReceived ? this.uniqueDecide(eligibleTeam) : null;
 
 		const lootResult: LootBank = {};
 

--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -118,6 +118,7 @@ export const tickers: {
 		name: 'hourly_tob_learner_mass',
 		timer: null,
 		interval: Time.Minute,
+		productionOnly: true,
 		cb: async () => {
 			await maybeStartScheduledTobMass();
 		}

--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -11,6 +11,7 @@ import { collectMetrics } from '@/lib/metrics.js';
 import { Farming } from '@/lib/skilling/skills/farming/index.js';
 import type { FarmingPatchName, FarmingPatchSettingsKey } from '@/lib/skilling/skills/farming/utils/farmingHelpers.js';
 import type { IPatchData } from '@/lib/skilling/skills/farming/utils/types.js';
+import { maybeStartScheduledTobMass } from '@/lib/tobAutoMass.js';
 import { MUserClass } from '@/lib/user/MUser.js';
 import { handleGiveawayCompletion } from '@/lib/util/giveaway.js';
 
@@ -111,6 +112,14 @@ export const tickers: {
 		interval: globalConfig.isProduction ? Time.Second * 5 : 500,
 		cb: async () => {
 			await ActivityManager.processPendingActivities();
+		}
+	},
+	{
+		name: 'hourly_tob_learner_mass',
+		timer: null,
+		interval: Time.Minute,
+		cb: async () => {
+			await maybeStartScheduledTobMass();
 		}
 	},
 	{

--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -118,7 +118,6 @@ export const tickers: {
 		name: 'hourly_tob_learner_mass',
 		timer: null,
 		interval: Time.Minute,
-		productionOnly: true,
 		cb: async () => {
 			await maybeStartScheduledTobMass();
 		}

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -3,24 +3,18 @@ import { Time } from '@oldschoolgg/toolkit';
 import { TimerManager } from '@sapphire/timer-manager';
 import { MathRNG } from 'node-rng';
 
-import { globalConfig } from '@/lib/constants.js';
 import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
 import { InteractionID } from '@/lib/InteractionID.js';
 import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
 
-const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 5;
 const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
-const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
-	? {
-			guildId: '342983479501389826',
-			channelId: '926750772081872956',
-			interval: Time.Hour
-		}
-	: {
-			guildId: '940758552425955348',
-			channelId: '1521092178955337871',
-			interval: Time.Minute * 5
-		};
+const AUTO_TOB_MASS_TARGET = {
+	guildId: '342983479501389826',
+	channelId: '926750772081872956',
+	interval: Time.Hour
+};
+const TOB_ROLE_ID = '924538465494904842';
 let lastAutoTobMassPeriod: number | null = null;
 
 function getRows() {
@@ -30,17 +24,17 @@ function getRows() {
 	];
 }
 
-async function getMessageContent(usersWhoJoined: string[], startedAt: number) {
+async function getMessageContent(usersWhoJoined: string[], finishAt: number, pingRole: boolean) {
 	const joined =
 		usersWhoJoined.length === 0
 			? 'None yet'
 			: (await Promise.all(usersWhoJoined.map(u => Cache.getBadgedUsername(u)))).join(', ');
 
-	return `A maxed fake ToB host is running a learner Theatre of Blood mass. Use the buttons below to join or leave.
+	return `${pingRole ? `<@&${TOB_ROLE_ID}>\n\n` : ''}A maxed fake ToB host is running a learner Theatre of Blood mass. Use the buttons below to join or leave.
 
 **Users Joined:** ${joined}
 
-This party will automatically depart in ${dateFm(startedAt + AUTO_TOB_MASS_TIMEOUT)}. Real users below ${TOB_FAKE_MASS_PURPLE_KC_CUTOFF} ToB KC and the fake host are eligible for purples; higher KC users still receive regular loot.`;
+This party will automatically depart in ${dateFm(finishAt)}. Real users below ${TOB_FAKE_MASS_PURPLE_KC_CUTOFF} ToB KC and the fake host are eligible for purples; higher KC users still receive regular loot.`;
 }
 
 export async function maybeStartScheduledTobMass() {
@@ -51,27 +45,34 @@ export async function maybeStartScheduledTobMass() {
 	lastAutoTobMassPeriod = periodKey;
 
 	const channelId = AUTO_TOB_MASS_TARGET.channelId;
-	const startedAt = Date.now();
+	const finishAt = Date.now() + AUTO_TOB_MASS_TIMEOUT;
+	await createScheduledTobMass(channelId, finishAt, true);
+}
+
+async function createScheduledTobMass(channelId: string, finishAt: number, pingRole: boolean) {
 	const usersWhoJoined: string[] = [];
 	let hasDeparted = false;
 
 	const message = await globalClient.sendMessage(channelId, {
-		content: await getMessageContent(usersWhoJoined, startedAt),
+		content: await getMessageContent(usersWhoJoined, finishAt, pingRole),
 		components: getRows(),
-		allowedMentions: { users: [] }
+		allowedMentions: { roles: pingRole ? [TOB_ROLE_ID] : [], users: [] }
 	});
 
 	const updateMessage = async (components = getRows()) => {
 		await globalClient.editMessage(channelId, message.id, {
-			content: await getMessageContent(usersWhoJoined, startedAt),
+			content: await getMessageContent(usersWhoJoined, finishAt, false),
 			components,
-			allowedMentions: { users: [] }
+			allowedMentions: { roles: [], users: [] }
 		});
 	};
 
-	const depart = async () => {
+	let timeout: NodeJS.Timeout | null = null;
+
+	const depart = async (openOverflowMass = false) => {
 		if (hasDeparted) return;
 		hasDeparted = true;
+		if (timeout) TimerManager.clearTimeout(timeout);
 		globalClient.removeListener('interactionCreate', listener);
 		await updateMessage([]);
 		if (usersWhoJoined.length === 0) {
@@ -114,44 +115,53 @@ export async function maybeStartScheduledTobMass() {
 			true
 		);
 		await globalClient.sendMessage(channelId, { content: result });
+		if (openOverflowMass && finishAt - Date.now() > Time.Second * 10) {
+			await createScheduledTobMass(channelId, finishAt, false);
+		}
 	};
 
 	const listener = async (rawInteraction: Parameters<(typeof globalClient)['apiInteractionParse']>[0]) => {
 		try {
 			const interaction = await globalClient.apiInteractionParse(rawInteraction);
 			if (!interaction?.isButton() || interaction.message?.id !== message.id) return;
-			await handleButton(interaction, usersWhoJoined, updateMessage);
+			const filledMass = await handleButton(interaction, usersWhoJoined, updateMessage);
+			if (filledMass) {
+				await depart(true);
+			}
 		} catch (err) {
 			Logging.logError(err as Error);
 		}
 	};
 
 	globalClient.on('interactionCreate', listener);
-	TimerManager.setTimeout(() => void depart().catch(err => Logging.logError(err)), AUTO_TOB_MASS_TIMEOUT);
+	timeout = TimerManager.setTimeout(
+		() => void depart().catch(err => Logging.logError(err)),
+		Math.max(finishAt - Date.now(), Time.Second)
+	);
 }
 
 async function handleButton(
 	interaction: ButtonMInteraction,
 	usersWhoJoined: string[],
 	updateMessage: () => Promise<void>
-) {
+): Promise<boolean> {
 	const user = await mUserFetch(interaction.userId);
 	if (!user.hasMinion || (await user.minionIsBusy())) {
 		await interaction.reply({
 			content: 'You cannot join this mass because your minion is busy or you do not have a minion.',
 			ephemeral: true
 		});
-		return;
+		return false;
 	}
 
 	if (interaction.customId === InteractionID.Party.Join) {
 		if (usersWhoJoined.includes(interaction.userId)) {
 			await interaction.reply({ content: 'You are already in this mass.', ephemeral: true });
-			return;
+			return false;
 		}
 		if (usersWhoJoined.length >= AUTO_TOB_MASS_MAX_REAL_USERS) {
 			await interaction.reply({ content: 'This mass is full.', ephemeral: true });
-			return;
+			return false;
 		}
 		const checkResult = await checkTOBUser(user, false, usersWhoJoined.length + 2, 1, true);
 		if (checkResult[0]) {
@@ -159,22 +169,24 @@ async function handleButton(
 				content: `You couldn't join this mass, for this reason: ${checkResult[1]}`,
 				ephemeral: true
 			});
-			return;
+			return false;
 		}
 		usersWhoJoined.push(interaction.userId);
 		await interaction.silentButtonAck();
 		await updateMessage();
-		return;
+		return usersWhoJoined.length >= AUTO_TOB_MASS_MAX_REAL_USERS;
 	}
 
 	if (interaction.customId === InteractionID.Party.Leave) {
 		const index = usersWhoJoined.indexOf(interaction.userId);
 		if (index === -1) {
 			await interaction.reply({ content: 'You are not in this mass.', ephemeral: true });
-			return;
+			return false;
 		}
 		usersWhoJoined.splice(index, 1);
 		await interaction.silentButtonAck();
 		await updateMessage();
 	}
+
+	return false;
 }

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -8,7 +8,7 @@ import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
 import { InteractionID } from '@/lib/InteractionID.js';
 import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
 
-const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 5;
 const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
 const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
 	? {

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -3,24 +3,17 @@ import { Time } from '@oldschoolgg/toolkit';
 import { TimerManager } from '@sapphire/timer-manager';
 import { MathRNG } from 'node-rng';
 
-import { globalConfig } from '@/lib/constants.js';
 import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
 import { InteractionID } from '@/lib/InteractionID.js';
 import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
 
-const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 5;
 const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
-const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
-	? {
-			guildId: '342983479501389826',
-			channelId: '926750772081872956',
-			interval: Time.Hour
-		}
-	: {
-			guildId: '940758552425955348',
-			channelId: '1521092178955337871',
-			interval: Time.Minute * 5
-		};
+const AUTO_TOB_MASS_TARGET = {
+	guildId: '342983479501389826',
+	channelId: '926750772081872956',
+	interval: Time.Hour
+};
 let lastAutoTobMassPeriod: number | null = null;
 
 function getRows() {

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -3,18 +3,24 @@ import { Time } from '@oldschoolgg/toolkit';
 import { TimerManager } from '@sapphire/timer-manager';
 import { MathRNG } from 'node-rng';
 
+import { globalConfig } from '@/lib/constants.js';
 import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
 import { InteractionID } from '@/lib/InteractionID.js';
 import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
 
-const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 5;
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
 const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
-const AUTO_TOB_MASS_TARGET = {
-	guildId: '342983479501389826',
-	channelId: '926750772081872956',
-	interval: Time.Hour
-};
-const TOB_ROLE_ID = '924538465494904842';
+const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
+	? {
+			guildId: '342983479501389826',
+			channelId: '926750772081872956',
+			interval: Time.Hour
+		}
+	: {
+			guildId: '940758552425955348',
+			channelId: '1521092178955337871',
+			interval: Time.Minute * 5
+		};
 let lastAutoTobMassPeriod: number | null = null;
 
 function getRows() {
@@ -30,9 +36,7 @@ async function getMessageContent(usersWhoJoined: string[], startedAt: number) {
 			? 'None yet'
 			: (await Promise.all(usersWhoJoined.map(u => Cache.getBadgedUsername(u)))).join(', ');
 
-	return `<@&${TOB_ROLE_ID}>
-
-A maxed fake ToB host is running a learner Theatre of Blood mass. Use the buttons below to join or leave.
+	return `A maxed fake ToB host is running a learner Theatre of Blood mass. Use the buttons below to join or leave.
 
 **Users Joined:** ${joined}
 
@@ -54,14 +58,14 @@ export async function maybeStartScheduledTobMass() {
 	const message = await globalClient.sendMessage(channelId, {
 		content: await getMessageContent(usersWhoJoined, startedAt),
 		components: getRows(),
-		allowedMentions: { roles: [TOB_ROLE_ID], users: [] }
+		allowedMentions: { users: [] }
 	});
 
 	const updateMessage = async (components = getRows()) => {
 		await globalClient.editMessage(channelId, message.id, {
 			content: await getMessageContent(usersWhoJoined, startedAt),
 			components,
-			allowedMentions: { roles: [], users: [] }
+			allowedMentions: { users: [] }
 		});
 	};
 

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -1,0 +1,180 @@
+import { ButtonBuilder, type ButtonMInteraction, ButtonStyle, dateFm } from '@oldschoolgg/discord';
+import { Time } from '@oldschoolgg/toolkit';
+import { TimerManager } from '@sapphire/timer-manager';
+import { MathRNG } from 'node-rng';
+
+import { globalConfig } from '@/lib/constants.js';
+import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
+import { InteractionID } from '@/lib/InteractionID.js';
+import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
+
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
+const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
+const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
+	? {
+		guildId: '342983479501389826',
+		channelId: '926750772081872956',
+		interval: Time.Hour
+	}
+	: {
+		guildId: '940758552425955348',
+		channelId: '1521092178955337871',
+		interval: Time.Minute * 5
+	};
+let lastAutoTobMassPeriod: number | null = null;
+
+function getRows() {
+	return [
+		new ButtonBuilder().setCustomId(InteractionID.Party.Join).setLabel('Join').setStyle(ButtonStyle.Primary),
+		new ButtonBuilder().setCustomId(InteractionID.Party.Leave).setLabel('Leave').setStyle(ButtonStyle.Secondary)
+	];
+}
+
+async function getMessageContent(usersWhoJoined: string[], startedAt: number) {
+	const joined =
+		usersWhoJoined.length === 0
+			? 'None yet'
+			: (await Promise.all(usersWhoJoined.map(u => Cache.getBadgedUsername(u)))).join(', ');
+
+	return `A maxed fake ToB host is running a learner Theatre of Blood mass. Use the buttons below to join or leave.
+
+**Users Joined:** ${joined}
+
+This party will automatically depart in ${dateFm(startedAt + AUTO_TOB_MASS_TIMEOUT)}. Real users below ${TOB_FAKE_MASS_PURPLE_KC_CUTOFF} ToB KC and the fake host are eligible for purples; higher KC users still receive regular loot.`;
+}
+
+export async function maybeStartScheduledTobMass() {
+	const now = new Date();
+	const periodKey = Math.floor(now.getTime() / AUTO_TOB_MASS_TARGET.interval);
+	if (lastAutoTobMassPeriod === periodKey) return;
+	if (now.getTime() % AUTO_TOB_MASS_TARGET.interval >= Time.Minute) return;
+	lastAutoTobMassPeriod = periodKey;
+
+	const channelId = AUTO_TOB_MASS_TARGET.channelId;
+	const startedAt = Date.now();
+	const usersWhoJoined: string[] = [];
+	let hasDeparted = false;
+
+	const message = await globalClient.sendMessage(channelId, {
+		content: await getMessageContent(usersWhoJoined, startedAt),
+		components: getRows(),
+		allowedMentions: { users: [] }
+	});
+
+	const updateMessage = async (components = getRows()) => {
+		await globalClient.editMessage(channelId, message.id, {
+			content: await getMessageContent(usersWhoJoined, startedAt),
+			components,
+			allowedMentions: { users: [] }
+		});
+	};
+
+	const depart = async () => {
+		if (hasDeparted) return;
+		hasDeparted = true;
+		globalClient.removeListener('interactionCreate', listener);
+		await updateMessage([]);
+		if (usersWhoJoined.length === 0) {
+			await globalClient.sendMessage(channelId, {
+				content: 'The learner Theatre of Blood mass did not start because nobody joined.'
+			});
+			return;
+		}
+
+		const users = await Promise.all(usersWhoJoined.map(userID => mUserFetch(userID)));
+		const validUsers: MUser[] = [];
+		const removedUsers: string[] = [];
+		for (const user of users) {
+			const checkResult = await checkTOBUser(user, false, users.length + 1, 1, true);
+			if (checkResult[0]) {
+				removedUsers.push(`${user.usernameOrMention}: ${checkResult[1]}`);
+			} else {
+				validUsers.push(user);
+			}
+		}
+		if (removedUsers.length > 0) {
+			await globalClient.sendMessage(channelId, {
+				content: `The following users were removed from the learner Theatre of Blood mass:\n${removedUsers.join('\n')}`
+			});
+		}
+		if (validUsers.length === 0) {
+			await globalClient.sendMessage(channelId, {
+				content: 'The learner Theatre of Blood mass did not start because no valid users were left.'
+			});
+			return;
+		}
+		const result = await startTheatreOfBloodTrip(
+			MathRNG,
+			channelId,
+			validUsers[0],
+			validUsers,
+			false,
+			1,
+			false,
+			true
+		);
+		await globalClient.sendMessage(channelId, { content: result });
+	};
+
+	const listener = async (rawInteraction: Parameters<(typeof globalClient)['apiInteractionParse']>[0]) => {
+		try {
+			const interaction = await globalClient.apiInteractionParse(rawInteraction);
+			if (!interaction?.isButton() || interaction.message?.id !== message.id) return;
+			await handleButton(interaction, usersWhoJoined, updateMessage);
+		} catch (err) {
+			Logging.logError(err as Error);
+		}
+	};
+
+	globalClient.on('interactionCreate', listener);
+	TimerManager.setTimeout(() => void depart().catch(err => Logging.logError(err)), AUTO_TOB_MASS_TIMEOUT);
+}
+
+async function handleButton(
+	interaction: ButtonMInteraction,
+	usersWhoJoined: string[],
+	updateMessage: () => Promise<void>
+) {
+	const user = await mUserFetch(interaction.userId);
+	if (!user.hasMinion || (await user.minionIsBusy())) {
+		await interaction.reply({
+			content: 'You cannot join this mass because your minion is busy or you do not have a minion.',
+			ephemeral: true
+		});
+		return;
+	}
+
+	if (interaction.customId === InteractionID.Party.Join) {
+		if (usersWhoJoined.includes(interaction.userId)) {
+			await interaction.reply({ content: 'You are already in this mass.', ephemeral: true });
+			return;
+		}
+		if (usersWhoJoined.length >= AUTO_TOB_MASS_MAX_REAL_USERS) {
+			await interaction.reply({ content: 'This mass is full.', ephemeral: true });
+			return;
+		}
+		const checkResult = await checkTOBUser(user, false, usersWhoJoined.length + 2, 1, true);
+		if (checkResult[0]) {
+			await interaction.reply({
+				content: `You couldn't join this mass, for this reason: ${checkResult[1]}`,
+				ephemeral: true
+			});
+			return;
+		}
+		usersWhoJoined.push(interaction.userId);
+		await interaction.silentButtonAck();
+		await updateMessage();
+		return;
+	}
+
+	if (interaction.customId === InteractionID.Party.Leave) {
+		const index = usersWhoJoined.indexOf(interaction.userId);
+		if (index === -1) {
+			await interaction.reply({ content: 'You are not in this mass.', ephemeral: true });
+			return;
+		}
+		usersWhoJoined.splice(index, 1);
+		await interaction.silentButtonAck();
+		await updateMessage();
+	}
+}

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -3,17 +3,24 @@ import { Time } from '@oldschoolgg/toolkit';
 import { TimerManager } from '@sapphire/timer-manager';
 import { MathRNG } from 'node-rng';
 
+import { globalConfig } from '@/lib/constants.js';
 import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
 import { InteractionID } from '@/lib/InteractionID.js';
 import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
 
-const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 5;
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
 const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
-const AUTO_TOB_MASS_TARGET = {
-	guildId: '342983479501389826',
-	channelId: '926750772081872956',
-	interval: Time.Hour
-};
+const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
+	? {
+			guildId: '342983479501389826',
+			channelId: '926750772081872956',
+			interval: Time.Hour
+		}
+	: {
+			guildId: '940758552425955348',
+			channelId: '1521092178955337871',
+			interval: Time.Minute * 5
+		};
 let lastAutoTobMassPeriod: number | null = null;
 
 function getRows() {

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -3,24 +3,18 @@ import { Time } from '@oldschoolgg/toolkit';
 import { TimerManager } from '@sapphire/timer-manager';
 import { MathRNG } from 'node-rng';
 
-import { globalConfig } from '@/lib/constants.js';
 import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
 import { InteractionID } from '@/lib/InteractionID.js';
 import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
 
-const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 5;
 const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
-const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
-	? {
-			guildId: '342983479501389826',
-			channelId: '926750772081872956',
-			interval: Time.Hour
-		}
-	: {
-			guildId: '940758552425955348',
-			channelId: '1521092178955337871',
-			interval: Time.Minute * 5
-		};
+const AUTO_TOB_MASS_TARGET = {
+	guildId: '342983479501389826',
+	channelId: '926750772081872956',
+	interval: Time.Hour
+};
+const TOB_ROLE_ID = '924538465494904842';
 let lastAutoTobMassPeriod: number | null = null;
 
 function getRows() {
@@ -36,7 +30,9 @@ async function getMessageContent(usersWhoJoined: string[], startedAt: number) {
 			? 'None yet'
 			: (await Promise.all(usersWhoJoined.map(u => Cache.getBadgedUsername(u)))).join(', ');
 
-	return `A maxed fake ToB host is running a learner Theatre of Blood mass. Use the buttons below to join or leave.
+	return `<@&${TOB_ROLE_ID}>
+
+A maxed fake ToB host is running a learner Theatre of Blood mass. Use the buttons below to join or leave.
 
 **Users Joined:** ${joined}
 
@@ -58,14 +54,14 @@ export async function maybeStartScheduledTobMass() {
 	const message = await globalClient.sendMessage(channelId, {
 		content: await getMessageContent(usersWhoJoined, startedAt),
 		components: getRows(),
-		allowedMentions: { users: [] }
+		allowedMentions: { roles: [TOB_ROLE_ID], users: [] }
 	});
 
 	const updateMessage = async (components = getRows()) => {
 		await globalClient.editMessage(channelId, message.id, {
 			content: await getMessageContent(usersWhoJoined, startedAt),
 			components,
-			allowedMentions: { users: [] }
+			allowedMentions: { roles: [], users: [] }
 		});
 	};
 

--- a/src/lib/tobAutoMass.ts
+++ b/src/lib/tobAutoMass.ts
@@ -8,19 +8,19 @@ import { TOB_FAKE_MASS_PURPLE_KC_CUTOFF } from '@/lib/data/tob.js';
 import { InteractionID } from '@/lib/InteractionID.js';
 import { checkTOBUser, startTheatreOfBloodTrip } from '@/mahoji/lib/abstracted_commands/tobCommand.js';
 
-const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 5;
+const AUTO_TOB_MASS_TIMEOUT = Time.Minute * 1;
 const AUTO_TOB_MASS_MAX_REAL_USERS = 4;
 const AUTO_TOB_MASS_TARGET = globalConfig.isProduction
 	? {
-		guildId: '342983479501389826',
-		channelId: '926750772081872956',
-		interval: Time.Hour
-	}
+			guildId: '342983479501389826',
+			channelId: '926750772081872956',
+			interval: Time.Hour
+		}
 	: {
-		guildId: '940758552425955348',
-		channelId: '1521092178955337871',
-		interval: Time.Minute * 5
-	};
+			guildId: '940758552425955348',
+			channelId: '1521092178955337871',
+			interval: Time.Minute * 5
+		};
 let lastAutoTobMassPeriod: number | null = null;
 
 function getRows() {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -522,6 +522,7 @@ export interface RaidsOptions extends ActivityTaskOptionsWithUsers {
 export interface TheatreOfBloodTaskOptions extends ActivityTaskOptionsWithUsers {
 	type: 'TheatreOfBlood';
 	leader: string;
+	isFakeMass?: boolean;
 	hardMode: boolean;
 	fakeDuration: number;
 	wipedRooms: (null | number)[];

--- a/src/mahoji/lib/abstracted_commands/tobCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/tobCommand.ts
@@ -8,8 +8,13 @@ import {
 	calculateTOBDeaths,
 	calculateTOBUserGearPercents,
 	createTOBRaid,
+	FAKE_TOB_HOST_ID,
 	minimumTOBSuppliesNeeded,
-	TENTACLE_CHARGES_PER_RAID
+	TENTACLE_CHARGES_PER_RAID,
+	TOBMaxMageGear,
+	TOBMaxMeleeGear,
+	TOBMaxRangeGear,
+	type TobTeam
 } from '@/lib/data/tob.js';
 import { checkUserCanUseDegradeableItem, degradeItem } from '@/lib/degradeableItems.js';
 import { trackLoot } from '@/lib/lootTrack.js';
@@ -64,11 +69,12 @@ async function calcTOBInput(u: MUser) {
 	return items;
 }
 
-async function checkTOBUser(
+export async function checkTOBUser(
 	user: MUser,
 	isHardMode: boolean,
 	teamSize?: number,
-	quantity = 1
+	quantity = 1,
+	skipDuoKCRequirement = false
 ): Promise<[false] | [true, string]> {
 	if (!user.hasMinion) {
 		return [true, `${user.usernameOrMention} doesn't have a minion`];
@@ -212,7 +218,7 @@ async function checkTOBUser(
 		}
 	}
 
-	if (teamSize === 2) {
+	if (teamSize === 2 && !skipDuoKCRequirement) {
 		const kc = await user.fetchMinigameScore(isHardMode ? 'tob_hard' : 'tob');
 		if (kc < 150) {
 			return [true, `${user.usernameOrMention} needs at least 150 KC before doing duo's.`];
@@ -222,24 +228,257 @@ async function checkTOBUser(
 	return [false];
 }
 
-async function checkTOBTeam(users: MUser[], isHardMode: boolean, solo: boolean, quantity = 1): Promise<string | null> {
+async function checkTOBTeam(
+	users: MUser[],
+	isHardMode: boolean,
+	solo: boolean,
+	quantity = 1,
+	isFakeMass = false
+): Promise<string | null> {
 	const userWithoutSupplies = users.find(u => !u.bank.has(minimumTOBSuppliesNeeded));
 	if (userWithoutSupplies) {
 		return `${userWithoutSupplies.usernameOrMention} doesn't have enough supplies`;
 	}
-	if ((!solo && users.length < 2) || users.length > 5) {
+	const effectiveTeamSize = solo ? 3 : isFakeMass ? users.length + 1 : users.length;
+	if ((!solo && effectiveTeamSize < 2) || effectiveTeamSize > 5) {
 		return 'TOB team must be 2-5 users';
 	}
 
 	for (const user of users) {
 		if (await user.minionIsBusy()) return `${user.usernameOrMention}'s minion is busy.`;
-		const checkResult = await checkTOBUser(user, isHardMode, users.length, quantity);
+		const checkResult = await checkTOBUser(user, isHardMode, effectiveTeamSize, quantity, isFakeMass);
 		if (checkResult[1]) {
 			return checkResult[1];
 		}
 	}
 
+	if (!isFakeMass && effectiveTeamSize === 2) {
+		const user = users[0];
+		const kc = await user.fetchMinigameScore(isHardMode ? 'tob_hard' : 'tob');
+		if (kc < 150) {
+			return `${user.usernameOrMention} needs at least 150 KC before doing duo's.`;
+		}
+	}
+
 	return null;
+}
+
+function createFakeTOBHost(): TobTeam {
+	const fakeUser = {
+		id: FAKE_TOB_HOST_ID,
+		usernameOrMention: 'a maxed fake ToB host',
+		minionName: 'maxed fake ToB host',
+		gear: {
+			melee: TOBMaxMeleeGear,
+			range: TOBMaxRangeGear,
+			mage: TOBMaxMageGear
+		},
+		getBlowpipe: () => ({
+			dartID: itemID('Dragon dart'),
+			dartQuantity: 1000,
+			scales: 1000
+		}),
+		hasEquipped: () => true,
+		hasEquippedOrInBank: () => true
+	} as unknown as MUser;
+
+	return {
+		user: fakeUser,
+		bank: new Bank(),
+		gear: {
+			melee: TOBMaxMeleeGear,
+			range: TOBMaxRangeGear,
+			mage: TOBMaxMageGear
+		},
+		kc: 1000,
+		hardKC: 1000,
+		attempts: 1000,
+		hardAttempts: 1000
+	};
+}
+
+export async function startTheatreOfBloodTrip(
+	rng: RNGProvider,
+	channelId: string,
+	leader: MUser,
+	users: MUser[],
+	isHardMode: boolean,
+	quantity: number | undefined,
+	solo: boolean,
+	isFakeMass: boolean
+) {
+	const team = await Promise.all(
+		users.map(async u => {
+			const [minigameScores, { tob_attempts, tob_hard_attempts }] = await Promise.all([
+				u.fetchMinigames(),
+				u.fetchStats()
+			]);
+			return {
+				user: u,
+				bank: u.bank,
+				gear: u.gear,
+				attempts: tob_attempts,
+				hardAttempts: tob_hard_attempts,
+				kc: minigameScores.tob,
+				hardKC: minigameScores.tob_hard
+			};
+		})
+	);
+
+	const teamForCalculations = solo ? [team[0], team[0], team[0]] : isFakeMass ? [...team, createFakeTOBHost()] : team;
+
+	const { baseDuration, reductions, maxUserReduction } = calcTOBBaseDuration({
+		team: teamForCalculations,
+		hardMode: isHardMode
+	});
+	const maxTripLength = await leader.calcMaxTripLength('TheatreOfBlood');
+
+	const maxTripsCanFit = Math.max(1, Math.floor(maxTripLength / baseDuration));
+
+	const qty = quantity ?? maxTripsCanFit;
+	if (qty > maxTripsCanFit) {
+		return `Your minion cannot go on trips longer than ${formatDuration(
+			maxTripLength
+		)}. The most you can do with your teams setup is ${maxTripsCanFit}.`;
+	}
+
+	const teamCheckFailure = await checkTOBTeam(users, isHardMode, solo, qty, isFakeMass);
+	if (teamCheckFailure) {
+		return `Your mass failed to start because of this reason: ${teamCheckFailure} ${users}`;
+	}
+
+	let totalDuration = 0;
+	let totalFakeDuration = 0;
+	const deaths: number[][][] = [];
+
+	const wipedRooms: (number | null)[] = [];
+	for (let tripIndex = 0; tripIndex < qty; tripIndex++) {
+		const {
+			duration,
+			wipedRoom: _wipedRoom,
+			deathDuration,
+			parsedTeam
+		} = createTOBRaid({
+			team: teamForCalculations,
+			hardMode: isHardMode,
+			baseDuration,
+			rng
+		});
+		const wipedRoom = _wipedRoom ? TOBRooms.indexOf(TOBRooms.find(room => _wipedRoom.name === room.name)!) : null;
+		wipedRooms.push(wipedRoom);
+		totalFakeDuration += duration;
+		totalDuration += deathDuration === null ? duration : deathDuration;
+		deaths.push(parsedTeam.map(member => member.deaths));
+	}
+
+	let debugStr = '';
+
+	const totalCost = new Bank();
+
+	const costResult = await Promise.all(
+		users.map(async u => {
+			const supplies = await calcTOBInput(u);
+			const { total } = calculateTOBUserGearPercents(u);
+			const blowpipeData = u.getBlowpipe();
+			const { realCost } = await u.specialRemoveItems(
+				supplies
+					.clone()
+					.add('Coins', 100_000)
+					.add(blowpipeData.dartID!, Math.floor(Math.min(blowpipeData.dartQuantity, 156)))
+					.add(u.gear.range.get('ammo')?.item, 100)
+					.multiply(qty)
+			);
+			await leader.statsBankUpdate('tob_cost', realCost);
+			const effectiveCost = realCost.clone().remove('Coins', realCost.amount('Coins'));
+			totalCost.add(effectiveCost);
+			if (u.gear.melee.hasEquipped('Abyssal tentacle')) {
+				await degradeItem({
+					item: Items.getOrThrow('Abyssal tentacle'),
+					user: u,
+					chargesToDegrade: TENTACLE_CHARGES_PER_RAID * qty
+				});
+			} else if (u.gear.melee.hasEquipped('Scythe of Vitur')) {
+				let usedCharges = 0;
+				for (let x = 0; x < qty; x++) {
+					usedCharges += rng.randomVariation(0.8 * SCYTHE_CHARGES_PER_RAID, 20);
+				}
+				await degradeItem({
+					item: Items.getOrThrow('Scythe of Vitur'),
+					user: u,
+					chargesToDegrade: usedCharges
+				});
+			}
+			debugStr += `**- ${u.usernameOrMention}** (${Emoji.Gear}${total.toFixed(1)}% ${
+				Emoji.CombatSword
+			}	${calcWhatPercent(reductions[u.id], maxUserReduction).toFixed(1)}%) used ${realCost}\n\n`;
+			return {
+				userID: u.id,
+				effectiveCost
+			};
+		})
+	);
+
+	await ClientSettings.updateBankSetting('tob_cost', totalCost);
+	await trackLoot({
+		totalCost,
+		id: isHardMode ? 'tob_hard' : 'tob',
+		type: 'Minigame',
+		changeType: 'cost',
+		users: costResult.map(i => ({
+			id: i.userID,
+			cost: i.effectiveCost,
+			totalDuration
+		}))
+	});
+
+	await ActivityManager.startTrip<TheatreOfBloodTaskOptions>({
+		userID: leader.id,
+		channelId,
+		duration: totalDuration,
+		type: 'TheatreOfBlood',
+		leader: leader.id,
+		users: users.map(u => u.id),
+		isFakeMass,
+		hardMode: isHardMode,
+		wipedRooms,
+		fakeDuration: totalFakeDuration,
+		quantity: qty,
+		deaths,
+		solo
+	});
+
+	let str = '';
+	if (solo) {
+		str = `${leader.usernameOrMention}'s party (${users
+			.map(u => u.usernameOrMention)
+			.join(
+				', '
+			)}) is now off to do ${qty}x Theatre of Blood raid${qty > 1 ? 's' : ''} - the total trip will return in about ${formatTripDuration(
+			leader,
+			totalFakeDuration
+		)}. You're in a team of 3.`;
+	} else if (isFakeMass) {
+		const participantIds = users.map(u => u.usernameOrMention).join(', ');
+		str = `${leader.usernameOrMention}'s party (${participantIds}${
+			participantIds.length > 0 ? ', ' : ''
+		}simulated host) is now off to do ${qty}x Theatre of Blood raid${qty > 1 ? 's' : ''} - the total trip will return in about ${formatTripDuration(
+			leader,
+			totalFakeDuration
+		)}.`;
+	} else {
+		str = `${leader.usernameOrMention}'s party (${users
+			.map(u => u.usernameOrMention)
+			.join(
+				', '
+			)}) is now off to do ${qty}x Theatre of Blood raid${qty > 1 ? 's' : ''} - the total trip will return in about ${formatTripDuration(
+			leader,
+			totalFakeDuration
+		)}.`;
+	}
+
+	str += ` \n\n${debugStr}`;
+
+	return str;
 }
 
 export async function tobStatsCommand({ user, rng }: OSInteraction) {
@@ -303,6 +542,7 @@ export async function tobStartCommand(
 		return "Your minion is busy, so you can't start a raid.";
 	}
 
+	const isSolo = solo;
 	const maxSize = mahojiParseNumber({ input: maxSizeInput, min: 2, max: 5 }) ?? 5;
 
 	const partyOptions: MakePartyOptions = {
@@ -323,157 +563,12 @@ export async function tobStartCommand(
 		}
 	};
 
-	const users = solo ? [user, user, user] : await globalClient.makeParty(partyOptions);
+	const users = isSolo ? [user] : await globalClient.makeParty(partyOptions);
 	if (await ActivityManager.anyMinionIsBusy(users)) {
 		return `All team members must have their minions free.`;
 	}
 
-	const team = await Promise.all(
-		users.map(async u => {
-			const [minigameScores, { tob_attempts, tob_hard_attempts }] = await Promise.all([
-				u.fetchMinigames(),
-				u.fetchStats()
-			]);
-			return {
-				user: u,
-				bank: u.bank,
-				gear: u.gear,
-				attempts: tob_attempts,
-				hardAttempts: tob_hard_attempts,
-				kc: minigameScores.tob,
-				hardKC: minigameScores.tob_hard
-			};
-		})
-	);
-	const { baseDuration, reductions, maxUserReduction } = calcTOBBaseDuration({ team, hardMode: isHardMode });
-	const maxTripLength = await user.calcMaxTripLength('TheatreOfBlood');
-
-	const maxTripsCanFit = Math.max(1, Math.floor(maxTripLength / baseDuration));
-
-	const qty = quantity ?? maxTripsCanFit;
-	if (qty > maxTripsCanFit) {
-		return `Your minion cannot go on trips longer than ${formatDuration(
-			maxTripLength
-		)}. The most you can do with your teams setup is ${maxTripsCanFit}.`;
-	}
-
-	const teamCheckFailure = await checkTOBTeam(users, isHardMode, solo, qty);
-	if (teamCheckFailure) {
-		return `Your mass failed to start because of this reason: ${teamCheckFailure} ${users}`;
-	}
-
-	let totalDuration = 0;
-	let totalFakeDuration = 0;
-	const deaths: number[][][] = [];
-
-	const wipedRooms: (number | null)[] = [];
-	for (let i = 0; i < qty; i++) {
-		const {
-			duration,
-			wipedRoom: _wipedRoom,
-			deathDuration,
-			parsedTeam
-		} = createTOBRaid({
-			team,
-			hardMode: isHardMode,
-			baseDuration,
-			rng
-		});
-		const wipedRoom = _wipedRoom ? TOBRooms.indexOf(TOBRooms.find(room => _wipedRoom.name === room.name)!) : null;
-		wipedRooms.push(wipedRoom);
-		totalFakeDuration += duration;
-		totalDuration += deathDuration === null ? duration : deathDuration;
-		if (solo) parsedTeam.length = 1;
-		deaths.push(parsedTeam.map(i => i.deaths));
-	}
-	if (solo) {
-		users.length = 1;
-		team.length = 1;
-	}
-	let debugStr = '';
-
-	const totalCost = new Bank();
-
-	const costResult = await Promise.all(
-		users.map(async u => {
-			const supplies = await calcTOBInput(u);
-			const { total } = calculateTOBUserGearPercents(u);
-			const blowpipeData = u.getBlowpipe();
-			const { realCost } = await u.specialRemoveItems(
-				supplies
-					.clone()
-					.add('Coins', 100_000)
-					.add(blowpipeData.dartID!, Math.floor(Math.min(blowpipeData.dartQuantity, 156)))
-					.add(u.gear.range.get('ammo')?.item, 100)
-					.multiply(qty)
-			);
-			await user.statsBankUpdate('tob_cost', realCost);
-			const effectiveCost = realCost.clone().remove('Coins', realCost.amount('Coins'));
-			totalCost.add(effectiveCost);
-			if (u.gear.melee.hasEquipped('Abyssal tentacle')) {
-				await degradeItem({
-					item: Items.getOrThrow('Abyssal tentacle'),
-					user: u,
-					chargesToDegrade: TENTACLE_CHARGES_PER_RAID * qty
-				});
-			} else if (u.gear.melee.hasEquipped('Scythe of Vitur')) {
-				let usedCharges = 0;
-				for (let x = 0; x < qty; x++) {
-					usedCharges += rng.randomVariation(0.8 * SCYTHE_CHARGES_PER_RAID, 20);
-				}
-				await degradeItem({
-					item: Items.getOrThrow('Scythe of Vitur'),
-					user: u,
-					chargesToDegrade: usedCharges
-				});
-			}
-			debugStr += `**- ${u.usernameOrMention}** (${Emoji.Gear}${total.toFixed(1)}% ${
-				Emoji.CombatSword
-			} ${calcWhatPercent(reductions[u.id], maxUserReduction).toFixed(1)}%) used ${realCost}\n\n`;
-			return {
-				userID: u.id,
-				effectiveCost
-			};
-		})
-	);
-
-	await ClientSettings.updateBankSetting('tob_cost', totalCost);
-	await trackLoot({
-		totalCost,
-		id: isHardMode ? 'tob_hard' : 'tob',
-		type: 'Minigame',
-		changeType: 'cost',
-		users: costResult.map(i => ({
-			id: i.userID,
-			cost: i.effectiveCost,
-			totalDuration
-		}))
-	});
-
-	await ActivityManager.startTrip<TheatreOfBloodTaskOptions>({
-		userID: user.id,
-		channelId,
-		duration: totalDuration,
-		type: 'TheatreOfBlood',
-		leader: user.id,
-		users: team.map(u => u.user.id),
-		hardMode: isHardMode,
-		wipedRooms,
-		fakeDuration: totalFakeDuration,
-		quantity: qty,
-		deaths,
-		solo
-	});
-
-	let str = `${partyOptions.leader.usernameOrMention}'s party (${users
-		.map(u => u.usernameOrMention)
-		.join(', ')}) is now off to do ${qty}x Theatre of Blood raid${
-		qty > 1 ? 's' : ''
-	} - the total trip will return in about ${formatTripDuration(user, totalFakeDuration)}.${solo ? " You're in a team of 3." : ''}`;
-
-	str += ` \n\n${debugStr}`;
-
-	return str;
+	return startTheatreOfBloodTrip(rng, channelId, user, users, isHardMode, quantity, isSolo, false);
 }
 
 export async function tobCheckCommand(user: MUser, hardMode: boolean) {

--- a/src/tasks/minions/minigames/tobActivity.ts
+++ b/src/tasks/minions/minigames/tobActivity.ts
@@ -3,7 +3,13 @@ import { Bank } from 'oldschooljs';
 
 import { drawChestLootImage } from '@/lib/canvas/chestImage.js';
 import { tobMetamorphPets } from '@/lib/data/CollectionsExport.js';
-import { TOBRooms, TOBUniques, TOBUniquesToAnnounce } from '@/lib/data/tob.js';
+import {
+	FAKE_TOB_HOST_ID,
+	TOB_FAKE_MASS_PURPLE_KC_CUTOFF,
+	TOBRooms,
+	TOBUniques,
+	TOBUniquesToAnnounce
+} from '@/lib/data/tob.js';
 import { trackLoot } from '@/lib/lootTrack.js';
 import { resolveAttackStyles } from '@/lib/minions/functions/index.js';
 import { TeamLoot } from '@/lib/simulation/TeamLoot.js';
@@ -44,6 +50,7 @@ export const tobTask: MinionTask = {
 	async run(data: TheatreOfBloodTaskOptions, { handleTripFinish, rng }) {
 		const { channelId, users, hardMode, leader, wipedRooms, duration, deaths: allDeaths, quantity } = data;
 		const allUsers = await Promise.all(users.map(async u => mUserFetch(u)));
+		const allUserMinigames = await Promise.all(allUsers.map(user => user.fetchMinigames()));
 		const minigameID = hardMode ? 'tob_hard' : 'tob';
 		const allTag = allUsers.map(u => u.toString()).join('');
 		const teamsLoot = new TeamLoot([]);
@@ -61,19 +68,32 @@ export const tobTask: MinionTask = {
 			totalXPCounts[user.id] = new XPCounter();
 		}
 
-		for (let i = 0; i < quantity; i++) {
-			raidId = i + 1;
-			const deaths = allDeaths[i];
-			const wipedRoom = wipedRooms[i];
-			const tobUsers = users.map((i, index) => ({ id: i, deaths: deaths[index] }));
+		for (let raidIndex = 0; raidIndex < quantity; raidIndex++) {
+			raidId = raidIndex + 1;
+			const deaths = allDeaths[raidIndex];
+			const wipedRoom = wipedRooms[raidIndex];
+			const tobUsers = users.map((userID, index) => ({ id: userID, deaths: deaths[index] }));
 			if (data.solo) {
 				tobUsers.push({ id: miniID(3), deaths: [] });
 				tobUsers.push({ id: miniID(3), deaths: [] });
+			} else if (data.isFakeMass) {
+				tobUsers.push({ id: FAKE_TOB_HOST_ID, deaths: deaths[users.length] ?? [] });
 			}
 
 			const result = TheatreOfBlood.complete({
 				hardMode,
 				team: tobUsers,
+				uniqueEligibleUserIDs: data.isFakeMass
+					? [
+							...allUsers
+								.filter(
+									(_, index) =>
+										hardMode || allUserMinigames[index].tob < TOB_FAKE_MASS_PURPLE_KC_CUTOFF
+								)
+								.map(u => u.id),
+							FAKE_TOB_HOST_ID
+						]
+					: undefined,
 				rng
 			});
 
@@ -105,7 +125,7 @@ export const tobTask: MinionTask = {
 
 			for (const [userID, _userLoot] of Object.entries(result.loot)) {
 				if (data.solo && userID !== leader) continue;
-				const user = allUsers.find(i => i.id === userID);
+				const user = allUsers.find(u => u.id === userID);
 				if (!user) continue;
 				const userDeaths = deaths[users.indexOf(user.id)];
 
@@ -149,7 +169,7 @@ export const tobTask: MinionTask = {
 					);
 				}
 				const deathStr =
-					userDeaths.length === 0 ? '' : `${Emoji.Skull}(${userDeaths.map(i => TOBRooms[i].name)})`;
+					userDeaths.length === 0 ? '' : `${Emoji.Skull}(${userDeaths.map(roomID => TOBRooms[roomID].name)})`;
 
 				const lootStr = userLoot.remove('Coins', 100_000).toString();
 				const str = isPurple ? `${Emoji.Purple} ||${lootStr.padEnd(30, ' ')}||` : `${lootStr}`;

--- a/tests/unit/tob.test.ts
+++ b/tests/unit/tob.test.ts
@@ -1,0 +1,131 @@
+import { Bank, itemID } from 'oldschooljs';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import './setup.js';
+
+import { FAKE_TOB_HOST_ID, TOB_FAKE_MASS_PURPLE_KC_CUTOFF, TOBUniques } from '@/lib/data/tob.js';
+import { TheatreOfBlood } from '@/lib/simulation/tob.js';
+import { tobTask } from '@/tasks/minions/minigames/tobActivity.js';
+
+const fakeRng = {
+	percentChance: () => true,
+	roll: () => false
+} as unknown as RNGProvider;
+
+function hasTobUnique(bank: Bank) {
+	return bank.items().some(([item]) => TOBUniques.includes(item.id));
+}
+
+function createMockTobUser(id: string, tobKC = 0) {
+	return {
+		id,
+		mention: `<@${id}>`,
+		badgedUsername: id,
+		cl: new Bank(),
+		allItemsOwned: new Bank(),
+		toString: () => `<@${id}>`,
+		getAttackStyles: () => ['attack'],
+		fetchMinigames: vi.fn(async () => ({ tob: tobKC, tob_hard: 0 })),
+		fetchMinigameScore: vi.fn(async () => tobKC),
+		statsBankUpdate: vi.fn(async () => undefined),
+		statsUpdate: vi.fn(async () => undefined),
+		incrementMinigameScore: vi.fn(async () => undefined),
+		addXPCounter: vi.fn(async () => undefined),
+		addItemsToBank: vi.fn(async () => ({
+			itemsAdded: new Bank(),
+			previousCL: new Bank()
+		}))
+	} as unknown as MUser & {
+		addItemsToBank: ReturnType<typeof vi.fn>;
+		fetchMinigames: ReturnType<typeof vi.fn>;
+	};
+}
+
+describe('TheatreOfBlood', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test('does not award purples to users outside uniqueEligibleUserIDs', () => {
+		const result = TheatreOfBlood.complete({
+			hardMode: false,
+			team: [
+				{ id: 'excluded_user', deaths: [] },
+				{ id: 'eligible_user', deaths: [] }
+			],
+			uniqueEligibleUserIDs: ['eligible_user'],
+			rng: fakeRng
+		});
+
+		expect(hasTobUnique(new Bank(result.loot.eligible_user))).toBe(true);
+		expect(hasTobUnique(new Bank(result.loot.excluded_user))).toBe(false);
+	});
+
+	test('fake learner masses roll with the fake host but do not give fake-host loot to a real user', async () => {
+		const realUser = createMockTobUser('123456789012345678', TOB_FAKE_MASS_PURPLE_KC_CUTOFF - 1);
+		vi.stubGlobal(
+			'mUserFetch',
+			vi.fn(async (userID: string) => {
+				if (userID === realUser.id) return realUser;
+				throw new Error(`Unexpected user fetch: ${userID}`);
+			})
+		);
+		vi.stubGlobal('prisma', {
+			lootTrack: {
+				findFirst: vi.fn(async () => null),
+				create: vi.fn(async () => undefined),
+				update: vi.fn(async () => undefined)
+			}
+		});
+		vi.spyOn(global.ClientSettings, 'updateBankSetting').mockResolvedValue();
+
+		const realUserLoot = new Bank()
+			.add('Vial of blood', 50)
+			.add('Death rune', 500)
+			.add('Blood rune', 500)
+			.add('Coal', 500)
+			.add('Gold ore', 300)
+			.add('Swamp tar', 500)
+			.add('Potato cactus', 50);
+		const fakeHostLoot = new Bank().add('Scythe of vitur (uncharged)');
+		const completeSpy = vi.spyOn(TheatreOfBlood, 'complete').mockReturnValue({
+			loot: {
+				[realUser.id]: realUserLoot,
+				[FAKE_TOB_HOST_ID]: fakeHostLoot
+			},
+			percentChanceOfUnique: 11,
+			totalDeaths: 0,
+			teamPoints: 44
+		});
+		const handleTripFinish = vi.fn(async () => undefined);
+
+		await tobTask.run(
+			{
+				type: 'TheatreOfBlood',
+				id: 1,
+				userID: realUser.id,
+				channelId: 'channel_id',
+				duration: 1000,
+				finishDate: Date.now(),
+				leader: realUser.id,
+				users: [realUser.id],
+				isFakeMass: true,
+				hardMode: false,
+				fakeDuration: 1000,
+				wipedRooms: [null],
+				deaths: [[[], []]],
+				quantity: 1
+			},
+			{ user: realUser, handleTripFinish, rng: fakeRng }
+		);
+
+		const completeOptions = completeSpy.mock.calls[0][0];
+		expect(completeOptions.team.map(member => member.id)).toEqual([realUser.id, FAKE_TOB_HOST_ID]);
+		expect(completeOptions.uniqueEligibleUserIDs).toEqual([realUser.id, FAKE_TOB_HOST_ID]);
+
+		expect(realUser.addItemsToBank).toHaveBeenCalledOnce();
+		const bankedLoot = realUser.addItemsToBank.mock.calls[0][0].items as Bank;
+		expect(bankedLoot.has(itemID('Vial of blood'))).toBe(true);
+		expect(bankedLoot.has(itemID('Scythe of vitur (uncharged)'))).toBe(false);
+	});
+});


### PR DESCRIPTION
The official server runs automatic learner ToB masses on the hour, with a 5 minute join timer. These masses use 1 maxed fake host, letting learners start a ToB mass even if only 1 real user joins. The fake host is included in the team for raid time, deaths, wipe chance and purple recipient rolls, but does not receive loot in a real bank. Regular loot, XP, KC and attempt mechanics are otherwise the same as normal ToB.

Real users below 150 ToB KC are eligible for purples in fake-host masses. Real users with 150 or more ToB KC can still join fake-host masses and receive regular loot, XP, KC and attempts, but they cannot receive a purple from that fake-host mass.

If they’re missing arrows, darts, scales, supplies, rune pouch, gear, etc., they get an ephemeral error and are not added to the mass.

At departure, it revalidates everyone. If someone became invalid after joining, only that user is removed and the mass still starts with any remaining valid users.

- [x] I have tested all my changes thoroughly.
