### PR TITLE
Show bank cost in mix command output

### DIFF
--- a/src/mahoji/commands/mix.ts
+++ b/src/mahoji/commands/mix.ts
@@ -134,6 +134,7 @@ export const mixCommand = defineCommand({
 
 		return `${user.minionName} ${cost} making ${quantity}x ${
 			mixableItem.outputMultiple ? 'batches of' : ''
-		} ${itemName}, it'll take around ${formatTripDuration(user, duration)} to finish.`;
+		} ${itemName}, it'll take around ${formatTripDuration(user, duration)} to finish.
+			\nRemoved ${finalCost} from your bank.`;
 	}
 });


### PR DESCRIPTION
Add a message to the mix command output that displays how much was removed from the player's bank, improving feedback when using the mixing activity.

Reported here - https://discord.com/channels/342983479501389826/1008945789860589628/1529064068898488412

- [x] I have tested all my changes thoroughly.
