### PR TITLE
Make new slayer task button messages visible

### DIFF
--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -446,7 +446,7 @@ async function globalButtonInteractionHandler({
 			});
 		}
 		case InteractionID.Commands.NewSlayerTask: {
-			return slayerNewTaskCommand({ user, interaction, showButtons: true });
+			return slayerNewTaskCommand({ user, interaction, showButtons: true, ephemeralButtonResponse: false });
 		}
 		case InteractionID.Commands.DoShootingStar: {
 			const validStar = await prisma.shootingStars.findFirst({

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -918,7 +918,12 @@ async function handleSlayerTaskFinishedPrompt(
 	const actionInteraction = toOSInteraction(selectedInteraction, interaction, user);
 
 	if (selectedInteraction.customId === SlayerTaskFinishedPromptID.NewTask) {
-		const response = await slayerNewTaskCommand({ user, interaction: actionInteraction, showButtons: true });
+		const response = await slayerNewTaskCommand({
+			user,
+			interaction: actionInteraction,
+			showButtons: true,
+			ephemeralButtonResponse: false
+		});
 		await replyToCollectedButton(actionInteraction, response);
 		return SpecialResponse.RespondedManually;
 	}

--- a/src/mahoji/lib/abstracted_commands/slayerTaskCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/slayerTaskCommand.ts
@@ -76,7 +76,8 @@ export async function slayerNewTaskCommand({
 	extraContent,
 	slayerMasterOverride,
 	saveDefaultSlayerMaster,
-	showButtons
+	showButtons,
+	ephemeralButtonResponse = true
 }: {
 	rng?: RNGProvider;
 	user: MUser;
@@ -85,6 +86,7 @@ export async function slayerNewTaskCommand({
 	slayerMasterOverride?: string | undefined;
 	saveDefaultSlayerMaster?: boolean;
 	showButtons?: boolean;
+	ephemeralButtonResponse?: boolean;
 }): CommandResponse {
 	if (!rng) rng = MathRNG;
 	const { currentTask } = await user.fetchSlayerInfo();
@@ -162,7 +164,7 @@ export async function slayerNewTaskCommand({
 		if (showButtons) {
 			return {
 				content: `${extraContent ?? ''}\n\n${returnMessage}`,
-				ephemeral: true,
+				ephemeral: ephemeralButtonResponse,
 				components: slayerActionButtons
 			};
 		}
@@ -196,7 +198,7 @@ export async function slayerNewTaskCommand({
 			if (showButtons) {
 				return {
 					content: `You already have a slayer task: ${resultMessage}`,
-					ephemeral: true,
+					ephemeral: ephemeralButtonResponse,
 					components: slayerActionButtons
 				};
 			}
@@ -237,7 +239,7 @@ export async function slayerNewTaskCommand({
 	if (showButtons) {
 		return {
 			content: resultMessage,
-			ephemeral: true,
+			ephemeral: ephemeralButtonResponse,
 			components: slayerActionButtons
 		};
 	}


### PR DESCRIPTION
Fixes the New Slayer Task button on return trips so the assigned task message appears normally in the channel instead of as a disappearing private message, avoiding cases where discord fails to show the response and leaves the minion idle.

As reported -https://discord.com/channels/342983479501389826/1261194896375812147/1528861309838561351

- [x] I have tested all my changes thoroughly.
