### PR TITLE
Fix discord timeout on Guthixian Cache join

### DIFF
--- a/src/lib/bso/commands/bsominigames.ts
+++ b/src/lib/bso/commands/bsominigames.ts
@@ -311,7 +311,7 @@ export const bsoMinigamesCommand = defineCommand({
 			]
 		}
 	],
-	run: async ({ options, user, channelId }) => {
+	run: async ({ interaction, options, user, channelId }) => {
 		const {
 			baxtorian_bathhouses,
 			monkey_rumble,
@@ -326,6 +326,7 @@ export const bsoMinigamesCommand = defineCommand({
 			return turaelsTrialsStartCommand(user, channelId, options.turaels_trials.start.method);
 		}
 		if (options.guthixian_cache?.join) {
+			await interaction.defer();
 			return joinGuthixianCache(user, channelId);
 		}
 		if (options.guthixian_cache?.stats) {


### PR DESCRIPTION
Joining a Guthixian Cache sometimes showed “The application did not respond” even though the trip started correctly.

This change makes the bot acknowledge the command immediately, then send the normal trip confirmation once it has finished starting the trip.

Reported here - https://discord.com/channels/342983479501389826/1528896625743757362/1528896751732260965

- [x] I have tested all my changes thoroughly.
