### PR TITLE
Allow Special Tradeables to be listed on GE

### DIFF
--- a/src/discord/presetCommandOptions.ts
+++ b/src/discord/presetCommandOptions.ts
@@ -10,6 +10,7 @@ import { type GlobalPreset, globalPresets } from '@/lib/gear/gearPresets.js';
 import killableMonsters from '@/lib/minions/data/killableMonsters/index.js';
 import { SkillsArray } from '@/lib/skilling/types.js';
 import { Gear } from '@/lib/structures/Gear.js';
+import itemIsTradeable from '@/lib/util/itemIsTradeable.js';
 
 export const filterOption = {
 	type: 'String',
@@ -28,7 +29,7 @@ export const filterOption = {
 
 const itemArr = Items.array().map(i => ({ ...i, key: `${i.name.toLowerCase()}_${i.id}` }));
 
-export const tradeableItemArr = itemArr.filter(i => i.tradeable_on_ge);
+export const tradeableItemArr = itemArr.filter(i => itemIsTradeable(i.id));
 
 export const allEquippableItems = Items.array().filter(i => i.equipable && i.equipment?.slot);
 

--- a/src/lib/grandExchange.ts
+++ b/src/lib/grandExchange.ts
@@ -295,7 +295,7 @@ class GrandExchangeSingleton {
 		}
 		if (user.isIronman) return { error: "You're an ironman." };
 		const item = Items.getItem(itemName);
-		if (!item || !itemIsTradeable(item.id) || !item.tradeable_on_ge || ['Coins'].includes(item.name)) {
+		if (!item || !itemIsTradeable(item.id) || ['Coins'].includes(item.name)) {
 			return {
 				error: "Hmm... That item is not tradeable on the Grand Exchange. It's possible it doesn't even exist, but if you think I'm writing a different message for every possibility think again."
 			};

--- a/src/mahoji/commands/ge.ts
+++ b/src/mahoji/commands/ge.ts
@@ -129,7 +129,7 @@ export const geCommand = defineCommand({
 					autocomplete: async ({ value, user }: StringAutoComplete) => {
 						return user.bank
 							.items()
-							.filter(i => i[0].tradeable_on_ge)
+							.filter(i => itemIsTradeable(i[0].id))
 							.filter(i => (!value ? true : i[0].name.toLowerCase().includes(value.toLowerCase())))
 							.map(i => ({ name: `${i[0].name} (${i[1]}x Owned)`, value: i[0].name }));
 					}
@@ -213,7 +213,7 @@ export const geCommand = defineCommand({
 			description: 'Lookup information about an item on the g.e',
 			options: [
 				{
-					...itemOption(item => Boolean(item.tradeable_on_ge)),
+					...itemOption(item => itemIsTradeable(item.id)),
 					name: 'item',
 					description: 'The item to view.'
 				}

--- a/src/mahoji/commands/price.ts
+++ b/src/mahoji/commands/price.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder } from '@oldschoolgg/discord';
 import { Items, toKMB } from 'oldschooljs';
 
 import { itemOption } from '@/discord/index.js';
+import itemIsTradeable from '@/lib/util/itemIsTradeable.js';
 import { sellPriceOfItem } from '@/mahoji/commands/sell.js';
 
 export const priceCommand = defineCommand({
@@ -9,7 +10,7 @@ export const priceCommand = defineCommand({
 	description: 'Looks up the price of an item.',
 	options: [
 		{
-			...itemOption(item => Boolean(item.tradeable_on_ge)),
+			...itemOption(item => itemIsTradeable(item.id)),
 			name: 'item',
 			required: true
 		}

--- a/tests/integration/grandExchange.test.ts
+++ b/tests/integration/grandExchange.test.ts
@@ -227,4 +227,31 @@ Based on G.E data, we should have received ${data.totalTax} tax`;
 		expect(data.taxBank, 'LZ9').toEqual(totalTax);
 		expect(data.totalTax, 'M39').toEqual(totalTax);
 	});
+
+	test('allows special tradeables to be listed', async () => {
+		await GrandExchange.totalReset();
+		await GrandExchange.init();
+
+		const user = await createTestUser(new Bank().add('Coins', 1_000_000).add('Birthday present', 1));
+
+		const response = await user.runCommand(geCommand, {
+			sell: {
+				item: 'Birthday present',
+				quantity: 1,
+				price: 100_000
+			}
+		});
+
+		expect((response as { content: string }).content).toContain('Successfully created a listing to sell');
+
+		const listings = await prisma.gEListing.findMany({
+			where: {
+				user_id: user.id
+			}
+		});
+		expect(listings).toHaveLength(1);
+		expect(listings[0].item_id).toEqual(resolveItems(['Birthday present'])[0]);
+
+		await cancelUsersListings(user);
+	});
 });

--- a/tests/unit/sanity.test.ts
+++ b/tests/unit/sanity.test.ts
@@ -4,6 +4,7 @@ import { Bank, EMonster, Items, itemID } from 'oldschooljs';
 import { clamp } from 'remeda';
 import { describe, expect, test } from 'vitest';
 
+import { tradeableItemArr } from '@/discord/presetCommandOptions.js';
 import killableMonsters from '@/lib/minions/data/killableMonsters/index.js';
 import Buyables from '../../src/lib/data/buyables/buyables.js';
 import { marketPriceOfBank } from '../../src/lib/marketPrices.js';
@@ -21,8 +22,17 @@ describe('Sanity', () => {
 		expect(itemID('Frozen key')).toEqual(26_356);
 		expect(itemID('Clue box')).toEqual(12_789);
 		expect(itemID('Beige pumpkin (happy)')).toEqual(30246);
-		expect(itemIsTradeable(itemID('Black santa hat'))).toEqual(true);
-		expect(itemIsTradeable(itemID('Inverted santa hat'))).toEqual(true);
+		for (const itemName of [
+			'Slice of birthday cake',
+			'War ship',
+			'Birthday present',
+			'Black santa hat',
+			'Inverted santa hat'
+		]) {
+			const id = itemID(itemName);
+			expect(itemIsTradeable(id)).toEqual(true);
+			expect(tradeableItemArr.some(i => i.id === id)).toEqual(true);
+		}
 		expect(itemIsTradeable(itemID('Santa hat'))).toEqual(true);
 		expect(itemIsTradeable(itemID('Trailblazer tool ornament kit'))).toEqual(false);
 		expect(itemIsTradeable(itemID('Twisted horns'))).toEqual(false);


### PR DESCRIPTION
Replace direct `tradeable_on_ge` property checks with the `itemIsTradeable()` utility function throughout the GE commands and preset options.

This allows special items like Birthday present and Black santa hat to be traded on the Grand Exchange.

Added integration and unit tests to verify special tradeable items work correctly and appear in tradeable item lists.

- [x] I have tested all my changes thoroughly.
