### PR TITLE
Fix workspace concurrency in dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"watch": "nodemon --delay 1ms -e ts -w src --exec \"pnpm exec-and-start\"",
 		"exec-and-start": "concurrently \"pnpm exec-sql\" \"pnpm build-and-run\"",
 		"build-and-run": "tsx esbuild.mts && node --trace-warnings --enable-source-maps dist",
-		"dev": "pnpm -r --filter \"oldschooljs\" --filter \"toolkit\" build && tsx --tsconfig=packages/cli/tsconfig.json --env-file=.env packages/cli/src/cli.tsx",
+		"dev": "pnpm -r --workspace-concurrency=1 --filter \"oldschooljs\" --filter \"toolkit\" build && tsx --tsconfig=packages/cli/tsconfig.json --env-file=.env packages/cli/src/cli.tsx",
 		"watch:tsc": "tsc -w -p src",
 		"start": "pnpm watch",
 		"lint": "tsx --tsconfig scripts/tsconfig.json scripts/lint.ts",


### PR DESCRIPTION
### Description:

Currently dev script hangs because too much is going on at once

### Changes:

Add concurrency limit to `pnpm dev`

### Other checks:

- [x] I have tested all my changes thoroughly.
