### PR TITLE
Filter out empty XP messages in raids

### DIFF
--- a/src/tasks/minions/minigames/raidsActivity.ts
+++ b/src/tasks/minions/minigames/raidsActivity.ts
@@ -207,7 +207,7 @@ export const raidsTask: MinionTask = {
 			if (!user) continue;
 
 			const [xpResult, { itemsAdded }] = await Promise.all([
-				handleCoxXP(user, quantity, challengeMode),
+				(await handleCoxXP(user, quantity, challengeMode)).filter(msg => msg.trim().length > 0),
 				user.transactItems({
 					itemsToAdd: loot,
 					collectionLog: true

--- a/src/tasks/minions/minigames/toaActivity.ts
+++ b/src/tasks/minions/minigames/toaActivity.ts
@@ -205,7 +205,7 @@ export const toaTask: MinionTask = {
 				teamSize: detailedUsers.length,
 				points: raidResults.get(user.id)!.points
 			});
-			const xpStrings = await Promise.all(xpPromises);
+			const xpStrings = (await Promise.all(xpPromises)).filter(msg => msg.trim().length > 0);
 			resultMessage += ` ${xpStrings.join(', ')}`;
 		}
 

--- a/src/tasks/minions/minigames/tobActivity.ts
+++ b/src/tasks/minions/minigames/tobActivity.ts
@@ -169,8 +169,10 @@ export const tobTask: MinionTask = {
 				allUsers.map(async u => {
 					const theirXP = totalXPCounts[u.id];
 					if (theirXP.length === 0) return null;
-					await u.addXPCounter({ xpCounter: theirXP, source: 'TheatreOfBlood', minimal: true });
-					return `${u.mention} received ${theirXP} XP`;
+					const displayedXP = (
+						await u.addXPCounter({ xpCounter: theirXP, source: 'TheatreOfBlood', minimal: true })
+					).trim();
+					return `${u.mention} received ${displayedXP.length > 0 ? displayedXP : 'no'} XP`;
 				})
 			)
 		).filter(i => i !== null);


### PR DESCRIPTION
### Description:

Removes XP messages from raids when XP is already 200m

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [x] I have tested all my changes thoroughly.
