### PR TITLE
Fix offer message when no XP is gained

### DIFF
--- a/src/mahoji/commands/offer.ts
+++ b/src/mahoji/commands/offer.ts
@@ -176,7 +176,9 @@ export const offerCommand = defineCommand({
 			});
 
 			return {
-				content: `You offered ${quantity}x ${egg.name} to the Shrine and received the attached loot and ${xpStr}.`,
+				content: `You offered ${quantity}x ${egg.name} to the Shrine and received the attached loot.${
+					xpStr.length > 0 ? ` ${xpStr}` : ''
+				}`,
 				files: [file]
 			};
 		}


### PR DESCRIPTION
The offer command message was always including 'and' before the XP string, resulting in awkward grammar like 'received the attached loot and .' when no XP was gained. 

Now the XP portion is only appended to the message if XP was actually received.

- [x] I have tested all my changes thoroughly.
