### PR TITLE
Correct clue tables for dt2 bosses

### DIFF
--- a/packages/oldschooljs/src/simulation/monsters/bosses/DukeSucellus.ts
+++ b/packages/oldschooljs/src/simulation/monsters/bosses/DukeSucellus.ts
@@ -15,10 +15,10 @@ const TradeableUniqueTable = new LootTable({ limit: 8 })
 	.add('Magus vestige', 1, 1);
 
 const ClueTable: LootTable = new LootTable()
-	.add('Clue scroll (easy)')
-	.add('Clue scroll (medium)')
-	.add('Clue scroll (hard)')
-	.add('Clue scroll (elite)');
+	.tertiary(160, 'Clue scroll (easy)')
+	.tertiary(160, 'Clue scroll (medium)')
+	.tertiary(160, 'Clue scroll (hard)')
+	.tertiary(160, 'Clue scroll (elite)');
 
 const SupplyTable: LootTable = new LootTable()
 	.every('Pineapple pizza', [3, 4])
@@ -83,9 +83,8 @@ class DukeSucellusSingleton extends Monster {
 				loot.add(ResourceTable.roll());
 			}
 
-			if (roll(40)) {
-				loot.add(ClueTable.roll());
-			}
+			const lootTableOptions = { ...options.lootTableOptions, targetBank: loot };
+			ClueTable.roll(1, lootTableOptions);
 			if (roll(2500)) {
 				loot.add('Baron');
 			}

--- a/packages/oldschooljs/src/simulation/monsters/bosses/TheLeviathan.ts
+++ b/packages/oldschooljs/src/simulation/monsters/bosses/TheLeviathan.ts
@@ -15,10 +15,10 @@ const TradeableUniqueTable = new LootTable({ limit: 8 })
 	.add("Leviathan's lure", 1, 1);
 
 const ClueTable: LootTable = new LootTable()
-	.add('Clue scroll (easy)')
-	.add('Clue scroll (medium)')
-	.add('Clue scroll (hard)')
-	.add('Clue scroll (elite)');
+	.tertiary(160, 'Clue scroll (easy)')
+	.tertiary(160, 'Clue scroll (medium)')
+	.tertiary(160, 'Clue scroll (hard)')
+	.tertiary(160, 'Clue scroll (elite)');
 
 const SupplyTable: LootTable = new LootTable()
 	.every('Prayer potion(3)', 1)
@@ -81,9 +81,8 @@ class TheLeviathanSingleton extends Monster {
 				loot.add(ResourceTable.roll());
 			}
 
-			if (roll(40)) {
-				loot.add(ClueTable.roll());
-			}
+			const lootTableOptions = { ...options.lootTableOptions, targetBank: loot };
+			ClueTable.roll(1, lootTableOptions);
 			if (roll(2500)) {
 				loot.add("Lil'viathan");
 			}

--- a/packages/oldschooljs/src/simulation/monsters/bosses/TheWhisperer.ts
+++ b/packages/oldschooljs/src/simulation/monsters/bosses/TheWhisperer.ts
@@ -15,10 +15,10 @@ const TradeableUniqueTable = new LootTable({ limit: 8 })
 	.add('Bellator vestige', 1, 1);
 
 const ClueTable: LootTable = new LootTable()
-	.add('Clue scroll (easy)')
-	.add('Clue scroll (medium)')
-	.add('Clue scroll (hard)')
-	.add('Clue scroll (elite)');
+	.tertiary(160, 'Clue scroll (easy)')
+	.tertiary(160, 'Clue scroll (medium)')
+	.tertiary(160, 'Clue scroll (hard)')
+	.tertiary(160, 'Clue scroll (elite)');
 
 const SupplyTable: LootTable = new LootTable()
 	.every('Manta ray', [3, 4])
@@ -82,9 +82,8 @@ class TheWhispererSingleton extends Monster {
 				loot.add(ResourceTable.roll());
 			}
 
-			if (roll(40)) {
-				loot.add(ClueTable.roll());
-			}
+			const lootTableOptions = { ...options.lootTableOptions, targetBank: loot };
+			ClueTable.roll(1, lootTableOptions);
 			if (roll(2000)) {
 				loot.add('Wisp');
 			}

--- a/packages/oldschooljs/src/simulation/monsters/bosses/Vardorvis.ts
+++ b/packages/oldschooljs/src/simulation/monsters/bosses/Vardorvis.ts
@@ -15,10 +15,10 @@ const TradeableUniqueTable = new LootTable({ limit: 8 })
 	.add('Ultor vestige', 1, 1);
 
 const ClueTable: LootTable = new LootTable()
-	.add('Clue scroll (easy)')
-	.add('Clue scroll (medium)')
-	.add('Clue scroll (hard)')
-	.add('Clue scroll (elite)');
+	.tertiary(160, 'Clue scroll (easy)')
+	.tertiary(160, 'Clue scroll (medium)')
+	.tertiary(160, 'Clue scroll (hard)')
+	.tertiary(160, 'Clue scroll (elite)');
 
 const SupplyTable: LootTable = new LootTable()
 	.every('Tuna potato', [3, 4])
@@ -81,9 +81,8 @@ class VardorvisSingleton extends Monster {
 				loot.add(ResourceTable.roll());
 			}
 
-			if (roll(40)) {
-				loot.add(ClueTable.roll());
-			}
+			const lootTableOptions = { ...options.lootTableOptions, targetBank: loot };
+			ClueTable.roll(1, lootTableOptions);
 			if (roll(3000)) {
 				loot.add('Butch');
 			}


### PR DESCRIPTION
### Description:

Move clues to tertiary to match osrs and allow CA boosts 

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [x] I have tested all my changes thoroughly.
