### PR TITLE
Report crop deaths in auto-farm return trip

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -361,6 +361,9 @@ export interface AutoFarmSummaryStep {
 	patchType: string;
 	plantsName: string;
 	quantity: number;
+	harvestedName?: string;
+	harvestedQuantity?: number;
+	alive?: number;
 	xp: number;
 	bonusXp: number;
 	weeds: number;

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -79,6 +79,9 @@ function updateAutoFarmSummary({
 				patchType: getPatchLabel(data),
 				plantsName,
 				quantity: stepQuantity,
+				harvestedName: stepSummary?.harvested?.itemName,
+				harvestedQuantity: stepSummary?.harvested?.quantity,
+				alive: stepSummary?.harvested?.alive,
 				xp: xpTotal,
 				bonusXp: bonusXP,
 				weeds,
@@ -122,6 +125,19 @@ function buildCombinedAutoFarmMessage(user: MUser, summary: AutoFarmSummary): st
 	if (summary.contractsCompleted > 0) {
 		const suffix = summary.contractsCompleted === 1 ? '' : 's';
 		lines.push(`Completed ${summary.contractsCompleted.toLocaleString()} farming contract${suffix}.`);
+	}
+
+	const survivalLines = summary.steps.flatMap(step => {
+		if (!step.harvestedName || step.harvestedQuantity === undefined || step.alive === undefined) {
+			return [];
+		}
+		if (step.alive >= step.harvestedQuantity) {
+			return [];
+		}
+		return `${step.harvestedName}: ${(step.harvestedQuantity - step.alive).toLocaleString()} died`;
+	});
+	if (survivalLines.length > 0) {
+		lines.push(`**Crop deaths:** ${survivalLines.join('; ')}.`);
 	}
 
 	const totalLoot = new Bank(summary.totalLoot ?? {});

--- a/tests/integration/autoFarmTask.test.ts
+++ b/tests/integration/autoFarmTask.test.ts
@@ -24,7 +24,13 @@ describe('farming task auto farm sequencing', () => {
 		vi.restoreAllMocks();
 	});
 
-	async function runAutoFarmScenario({ combinedMode = false }: { combinedMode?: boolean } = {}) {
+	async function runAutoFarmScenario({
+		combinedMode = false,
+		watermelonAlive = 8
+	}: {
+		combinedMode?: boolean;
+		watermelonAlive?: number;
+	} = {}) {
 		const user = await createTestUser();
 
 		const basePatch: IPatchData = {
@@ -84,7 +90,7 @@ describe('farming task auto farm sequencing', () => {
 				payNote: 'Paid 3x Tomatoes to keep the farmers happy.'
 			},
 			{
-				harvested: { itemName: 'Watermelon', quantity: 8, alive: 8, died: 0 },
+				harvested: { itemName: 'Watermelon', quantity: 8, alive: watermelonAlive, died: 8 - watermelonAlive },
 				duration: Time.Minute,
 				xp: {
 					totalFarming: 200,
@@ -221,6 +227,7 @@ describe('farming task auto farm sequencing', () => {
 		expect(messageContent).not.toContain('Seed pack');
 		expect(messageContent).toContain('Woodcutting 100 XP (3k/Hr)');
 		expect(messageContent).toContain('Farming 300 XP (9k/Hr)');
+		expect(messageContent).not.toContain('**Crop deaths:**');
 		expect(messageContent).not.toContain('**Total loot:**');
 		expect(messageContent).not.toContain('**Patches farmed:**');
 		expect(messageContent).toContain('**Boosts:** Graceful.');
@@ -229,5 +236,22 @@ describe('farming task auto farm sequencing', () => {
 		const finalLoot = finalCall?.loot;
 		expect(finalLoot?.has('Seed pack')).toBe(true);
 		expect(finalLoot?.has('Watermelon')).toBe(true);
+	});
+
+	it('only lists crop deaths when crops died', async () => {
+		const { handleTripFinishSpy } = await runAutoFarmScenario({
+			combinedMode: true,
+			watermelonAlive: 6
+		});
+
+		const finalCall = handleTripFinishSpy.mock.calls[0]?.[0] as
+			| { message?: string | { content?: string; files?: SendableFile[] } }
+			| undefined;
+		const messageContent =
+			typeof finalCall?.message === 'string' ? finalCall.message : (finalCall?.message?.content ?? '');
+
+		expect(messageContent).toContain('**Crop deaths:** Watermelon: 2 died.');
+		expect(messageContent).not.toContain('Guam');
+		expect(messageContent).not.toContain('6/8 survived');
 	});
 });


### PR DESCRIPTION
Add harvestedName, harvestedQuantity and alive to AutoFarmSummaryStep and populate them during auto-farm summary construction. 

Update combined auto-farm message to list crop deaths per-plant only when deaths occurred. 

Adjust tests to vary watermelon alive count and add an integration test verifying crop deaths are shown only when some plants die.

- [x] I have tested all my changes thoroughly.
