### PR TITLE
Add auto-sell and auto-drop feature

### DIFF
--- a/docs/src/content/docs/osb/Getting Started/bank-filters.md
+++ b/docs/src/content/docs/osb/Getting Started/bank-filters.md
@@ -36,6 +36,15 @@ When searching your bank, you can use multiple options to find exactly what you'
 
 The following command is an example of a bank search for the term "rune" with many filters: [[/bank search\:rune flag\:show_names flag_extra\:wide]].
 
+### Auto Sell And Auto Drop
+
+Tier 3+ patrons can set items to be automatically sold or dropped whenever they are added to their bank. Manage these preferences with [[/config user auto_sell_drop]].
+
+- Auto-sell uses the same behaviour as [[/sell]], including special exchanges such as mole parts into nest boxes and spirit seeds into Tier 5 seed pack loot.
+- Auto-drop permanently removes the configured item instead of keeping it in your bank.
+- When an item can be added to your collection log, it is added to the collection log before auto-sell or auto-drop is applied.
+- Adding an item to auto-sell removes it from auto-drop, and adding an item to auto-drop removes it from auto-sell.
+
 ### Category Filters
 
 The following bank filters can be used with either of the bank search commands to display items of a specific category. Some examples include:

--- a/docs/src/content/docs/osb/Getting Started/bank-filters.md
+++ b/docs/src/content/docs/osb/Getting Started/bank-filters.md
@@ -42,6 +42,7 @@ Tier 3+ patrons can set items to be automatically sold or dropped whenever they 
 
 - Auto-sell uses the same behaviour as [[/sell]], including special exchanges such as mole parts into nest boxes and spirit seeds into Tier 5 seed pack loot.
 - Auto-drop permanently removes the configured item instead of keeping it in your bank.
+- When `Show Detailed Info` is toggled on, automatically sold or dropped items are shown in trip/open messages with what they were sold for or that they were dropped, rather than being mixed into the normal trip loot.
 - When an item can be added to your collection log, it is added to the collection log before auto-sell or auto-drop is applied.
 - Adding an item to auto-sell removes it from auto-drop, and adding an item to auto-drop removes it from auto-sell.
 

--- a/packages/robochimp/prisma/bso_schema.prisma
+++ b/packages/robochimp/prisma/bso_schema.prisma
@@ -383,6 +383,8 @@ model User {
   favorite_alchables         Int[]              @default([])
   favorite_food              Int[]              @default([])
   favorite_bh_seeds          Int[]              @default([])
+  auto_sell_bank             Json               @default("{}") @db.Json
+  auto_drop_bank             Json               @default("{}") @db.Json
   minion_defaultPay          Boolean            @default(false) @map("minion.defaultPay")
   minion_icon                String?            @map("minion.icon")
   minion_name                String?            @map("minion.name")

--- a/packages/robochimp/prisma/osb_schema.prisma
+++ b/packages/robochimp/prisma/osb_schema.prisma
@@ -329,6 +329,8 @@ model User {
   favorite_alchables         Int[]              @default([])
   favorite_food              Int[]              @default([])
   favorite_bh_seeds          Int[]              @default([])
+  auto_sell_bank             Json               @default("{}") @db.Json
+  auto_drop_bank             Json               @default("{}") @db.Json
   minion_defaultPay          Boolean            @default(false) @map("minion.defaultPay")
   minion_icon                String?            @map("minion.icon")
   minion_name                String?            @map("minion.name")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -327,6 +327,8 @@ model User {
   favorite_alchables         Int[]              @default([])
   favorite_food              Int[]              @default([])
   favorite_bh_seeds          Int[]              @default([])
+  auto_sell_bank             Json               @default("{}") @db.Json
+  auto_drop_bank             Json               @default("{}") @db.Json
   minion_defaultPay          Boolean            @default(false) @map("minion.defaultPay")
   minion_icon                String?            @map("minion.icon")
   minion_name                String?            @map("minion.name") @db.Text()

--- a/src/lib/user/BaseUser.ts
+++ b/src/lib/user/BaseUser.ts
@@ -32,6 +32,8 @@ const USER_DEFAULTS = {
 	favorite_alchables: [],
 	favorite_food: [],
 	favorite_bh_seeds: [],
+	auto_sell_bank: {},
+	auto_drop_bank: {},
 	attack_style: [],
 	combat_options: [],
 	slayer_autoslay_options: [],

--- a/src/lib/user/MUser.ts
+++ b/src/lib/user/MUser.ts
@@ -14,15 +14,7 @@ import { cryptoRng } from 'node-rng/crypto';
 import { Bank, EMonster, type Item, type ItemBank, Items } from 'oldschooljs';
 import { clone } from 'remeda';
 
-import type {
-	activity_type_enum,
-	GearSetupType,
-	Minigame,
-	Prisma,
-	User,
-	UserStats,
-	XpGainSource
-} from '@/prisma/main.js';
+import type { activity_type_enum, GearSetupType, Minigame, Prisma, UserStats, XpGainSource } from '@/prisma/main.js';
 import { addXP } from '@/lib/addXP.js';
 import { MUTEX_CACHE } from '@/lib/cache.js';
 import { generateAllGearImage, generateGearImage } from '@/lib/canvas/generateGearImage.js';
@@ -72,8 +64,16 @@ import type { JsonKeys } from '@/lib/util.js';
 import { getParsedStashUnits } from '@/mahoji/lib/abstracted_commands/stashUnitsCommand.js';
 
 export class MUserClass extends BaseUser {
-	constructor(user: User) {
-		super(user);
+	private autoSellDropMessages: string[] = [];
+
+	addAutoSellDropMessages(messages: string[]) {
+		this.autoSellDropMessages.push(...messages);
+	}
+
+	consumeAutoSellDropMessages() {
+		const messages = [...this.autoSellDropMessages];
+		this.autoSellDropMessages = [];
+		return messages;
 	}
 
 	getGearUpdateData(gearUpdates: GearWithSetupType[]) {

--- a/src/lib/user/update.ts
+++ b/src/lib/user/update.ts
@@ -50,7 +50,14 @@ type PrismaBigIntUpdateInput = bigint | number | { increment: bigint | number } 
 
 type PrismaBigIntKeys = 'premium_balance_expiry_date' | 'GP' | 'sacrificedValue' | `skills_${SkillNameType}`;
 
-type PrismaItemBankKeys = 'bank' | 'collectionLogBank' | 'bank_sort_weightings' | 'temp_cl' | 'pets';
+type PrismaItemBankKeys =
+	| 'bank'
+	| 'collectionLogBank'
+	| 'bank_sort_weightings'
+	| 'temp_cl'
+	| 'pets'
+	| 'auto_sell_bank'
+	| 'auto_drop_bank';
 
 type PrismaDateKeys = 'last_temp_cl_reset' | 'gambling_lockout_expiry' | 'minion_bought_date' | 'last_command_date';
 

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -331,11 +331,16 @@ export async function handleTripFinish(
 	}
 
 	if (_messages) messages.push(..._messages);
+	const generatedAutoSellDropMessages = user.consumeAutoSellDropMessages();
+	const autoSellDropMessages = user.bitfield.includes(BitField.ShowDetailedInfo) ? generatedAutoSellDropMessages : [];
 	if (messages.length > 0) {
 		message.addContent(`\n**Messages:** ${messages.join(', ')}`);
 	}
 
 	message.addContent(displayCluesAndPets(user, loot));
+	if (autoSellDropMessages.length > 0) {
+		message.addContent(`\n\n${autoSellDropMessages.join('\n')}`);
+	}
 
 	if (components.length > 0) {
 		message.addComponents(components);

--- a/src/lib/util/sellPrices.ts
+++ b/src/lib/util/sellPrices.ts
@@ -1,0 +1,52 @@
+import { reduceNumByPercent } from '@oldschoolgg/toolkit';
+import { type Item, itemID, MAX_INT_JAVA } from 'oldschooljs';
+import { clamp } from 'remeda';
+
+import { CUSTOM_PRICE_CACHE } from '@/lib/cache.js';
+
+/**
+ * - Hardcoded prices
+ * - Can be sold by ironmen
+ */
+export const specialSoldItems = new Map([
+	// Emblem Trader Items
+	[itemID('Ancient emblem'), 500_000],
+	[itemID('Ancient totem'), 1_000_000],
+	[itemID('Ancient statuette'), 2_000_000],
+	[itemID('Ancient medallion'), 4_000_000],
+	[itemID('Ancient effigy'), 8_000_000],
+	[itemID('Ancient relic'), 16_000_000],
+	// Simon Templeton Items
+	[itemID('Ivory comb'), 50],
+	[itemID('Pottery scarab'), 75],
+	[itemID('Stone seal'), 100],
+	[itemID('Stone scarab'), 175],
+	[itemID('Stone statuette'), 200],
+	[itemID('Gold seal'), 750],
+	[itemID('Golden scarab'), 1000],
+	[itemID('Golden statuette'), 1250],
+	// Ecumenical Key - requires wildy hard diary
+	[itemID('Ecumenical key'), 61_500]
+]);
+
+export function sellPriceOfItem(item: Item, taxRate = 20): { price: number; basePrice: number } {
+	const cachePrice = CUSTOM_PRICE_CACHE.get(item.id);
+	if (!cachePrice && (item.price === undefined || !item.tradeable)) {
+		return { price: 0, basePrice: 0 };
+	}
+	const basePrice = cachePrice ?? item.price ?? 0;
+	let price = basePrice;
+	price = reduceNumByPercent(price, taxRate);
+	price = clamp(price, { min: 0, max: MAX_INT_JAVA });
+	return { price, basePrice };
+}
+
+export function sellStorePriceOfItem(item: Item, qty: number): { price: number; basePrice: number } {
+	if (!item.cost || !item.lowalch) return { price: 0, basePrice: 0 };
+	const basePrice = item.cost;
+	// Sell price decline with stock by 3% until 10% of item value and is always low alch price when stock is 0.
+	const percentageFirstEleven = (0.4 - 0.015 * Math.min(qty - 1, 10)) * Math.min(qty, 11);
+	let price = ((percentageFirstEleven + Math.max(qty - 11, 0) * 0.1) * item.cost) / qty;
+	price = clamp(price, { min: 0, max: MAX_INT_JAVA });
+	return { price, basePrice };
+}

--- a/src/lib/util/specialSellExchanges.ts
+++ b/src/lib/util/specialSellExchanges.ts
@@ -1,0 +1,156 @@
+import { Bank, EItem } from 'oldschooljs';
+
+import { NestBoxesTable } from '@/lib/simulation/misc.js';
+import { Farming } from '@/lib/skilling/skills/farming/index.js';
+
+export interface SpecialSellExchange {
+	itemsToRemove: Bank;
+	itemsToAdd: Bank;
+	collectionLog: boolean;
+	extraCollectionLogItems?: Bank;
+	confirmationMessage?: (user: MUser) => string;
+	successMessage: string;
+}
+
+export const specialSellExchangeItemIDs = new Set([
+	EItem.MOLE_CLAW,
+	EItem.MOLE_SKIN,
+	EItem.ABYSSAL_BLUE_DYE,
+	EItem.ABYSSAL_GREEN_DYE,
+	EItem.ABYSSAL_RED_DYE,
+	EItem.ABYSSAL_LANTERN,
+	EItem.SPIRIT_SEED,
+	EItem.GOLDEN_PHEASANT_EGG,
+	EItem.FOX_WHISTLE,
+	EItem.PETAL_GARLAND,
+	EItem.PHEASANT_TAIL_FEATHERS,
+	EItem.STURDY_BEEHIVE_PARTS,
+	EItem.GOLDEN_TENCH
+]);
+
+export function getSpecialSellExchange(bankToSell: Bank): SpecialSellExchange | null {
+	if (bankToSell.has(EItem.MOLE_CLAW) || bankToSell.has(EItem.MOLE_SKIN)) {
+		const moleBank = new Bank();
+		if (bankToSell.has(EItem.MOLE_CLAW)) moleBank.add(EItem.MOLE_CLAW, bankToSell.amount(EItem.MOLE_CLAW));
+		if (bankToSell.has(EItem.MOLE_SKIN)) moleBank.add(EItem.MOLE_SKIN, bankToSell.amount(EItem.MOLE_SKIN));
+
+		const loot = new Bank();
+		for (let i = 0; i < moleBank.amount(EItem.MOLE_CLAW) + moleBank.amount(EItem.MOLE_SKIN); i++) {
+			loot.add(NestBoxesTable.roll());
+		}
+
+		return {
+			itemsToRemove: moleBank,
+			itemsToAdd: loot,
+			collectionLog: true,
+			successMessage: `You exchanged ${moleBank} and received: ${loot}.`
+		};
+	}
+
+	if (
+		bankToSell.has(EItem.ABYSSAL_BLUE_DYE) ||
+		bankToSell.has(EItem.ABYSSAL_GREEN_DYE) ||
+		bankToSell.has(EItem.ABYSSAL_RED_DYE) ||
+		bankToSell.has(EItem.ABYSSAL_LANTERN)
+	) {
+		const abbyBank = new Bank();
+		const loot = new Bank();
+		if (bankToSell.has(EItem.ABYSSAL_LANTERN)) {
+			abbyBank.add(EItem.ABYSSAL_LANTERN, bankToSell.amount(EItem.ABYSSAL_LANTERN));
+			loot.add('Abyssal pearls', bankToSell.amount(EItem.ABYSSAL_LANTERN) * 100);
+		}
+		if (bankToSell.has(EItem.ABYSSAL_RED_DYE)) {
+			abbyBank.add(EItem.ABYSSAL_RED_DYE, bankToSell.amount(EItem.ABYSSAL_RED_DYE));
+			loot.add('Abyssal pearls', bankToSell.amount(EItem.ABYSSAL_RED_DYE) * 50);
+		}
+		if (bankToSell.has(EItem.ABYSSAL_BLUE_DYE)) {
+			abbyBank.add(EItem.ABYSSAL_BLUE_DYE, bankToSell.amount(EItem.ABYSSAL_BLUE_DYE));
+			loot.add('Abyssal pearls', bankToSell.amount(EItem.ABYSSAL_BLUE_DYE) * 50);
+		}
+		if (bankToSell.has(EItem.ABYSSAL_GREEN_DYE)) {
+			abbyBank.add(EItem.ABYSSAL_GREEN_DYE, bankToSell.amount(EItem.ABYSSAL_GREEN_DYE));
+			loot.add('Abyssal pearls', bankToSell.amount(EItem.ABYSSAL_GREEN_DYE) * 50);
+		}
+
+		return {
+			itemsToRemove: abbyBank,
+			itemsToAdd: loot,
+			collectionLog: false,
+			confirmationMessage: user => `${user}, please confirm you want to sell ${abbyBank} for **${loot}**.`,
+			successMessage: `You exchanged ${abbyBank} and received: ${loot}.`
+		};
+	}
+
+	if (bankToSell.has(EItem.SPIRIT_SEED)) {
+		const quantity = bankToSell.amount(EItem.SPIRIT_SEED);
+		const seedsBank = new Bank().add(EItem.SPIRIT_SEED, quantity);
+		const loot = new Bank();
+		for (let i = 0; i < quantity; i++) {
+			loot.add(Farming.openSeedPack(5));
+		}
+
+		return {
+			itemsToRemove: seedsBank,
+			itemsToAdd: loot,
+			collectionLog: true,
+			extraCollectionLogItems: new Bank().add(EItem.SEED_PACK, quantity),
+			confirmationMessage: user =>
+				`${user}, please confirm you want to trade ${seedsBank} for Tier 5 seed pack loot.`,
+			successMessage: `You exchanged ${seedsBank} and received: ${loot}.`
+		};
+	}
+
+	if (
+		bankToSell.has(EItem.GOLDEN_PHEASANT_EGG) ||
+		bankToSell.has(EItem.FOX_WHISTLE) ||
+		bankToSell.has(EItem.PETAL_GARLAND) ||
+		bankToSell.has(EItem.PHEASANT_TAIL_FEATHERS) ||
+		bankToSell.has(EItem.STURDY_BEEHIVE_PARTS)
+	) {
+		const forestryBank = new Bank();
+		const loot = new Bank();
+		if (bankToSell.has(EItem.GOLDEN_PHEASANT_EGG)) {
+			forestryBank.add(EItem.GOLDEN_PHEASANT_EGG, bankToSell.amount(EItem.GOLDEN_PHEASANT_EGG));
+			loot.add('Anima-infused bark', bankToSell.amount(EItem.GOLDEN_PHEASANT_EGG) * 250);
+		}
+		if (bankToSell.has(EItem.FOX_WHISTLE)) {
+			forestryBank.add(EItem.FOX_WHISTLE, bankToSell.amount(EItem.FOX_WHISTLE));
+			loot.add('Anima-infused bark', bankToSell.amount(EItem.FOX_WHISTLE) * 250);
+		}
+		if (bankToSell.has(EItem.PETAL_GARLAND)) {
+			forestryBank.add(EItem.PETAL_GARLAND, bankToSell.amount(EItem.PETAL_GARLAND));
+			loot.add('Anima-infused bark', bankToSell.amount(EItem.PETAL_GARLAND) * 150);
+		}
+		if (bankToSell.has(EItem.PHEASANT_TAIL_FEATHERS)) {
+			forestryBank.add(EItem.PHEASANT_TAIL_FEATHERS, bankToSell.amount(EItem.PHEASANT_TAIL_FEATHERS));
+			loot.add('Anima-infused bark', bankToSell.amount(EItem.PHEASANT_TAIL_FEATHERS) * 5);
+		}
+		if (bankToSell.has(EItem.STURDY_BEEHIVE_PARTS)) {
+			forestryBank.add(EItem.STURDY_BEEHIVE_PARTS, bankToSell.amount(EItem.STURDY_BEEHIVE_PARTS));
+			loot.add('Anima-infused bark', bankToSell.amount(EItem.STURDY_BEEHIVE_PARTS) * 25);
+		}
+
+		return {
+			itemsToRemove: forestryBank,
+			itemsToAdd: loot,
+			collectionLog: false,
+			confirmationMessage: user => `${user}, please confirm you want to sell ${forestryBank} for **${loot}**.`,
+			successMessage: `You exchanged ${forestryBank} and received: ${loot}.`
+		};
+	}
+
+	if (bankToSell.has(EItem.GOLDEN_TENCH)) {
+		const tenchBank = new Bank().add(EItem.GOLDEN_TENCH, bankToSell.amount(EItem.GOLDEN_TENCH));
+		const loot = new Bank().add(EItem.MOLCH_PEARL, tenchBank.amount(EItem.GOLDEN_TENCH) * 100);
+
+		return {
+			itemsToRemove: tenchBank,
+			itemsToAdd: loot,
+			collectionLog: false,
+			confirmationMessage: user => `${user}, please confirm you want to sell ${tenchBank} for **${loot}**.`,
+			successMessage: `You exchanged ${tenchBank} and received: ${loot}.`
+		};
+	}
+
+	return null;
+}

--- a/src/lib/util/specialSellExchanges.ts
+++ b/src/lib/util/specialSellExchanges.ts
@@ -8,6 +8,7 @@ export interface SpecialSellExchange {
 	itemsToAdd: Bank;
 	collectionLog: boolean;
 	extraCollectionLogItems?: Bank;
+	autoSellMessage?: string;
 	confirmationMessage?: (user: MUser) => string;
 	successMessage: string;
 }
@@ -94,6 +95,7 @@ export function getSpecialSellExchange(bankToSell: Bank): SpecialSellExchange | 
 			itemsToAdd: loot,
 			collectionLog: true,
 			extraCollectionLogItems: new Bank().add(EItem.SEED_PACK, quantity),
+			autoSellMessage: `${quantity.toLocaleString()}x Tier 5 seed pack loot`,
 			confirmationMessage: user =>
 				`${user}, please confirm you want to trade ${seedsBank} for Tier 5 seed pack loot.`,
 			successMessage: `You exchanged ${seedsBank} and received: ${loot}.`

--- a/src/lib/util/transactItemsFromBank.ts
+++ b/src/lib/util/transactItemsFromBank.ts
@@ -25,6 +25,27 @@ export interface TransactItemsArgs {
 }
 
 const autoSellTaxRatePercent = 25;
+const maxAutoSellDropMessageBankSize = 12;
+
+function formatAutoSellDropBank(bank: Bank) {
+	if (bank.length <= maxAutoSellDropMessageBankSize) return bank.toString();
+	const [firstItem, quantity] = bank.items()[0];
+	return `${new Bank().add(firstItem.id, quantity)}, and ${bank.length - 1} other items`;
+}
+
+function formatAutoSellDropMessage(itemsReceived: Bank, action: 'sold' | 'dropped', received?: Bank | number | string) {
+	const outcome =
+		action === 'sold'
+			? `sold for ${
+					received instanceof Bank
+						? formatAutoSellDropBank(received)
+						: typeof received === 'string'
+							? received
+							: `${received!.toLocaleString()} GP`
+				}`
+			: 'dropped';
+	return `You received ${formatAutoSellDropBank(itemsReceived)}. It was automatically ${outcome}.`;
+}
 
 function calcAutoSellBank(user: MUser, bankToSell: Bank) {
 	const soldBank = new Bank();
@@ -107,20 +128,25 @@ async function unqueuedTransactItems({
 	}
 
 	let gpUpdate: { increment: number } | undefined;
+	let gpAddedFromLoot = 0;
+	let itemsAdded = new Bank();
 	if (itemsToAdd) {
 		const coinsInLoot = itemsToAdd.amount('Coins');
 		if (coinsInLoot > 0) {
+			gpAddedFromLoot = coinsInLoot;
 			gpUpdate = {
 				increment: coinsInLoot
 			};
 			itemsToAdd.remove('Coins', itemsToAdd.amount('Coins'));
 		}
+		itemsAdded = itemsToAdd.clone();
 	}
 
 	let autoSoldBank = new Bank();
 	let autoDroppedBank = new Bank();
 	let autoSellGPReceived = 0;
 	let autoSellData: Prisma.BotItemSellCreateManyInput[] = [];
+	const autoSellDropMessages: string[] = [];
 
 	if (itemsToAdd && itemsToAdd.length > 0 && (await user.fetchPerkTier()) >= PerkTier.Four) {
 		const autoSellPreference = new Bank(user.user.auto_sell_bank as ItemBank);
@@ -134,6 +160,14 @@ async function unqueuedTransactItems({
 				if (!specialExchange) break;
 				itemsToAdd.remove(specialExchange.itemsToRemove);
 				itemsToAdd.add(specialExchange.itemsToAdd);
+				itemsAdded.remove(specialExchange.itemsToRemove);
+				autoSellDropMessages.push(
+					formatAutoSellDropMessage(
+						specialExchange.itemsToRemove,
+						'sold',
+						specialExchange.autoSellMessage ?? specialExchange.itemsToAdd
+					)
+				);
 				if (specialExchange.collectionLog) clItemsAdded.add(specialExchange.itemsToAdd);
 				if (specialExchange.extraCollectionLogItems) clItemsAdded.add(specialExchange.extraCollectionLogItems);
 			}
@@ -147,6 +181,8 @@ async function unqueuedTransactItems({
 			autoSellData = sellResult.botItemSellData;
 			if (autoSoldBank.length > 0) {
 				itemsToAdd.remove(autoSoldBank);
+				itemsAdded.remove(autoSoldBank);
+				autoSellDropMessages.push(formatAutoSellDropMessage(autoSoldBank, 'sold', autoSellGPReceived));
 				if (gpUpdate) gpUpdate.increment += autoSellGPReceived;
 				else gpUpdate = { increment: autoSellGPReceived };
 			}
@@ -154,7 +190,11 @@ async function unqueuedTransactItems({
 
 		if (autoDropPreference.length > 0) {
 			autoDroppedBank = itemsToAdd.filter(item => autoDropPreference.has(item.id));
-			if (autoDroppedBank.length > 0) itemsToAdd.remove(autoDroppedBank);
+			if (autoDroppedBank.length > 0) {
+				itemsToAdd.remove(autoDroppedBank);
+				itemsAdded.remove(autoDroppedBank);
+				autoSellDropMessages.push(formatAutoSellDropMessage(autoDroppedBank, 'dropped'));
+			}
 		}
 	}
 
@@ -209,10 +249,7 @@ async function unqueuedTransactItems({
 	} as const;
 	const newUser = await user.rawUpdate({ data: updateData, gearUpdates });
 
-	const itemsAdded = new Bank(itemsToAdd);
-	if (itemsAdded && gpUpdate && gpUpdate.increment > 0) {
-		itemsAdded.add('Coins', gpUpdate.increment);
-	}
+	if (gpAddedFromLoot > 0) itemsAdded.add('Coins', gpAddedFromLoot);
 
 	const itemsRemoved = new Bank(itemsToRemove);
 	if (itemsRemoved && gpUpdate && gpUpdate.increment < 0) {
@@ -252,6 +289,7 @@ async function unqueuedTransactItems({
 		sideEffects.push(ClientSettings.updateBankSetting('dropped_items', autoDroppedBank));
 	}
 	if (sideEffects.length > 0) await Promise.all(sideEffects);
+	if (autoSellDropMessages.length > 0) user.addAutoSellDropMessages(autoSellDropMessages);
 
 	return {
 		previousCL,

--- a/src/lib/util/transactItemsFromBank.ts
+++ b/src/lib/util/transactItemsFromBank.ts
@@ -1,10 +1,14 @@
-import { Bank, type ItemBank } from 'oldschooljs';
+import { Bank, EItem, type ItemBank } from 'oldschooljs';
 
+import type { Prisma } from '@/prisma/main.js';
 import { deduplicateClueScrolls } from '@/lib/clues/clueUtils.js';
+import { PerkTier } from '@/lib/constants.js';
 import { handleNewCLItems } from '@/lib/handleNewCLItems.js';
 import { filterLootReplace } from '@/lib/slayer/slayerUtil.js';
 import type { SafeUserUpdateInput } from '@/lib/user/update.js';
 import type { GearWithSetupType } from '@/lib/user/userTypes.js';
+import { sellPriceOfItem, sellStorePriceOfItem, specialSoldItems } from '@/lib/util/sellPrices.js';
+import { getSpecialSellExchange } from '@/lib/util/specialSellExchanges.js';
 import { userQueueFn } from '@/lib/util/userQueues.js';
 import { findBingosWithUserParticipating } from '@/mahoji/lib/bingo/BingoManager.js';
 
@@ -18,6 +22,39 @@ export interface TransactItemsArgs {
 	neverUpdateHistory?: boolean;
 	otherUpdates?: SafeUserUpdateInput;
 	gearUpdates?: GearWithSetupType[];
+}
+
+const autoSellTaxRatePercent = 25;
+
+function calcAutoSellBank(user: MUser, bankToSell: Bank) {
+	const soldBank = new Bank();
+	const botItemSellData: Prisma.BotItemSellCreateManyInput[] = [];
+	let gpReceived = 0;
+
+	for (const [item, qty] of bankToSell.items()) {
+		if (item.id === EItem.ECUMENICAL_KEY && !user.hasDiary('wilderness.hard')) continue;
+		const specialPrice = specialSoldItems.get(item.id);
+		const pricePerStack =
+			specialPrice !== undefined
+				? Math.floor(specialPrice * qty)
+				: Math.floor(
+						(user.isIronman
+							? sellStorePriceOfItem(item, qty).price
+							: sellPriceOfItem(item, autoSellTaxRatePercent).price) * qty
+					);
+		if (pricePerStack <= 0) continue;
+
+		soldBank.add(item.id, qty);
+		gpReceived += pricePerStack;
+		botItemSellData.push({
+			item_id: item.id,
+			quantity: qty,
+			gp_received: pricePerStack,
+			user_id: user.id
+		});
+	}
+
+	return { soldBank, gpReceived, botItemSellData };
 }
 
 async function unqueuedTransactItems({
@@ -51,8 +88,8 @@ async function unqueuedTransactItems({
 	const currentBank = new Bank(user.user.bank as ItemBank);
 	const previousCL = new Bank(user.user.collectionLogBank as ItemBank);
 
-	let clUpdates: Partial<Record<'temp_cl' | 'collectionLogBank', ItemBank>> = {};
 	let clLootBank: Bank | null = null;
+	const clItemsAdded = new Bank();
 	if (itemsToAdd) {
 		const errors = itemsToAdd.validate();
 		if (errors.length > 0) {
@@ -66,7 +103,7 @@ async function unqueuedTransactItems({
 		clLootBank = clLoot;
 		itemsToAdd = bankLoot;
 
-		clUpdates = collectionLog ? user.calculateAddItemsToCLUpdates({ items: clLoot, dontAddToTempCL }) : {};
+		if (collectionLog) clItemsAdded.add(clLoot);
 	}
 
 	let gpUpdate: { increment: number } | undefined;
@@ -77,6 +114,47 @@ async function unqueuedTransactItems({
 				increment: coinsInLoot
 			};
 			itemsToAdd.remove('Coins', itemsToAdd.amount('Coins'));
+		}
+	}
+
+	let autoSoldBank = new Bank();
+	let autoDroppedBank = new Bank();
+	let autoSellGPReceived = 0;
+	let autoSellData: Prisma.BotItemSellCreateManyInput[] = [];
+
+	if (itemsToAdd && itemsToAdd.length > 0 && (await user.fetchPerkTier()) >= PerkTier.Four) {
+		const autoSellPreference = new Bank(user.user.auto_sell_bank as ItemBank);
+		const autoDropPreference = new Bank(user.user.auto_drop_bank as ItemBank);
+
+		if (autoSellPreference.length > 0) {
+			for (let i = 0; i < 20; i++) {
+				const specialExchange = getSpecialSellExchange(
+					itemsToAdd.filter(item => autoSellPreference.has(item.id))
+				);
+				if (!specialExchange) break;
+				itemsToAdd.remove(specialExchange.itemsToRemove);
+				itemsToAdd.add(specialExchange.itemsToAdd);
+				if (specialExchange.collectionLog) clItemsAdded.add(specialExchange.itemsToAdd);
+				if (specialExchange.extraCollectionLogItems) clItemsAdded.add(specialExchange.extraCollectionLogItems);
+			}
+
+			const sellResult = calcAutoSellBank(
+				user,
+				itemsToAdd.filter(item => autoSellPreference.has(item.id))
+			);
+			autoSoldBank = sellResult.soldBank;
+			autoSellGPReceived = sellResult.gpReceived;
+			autoSellData = sellResult.botItemSellData;
+			if (autoSoldBank.length > 0) {
+				itemsToAdd.remove(autoSoldBank);
+				if (gpUpdate) gpUpdate.increment += autoSellGPReceived;
+				else gpUpdate = { increment: autoSellGPReceived };
+			}
+		}
+
+		if (autoDropPreference.length > 0) {
+			autoDroppedBank = itemsToAdd.filter(item => autoDropPreference.has(item.id));
+			if (autoDroppedBank.length > 0) itemsToAdd.remove(autoDroppedBank);
 		}
 	}
 
@@ -120,6 +198,9 @@ async function unqueuedTransactItems({
 
 	deduplicateClueScrolls(newBank);
 
+	const clUpdates: Partial<Record<'temp_cl' | 'collectionLogBank', ItemBank>> =
+		clItemsAdded.length > 0 ? user.calculateAddItemsToCLUpdates({ items: clItemsAdded, dontAddToTempCL }) : {};
+
 	const updateData = {
 		bank: newBank.toJSON(),
 		GP: gpUpdate,
@@ -140,18 +221,37 @@ async function unqueuedTransactItems({
 
 	const newCL = new Bank(newUser.user.collectionLogBank as ItemBank);
 
-	if (!dontAddToTempCL && collectionLog) {
+	if (!dontAddToTempCL && clItemsAdded.length > 0) {
 		const activeBingos = await findBingosWithUserParticipating(user.id);
 		for (const bingo of activeBingos) {
 			if (bingo.isActive()) {
-				bingo.handleNewItems(user.id, itemsAdded);
+				bingo.handleNewItems(user.id, clItemsAdded);
 			}
 		}
 	}
 
 	if (!neverUpdateHistory) {
-		await handleNewCLItems({ itemsAdded, user: user, previousCL, newCL });
+		await handleNewCLItems({ itemsAdded: clItemsAdded, user: user, previousCL, newCL });
 	}
+
+	const sideEffects: Promise<unknown>[] = [];
+	if (autoSoldBank.length > 0) {
+		sideEffects.push(
+			ClientSettings.updateClientGPTrackSetting('gp_sell', autoSellGPReceived),
+			ClientSettings.updateBankSetting('sold_items_bank', autoSoldBank),
+			user.statsBankUpdate('items_sold_bank', autoSoldBank),
+			user.statsUpdate({
+				sell_gp: {
+					increment: autoSellGPReceived
+				}
+			}),
+			prisma.botItemSell.createMany({ data: autoSellData })
+		);
+	}
+	if (autoDroppedBank.length > 0) {
+		sideEffects.push(ClientSettings.updateBankSetting('dropped_items', autoDroppedBank));
+	}
+	if (sideEffects.length > 0) await Promise.all(sideEffects);
 
 	return {
 		previousCL,

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -10,7 +10,7 @@ import {
 	Time,
 	uniqueArr
 } from '@oldschoolgg/toolkit';
-import { Bank, type ItemBank, Items } from 'oldschooljs';
+import { Bank, EItem, type ItemBank, Items } from 'oldschooljs';
 import { clamp } from 'remeda';
 
 import type { activity_type_enum } from '@/prisma/main/enums.js';
@@ -25,7 +25,9 @@ import { autoslayChoices, slayerMasterChoices } from '@/lib/slayer/constants.js'
 import { setDefaultAutoslay, setDefaultSlayerMaster } from '@/lib/slayer/slayerUtil.js';
 import { BankSortMethods, isValidBankSortMethod } from '@/lib/sorts.js';
 import { parseBank } from '@/lib/util/parseStringBank.js';
+import { sellPriceOfItem, sellStorePriceOfItem, specialSoldItems } from '@/lib/util/sellPrices.js';
 import { isValidNickname, patronMsg } from '@/lib/util/smallUtils.js';
+import { specialSellExchangeItemIDs } from '@/lib/util/specialSellExchanges.js';
 import { toggleBitfield } from '@/lib/util.js';
 
 type ExtendedBitFieldDataa = (typeof BitFieldData)[BitField] & {
@@ -270,6 +272,87 @@ async function favBhSeedsConfig(
 		currentFavorites.length === 0 ? 'None' : currentFavorites.map(i => Items.itemNameFromId(i)).join(', ')
 	}.`;
 	return currentItems;
+}
+
+type AutoSellDropAction = 'list' | 'add_sell' | 'add_drop' | 'remove' | 'reset';
+
+function autoSellDropStatus(user: MUser, sellBank: Bank, dropBank: Bank) {
+	const sellStr = sellBank.length === 0 ? 'None' : sellBank.toString();
+	const dropStr = dropBank.length === 0 ? 'None' : dropBank.toString();
+	return `${user}, your auto sell/drop preferences are:\n**Auto-sell:** ${sellStr}\n**Auto-drop:** ${dropStr}`;
+}
+
+async function autoSellDropConfig(user: MUser, action: AutoSellDropAction = 'list', input?: string) {
+	const perkTier = await user.fetchPerkTier();
+	if (perkTier < PerkTier.Four) {
+		return patronMsg(PerkTier.Four);
+	}
+
+	const sellBank = new Bank(user.user.auto_sell_bank as ItemBank);
+	const dropBank = new Bank(user.user.auto_drop_bank as ItemBank);
+
+	if (action === 'list') {
+		return autoSellDropStatus(user, sellBank, dropBank);
+	}
+
+	if (action === 'reset') {
+		await user.update({
+			auto_sell_bank: {},
+			auto_drop_bank: {}
+		});
+		return 'Reset your auto sell/drop preferences.';
+	}
+
+	if (!input) return 'You need to provide some items.';
+
+	const parsedBank = parseBank({
+		inputStr: input,
+		noDuplicateItems: true,
+		maxSize: 70
+	}).filter(i => i.id !== EItem.COINS);
+	if (parsedBank.length === 0) return 'No valid non-coin items were given.';
+
+	const preferenceBank = new Bank();
+	for (const [item] of parsedBank.items()) {
+		preferenceBank.add(item.id);
+	}
+
+	if (action === 'remove') {
+		sellBank.remove(preferenceBank);
+		dropBank.remove(preferenceBank);
+		await user.update({
+			auto_sell_bank: sellBank.toJSON(),
+			auto_drop_bank: dropBank.toJSON()
+		});
+		return autoSellDropStatus(user, sellBank, dropBank);
+	}
+
+	if (action === 'add_sell') {
+		const sellableBank = preferenceBank.filter(item => {
+			if (specialSellExchangeItemIDs.has(item.id)) return true;
+			if (item.id === EItem.ECUMENICAL_KEY && !user.hasDiary('wilderness.hard')) return false;
+			if (specialSoldItems.has(item.id)) return true;
+			const { price } = user.isIronman ? sellStorePriceOfItem(item, 1) : sellPriceOfItem(item, 25);
+			return price > 0;
+		});
+		if (sellableBank.length === 0) return 'None of those items can be sold for GP.';
+
+		dropBank.remove(sellableBank);
+		sellBank.add(sellableBank);
+		await user.update({
+			auto_sell_bank: sellBank.toJSON(),
+			auto_drop_bank: dropBank.toJSON()
+		});
+		return autoSellDropStatus(user, sellBank, dropBank);
+	}
+
+	dropBank.add(preferenceBank);
+	sellBank.remove(preferenceBank);
+	await user.update({
+		auto_sell_bank: sellBank.toJSON(),
+		auto_drop_bank: dropBank.toJSON()
+	});
+	return autoSellDropStatus(user, sellBank, dropBank);
 }
 
 async function bankSortConfig(
@@ -925,6 +1008,32 @@ export const configCommand = defineCommand({
 				},
 				{
 					type: 'Subcommand',
+					name: 'auto_sell_drop',
+					description: 'Manage items to auto-sell or auto-drop when added to your bank.',
+					options: [
+						{
+							type: 'String',
+							name: 'action',
+							description: 'The action you want to perform.',
+							required: true,
+							choices: [
+								{ name: 'List', value: 'list' },
+								{ name: 'Add Auto-sell', value: 'add_sell' },
+								{ name: 'Add Auto-drop', value: 'add_drop' },
+								{ name: 'Remove', value: 'remove' },
+								{ name: 'Reset', value: 'reset' }
+							]
+						},
+						{
+							type: 'String',
+							name: 'items',
+							description: "The items to add or remove, e.g. 'trout, coal'.",
+							required: false
+						}
+					]
+				},
+				{
+					type: 'Subcommand',
 					name: 'slayer',
 					description: 'Manage your Slayer options',
 					options: [
@@ -1050,6 +1159,7 @@ LIMIT 20;
 				favorite_food,
 				favorite_items,
 				favorite_bh_seeds,
+				auto_sell_drop,
 				slayer,
 				pin_trip,
 				icon_pack
@@ -1122,6 +1232,9 @@ LIMIT 20;
 					favorite_bh_seeds.remove,
 					Boolean(favorite_bh_seeds.reset)
 				);
+			}
+			if (auto_sell_drop) {
+				return autoSellDropConfig(user, auto_sell_drop.action as AutoSellDropAction, auto_sell_drop.items);
 			}
 			if (slayer) {
 				if (slayer.autoslay) {

--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -1,60 +1,12 @@
-import { reduceNumByPercent } from '@oldschoolgg/toolkit';
-import { Bank, type Item, itemID, MAX_INT_JAVA, toKMB } from 'oldschooljs';
-import { clamp } from 'remeda';
+import { Bank, toKMB } from 'oldschooljs';
 
 import type { Prisma } from '@/prisma/main.js';
 import { filterOption } from '@/discord/index.js';
-import { CUSTOM_PRICE_CACHE } from '@/lib/cache.js';
-import { NestBoxesTable } from '@/lib/simulation/misc.js';
-import { Farming } from '@/lib/skilling/skills/farming/index.js';
 import { parseBank } from '@/lib/util/parseStringBank.js';
+import { sellPriceOfItem, sellStorePriceOfItem, specialSoldItems } from '@/lib/util/sellPrices.js';
+import { getSpecialSellExchange } from '@/lib/util/specialSellExchanges.js';
 
-/**
- * - Hardcoded prices
- * - Can be sold by ironmen
- */
-const specialSoldItems = new Map([
-	// Emblem Trader Items
-	[itemID('Ancient emblem'), 500_000],
-	[itemID('Ancient totem'), 1_000_000],
-	[itemID('Ancient statuette'), 2_000_000],
-	[itemID('Ancient medallion'), 4_000_000],
-	[itemID('Ancient effigy'), 8_000_000],
-	[itemID('Ancient relic'), 16_000_000],
-	// Simon Templeton Items
-	[itemID('Ivory comb'), 50],
-	[itemID('Pottery scarab'), 75],
-	[itemID('Stone seal'), 100],
-	[itemID('Stone scarab'), 175],
-	[itemID('Stone statuette'), 200],
-	[itemID('Gold seal'), 750],
-	[itemID('Golden scarab'), 1000],
-	[itemID('Golden statuette'), 1250],
-	// Ecumenical Key - requires wildy hard diary
-	[itemID('Ecumenical key'), 61_500]
-]);
-
-export function sellPriceOfItem(item: Item, taxRate = 20): { price: number; basePrice: number } {
-	const cachePrice = CUSTOM_PRICE_CACHE.get(item.id);
-	if (!cachePrice && (item.price === undefined || !item.tradeable)) {
-		return { price: 0, basePrice: 0 };
-	}
-	const basePrice = cachePrice ?? item.price ?? 0;
-	let price = basePrice;
-	price = reduceNumByPercent(price, taxRate);
-	price = clamp(price, { min: 0, max: MAX_INT_JAVA });
-	return { price, basePrice };
-}
-
-export function sellStorePriceOfItem(item: Item, qty: number): { price: number; basePrice: number } {
-	if (!item.cost || !item.lowalch) return { price: 0, basePrice: 0 };
-	const basePrice = item.cost;
-	// Sell price decline with stock by 3% until 10% of item value and is always low alch price when stock is 0.
-	const percentageFirstEleven = (0.4 - 0.015 * Math.min(qty - 1, 10)) * Math.min(qty, 11);
-	let price = ((percentageFirstEleven + Math.max(qty - 11, 0) * 0.1) * item.cost) / qty;
-	price = clamp(price, { min: 0, max: MAX_INT_JAVA });
-	return { price, basePrice };
-}
+export { sellPriceOfItem, sellStorePriceOfItem };
 
 export const sellCommand = defineCommand({
 	name: 'sell',
@@ -90,138 +42,22 @@ export const sellCommand = defineCommand({
 		});
 		if (bankToSell.length === 0) return 'No items provided.';
 
-		if (bankToSell.has('mole claw') || bankToSell.has('mole skin')) {
-			const moleBank = new Bank();
-			if (bankToSell.has('Mole claw')) {
-				moleBank.add('Mole claw', bankToSell.amount('Mole claw'));
-			}
-			if (bankToSell.has('Mole skin')) {
-				moleBank.add('Mole skin', bankToSell.amount('Mole skin'));
-			}
-			const loot = new Bank();
-			for (let i = 0; i < moleBank.amount('Mole claw') + moleBank.amount('Mole skin'); i++) {
-				loot.add(NestBoxesTable.roll());
+		const specialExchange = getSpecialSellExchange(bankToSell);
+		if (specialExchange) {
+			if (specialExchange.confirmationMessage) {
+				await interaction.confirmation(specialExchange.confirmationMessage(user));
 			}
 			await user.transactItems({
-				collectionLog: true,
-				itemsToAdd: loot,
-				itemsToRemove: moleBank
+				collectionLog: specialExchange.collectionLog,
+				itemsToAdd: specialExchange.itemsToAdd,
+				itemsToRemove: specialExchange.itemsToRemove
 			});
-			return `You exchanged ${moleBank} and received: ${loot}.`;
-		}
-
-		if (
-			bankToSell.has('Abyssal blue dye') ||
-			bankToSell.has('Abyssal green dye') ||
-			bankToSell.has('Abyssal red dye') ||
-			bankToSell.has('Abyssal lantern')
-		) {
-			const abbyBank = new Bank();
-			const loot = new Bank();
-			if (bankToSell.has('Abyssal lantern')) {
-				abbyBank.add('Abyssal lantern', bankToSell.amount('Abyssal lantern'));
-				loot.add('Abyssal pearls', bankToSell.amount('Abyssal lantern') * 100);
+			if (specialExchange.extraCollectionLogItems) {
+				await user.addItemsToCollectionLog({
+					itemsToAdd: specialExchange.extraCollectionLogItems
+				});
 			}
-			if (bankToSell.has('Abyssal red dye')) {
-				abbyBank.add('Abyssal red dye', bankToSell.amount('Abyssal red dye'));
-				loot.add('Abyssal pearls', bankToSell.amount('Abyssal red dye') * 50);
-			}
-			if (bankToSell.has('Abyssal blue dye')) {
-				abbyBank.add('Abyssal blue dye', bankToSell.amount('Abyssal blue dye'));
-				loot.add('Abyssal pearls', bankToSell.amount('Abyssal blue dye') * 50);
-			}
-			if (bankToSell.has('Abyssal green dye')) {
-				abbyBank.add('Abyssal green dye', bankToSell.amount('Abyssal green dye'));
-				loot.add('Abyssal pearls', bankToSell.amount('Abyssal green dye') * 50);
-			}
-
-			await interaction.confirmation(`${user}, please confirm you want to sell ${abbyBank} for **${loot}**.`);
-
-			await user.transactItems({
-				collectionLog: false,
-				itemsToAdd: loot,
-				itemsToRemove: abbyBank
-			});
-			return `You exchanged ${abbyBank} and received: ${loot}.`;
-		}
-
-		if (bankToSell.has('Spirit seed')) {
-			const quantity = bankToSell.amount('Spirit seed');
-			const seedsBank = new Bank().add('Spirit seed', quantity);
-
-			await interaction.confirmation(
-				`${user}, please confirm you want to trade ${seedsBank} for Tier 5 seed pack loot.`
-			);
-
-			const loot = new Bank();
-			for (let i = 0; i < quantity; i++) {
-				loot.add(Farming.openSeedPack(5));
-			}
-
-			await user.transactItems({
-				collectionLog: true,
-				itemsToAdd: loot,
-				itemsToRemove: seedsBank
-			});
-
-			await user.addItemsToCollectionLog({
-				itemsToAdd: new Bank().add('Seed pack', quantity)
-			});
-
-			return `You exchanged ${seedsBank} and received: ${loot}.`;
-		}
-
-		if (
-			bankToSell.has('Golden pheasant egg') ||
-			bankToSell.has('Fox whistle') ||
-			bankToSell.has('Petal garland') ||
-			bankToSell.has('Pheasant tail feathers') ||
-			bankToSell.has('Sturdy beehive parts')
-		) {
-			const forestryBank = new Bank();
-			const loot = new Bank();
-			if (bankToSell.has('Golden pheasant egg')) {
-				forestryBank.add('Golden pheasant egg', bankToSell.amount('Golden pheasant egg'));
-				loot.add('Anima-infused bark', bankToSell.amount('Golden pheasant egg') * 250);
-			}
-			if (bankToSell.has('Fox whistle')) {
-				forestryBank.add('Fox whistle', bankToSell.amount('Fox whistle'));
-				loot.add('Anima-infused bark', bankToSell.amount('Fox whistle') * 250);
-			}
-			if (bankToSell.has('Petal garland')) {
-				forestryBank.add('Petal garland', bankToSell.amount('Petal garland'));
-				loot.add('Anima-infused bark', bankToSell.amount('Petal garland') * 150);
-			}
-			if (bankToSell.has('Pheasant tail feathers')) {
-				forestryBank.add('Pheasant tail feathers', bankToSell.amount('Pheasant tail feathers'));
-				loot.add('Anima-infused bark', bankToSell.amount('Pheasant tail feathers') * 5);
-			}
-			if (bankToSell.has('Sturdy beehive parts')) {
-				forestryBank.add('Sturdy beehive parts', bankToSell.amount('Sturdy beehive parts'));
-				loot.add('Anima-infused bark', bankToSell.amount('Sturdy beehive parts') * 25);
-			}
-
-			await interaction.confirmation(`${user}, please confirm you want to sell ${forestryBank} for **${loot}**.`);
-
-			await user.transactItems({
-				collectionLog: false,
-				itemsToAdd: loot,
-				itemsToRemove: forestryBank
-			});
-			return `You exchanged ${forestryBank} and received: ${loot}.`;
-		}
-
-		if (bankToSell.has('Golden tench')) {
-			const loot = new Bank();
-			const tenchBank = new Bank();
-			tenchBank.add('Golden tench', bankToSell.amount('Golden tench'));
-
-			loot.add('Molch pearl', tenchBank.amount('Golden tench') * 100);
-
-			await interaction.confirmation(`${user}, please confirm you want to sell ${tenchBank} for **${loot}**.`);
-
-			await user.transactItems({ itemsToRemove: tenchBank, itemsToAdd: loot });
-			return `You exchanged ${tenchBank} and received: ${loot}.`;
+			return specialExchange.successMessage;
 		}
 
 		if (bankToSell.has('Ecumenical key')) {

--- a/src/mahoji/lib/abstracted_commands/openCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/openCommand.ts
@@ -121,11 +121,13 @@ async function finalizeOpening({
 	const newOpenableScores = await addToOpenablesScores(user, kcBank);
 	await user.transactItems({ itemsToRemove: cost });
 
-	const { previousCL } = await user.transactItems({
+	const { itemsAdded, previousCL } = await user.transactItems({
 		itemsToAdd: loot,
 		collectionLog: true,
 		filterLoot: false
 	});
+	const generatedAutoSellDropMessages = user.consumeAutoSellDropMessages();
+	const autoSellDropMessages = user.bitfield.includes(BitField.ShowDetailedInfo) ? generatedAutoSellDropMessages : [];
 
 	if (loot.has('Coins')) {
 		await ClientSettings.updateClientGPTrackSetting('gp_open', loot.amount('Coins'));
@@ -140,11 +142,16 @@ async function finalizeOpening({
 
 	const response = new MessageBuilder()
 		.setContent(
-			`You have now opened a total of ${openedStr}
-${messages.join(', ')}`.trim()
+			[
+				`You have now opened a total of ${openedStr}
+${messages.join(', ')}`.trim(),
+				...autoSellDropMessages
+			]
+				.filter(Boolean)
+				.join('\n')
 		)
 		.addBankImage({
-			bank: loot,
+			bank: itemsAdded,
 			title:
 				openables.length === 1
 					? `Loot from ${cost.amount(openables[0].openedItem.id)}x ${openables[0].name}`

--- a/tests/integration/commands/open.test.ts
+++ b/tests/integration/commands/open.test.ts
@@ -1,6 +1,7 @@
 import { Bank } from 'oldschooljs';
 import { describe, expect, test } from 'vitest';
 
+import { BitField } from '../../../src/lib/constants.js';
 import { openCommand } from '../../../src/mahoji/commands/open.js';
 import { createTestUser, mockClient, mockMathRandom } from '../util.js';
 
@@ -115,5 +116,38 @@ describe('Open Command', async () => {
 			name: 'all'
 		});
 		expect(res).toEqual('You have no openable items.');
+	});
+
+	test('Auto sell/drop details from opened loot only show with detailed info enabled', async () => {
+		const hiddenUser = await createTestUser();
+		await hiddenUser.givePatronTier(3);
+		await hiddenUser.addItemsToBank({ items: new Bank().add('Amylase pack') });
+		await hiddenUser.update({
+			auto_drop_bank: new Bank().add('Amylase crystal').toJSON()
+		});
+
+		const hiddenResult = await hiddenUser.runCommand(openCommand, { name: 'amylase pack' });
+		expect(hiddenResult).toMatchObject({
+			content: expect.not.stringContaining('automatically dropped')
+		});
+		await hiddenUser.bankMatch(new Bank());
+		expect(hiddenUser.consumeAutoSellDropMessages()).toHaveLength(0);
+
+		const detailedUser = await createTestUser();
+		await detailedUser.givePatronTier(3);
+		await detailedUser.addItemsToBank({ items: new Bank().add('Amylase pack') });
+		await detailedUser.update({
+			auto_drop_bank: new Bank().add('Amylase crystal').toJSON(),
+			bitfield: {
+				push: BitField.ShowDetailedInfo
+			}
+		});
+
+		const detailedResult = await detailedUser.runCommand(openCommand, { name: 'amylase pack' });
+		expect(detailedResult).toMatchObject({
+			content: expect.stringContaining('You received 100x Amylase crystal. It was automatically dropped.')
+		});
+		await detailedUser.bankMatch(new Bank());
+		expect(detailedUser.consumeAutoSellDropMessages()).toHaveLength(0);
 	});
 });

--- a/tests/integration/user/cl.test.ts
+++ b/tests/integration/user/cl.test.ts
@@ -1,6 +1,7 @@
-import { Bank, EItem } from 'oldschooljs';
+import { Bank, EItem, Items } from 'oldschooljs';
 import { describe, expect, it } from 'vitest';
 
+import { sellPriceOfItem } from '@/lib/util/sellPrices.js';
 import { createTestUser } from '../util.js';
 
 describe('updateCL()', () => {
@@ -135,5 +136,95 @@ describe('updateCL()', () => {
 		expect(cl.length).toBe(3);
 
 		expect(cl.equals(user.cl)).toBe(true);
+	});
+
+	it('auto-sells configured items after adding them to CL for T3+ users', async () => {
+		const user = await createTestUser();
+		await user.givePatronTier(3);
+		await user.update({
+			auto_sell_bank: new Bank().add(EItem.ABYSSAL_WHIP).toJSON()
+		});
+
+		const { itemsAdded } = await user.transactItems({
+			itemsToAdd: new Bank().add(EItem.ABYSSAL_WHIP),
+			collectionLog: true
+		});
+
+		const expectedGP = Math.floor(sellPriceOfItem(Items.getOrThrow(EItem.ABYSSAL_WHIP), 25).price);
+		expect(user.cl.amount(EItem.ABYSSAL_WHIP)).toBe(1);
+		expect(user.bank.has(EItem.ABYSSAL_WHIP)).toBe(false);
+		expect(user.GP).toBe(expectedGP);
+		expect(itemsAdded.equals(new Bank().add(EItem.COINS, expectedGP))).toBe(true);
+	});
+
+	it('auto-exchanges configured mole parts through the special sell path', async () => {
+		const user = await createTestUser();
+		await user.givePatronTier(3);
+		await user.update({
+			auto_sell_bank: new Bank().add(EItem.MOLE_CLAW).toJSON()
+		});
+
+		const { itemsAdded } = await user.transactItems({
+			itemsToAdd: new Bank().add(EItem.MOLE_CLAW),
+			collectionLog: true
+		});
+
+		expect(user.cl.amount(EItem.MOLE_CLAW)).toBe(1);
+		expect(user.bank.has(EItem.MOLE_CLAW)).toBe(false);
+		expect(itemsAdded.length).toBeGreaterThan(0);
+		expect(user.bank.has(itemsAdded)).toBe(true);
+	});
+
+	it('auto-exchanges configured spirit seeds through the special sell path', async () => {
+		const user = await createTestUser();
+		await user.givePatronTier(3);
+		await user.update({
+			auto_sell_bank: new Bank().add(EItem.SPIRIT_SEED).toJSON()
+		});
+
+		const { itemsAdded } = await user.transactItems({
+			itemsToAdd: new Bank().add(EItem.SPIRIT_SEED),
+			collectionLog: true
+		});
+
+		expect(user.cl.amount(EItem.SPIRIT_SEED)).toBe(1);
+		expect(user.cl.amount(EItem.SEED_PACK)).toBe(1);
+		expect(user.bank.has(EItem.SPIRIT_SEED)).toBe(false);
+		expect(itemsAdded.length).toBeGreaterThan(0);
+		expect(user.bank.has(itemsAdded)).toBe(true);
+	});
+
+	it('auto-drops configured items after adding them to CL for T3+ users', async () => {
+		const user = await createTestUser();
+		await user.givePatronTier(3);
+		await user.update({
+			auto_drop_bank: new Bank().add(EItem.ABYSSAL_WHIP).toJSON()
+		});
+
+		const { itemsAdded } = await user.transactItems({
+			itemsToAdd: new Bank().add(EItem.ABYSSAL_WHIP),
+			collectionLog: true
+		});
+
+		expect(user.cl.amount(EItem.ABYSSAL_WHIP)).toBe(1);
+		expect(user.bank.has(EItem.ABYSSAL_WHIP)).toBe(false);
+		expect(itemsAdded.length).toBe(0);
+	});
+
+	it('does not auto-sell/drop for users below T3', async () => {
+		const user = await createTestUser();
+		await user.givePatronTier(2);
+		await user.update({
+			auto_sell_bank: new Bank().add(EItem.ABYSSAL_WHIP).toJSON(),
+			auto_drop_bank: new Bank().add(EItem.TROUT).toJSON()
+		});
+
+		await user.transactItems({
+			itemsToAdd: new Bank().add(EItem.ABYSSAL_WHIP).add(EItem.TROUT),
+			collectionLog: true
+		});
+
+		expect(user.cl.has(new Bank().add(EItem.ABYSSAL_WHIP).add(EItem.TROUT))).toBe(true);
+		expect(user.bank.has(new Bank().add(EItem.ABYSSAL_WHIP).add(EItem.TROUT))).toBe(true);
 	});
 });

--- a/tests/integration/user/cl.test.ts
+++ b/tests/integration/user/cl.test.ts
@@ -154,7 +154,11 @@ describe('updateCL()', () => {
 		expect(user.cl.amount(EItem.ABYSSAL_WHIP)).toBe(1);
 		expect(user.bank.has(EItem.ABYSSAL_WHIP)).toBe(false);
 		expect(user.GP).toBe(expectedGP);
-		expect(itemsAdded.equals(new Bank().add(EItem.COINS, expectedGP))).toBe(true);
+		expect(itemsAdded.length).toBe(0);
+		const messages = user.consumeAutoSellDropMessages();
+		expect(messages).toHaveLength(1);
+		expect(messages[0]).toContain('Abyssal whip');
+		expect(messages[0]).toContain(`${expectedGP.toLocaleString()} GP`);
 	});
 
 	it('auto-exchanges configured mole parts through the special sell path', async () => {
@@ -171,8 +175,9 @@ describe('updateCL()', () => {
 
 		expect(user.cl.amount(EItem.MOLE_CLAW)).toBe(1);
 		expect(user.bank.has(EItem.MOLE_CLAW)).toBe(false);
-		expect(itemsAdded.length).toBeGreaterThan(0);
-		expect(user.bank.has(itemsAdded)).toBe(true);
+		expect(itemsAdded.length).toBe(0);
+		expect(user.bank.length).toBeGreaterThan(0);
+		expect(user.consumeAutoSellDropMessages()[0]).toContain('automatically sold for');
 	});
 
 	it('auto-exchanges configured spirit seeds through the special sell path', async () => {
@@ -190,8 +195,11 @@ describe('updateCL()', () => {
 		expect(user.cl.amount(EItem.SPIRIT_SEED)).toBeGreaterThanOrEqual(1);
 		expect(user.cl.amount(EItem.SEED_PACK)).toBe(1);
 		expect(user.bank.has(EItem.SPIRIT_SEED)).toBe(false);
-		expect(itemsAdded.length).toBeGreaterThan(0);
-		expect(user.bank.has(itemsAdded)).toBe(true);
+		expect(itemsAdded.length).toBe(0);
+		expect(user.bank.length).toBeGreaterThan(0);
+		const messages = user.consumeAutoSellDropMessages();
+		expect(messages.some(message => message.includes('Spirit seed'))).toBe(true);
+		expect(messages.some(message => message.includes('Tier 5 seed pack loot'))).toBe(true);
 	});
 
 	it('auto-drops configured items after adding them to CL for T3+ users', async () => {
@@ -209,6 +217,7 @@ describe('updateCL()', () => {
 		expect(user.cl.amount(EItem.ABYSSAL_WHIP)).toBe(1);
 		expect(user.bank.has(EItem.ABYSSAL_WHIP)).toBe(false);
 		expect(itemsAdded.length).toBe(0);
+		expect(user.consumeAutoSellDropMessages()[0]).toContain('automatically dropped');
 	});
 
 	it('does not auto-sell/drop for users below T3', async () => {

--- a/tests/integration/user/cl.test.ts
+++ b/tests/integration/user/cl.test.ts
@@ -187,7 +187,7 @@ describe('updateCL()', () => {
 			collectionLog: true
 		});
 
-		expect(user.cl.amount(EItem.SPIRIT_SEED)).toBe(1);
+		expect(user.cl.amount(EItem.SPIRIT_SEED)).toBeGreaterThanOrEqual(1);
 		expect(user.cl.amount(EItem.SEED_PACK)).toBe(1);
 		expect(user.bank.has(EItem.SPIRIT_SEED)).toBe(false);
 		expect(itemsAdded.length).toBeGreaterThan(0);


### PR DESCRIPTION
Implement auto-sell and auto-drop preferences for Tier 3+ patrons that automatically sell or drop items when they're added to the bank. 
Items are added to collection log before auto-sell/drop is applied. 
Auto-sell uses the same behaviour as the /sell command, including special exchanges (mole parts → nest boxes, spirit seeds → seed pack loot). 
Refactored sell logic into reusable utilities (sellPrices.ts, specialSellExchanges.ts). 
Added /config user auto_sell_drop command to manage preferences and comprehensive tests for the feature.

- [x] I have tested all my changes thoroughly.
