### PR TITLE
Update BSO pets list and drop rates

### DIFF
--- a/docs/src/content/docs/bso/Custom Items/pets.mdx
+++ b/docs/src/content/docs/bso/Custom Items/pets.mdx
@@ -149,11 +149,14 @@ There are pets exclusive to BSO that provide unique and powerful perks and are r
 | [[Baby yaga house]]        | None                                                                                         | XP-based. 1/32,467 Elder tables, 1/59,523 Mahogany. See [[/droprate thing\:Baby yaga house pet]] |
 | [[Gary]]                   | None                                                                                         | 1/1,200 for Urium, +1,200 per lower tier                                                         |
 | [[Crush]]                  | None                                                                                         | Depths of Atlantis                                                                               |
-| [[Herbi]]                  | None                                                                                         | Herblore                                                                                         |
+| [[Herbert]]                | None                                                                                         | Herblore pet from mixing potions; rolled once per minute, with rates shown in [[/droprate thing\:Herbert (pet)]] |
 | [[Echo]]                   | None                                                                                         | Vladimir Drakan                                                                                  |
+| [[Doopy]]                  | None                                                                                         | Divination pet; 1 / ((200 - energy level) * 3,714) per memory converted                          |
 | [[Noom]]                   | None                                                                                         | 1/300 from Celestara                                                                             |
-| [[Fungo]]                  | None                                                                                         | 1/50 per harvest                                                                                 |
-
+| [[Fungo]]                  | None                                                                                         | 1/50 per planted zygomite harvest, then x1.5 rarer per Fungo in CL                              |
+| [[Baby venatrix]]          | None                                                                                         | 1/1,000 from opening [[Venatrix eggs]] dropped by [[Venatrix]]                                   |
+| [[Mini akumu]]             | None                                                                                         | 1/1,000 from [[Akumu]]                                                                           |
+| [[Octo]]                   | None                                                                                         | 1/700 from [[Elder casket]]  
 
 ## Pets that get rarer (CL scaling)
 


### PR DESCRIPTION
Rename Herbi to Herbert and add Herbert description/link to droprate. Add new pets Doopy, Baby venatrix, Mini akumu, and Octo with their drop sources/rates. 
Clarify Fungo drop: 1/50 per planted zygomite harvest and increases x1.5 rarer per Fungo in CL. 
Minor formatting fixes.

- [ ] I have tested all my changes thoroughly.
