### PR TITLE
Add qty field to /farming set_preferred

### DIFF
--- a/docs/src/content/docs/osb/Skills/farming/README.md
+++ b/docs/src/content/docs/osb/Skills/farming/README.md
@@ -59,7 +59,7 @@ Use [[/farming auto_farm]] to process every patch your current filter/preference
 
 - Builds a combined plan that spends the entire Farming trip length, chaining each patch back-to-back.
 - Respects [[/farming auto_farm_filter]] choices (`AllFarm` to use your best seeds everywhere, `Replant` to stick to what was already growing).
-- Supports [[/farming set_preferred]] for per-patch behavior (`seed`, `highest_available`, or `empty`) plus optional contract prioritization.
+- Supports [[/farming set_preferred]] for per-patch behaviour (`seed`, `highest_available`, or `empty`), an optional planting quantity, and contract prioritisation.
 - Applies your [[/farming default_compost]] choice and [[/farming always_pay]] setting automatically.
 - Skips patches that would push the trip beyond the max duration or when required resources are missing.
 

--- a/docs/src/content/docs/osb/Skills/farming/auto-farming.md
+++ b/docs/src/content/docs/osb/Skills/farming/auto-farming.md
@@ -17,6 +17,7 @@ Auto farming collects ready patches into a single Farming activity so you can ha
 - **Replant** - Only replants patches that already contained that crop and that you still have seeds for. Empty patches stay empty.
 - Configure the behaviour with [[/farming auto_farm_filter auto_farm_filter_data:AllFarm]] or [[/farming auto_farm_filter auto_farm_filter_data:Replant]].
 - Use [[/farming set_preferred]] for per-patch overrides:
+  - Set `quantity` to limit how many patches auto farm plants or replants for that patch type.
   - `seed` to force a specific seed for that patch type
   - `highest_available` to always choose best available for that patch
   - `empty` to skip that patch type entirely

--- a/src/lib/minions/functions/autoFarm.ts
+++ b/src/lib/minions/functions/autoFarm.ts
@@ -41,6 +41,7 @@ interface PlanRequest {
 	type: 'highest' | 'plant';
 	patch: IPatchDataDetailed;
 	plant?: Plant;
+	quantity?: number;
 }
 
 interface BuildSummaryResult {
@@ -178,6 +179,7 @@ export async function autoFarm(
 
 	const planRequests: PlanRequest[] = [];
 	for (const patch of patchesDetailed) {
+		const preferredQuantity = preferredSeeds.get(patch.patchName)?.quantity;
 		const resolved = resolveSeedForPatch({
 			patch,
 			preferContract,
@@ -192,7 +194,12 @@ export async function autoFarm(
 		}
 
 		if (resolved.type === 'plant') {
-			const planRequest: PlanRequest = { type: 'plant', patch, plant: resolved.plant };
+			const planRequest: PlanRequest = {
+				type: 'plant',
+				patch,
+				plant: resolved.plant,
+				quantity: preferredQuantity
+			};
 			if (resolved.reason === 'contract') {
 				// Always attempt the contract patch first when contract priority is enabled.
 				planRequests.unshift(planRequest);
@@ -202,7 +209,7 @@ export async function autoFarm(
 			continue;
 		}
 
-		planRequests.push({ type: 'highest', patch });
+		planRequests.push({ type: 'highest', patch, quantity: preferredQuantity });
 	}
 
 	for (const request of planRequests) {
@@ -220,7 +227,7 @@ export async function autoFarm(
 			const prepared = await prepareFarmingStep({
 				user,
 				plant: candidate,
-				quantity: null,
+				quantity: request.quantity ?? null,
 				pay: false,
 				patchDetailed: patch,
 				maxTripLength,

--- a/src/lib/skilling/skills/farming/autoFarm/preferences.ts
+++ b/src/lib/skilling/skills/farming/autoFarm/preferences.ts
@@ -38,7 +38,7 @@ export function findPlantBySeedID(seedID: number, patchName: FarmingPatchName): 
 	return null;
 }
 
-function isValidPreferenceRecord(value: unknown): value is { type: string; seedID?: unknown } {
+function isValidPreferenceRecord(value: unknown): value is { type: string; seedID?: unknown; quantity?: unknown } {
 	return isRecord(value) && typeof value.type === 'string';
 }
 
@@ -47,18 +47,29 @@ export function normalizeSeedPreference(patchName: FarmingPatchName, value: unkn
 		return null;
 	}
 
+	const quantity =
+		value.quantity === undefined
+			? undefined
+			: typeof value.quantity === 'number' && Number.isSafeInteger(value.quantity) && value.quantity > 0
+				? value.quantity
+				: null;
+	if (quantity === null) {
+		return null;
+	}
+	const quantityData = quantity === undefined ? {} : { quantity };
+
 	if (value.type === 'highest_available') {
-		return { type: 'highest_available' };
+		return { type: 'highest_available', ...quantityData };
 	}
 	if (value.type === 'empty') {
-		return { type: 'empty' };
+		return { type: 'empty', ...quantityData };
 	}
 	if (value.type === 'seed' && typeof value.seedID === 'number') {
 		const plant = findPlantBySeedID(value.seedID, patchName);
 		if (!plant) {
 			return null;
 		}
-		return { type: 'seed', seedID: value.seedID };
+		return { type: 'seed', seedID: value.seedID, ...quantityData };
 	}
 	return null;
 }

--- a/src/lib/skilling/skills/farming/utils/types.ts
+++ b/src/lib/skilling/skills/farming/utils/types.ts
@@ -38,8 +38,8 @@ export type DetailedFarmingContract = {
 };
 
 export type FarmingSeedPreference =
-	| { type: 'seed'; seedID: number }
-	| { type: 'highest_available' }
-	| { type: 'empty' };
+	| { type: 'seed'; seedID: number; quantity?: number }
+	| { type: 'highest_available'; quantity?: number }
+	| { type: 'empty'; quantity?: number };
 
 export type FarmingPreferredSeeds = Record<string, FarmingSeedPreference>;

--- a/src/mahoji/commands/farming.ts
+++ b/src/mahoji/commands/farming.ts
@@ -18,6 +18,7 @@ import {
 	serializePreferredSeeds
 } from '@/lib/skilling/skills/farming/autoFarm/preferences.js';
 import { CompostTiers, Farming } from '@/lib/skilling/skills/farming/index.js';
+import { calcNumOfPatches } from '@/lib/skilling/skills/farming/utils/calcsFarming.js';
 import type { FarmingPatchName } from '@/lib/skilling/skills/farming/utils/farmingHelpers.js';
 import type { FarmingSeedPreference } from '@/lib/skilling/skills/farming/utils/types.js';
 import { ContractOptions } from '@/lib/skilling/skills/farming/utils/types.js';
@@ -44,15 +45,13 @@ function formatPreference(preference: FarmingSeedPreference | undefined, autoFar
 			? 'not set (AllFarm: highest available)'
 			: 'not set (Replant: same crop only)';
 	}
-	if (preference.type === 'highest_available') {
-		return 'highest_available';
-	}
-	if (preference.type === 'empty') {
-		return 'empty';
-	}
-	const item = Items.getItem(preference.seedID);
-	const itemName = item?.name ?? `Item ${preference.seedID}`;
-	return `seed: ${itemName}`;
+	const preferenceText =
+		preference.type === 'highest_available'
+			? 'highest_available'
+			: preference.type === 'empty'
+				? 'empty'
+				: `seed: ${Items.getItem(preference.seedID)?.name ?? `Item ${preference.seedID}`}`;
+	return preference.quantity === undefined ? preferenceText : `${preferenceText}, quantity: ${preference.quantity}`;
 }
 
 function buildPreferencesEmbed(
@@ -193,6 +192,13 @@ export const farmingCommand = defineCommand({
 					description: "Preferred seed (item name, 'highest_available', or 'empty').",
 					required: false,
 					autocomplete: farmingPreferredSeedAutoComplete
+				},
+				{
+					type: 'Integer',
+					name: 'quantity',
+					description: 'The maximum number of patches to plant or replant.',
+					required: false,
+					min_value: 1
 				},
 				{
 					type: 'Boolean',
@@ -358,15 +364,16 @@ export const farmingCommand = defineCommand({
 			const responses: string[] = [];
 			const patchNameInput = options.set_preferred.patch as FarmingPatchName | undefined;
 			const seedInput = options.set_preferred.seed ?? undefined;
+			const quantityInput = options.set_preferred.quantity ?? undefined;
 			const preferContractInput = options.set_preferred.prefer_contract;
 			const resetAllInput = Boolean(options.set_preferred.reset_all);
 			const resetPatchInput = Boolean(options.set_preferred.reset_patch);
 
-			if (resetAllInput && (patchNameInput || seedInput || resetPatchInput)) {
-				return 'You cannot use reset_all with patch, seed, or reset_patch options.';
+			if (resetAllInput && (patchNameInput || seedInput || quantityInput !== undefined || resetPatchInput)) {
+				return 'You cannot use reset_all with patch, seed, quantity, or reset_patch options.';
 			}
-			if (resetPatchInput && seedInput) {
-				return 'You cannot use reset_patch with a seed option.';
+			if (resetPatchInput && (seedInput || quantityInput !== undefined)) {
+				return 'You cannot use reset_patch with a seed or quantity option.';
 			}
 			if (resetPatchInput && !patchNameInput) {
 				return 'You must provide a patch when clearing one saved preference.';
@@ -390,7 +397,7 @@ export const farmingCommand = defineCommand({
 				responses.push('Cleared all saved per-patch seed preferences.');
 			}
 
-			if (!patchNameInput && !seedInput && !resetAllInput && !resetPatchInput) {
+			if (!patchNameInput && !seedInput && quantityInput === undefined && !resetAllInput && !resetPatchInput) {
 				const embed = buildPreferencesEmbed(
 					patchesDetailed,
 					preferenceMap,
@@ -403,14 +410,24 @@ export const farmingCommand = defineCommand({
 				return { embeds: [embed] };
 			}
 
-			if (!patchNameInput && seedInput) {
-				return 'You must provide a patch when setting a seed preference.';
+			if (!patchNameInput && (seedInput || quantityInput !== undefined)) {
+				return 'You must provide a patch when setting a seed or quantity preference.';
 			}
 
 			if (patchNameInput) {
 				const patchData = patchesDetailed.find(patch => patch.patchName === patchNameInput);
 				if (!patchData) {
 					return 'Invalid patch.';
+				}
+				if (quantityInput !== undefined) {
+					const maximumQuantity = Math.max(
+						...getPlantsForPatch(patchData.patchName).map(
+							plant => calcNumOfPatches(plant, user, user.QP)[0]
+						)
+					);
+					if (!Number.isSafeInteger(quantityInput) || quantityInput < 1 || quantityInput > maximumQuantity) {
+						return `Quantity for ${patchData.friendlyName} must be between 1 and ${maximumQuantity}.`;
+					}
 				}
 
 				if (resetPatchInput) {
@@ -429,7 +446,7 @@ export const farmingCommand = defineCommand({
 					return responses.join('\n');
 				}
 
-				if (!seedInput) {
+				if (!seedInput && quantityInput === undefined) {
 					const summary = `${patchData.friendlyName} -> ${formatPreference(
 						preferenceMap.get(patchData.patchName),
 						autoFarmFilter
@@ -441,10 +458,25 @@ export const farmingCommand = defineCommand({
 					return summary;
 				}
 
-				const resolvedPreference = resolveSeedPreferenceInput(patchData.patchName, seedInput);
-				if (typeof resolvedPreference === 'string') {
-					return resolvedPreference;
+				let resolvedPreference = preferenceMap.get(patchData.patchName);
+				if (seedInput) {
+					const existingQuantity = resolvedPreference?.quantity;
+					const resolvedSeedPreference = resolveSeedPreferenceInput(patchData.patchName, seedInput);
+					if (typeof resolvedSeedPreference === 'string') {
+						return resolvedSeedPreference;
+					}
+					resolvedPreference =
+						existingQuantity === undefined
+							? resolvedSeedPreference
+							: { ...resolvedSeedPreference, quantity: existingQuantity };
 				}
+				if (!resolvedPreference) {
+					return 'You must set a seed preference before setting its quantity.';
+				}
+				resolvedPreference =
+					quantityInput === undefined
+						? resolvedPreference
+						: { ...resolvedPreference, quantity: quantityInput };
 
 				preferenceMap.set(patchData.patchName, resolvedPreference);
 				await user.update({

--- a/tests/unit/autoFarm.test.ts
+++ b/tests/unit/autoFarm.test.ts
@@ -652,7 +652,7 @@ describe('auto farm helpers', () => {
 			contractsCompleted: 0
 		};
 		(mutableUser as any).minion_farmingPreferredSeeds = {
-			herb: { type: 'seed', seedID: itemID('Ranarr seed') }
+			herb: { type: 'seed', seedID: itemID('Ranarr seed'), quantity: 2 }
 		};
 
 		const transactResult = {
@@ -679,6 +679,10 @@ describe('auto farm helpers', () => {
 
 		// As above – detailed choice logic is tested in resolveSeedForPatch.
 		expect(addSubTaskToActivityTask).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(addSubTaskToActivityTask).mock.calls[0]?.[0]).toMatchObject({
+			quantity: 2,
+			autoFarmPlan: [expect.objectContaining({ quantity: 2 })]
+		});
 	});
 
 	it('autoFarm starts with the contract patch when contract priority is enabled', async () => {

--- a/tests/unit/farmingPreferences.test.ts
+++ b/tests/unit/farmingPreferences.test.ts
@@ -54,7 +54,7 @@ describe('farming seed preferences', () => {
 
 	it('parsePreferredSeeds normalizes valid preferences and ignores invalid patch names', () => {
 		const raw = {
-			[herbPlant.seedType]: { type: 'seed', seedID: herbSeedID },
+			[herbPlant.seedType]: { type: 'seed', seedID: herbSeedID, quantity: 2 },
 			[treePlant.seedType]: { type: 'highest_available' },
 			[cactusPlant.seedType]: { type: 'empty' },
 			invalid_patch: { type: 'seed', seedID: 12345 },
@@ -65,7 +65,8 @@ describe('farming seed preferences', () => {
 
 		expect(result.get(herbPlant.seedType as FarmingPatchName)).toEqual({
 			type: 'seed',
-			seedID: herbSeedID
+			seedID: herbSeedID,
+			quantity: 2
 		});
 		expect(result.get(treePlant.seedType as FarmingPatchName)).toEqual({
 			type: 'highest_available'
@@ -74,6 +75,15 @@ describe('farming seed preferences', () => {
 			type: 'empty'
 		});
 		expect(result.size).toBe(3);
+	});
+
+	it('parsePreferredSeeds rejects invalid quantities', () => {
+		for (const quantity of [0, -1, 1.5, '2']) {
+			const result = parsePreferredSeeds({
+				[herbPlant.seedType]: { type: 'seed', seedID: herbSeedID, quantity }
+			});
+			expect(result.size).toBe(0);
+		}
 	});
 
 	it('parsePreferredSeeds skips entries with unknown seed IDs', () => {


### PR DESCRIPTION
This enables users to only plant x amount of seeds in a patch, e.g. 2 allotment instead of a full trip each time

- [x] I have tested all my changes thoroughly.
