### PR TITLE
Enforce sequential diary tier progression

### DIFF
--- a/src/lib/user/MUser.ts
+++ b/src/lib/user/MUser.ts
@@ -749,7 +749,13 @@ Charge your items using ${globalClient.mentionCommand('minion', 'charge')}.`
 	}
 
 	public hasDiary(key: HasDiaryDiaryKey): boolean {
-		return this.user.completed_achievement_diaries.includes(key);
+		const [region, tier] = key.split('.') as [string, 'easy' | 'medium' | 'hard' | 'elite'];
+		const tiers = ['easy', 'medium', 'hard', 'elite'] as const;
+		const tierIndex = tiers.indexOf(tier);
+
+		return tiers
+			.slice(0, tierIndex + 1)
+			.every(requiredTier => this.user.completed_achievement_diaries.includes(`${region}.${requiredTier}`));
 	}
 
 	hasGracefulEquipped(): boolean {
@@ -887,6 +893,8 @@ Charge your items using ${globalClient.mentionCommand('minion', 'charge')}.`
 				const { hasDiary } = userhasDiaryTierSync(this, diary[tier], { stats, minigameScores });
 				if (hasDiary) {
 					completedKeys.push(key);
+				} else {
+					break;
 				}
 			}
 		}

--- a/tests/unit/MUser.test.ts
+++ b/tests/unit/MUser.test.ts
@@ -66,4 +66,14 @@ describe('MUser.test', () => {
 		expect(testUser.cl.has('Coal')).toEqual(true);
 		expect(testUser.cl.length).toEqual(1);
 	});
+	test('hasDiary requires all preceding tiers', () => {
+		const user = mockMUser({
+			completedAchievementDiaries: ['karamja.easy', 'karamja.hard', 'karamja.elite']
+		});
+
+		expect(user.hasDiary('karamja.easy')).toEqual(true);
+		expect(user.hasDiary('karamja.medium')).toEqual(false);
+		expect(user.hasDiary('karamja.hard')).toEqual(false);
+		expect(user.hasDiary('karamja.elite')).toEqual(false);
+	});
 });

--- a/tests/unit/userutil.ts
+++ b/tests/unit/userutil.ts
@@ -34,6 +34,7 @@ export interface MockUserArgs {
 	skills_fishing?: number;
 	GP?: number;
 	bitfield?: BitField[];
+	completedAchievementDiaries?: string[];
 	id?: string;
 }
 
@@ -83,6 +84,7 @@ const mockUser = (overrides?: MockUserArgs): User => {
 		id: overrides?.id ?? '',
 		monsterScores: {},
 		badges: [],
+		completed_achievement_diaries: overrides?.completedAchievementDiaries ?? [],
 		minion_farmingContract: null,
 		minion_farmingPreferredContract: false,
 		minion_farmingPreferredSeeds: {}


### PR DESCRIPTION
The hasDiary() method now validates that all preceding tiers are completed before recognizing a higher tier as done. 

This prevents situations where a player has skipped intermediate tiers (e.g., completed easy and elite but not medium). 

Added test coverage and mock utility support for completed achievement diaries.

- [x] I have tested all my changes thoroughly.
