### PR TITLE
Trim whitespace from messages in handleTripFinish and monsterActivity

### DIFF
--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -331,8 +331,9 @@ export async function handleTripFinish(
 	}
 
 	if (_messages) messages.push(..._messages);
-	if (messages.length > 0) {
-		message.addContent(`\n**Messages:** ${messages.join(', ')}`);
+	const displayedMessages = messages.map(msg => msg.trim()).filter(msg => msg.length > 0);
+	if (displayedMessages.length > 0) {
+		message.addContent(`\n**Messages:** ${displayedMessages.join(', ')}`);
 	}
 
 	message.addContent(displayCluesAndPets(user, loot));

--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -544,7 +544,7 @@ export const monsterTask: MinionTask = {
 			return;
 		}
 		const { itemTransactionResult, rawResults } = resultOrError;
-		messages.push(...rawResults.filter(r => typeof r === 'string'));
+		messages.push(...rawResults.filter(r => typeof r === 'string' && r.trim().length > 0));
 		const str = `${user}, ${user.minionName} finished killing ${quantity} ${monster.name} (${calcPerHour(data.q, data.duration).toFixed(1)}/hr), you now have ${newKC} KC.`;
 
 		let image: Awaited<ReturnType<typeof makeBankImage>> | undefined;


### PR DESCRIPTION
### Description:

Non empty messages with a bunch of whitespace are leading to `Messages:` line with no actual messages

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [x] I have tested all my changes thoroughly.
