### PR TITLE
Fix Virtus boost logic

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKillData.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKillData.ts
@@ -1,4 +1,4 @@
-import { EItem, ItemGroups, Items } from 'oldschooljs';
+import { EItem, ItemGroups, Items, type Monster, MonsterAttribute } from 'oldschooljs';
 
 import type { GearBank } from '@/lib/structures/GearBank.js';
 
@@ -23,24 +23,29 @@ export const dragonHunterWeapons = [
 export function calculateVirtusBoost({
 	isInWilderness,
 	gearBank,
-	isOnTask
+	isOnTask,
+	osjsMon
 }: {
 	gearBank: GearBank;
 	isInWilderness: boolean;
 	isOnTask: boolean;
+	osjsMon: Monster | undefined;
 }) {
 	let virtusPiecesEquipped = 0;
-	const hasBlackMask =
-		(isOnTask && gearBank.gear.mage.hasEquipped('Black mask (i)')) ||
-		gearBank.gear.wildy.hasEquipped('Black mask (i)');
+	// Undead monsters get salve boost instead of black mask, so can add virtus mask boost as well.
+	const isUndead = osjsMon?.data?.attributes?.includes(MonsterAttribute.Undead);
+	const hasSalveBoost = isUndead && gearBank.hasEquippedOrInBank(['Salve amulet (i)', 'Salve amulet (ei)']);
+	const hasBlackMaskBoost = isOnTask && gearBank.hasEquippedOrInBank('Black mask (i)');
+	const virtusMaskAllowed = !hasBlackMaskBoost || hasSalveBoost;
 
 	for (const item of ItemGroups.virtusOutfit) {
-		if (isInWilderness) {
-			if (gearBank.gear.wildy.hasEquipped(item)) {
-				virtusPiecesEquipped += hasBlackMask && item === EItem.VIRTUS_MASK ? 0 : 1;
-			}
-		} else if (gearBank.gear.mage.hasEquipped(item)) {
-			virtusPiecesEquipped += hasBlackMask && item === EItem.VIRTUS_MASK ? 0 : 1;
+		if (isInWilderness && gearBank.gear.wildy.hasEquipped(item)) {
+			// If in the wilderness, count all equipped wilderness virtus pieces.
+			virtusPiecesEquipped += 1;
+		}
+		if (!isInWilderness && gearBank.gear.mage.hasEquipped(item)) {
+			// If not in the wilderness, only use mask boost if no black mask boost (either not owned, or getting salve boost instead).
+			virtusPiecesEquipped += item !== EItem.VIRTUS_MASK || virtusMaskAllowed ? 1 : 0;
 		}
 	}
 

--- a/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
@@ -181,7 +181,7 @@ const salveBoost: Boost = {
 			const percent = salveEnhanced ? 20 : oneSixthBoost;
 			return {
 				percentageReduction: percent,
-				message: `${percent}% for Salve amulet${salveEnhanced ? ' (e)' : ''} on melee task`
+				message: `${percent}% for Salve amulet${salveEnhanced ? ' (e)' : ''}`
 			};
 		}
 	}
@@ -311,7 +311,7 @@ export const mainBoostEffects: (Boost | Boost[])[] = [
 	cannonBoost,
 	{
 		description: 'Barrage/Bursting',
-		run: ({ monster, attackStyles, combatMethods, isOnTask, isInWilderness, gearBank }) => {
+		run: ({ monster, attackStyles, combatMethods, isOnTask, isInWilderness, gearBank, osjsMon }) => {
 			const isBarraging = combatMethods.includes('barrage');
 			const isBursting = combatMethods.includes('burst');
 			const canBarrageMonster = monster.canBarrage || (monster.id === Monsters.Jelly.id && isInWilderness);
@@ -326,12 +326,12 @@ export const mainBoostEffects: (Boost | Boost[])[] = [
 				}
 			}
 
-			const { virtusBoost } = calculateVirtusBoost({ isInWilderness, gearBank, isOnTask });
+			const { virtusBoost } = calculateVirtusBoost({ isInWilderness, gearBank, isOnTask, osjsMon });
 			if (isBarraging && attackStyles.includes('magic')) {
 				return {
 					percentageReduction: boostIceBarrage + virtusBoost,
 					consumables: [iceBarrageConsumables],
-					message: `${boostIceBarrage + virtusBoost}% for Ice Barrage`,
+					message: `${boostIceBarrage + virtusBoost}% for Ice Barrage${virtusBoost > 0 ? ` with ${virtusBoost / 2} Virtus pieces` : ''}`,
 					changes: {
 						bob: SlayerActivityConstants.IceBarrage,
 						attackStyles: newAttackStyles


### PR DESCRIPTION
### Description:

Virtus mask is not applying when it should do. Fixes (again)
Before:
- Black mask in wildy gear -> no virtus mask boost when off slayer task
- Out of wildy, black mask but getting salve boost -> no virtus mask boost

Adds message for number of pieces equipped, and removes weird melee task salve message
### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [x] I have tested all my changes thoroughly.
