### PR TITLE
Add Bert's Sand daily activity

### DIFF
--- a/packages/robochimp/prisma/osb_schema.prisma
+++ b/packages/robochimp/prisma/osb_schema.prisma
@@ -753,6 +753,7 @@ model UserStats {
 
   last_daily_timestamp           BigInt @default(0)
   last_tears_of_guthix_timestamp BigInt @default(0)
+  last_bert_sand_timestamp       BigInt @default(0)
 
   herbs_cleaned_while_farming_bank Json @default("{}") @db.Json
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -763,6 +763,7 @@ model UserStats {
 
   last_daily_timestamp           BigInt @default(0)
   last_tears_of_guthix_timestamp BigInt @default(0)
+  last_bert_sand_timestamp       BigInt @default(0)
 
   herbs_cleaned_while_farming_bank Json @default("{}") @db.Json
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -6,6 +6,7 @@ import { cryptoRng } from 'node-rng/crypto';
 import { type ItemBank, Items, toKMB } from 'oldschooljs';
 
 import type { command_name_enum } from '@/prisma/main/enums.js';
+import type { UserStats } from '@/prisma/main.js';
 import { CHAT_PET_COOLDOWN_CACHE, lastRoboChimpSyncCache, RARE_ROLES_CACHE } from '@/lib/cache.js';
 import { CONSTANTS, globalConfig } from '@/lib/constants.js';
 import pets from '@/lib/data/pets.js';
@@ -113,7 +114,10 @@ const mentionRegex = new RegExp(`^(\\s*<@&?[0-9]+>)*\\s*<@${globalConfig.clientI
 
 const cooldownTimers: {
 	name: string;
-	timeStamp: (user: MUser, stats: { last_daily_timestamp: bigint; last_tears_of_guthix_timestamp: bigint }) => number;
+	timeStamp: (
+		user: MUser,
+		stats: Pick<UserStats, 'last_daily_timestamp' | 'last_tears_of_guthix_timestamp' | 'last_bert_sand_timestamp'>
+	) => number;
 	cd: number | ((user: MUser) => number);
 	command: [string] | [string, string] | [string, string, string];
 	utcReset: boolean;
@@ -131,6 +135,13 @@ const cooldownTimers: {
 		cd: CONSTANTS.DAILY_COOLDOWN,
 		command: ['minion', 'daily'],
 		utcReset: false
+	},
+	{
+		name: "Bert's sand",
+		timeStamp: (_, stats) => Number(stats.last_bert_sand_timestamp ?? 0n),
+		cd: Time.Day,
+		command: ['activities', 'collect', 'item:bert_sand'],
+		utcReset: true
 	}
 ];
 

--- a/src/lib/minions/data/bertSand.ts
+++ b/src/lib/minions/data/bertSand.ts
@@ -1,0 +1,35 @@
+import { getNextUTCReset, Time, toTitleCase } from '@oldschoolgg/toolkit';
+import { Items } from 'oldschooljs';
+
+import type { SkillNameType } from '@/lib/skilling/types.js';
+
+export const BERT_SAND_ID = 'bert_sand' as const;
+export const BERT_SAND_AUTOCOMPLETE_VALUE = 'BERT_SAND_DAILY' as const;
+export const BERT_SAND_BUCKETS = 84;
+export const BERT_SAND_DURATION = Time.Second * 15;
+export const BERT_SAND_SKILL_REQS: readonly [SkillNameType, number][] = [
+	['crafting', 49],
+	['thieving', 17]
+];
+export const BERT_SAND_QP_REQUIRED = 5;
+export const BERT_SAND_ITEM_ID = Items.getOrThrow('Bucket of sand').id;
+
+export const bertResetStart = (now = Date.now()) => getNextUTCReset(now, Time.Day) - Time.Day;
+
+export function hasCollectedThisReset(lastCollected: number, now = Date.now()) {
+	return lastCollected >= bertResetStart(now);
+}
+
+export function isManualEligible(user: MUserClass): string | null {
+	if (user.QP < BERT_SAND_QP_REQUIRED) {
+		return `You need at least ${BERT_SAND_QP_REQUIRED} Quest Points to collect sand for Bert.`;
+	}
+
+	for (const [skill, level] of BERT_SAND_SKILL_REQS) {
+		if (user.skillsAsLevels[skill] < level) {
+			return `You need level ${level} ${toTitleCase(skill)} to collect sand for Bert.`;
+		}
+	}
+
+	return null;
+}

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -11,12 +11,18 @@ import type { SharkLureQuantity } from '@/lib/skilling/skills/fishing/fishingUti
 import type { TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 import type { Peak } from '@/lib/util/peaks.js';
 
+export interface ActivityTaskMetadata {
+	activityID?: string;
+	nonRepeatable?: boolean;
+}
+
 export interface ActivityTaskOptions {
 	userID: string;
 	duration: number;
 	id: number;
 	finishDate: number;
 	channelId: string;
+	metadata?: ActivityTaskMetadata;
 }
 
 export interface ActivityTaskOptionsWithNoChanges extends ActivityTaskOptions {
@@ -570,6 +576,7 @@ export interface CollectingOptions extends ActivityTaskOptions {
 	collectableID: number;
 	quantity: number;
 	noStaminas?: boolean;
+	lootQuantityOverride?: number;
 }
 
 export interface KourendFavourActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/addSubTaskToActivityTask.ts
+++ b/src/lib/util/addSubTaskToActivityTask.ts
@@ -43,17 +43,16 @@ export default async function addSubTaskToActivityTask(taskToAdd: Omit<ActivityT
 
 	const newData: DatabaseStoredActivityData = omit(taskToAdd, ['type', 'userID', 'channelId', 'duration']);
 
-	const data: Prisma.ActivityCreateInput = {
+	const data: Prisma.ActivityUncheckedCreateInput = {
 		user_id: BigInt(taskToAdd.userID),
 		start_date: new Date(),
 		finish_date: finishDate,
 		completed: false,
 		type: taskToAdd.type,
-		data: newData,
+		data: newData as Prisma.InputJsonValue,
 		group_activity: isGroupActivity(taskToAdd),
 		channel_id: BigInt(taskToAdd.channelId),
-		duration,
-		all_user_ids: userIds.map(i => BigInt(i))
+		duration
 	};
 	try {
 		const createdActivity = await prisma.activity.create({

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -45,6 +45,7 @@ const activitiesToTrackAsPVMGPSource: activity_type_enum[] = [
 	'Raids',
 	'ClueCompletion'
 ];
+const BERT_SAND_AUTO_DELIVERY_MESSAGE_PREFIX = 'Bert has delivered';
 
 interface TripFinishEffectOptions {
 	data: ActivityTaskData;
@@ -374,11 +375,17 @@ export async function handleTripFinish(
 
 	if (_messages) messages.push(..._messages);
 	const displayedMessages = messages.map(msg => msg.trim()).filter(msg => msg.length > 0);
-	if (displayedMessages.length > 0) {
-		message.addContent(`\n**Messages:** ${displayedMessages.join(', ')}`);
+	const bertSandMessages = displayedMessages.filter(msg => msg.startsWith(BERT_SAND_AUTO_DELIVERY_MESSAGE_PREFIX));
+	const regularMessages = displayedMessages.filter(msg => !msg.startsWith(BERT_SAND_AUTO_DELIVERY_MESSAGE_PREFIX));
+	if (regularMessages.length > 0) {
+		message.addContent(`\n**Messages:** ${regularMessages.join(', ')}`);
 	}
 
 	message.addContent(displayCluesAndPets(user, loot));
+
+	if (bertSandMessages.length > 0) {
+		message.addContent(`\n\n${bertSandMessages.join('\n')}`);
+	}
 
 	if (components.length > 0) {
 		message.addComponents(components);

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -11,6 +11,7 @@ import { combatAchievementTripEffect } from '@/lib/combat_achievements/combatAch
 import { BitField, CONSTANTS, PerkTier } from '@/lib/constants.js';
 import { handleGrowablePetGrowth } from '@/lib/growablePets.js';
 import { handlePassiveImplings } from '@/lib/implings.js';
+import { BERT_SAND_BUCKETS, hasCollectedThisReset, isManualEligible } from '@/lib/minions/data/bertSand.js';
 import { triggerRandomEvent } from '@/lib/randomEvents.js';
 import { canShowAutoFarmButton } from '@/lib/skilling/skills/farming/utils/farmingHelpers.js';
 import type { ActivityTaskData } from '@/lib/types/minions.js';
@@ -78,6 +79,47 @@ const tripFinishEffects: TripFinishEffect[] = [
 					await ClientSettings.updateClientGPTrackSetting('gp_pvm', GP);
 				}
 			}
+			return {};
+		}
+	},
+	{
+		name: "Bert's Sand Auto Delivery",
+		fn: async ({ user, messages }) => {
+			if (!user.hasDiary('ardougne.elite')) {
+				return {};
+			}
+
+			const requirementError = isManualEligible(user);
+			if (requirementError) {
+				return {};
+			}
+
+			const now = Date.now();
+			const stats = await user.fetchStats();
+			const lastCollectedBigInt = stats.last_bert_sand_timestamp ?? 0n;
+			const lastCollected = Number(lastCollectedBigInt);
+
+			if (hasCollectedThisReset(lastCollected, now)) {
+				return {};
+			}
+
+			const updated = await prisma.userStats.updateMany({
+				where: {
+					user_id: BigInt(user.id),
+					last_bert_sand_timestamp: lastCollectedBigInt
+				},
+				data: {
+					last_bert_sand_timestamp: BigInt(now)
+				}
+			});
+
+			if (updated.count === 0) {
+				return {};
+			}
+
+			const loot = new Bank({ 'Bucket of sand': BERT_SAND_BUCKETS });
+			await user.addItemsToBank({ items: loot, collectionLog: true });
+			messages.push(`Bert has delivered ${BERT_SAND_BUCKETS.toLocaleString()} Buckets of sand to your bank`);
 			return {};
 		}
 	},

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -4,6 +4,7 @@ import { Items } from 'oldschooljs';
 
 import { ClueTiers } from '@/lib/clues/clueTiers.js';
 import { findTripBuyable } from '@/lib/data/buyables/tripBuyables.js';
+import { BERT_SAND_BUCKETS, BERT_SAND_ID } from '@/lib/minions/data/bertSand.js';
 import killableMonsters from '@/lib/minions/data/killableMonsters/index.js';
 import { Planks } from '@/lib/minions/data/planks.js';
 import { quests } from '@/lib/minions/data/quests.js';
@@ -569,10 +570,15 @@ export function minionStatus(user: MUser, currentTask: ActivityTaskData | null, 
 
 		case 'Collecting': {
 			const data = currentTask as CollectingOptions;
+			if (data.metadata?.activityID === BERT_SAND_ID) {
+				return `${name} is currently collecting ${BERT_SAND_BUCKETS.toLocaleString()} buckets of sand for Bert. ${formattedDuration}`;
+			}
 			const collectable = collectables.find(c => c.item.id === data.collectableID)!;
-			return `${name} is currently collecting ${data.quantity * collectable.quantity}x ${
-				collectable.item.name
-			}. ${formattedDuration}`;
+			const totalQuantity =
+				typeof data.lootQuantityOverride === 'number'
+					? data.lootQuantityOverride
+					: data.quantity * collectable.quantity;
+			return `${name} is currently collecting ${totalQuantity}x ${collectable.item.name}. ${formattedDuration}`;
 		}
 
 		case 'MageTrainingArena': {

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -86,7 +86,15 @@ import { giantsFoundryAlloys } from '@/mahoji/lib/abstracted_commands/giantsFoun
 import puroOptions from '@/mahoji/lib/abstracted_commands/puroPuroCommand.js';
 import { slayerNewTaskCommand } from '@/mahoji/lib/abstracted_commands/slayerTaskCommand.js';
 
+function isNonRepeatableTrip({ data }: Activity) {
+	if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+	return Boolean((data as { metadata?: { nonRepeatable?: boolean } }).metadata?.nonRepeatable);
+}
+
 const taskCanBeRepeated = (activity: Activity, user: MUser, taskIndex: number) => {
+	if (isNonRepeatableTrip(activity)) {
+		return false;
+	}
 	const data = ActivityManager.convertStoredActivityToFlatActivity(activity);
 	if (data.type === activity_type_enum.Farming) {
 		return taskIndex === 0 && data.autoFarmed;
@@ -952,6 +960,9 @@ export async function repeatTrip(
 ): CommandResponse {
 	if (!activity || !activity.data || !activity.type) {
 		return { content: "Couldn't find any trip to repeat.", ephemeral: true };
+	}
+	if (isNonRepeatableTrip(activity)) {
+		return { content: 'That activity is not repeatable.', ephemeral: true };
 	}
 	const handler = tripHandlers[activity.type];
 	const args: ActivityTaskData = ActivityManager.convertStoredActivityToFlatActivity(activity);

--- a/src/mahoji/commands/activities.ts
+++ b/src/mahoji/commands/activities.ts
@@ -1,4 +1,7 @@
+import { stringMatches } from '@oldschoolgg/toolkit';
+
 import { ownedItemOption } from '@/discord/index.js';
+import { BERT_SAND_AUTOCOMPLETE_VALUE } from '@/lib/minions/data/bertSand.js';
 import { Planks } from '@/lib/minions/data/planks.js';
 import Potions from '@/lib/minions/data/potions.js';
 import { quests } from '@/lib/minions/data/quests.js';
@@ -17,6 +20,7 @@ import { castCommand } from '@/mahoji/lib/abstracted_commands/castCommand.js';
 import { chargeGloriesCommand } from '@/mahoji/lib/abstracted_commands/chargeGloriesCommand.js';
 import { chargeWealthCommand } from '@/mahoji/lib/abstracted_commands/chargeWealthCommand.js';
 import { chompyHuntClaimCommand, chompyHuntCommand } from '@/mahoji/lib/abstracted_commands/chompyHuntCommand.js';
+import { collectBertSand } from '@/mahoji/lib/abstracted_commands/collectBertSand.js';
 import { collectCommand } from '@/mahoji/lib/abstracted_commands/collectCommand.js';
 import { decantCommand } from '@/mahoji/lib/abstracted_commands/decantCommand.js';
 import { driftNetCommand } from '@/mahoji/lib/abstracted_commands/driftNetCommand.js';
@@ -140,9 +144,17 @@ export const activitiesCommand = defineCommand({
 					name: 'item',
 					description: 'The item to collect.',
 					autocomplete: async ({ value }: StringAutoComplete) => {
-						return collectables
-							.filter(p => (!value ? true : p.item.name.toLowerCase().includes(value.toLowerCase())))
+						const query = value?.toLowerCase() ?? '';
+
+						const dailyOptions = [
+							{ name: "Bert's sand (Daily)", value: BERT_SAND_AUTOCOMPLETE_VALUE }
+						].filter(option => (!query ? true : option.name.toLowerCase().includes(query)));
+
+						const regularOptions = collectables
+							.filter(p => (!query ? true : p.item.name.toLowerCase().includes(query)))
 							.map(p => ({ name: p.item.name, value: p.item.name }));
+
+						return [...dailyOptions, ...regularOptions];
 					},
 					required: true
 				},
@@ -560,6 +572,10 @@ export const activitiesCommand = defineCommand({
 			return camdozaalCommand(rng, user, channelId, options.camdozaal.action, options.camdozaal.quantity);
 		}
 		if (options.collect) {
+			const bertSandAliases = ["Bert's sand", "Bert's sand (Daily)", BERT_SAND_AUTOCOMPLETE_VALUE];
+			if (bertSandAliases.some(alias => stringMatches(options.collect?.item, alias))) {
+				return collectBertSand(user, channelId);
+			}
 			return collectCommand(
 				user,
 				channelId,

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -17,6 +17,7 @@ import { COXMaxMageGear, COXMaxMeleeGear, COXMaxRangeGear } from '@/lib/data/cox
 import { leaguesCreatables } from '@/lib/data/creatables/leagueCreatables.js';
 import { Eatables } from '@/lib/data/eatables.js';
 import { TOBMaxMageGear, TOBMaxMeleeGear, TOBMaxRangeGear } from '@/lib/data/tob.js';
+import { diaries } from '@/lib/diaries.js';
 import { effectiveMonsters } from '@/lib/minions/data/killableMonsters/index.js';
 import potions from '@/lib/minions/data/potions.js';
 import { MAX_QP, quests } from '@/lib/minions/data/quests.js';
@@ -43,6 +44,7 @@ import { getPOH } from '@/mahoji/lib/abstracted_commands/pohCommand.js';
 import { shades, shadesLogs } from '@/mahoji/lib/abstracted_commands/shadesOfMortonCommand.js';
 import { allUsableItems } from '@/mahoji/lib/abstracted_commands/useCommand.js';
 import { BingoManager } from '@/mahoji/lib/bingo/BingoManager.js';
+import { uniqueArr } from '../../../packages/util/dist/array.js';
 
 export function getMaxUserValues(): SafeUserUpdateInput {
 	const updates: SafeUserUpdateInput = {};
@@ -146,6 +148,17 @@ const thingsToReset = [
 				}
 			});
 			return 'Reset your bank.';
+		}
+	},
+	{
+		name: 'Dailies/Weeklies',
+		run: async (user: MUser) => {
+			await user.statsUpdate({
+				last_daily_timestamp: 0,
+				last_tears_of_guthix_timestamp: 0,
+				last_bert_sand_timestamp: 0
+			});
+			return 'Reset your daily and weekly timers.';
 		}
 	}
 ];
@@ -464,6 +477,45 @@ export const testPotatoCommand = globalConfig.isProduction
 							required: true,
 							min_value: 1,
 							max_value: 200_000_000
+						}
+					]
+				},
+				{
+					type: 'Subcommand',
+					name: 'setdiary',
+					description: 'Mark an achievement diary tier as completed.',
+					options: [
+						{
+							type: 'String',
+							name: 'diary',
+							description: 'The diary you want to mark as completed.',
+							required: true,
+							autocomplete: async ({ value }: StringAutoComplete) => {
+								return diaries
+									.filter(diary =>
+										!value
+											? true
+											: [diary.name, ...(diary.alias ?? [])].some(alias =>
+													alias.toLowerCase().includes(value.toLowerCase())
+												)
+									)
+									.map(diary => ({
+										name: diary.name,
+										value: diary.name
+									}));
+							}
+						},
+						{
+							type: 'String',
+							name: 'tier',
+							description: 'The tier to complete.',
+							required: true,
+							choices: [
+								{ name: 'Easy', value: 'easy' },
+								{ name: 'Medium', value: 'medium' },
+								{ name: 'Hard', value: 'hard' },
+								{ name: 'Elite', value: 'elite' }
+							]
 						}
 					]
 				},
@@ -1067,6 +1119,27 @@ export const testPotatoCommand = globalConfig.isProduction
 				}
 				if (options.setxp) {
 					return setXP(user, options.setxp.skill, options.setxp.xp);
+				}
+				if (options.setdiary) {
+					const setDiary = options.setdiary;
+					const selectedDiary = diaries.find(
+						diary =>
+							stringMatches(diary.name, setDiary.diary) ||
+							diary.alias?.some(alias => stringMatches(alias, setDiary.diary))
+					);
+					if (!selectedDiary) return 'Invalid diary.';
+					const tierOrder = ['easy', 'medium', 'hard', 'elite'] as const;
+					const selectedIndex = tierOrder.indexOf(setDiary.tier);
+					const diaryKeys = tierOrder
+						.slice(0, selectedIndex + 1)
+						.map(tier => `${selectedDiary.name}.${tier}`.replace(/\s/g, '').toLowerCase());
+					await user.update({
+						completed_achievement_diaries: uniqueArr([
+							...user.user.completed_achievement_diaries,
+							...diaryKeys
+						])
+					});
+					return `Marked ${selectedDiary.name} ${setDiary.tier} diary as completed.`;
 				}
 				if (options.spawn) {
 					const { preset, collectionlog, item, items } = options.spawn;

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -44,7 +44,7 @@ import { getPOH } from '@/mahoji/lib/abstracted_commands/pohCommand.js';
 import { shades, shadesLogs } from '@/mahoji/lib/abstracted_commands/shadesOfMortonCommand.js';
 import { allUsableItems } from '@/mahoji/lib/abstracted_commands/useCommand.js';
 import { BingoManager } from '@/mahoji/lib/bingo/BingoManager.js';
-import { uniqueArr } from '../../../packages/util/dist/array.js';
+import { satisfyDiaryRequirements } from '@/mahoji/lib/testPotato/satisfyDiaryRequirements.js';
 
 export function getMaxUserValues(): SafeUserUpdateInput {
 	const updates: SafeUserUpdateInput = {};
@@ -208,6 +208,7 @@ async function setXP(user: MUser, skillName: string, xp: number) {
 	});
 	return `Set ${skill.name} XP to ${xp}.`;
 }
+
 const openablesBank = new Bank();
 for (const i of allOpenables.values()) {
 	openablesBank.add(i.id, 100);
@@ -1122,24 +1123,7 @@ export const testPotatoCommand = globalConfig.isProduction
 				}
 				if (options.setdiary) {
 					const setDiary = options.setdiary;
-					const selectedDiary = diaries.find(
-						diary =>
-							stringMatches(diary.name, setDiary.diary) ||
-							diary.alias?.some(alias => stringMatches(alias, setDiary.diary))
-					);
-					if (!selectedDiary) return 'Invalid diary.';
-					const tierOrder = ['easy', 'medium', 'hard', 'elite'] as const;
-					const selectedIndex = tierOrder.indexOf(setDiary.tier);
-					const diaryKeys = tierOrder
-						.slice(0, selectedIndex + 1)
-						.map(tier => `${selectedDiary.name}.${tier}`.replace(/\s/g, '').toLowerCase());
-					await user.update({
-						completed_achievement_diaries: uniqueArr([
-							...user.user.completed_achievement_diaries,
-							...diaryKeys
-						])
-					});
-					return `Marked ${selectedDiary.name} ${setDiary.tier} diary as completed.`;
+					return satisfyDiaryRequirements(user, setDiary.diary, setDiary.tier);
 				}
 				if (options.spawn) {
 					const { preset, collectionlog, item, items } = options.spawn;

--- a/src/mahoji/lib/abstracted_commands/collectBertSand.ts
+++ b/src/mahoji/lib/abstracted_commands/collectBertSand.ts
@@ -1,0 +1,45 @@
+import { formatDuration, getNextUTCReset, Time } from '@oldschoolgg/toolkit';
+
+import {
+	BERT_SAND_BUCKETS,
+	BERT_SAND_DURATION,
+	BERT_SAND_ID,
+	BERT_SAND_ITEM_ID,
+	hasCollectedThisReset,
+	isManualEligible
+} from '@/lib/minions/data/bertSand.js';
+import type { ActivityTaskMetadata, CollectingOptions } from '@/lib/types/minions.js';
+
+const NON_REPEATABLE_METADATA: ActivityTaskMetadata = {
+	activityID: BERT_SAND_ID,
+	nonRepeatable: true
+};
+
+export async function collectBertSand(user: MUser, channelId: string) {
+	const now = Date.now();
+	const stats = await user.fetchStats();
+	const lastCollected = Number(stats.last_bert_sand_timestamp ?? 0n);
+
+	const requirementError = isManualEligible(user);
+	if (requirementError) {
+		return requirementError;
+	}
+
+	if (hasCollectedThisReset(lastCollected, now)) {
+		const nextReset = getNextUTCReset(now, Time.Day);
+		return `Bert will have more buckets of sand for you in ${formatDuration(nextReset - now)}.`;
+	}
+
+	await ActivityManager.startTrip<CollectingOptions>({
+		collectableID: BERT_SAND_ITEM_ID,
+		userID: user.id,
+		channelId,
+		quantity: 1,
+		duration: BERT_SAND_DURATION,
+		type: 'Collecting',
+		lootQuantityOverride: BERT_SAND_BUCKETS,
+		metadata: NON_REPEATABLE_METADATA
+	});
+
+	return `Bert is collecting your buckets of sand… (This will take ${formatDuration(BERT_SAND_DURATION)})`;
+}

--- a/src/mahoji/lib/testPotato/satisfyDiaryRequirements.ts
+++ b/src/mahoji/lib/testPotato/satisfyDiaryRequirements.ts
@@ -1,0 +1,124 @@
+import { stringMatches, uniqueArr } from '@oldschoolgg/toolkit';
+import { Bank, convertLVLtoXP } from 'oldschooljs';
+
+import { diaries } from '@/lib/diaries.js';
+import { MAX_QP } from '@/lib/minions/data/quests.js';
+import Agility from '@/lib/skilling/skills/agility.js';
+import type { SafeUserUpdateInput } from '@/lib/user/update.js';
+
+export async function satisfyDiaryRequirements(user: MUser, diaryName: string, tierName: string) {
+	const selectedDiary = diaries.find(
+		diary => stringMatches(diary.name, diaryName) || diary.alias?.some(alias => stringMatches(alias, diaryName))
+	);
+	if (!selectedDiary) return 'Invalid diary.';
+
+	const tierOrder = ['easy', 'medium', 'hard', 'elite'] as const;
+	const selectedIndex = tierOrder.indexOf(tierName as (typeof tierOrder)[number]);
+	if (selectedIndex === -1) return 'Invalid diary tier.';
+
+	const tiersToComplete = tierOrder.slice(0, selectedIndex + 1);
+	const userUpdates: SafeUserUpdateInput = {};
+	const stats = await user.fetchStats();
+	const monsterScores = { ...(stats.monster_scores as Record<string, number>) };
+	const lapsScores = { ...(stats.laps_scores as Record<string, number>) };
+	const minigameUpdates: Record<string, number> = {};
+	const itemsToOwn = new Bank();
+	const collectionLogItems = new Bank();
+
+	for (const tierKey of tiersToComplete) {
+		const tier = selectedDiary[tierKey];
+
+		for (const [skillName, level] of Object.entries(tier.skillReqs)) {
+			if (!level) continue;
+			const skill = skillName as keyof typeof user.skillsAsXP;
+			const xpRequired = convertLVLtoXP(level);
+			if (user.skillsAsXP[skill] < xpRequired) {
+				userUpdates[`skills_${skill}`] = xpRequired;
+			}
+		}
+
+		if (tier.qp && user.QP < tier.qp) {
+			userUpdates.QP = Math.max(Number(userUpdates.QP ?? user.QP), tier.qp);
+		}
+
+		if (tier.ownedItems) {
+			for (const item of tier.ownedItems) itemsToOwn.add(item);
+		}
+
+		if (tier.collectionLogReqs) {
+			for (const item of tier.collectionLogReqs) collectionLogItems.add(item);
+		}
+
+		if (tier.minigameReqs) {
+			for (const [minigame, requiredKC] of Object.entries(tier.minigameReqs)) {
+				if (!requiredKC) continue;
+				minigameUpdates[minigame] = Math.max(minigameUpdates[minigame] ?? 0, requiredKC);
+			}
+		}
+
+		if (tier.monsterScores) {
+			for (const [monsterID, requiredKC] of Object.entries(tier.monsterScores)) {
+				if (!requiredKC) continue;
+				monsterScores[monsterID] = Math.max(monsterScores[monsterID] ?? 0, requiredKC);
+			}
+		}
+
+		if (tier.lapsReqs) {
+			for (const [courseName, requiredLaps] of Object.entries(tier.lapsReqs)) {
+				const agilityCourse = Agility.Courses.find(course => course.name === courseName);
+				if (!agilityCourse || !requiredLaps) continue;
+				lapsScores[agilityCourse.id] = Math.max(lapsScores[agilityCourse.id] ?? 0, requiredLaps);
+			}
+		}
+	}
+
+	if (selectedDiary.name === 'Falador' && tiersToComplete.includes('elite')) {
+		itemsToOwn.add('Quest point cape');
+		userUpdates.QP = MAX_QP;
+	}
+
+	if (selectedDiary.name === 'Kandarin' && tiersToComplete.includes('elite')) {
+		await user.statsUpdate({
+			honour_level: {
+				set: Math.max(stats.honour_level, 5)
+			}
+		});
+	}
+
+	if (Object.keys(userUpdates).length > 0) {
+		await user.update(userUpdates);
+	}
+
+	if (itemsToOwn.length > 0) {
+		await user.addItemsToBank({ items: itemsToOwn, collectionLog: false });
+	}
+
+	if (collectionLogItems.length > 0) {
+		await user.addItemsToBank({ items: collectionLogItems, collectionLog: true });
+	}
+
+	if (Object.keys(minigameUpdates).length > 0) {
+		await prisma.minigame.upsert({
+			where: {
+				user_id: user.id
+			},
+			update: minigameUpdates,
+			create: {
+				user_id: user.id,
+				...minigameUpdates
+			}
+		});
+	}
+
+	await user.statsUpdate({
+		monster_scores: monsterScores,
+		laps_scores: lapsScores
+	});
+
+	const diaryKeys = tiersToComplete.map(tier => `${selectedDiary.name}.${tier}`.replace(/\s/g, '').toLowerCase());
+	await user.update({
+		completed_achievement_diaries: uniqueArr([...user.user.completed_achievement_diaries, ...diaryKeys])
+	});
+
+	return `Marked ${selectedDiary.name} ${tierName} diary as completed and added its test requirements.`;
+}

--- a/src/tasks/minions/collectingActivity.ts
+++ b/src/tasks/minions/collectingActivity.ts
@@ -1,13 +1,53 @@
-import { Time } from '@oldschoolgg/toolkit';
+import { formatDuration, getNextUTCReset, Time } from '@oldschoolgg/toolkit';
 import { Bank } from 'oldschooljs';
 
+import { BERT_SAND_BUCKETS, BERT_SAND_ID, bertResetStart, isManualEligible } from '@/lib/minions/data/bertSand.js';
 import type { CollectingOptions } from '@/lib/types/minions.js';
 import { collectables } from '@/mahoji/lib/collectables.js';
 
 export const collectingTask: MinionTask = {
 	type: 'Collecting',
 	async run(data: CollectingOptions, { user, handleTripFinish }) {
-		const { collectableID, quantity, channelId, duration } = data;
+		const { collectableID, quantity, channelId, duration, lootQuantityOverride, metadata } = data;
+		const isBertSandTrip = metadata?.activityID === BERT_SAND_ID;
+
+		if (isBertSandTrip) {
+			const sendResult = (message: string, loot: Bank | null = null) =>
+				handleTripFinish({ user, channelId, message: `${user}, ${message}`, data, loot });
+
+			const requirementError = isManualEligible(user);
+			if (requirementError) {
+				sendResult(requirementError);
+				return;
+			}
+
+			const now = Date.now();
+			const updated = await prisma.userStats.updateMany({
+				where: {
+					user_id: BigInt(user.id),
+					last_bert_sand_timestamp: { lt: BigInt(bertResetStart(now)) }
+				},
+				data: { last_bert_sand_timestamp: BigInt(now) }
+			});
+
+			if (updated.count === 0) {
+				const nextReset = getNextUTCReset(now, Time.Day);
+				sendResult(
+					`Bert already delivered today. You can collect again in ${formatDuration(nextReset - now)}.`
+				);
+				return;
+			}
+
+			const loot = new Bank({ 'Bucket of sand': BERT_SAND_BUCKETS });
+			await user.addItemsToBank({
+				items: loot,
+				collectionLog: true
+			});
+			await ClientSettings.updateBankSetting('collecting_loot', loot);
+
+			sendResult(`Bert hands you ${BERT_SAND_BUCKETS.toLocaleString()} Buckets of sand.`, loot);
+			return;
+		}
 
 		const collectable = collectables.find(c => c.item.id === collectableID)!;
 		let colQuantity = collectable.quantity;
@@ -17,8 +57,12 @@ export const collectingTask: MinionTask = {
 		if (moryHardBoost) {
 			colQuantity *= 2;
 		}
-		const totalQuantity = quantity * colQuantity;
+		let totalQuantity = quantity * colQuantity;
+		if (typeof lootQuantityOverride === 'number') {
+			totalQuantity = lootQuantityOverride;
+		}
 		const loot = new Bank().add(collectable.item.id, totalQuantity);
+
 		await user.transactItems({
 			collectionLog: true,
 			itemsToAdd: loot

--- a/tests/unit/bertSand.test.ts
+++ b/tests/unit/bertSand.test.ts
@@ -1,0 +1,48 @@
+import { convertLVLtoXP } from 'oldschooljs';
+import { describe, expect, test } from 'vitest';
+
+import {
+	BERT_SAND_QP_REQUIRED,
+	BERT_SAND_SKILL_REQS,
+	bertResetStart,
+	hasCollectedThisReset,
+	isManualEligible
+} from '@/lib/minions/data/bertSand.js';
+import { mockMUser } from './userutil.js';
+
+describe('bertSand', () => {
+	test('hasCollectedThisReset respects UTC reset window', () => {
+		const now = Date.UTC(2024, 0, 2, 12, 0, 0);
+		const resetStart = bertResetStart(now);
+
+		expect(hasCollectedThisReset(resetStart - 1, now)).toEqual(false);
+		expect(hasCollectedThisReset(resetStart, now)).toEqual(true);
+		expect(hasCollectedThisReset(resetStart + 1, now)).toEqual(true);
+	});
+
+	test('isManualEligible returns QP error when below requirement', () => {
+		const user = mockMUser({ QP: BERT_SAND_QP_REQUIRED - 1 });
+		expect(isManualEligible(user)).toEqual(
+			`You need at least ${BERT_SAND_QP_REQUIRED} Quest Points to collect sand for Bert.`
+		);
+	});
+
+	test('isManualEligible returns skill error when below requirement', () => {
+		const [, level] = BERT_SAND_SKILL_REQS[0];
+		const user = mockMUser({
+			QP: BERT_SAND_QP_REQUIRED,
+			skills_crafting: convertLVLtoXP(level - 1),
+			skills_thieving: convertLVLtoXP(99)
+		});
+		expect(isManualEligible(user)).toEqual(`You need level ${level} Crafting to collect sand for Bert.`);
+	});
+
+	test('isManualEligible returns null when requirements met', () => {
+		const user = mockMUser({
+			QP: BERT_SAND_QP_REQUIRED,
+			skills_crafting: convertLVLtoXP(49),
+			skills_thieving: convertLVLtoXP(17)
+		});
+		expect(isManualEligible(user)).toBeNull();
+	});
+});

--- a/tests/unit/userutil.ts
+++ b/tests/unit/userutil.ts
@@ -32,6 +32,8 @@ export interface MockUserArgs {
 	skills_hitpoints?: number;
 	skills_prayer?: number;
 	skills_fishing?: number;
+	skills_crafting?: number;
+	skills_thieving?: number;
 	GP?: number;
 	bitfield?: BitField[];
 	id?: string;
@@ -60,10 +62,10 @@ const mockUser = (overrides?: MockUserArgs): User => {
 		skills_woodcutting: overrides?.skills_woodcutting ?? 0,
 		skills_firemaking: 0,
 		skills_runecraft: 0,
-		skills_crafting: 0,
+		skills_crafting: overrides?.skills_crafting ?? 0,
 		skills_prayer: overrides?.skills_prayer ?? 0,
 		skills_fletching: 0,
-		skills_thieving: 0,
+		skills_thieving: overrides?.skills_thieving ?? 0,
 		skills_farming: overrides?.skills_farming ?? 0,
 		skills_herblore: 0,
 		skills_hunter: 0,


### PR DESCRIPTION
This update introduces Bert’s Sand as a new daily activity for minions. Players can now collect 84 Buckets of sand once per UTC day via a short 15-second trip or receive it automatically if they’ve completed the Ardougne Elite Diary.

- [x] I have tested all my changes thoroughly.
