### PR TITLE
Update Zulrah Boss Task Quantity

### DIFF
--- a/src/lib/slayer/tasks/bossTasks.ts
+++ b/src/lib/slayer/tasks/bossTasks.ts
@@ -224,7 +224,7 @@ export const bossTasks: AssignableSlayerTask[] = [
 	},
 	{
 		monster: Monsters.Zulrah,
-		amount: [3, 15],
+		amount: [3, 35],
 		weight: 1,
 		levelRequirements: {
 			prayer: 43


### PR DESCRIPTION
Not sure why zulrah was set with a 15 cap, checked all over the osrs wiki and couldnt see any reason

So this pr updates it to a cap of 35 like the rest instead

- [x] I have tested all my changes thoroughly.
