### PR TITLE
add ability to "scout" ent events to /chop

### DIFF
--- a/src/lib/skilling/functions/determineWoodcuttingTime.ts
+++ b/src/lib/skilling/functions/determineWoodcuttingTime.ts
@@ -34,7 +34,7 @@ export function determineWoodcuttingTime({
 	const { findNewTreeTime } = log;
 
 	let teakTick = false;
-	
+
 	if (forestry === 'false' && woodcuttingLvl >= 92) {
 		if (log.id === EItem.TEAK_LOGS && farmingLvl >= 35) {
 			teakTick = true;

--- a/src/lib/skilling/functions/determineWoodcuttingTime.ts
+++ b/src/lib/skilling/functions/determineWoodcuttingTime.ts
@@ -9,7 +9,7 @@ interface WoodcuttingTimeOptions {
 	log: Log;
 	axeMultiplier: number;
 	powerchopping: boolean;
-	forestry: boolean;
+	forestry: string;
 	woodcuttingLvl: number;
 	maxTripLength: number;
 	rng: RNGProvider;
@@ -34,7 +34,8 @@ export function determineWoodcuttingTime({
 	const { findNewTreeTime } = log;
 
 	let teakTick = false;
-	if (!forestry && woodcuttingLvl >= 92) {
+	
+	if (forestry === 'false' && woodcuttingLvl >= 92) {
 		if (log.id === EItem.TEAK_LOGS && farmingLvl >= 35) {
 			teakTick = true;
 		}

--- a/src/lib/skilling/skills/woodcutting/woodcutting.ts
+++ b/src/lib/skilling/skills/woodcutting/woodcutting.ts
@@ -219,8 +219,8 @@ const logs: Log[] = [
 const twitchersGloves = ['egg', 'ring', 'seed', 'clue'] as const;
 export type TwitcherGloves = (typeof twitchersGloves)[number];
 
-const forestry_events = ['false', 'normal', 'egg_hunting'] as const;
-export type ForestryEvents = (typeof forestry_events)[number];
+const forestryType = ['false', 'normal', 'ent_scouting'] as const;
+export type ForestryType = (typeof forestryType)[number];
 
 const lumberjackItems: { [key: number]: number } = {
 	[itemID('Lumberjack hat')]: 0.4,
@@ -237,7 +237,7 @@ const Woodcutting = defineSkill({
 	name: 'Woodcutting',
 	lumberjackItems,
 	twitchersGloves,
-	forestry_events
+	forestryType
 });
 
 export default Woodcutting;

--- a/src/lib/skilling/skills/woodcutting/woodcutting.ts
+++ b/src/lib/skilling/skills/woodcutting/woodcutting.ts
@@ -219,6 +219,9 @@ const logs: Log[] = [
 const twitchersGloves = ['egg', 'ring', 'seed', 'clue'] as const;
 export type TwitcherGloves = (typeof twitchersGloves)[number];
 
+const forestry_events = ['false', 'normal', 'egg_hunting'] as const;
+export type ForestryEvents = (typeof forestry_events)[number];
+
 const lumberjackItems: { [key: number]: number } = {
 	[itemID('Lumberjack hat')]: 0.4,
 	[itemID('Lumberjack top')]: 0.8,
@@ -233,7 +236,8 @@ const Woodcutting = defineSkill({
 	emoji: Emoji.Woodcutting,
 	name: 'Woodcutting',
 	lumberjackItems,
-	twitchersGloves
+	twitchersGloves,
+	forestry_events
 });
 
 export default Woodcutting;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -8,7 +8,7 @@ import type { MinigameName } from '@/lib/settings/minigames.js';
 import type { UnderwaterAgilityThievingTrainingSkill } from '@/lib/skilling/skills/agility.js';
 import type { IPatchData } from '@/lib/skilling/skills/farming/utils/types.js';
 import type { SharkLureQuantity } from '@/lib/skilling/skills/fishing/fishingUtil.js';
-import type { ForestryEvents, TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
+import type { ForestryType, TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 import type { Peak } from '@/lib/util/peaks.js';
 
 export interface ActivityTaskOptions {
@@ -222,7 +222,8 @@ export interface WoodcuttingActivityTaskOptions extends ActivityTaskOptions {
 	fakeDurationMax: number;
 	fakeDurationMin: number;
 	powerchopping?: boolean;
-	forestry?: ForestryEvents;
+	forestryBlocked: boolean;
+	forestry?: ForestryType;
 	twitchers?: TwitcherGloves;
 	logID: number;
 	quantity: number;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -8,7 +8,7 @@ import type { MinigameName } from '@/lib/settings/minigames.js';
 import type { UnderwaterAgilityThievingTrainingSkill } from '@/lib/skilling/skills/agility.js';
 import type { IPatchData } from '@/lib/skilling/skills/farming/utils/types.js';
 import type { SharkLureQuantity } from '@/lib/skilling/skills/fishing/fishingUtil.js';
-import type { TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
+import type { ForestryEvents, TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 import type { Peak } from '@/lib/util/peaks.js';
 
 export interface ActivityTaskOptions {
@@ -222,7 +222,7 @@ export interface WoodcuttingActivityTaskOptions extends ActivityTaskOptions {
 	fakeDurationMax: number;
 	fakeDurationMin: number;
 	powerchopping?: boolean;
-	forestry?: boolean;
+	forestry?: ForestryEvents;
 	twitchers?: TwitcherGloves;
 	logID: number;
 	quantity: number;

--- a/src/lib/util/activityInArea.ts
+++ b/src/lib/util/activityInArea.ts
@@ -49,7 +49,7 @@ const WorldLocationsChecker = [
 					resolveItems(['Teak logs', 'Mahogany logs']).includes(
 						(activity as WoodcuttingActivityTaskOptions).logID
 					) &&
-					(activity as WoodcuttingActivityTaskOptions).forestry === true
+					(activity as WoodcuttingActivityTaskOptions).forestry !== 'false' 
 				) {
 					return true;
 				}

--- a/src/lib/util/activityInArea.ts
+++ b/src/lib/util/activityInArea.ts
@@ -49,7 +49,7 @@ const WorldLocationsChecker = [
 					resolveItems(['Teak logs', 'Mahogany logs']).includes(
 						(activity as WoodcuttingActivityTaskOptions).logID
 					) &&
-					(activity as WoodcuttingActivityTaskOptions).forestry !== 'false' 
+					(activity as WoodcuttingActivityTaskOptions).forestry !== 'false'
 				) {
 					return true;
 				}

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -172,7 +172,9 @@ export const chopCommand = defineCommand({
 		if (forestry_events === 'normal') {
 			boosts.push('Participating in Forestry events. (-15% logs/xp)');
 		} else if (forestry_events === 'ent_scouting') {
-			boosts.push('Participating in Forestry events & ent scouting. (avg 8 ent events scouted per hour) (-40% normal events, -30% logs/xp)');
+			boosts.push(
+				'Participating in Forestry events & ent scouting. (avg 8 ent events scouted per hour) (-40% normal events, -30% logs/xp)'
+			);
 		}
 
 		// Default bronze axe, last in the array

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -2,9 +2,9 @@ import { increaseNumByPercent, reduceNumByPercent, stringMatches } from '@oldsch
 import { Items, itemID, resolveItems } from 'oldschooljs';
 
 import { determineWoodcuttingTime } from '@/lib/skilling/functions/determineWoodcuttingTime.js';
+import Woodcutting, { type ForestryType } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 import type { WoodcuttingActivityTaskOptions } from '@/lib/types/minions.js';
 import { formatTripDuration } from '@/lib/util/minionUtils.js';
-import Woodcutting, { ForestryEvents } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 
 const axes = [
 	{
@@ -99,9 +99,9 @@ export const chopCommand = defineCommand({
 		{
 			type: 'String',
 			name: 'forestry_events',
-			description: 'false, normal, or egg_hunting (scouts ent events for eggs) (default false, optional).',
+			description: 'false, normal, or ent_scouting (scouts ent events for eggs) (default false, optional).',
 			required: false,
-			choices: Woodcutting.forestry_events.map(i => ({ name: i, value: i }))
+			choices: Woodcutting.forestryType.map(i => ({ name: i, value: i }))
 		},
 		{
 			type: 'String',
@@ -124,7 +124,7 @@ export const chopCommand = defineCommand({
 		let { quantity, powerchop, twitchers_gloves } = options;
 
 		const skills = user.skillsAsLevels;
-		let forestry_events: ForestryEvents = (options.forestry_events ?? 'false') as ForestryEvents;
+		let forestry_events: ForestryType = (options.forestry_events ?? 'false') as ForestryType;
 
 		if (skills.woodcutting < log.level) {
 			return `${user.minionName} needs ${log.level} Woodcutting to chop ${log.name}.`;
@@ -144,35 +144,35 @@ export const chopCommand = defineCommand({
 		let wcLvl = skills.woodcutting;
 		const farmingLvl = user.skillsAsLevels.farming;
 
-		// Handle blocking or allowing forestry events, egg_hunting can still be done with log types
-		const forestryBlocked = resolveItems(['Redwood logs', 'Logs']).includes(log.id) || log.lootTable;
+		// Handle blocking or allowing forestry events, ent_scouting can still be done with these log types
+		const forestryBlocked = resolveItems(['Redwood logs', 'Logs']).includes(log.id) || Boolean(log.lootTable);
 		if (forestryBlocked && forestry_events === 'normal') {
 			forestry_events = 'false';
 		}
-		
-		if (forestry_events === 'false' || forestry_events === 'egg_hunting') {
+
+		if (forestry_events === 'false') {
 			// Invisible wc boost for woodcutting guild
 			if (skills.woodcutting >= 60 && log.wcGuild) {
 				boosts.push('+7 invisible WC lvls at the Woodcutting guild');
 				wcLvl += 7;
 			}
-		
+
 			// 1.5 tick hardwood at 92 wc, 1.5t is only possible at farming patches
 			if (skills.woodcutting >= 92) {
 				if (resolveItems('Teak logs').includes(log.id) && farmingLvl >= 35) {
 					boosts.push('1.5t woodcutting teak trees with 92+ wc & 35+ farming');
 				}
-		
+
 				if (resolveItems('Mahogany logs').includes(log.id) && farmingLvl >= 55) {
 					boosts.push('1.5t woodcutting mahogany trees with 92+ wc & 55+ farming');
 				}
 			}
-		} 
+		}
 
 		if (forestry_events === 'normal') {
-			boosts.push('Participating in Forestry events');
-		} else if (forestry_events === 'egg_hunting') {
-			boosts.push('Participating in Forestry events (egg hunting)');
+			boosts.push('Participating in Forestry events. (-15% logs/xp)');
+		} else if (forestry_events === 'ent_scouting') {
+			boosts.push('Participating in Forestry events & ent scouting. (avg 8 ent events scouted per hour) (-40% normal events, -30% logs/xp)');
 		}
 
 		// Default bronze axe, last in the array
@@ -235,6 +235,7 @@ export const chopCommand = defineCommand({
 			quantity: newQuantity,
 			iQty: options.quantity ? options.quantity : undefined,
 			powerchopping: powerchop === true ? true : undefined,
+			forestryBlocked,
 			forestry: forestry_events,
 			twitchers: twitchers_gloves,
 			duration,

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -2,9 +2,9 @@ import { increaseNumByPercent, reduceNumByPercent, stringMatches } from '@oldsch
 import { Items, itemID, resolveItems } from 'oldschooljs';
 
 import { determineWoodcuttingTime } from '@/lib/skilling/functions/determineWoodcuttingTime.js';
-import Woodcutting from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 import type { WoodcuttingActivityTaskOptions } from '@/lib/types/minions.js';
 import { formatTripDuration } from '@/lib/util/minionUtils.js';
+import Woodcutting, { ForestryEvents } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 
 const axes = [
 	{
@@ -97,10 +97,11 @@ export const chopCommand = defineCommand({
 			required: false
 		},
 		{
-			type: 'Boolean',
+			type: 'String',
 			name: 'forestry_events',
-			description: 'Set this to true to participate in forestry events. (default false, optional).',
-			required: false
+			description: 'false, normal, or egg_hunting (scouts ent events for eggs) (default false, optional).',
+			required: false,
+			choices: Woodcutting.forestry_events.map(i => ({ name: i, value: i }))
 		},
 		{
 			type: 'String',
@@ -120,9 +121,10 @@ export const chopCommand = defineCommand({
 
 		if (!log) return "That's not a valid log to chop.";
 
-		let { quantity, powerchop, forestry_events, twitchers_gloves } = options;
+		let { quantity, powerchop, twitchers_gloves } = options;
 
 		const skills = user.skillsAsLevels;
+		let forestry_events: ForestryEvents = (options.forestry_events ?? 'false') as ForestryEvents;
 
 		if (skills.woodcutting < log.level) {
 			return `${user.minionName} needs ${log.level} Woodcutting to chop ${log.name}.`;
@@ -142,25 +144,35 @@ export const chopCommand = defineCommand({
 		let wcLvl = skills.woodcutting;
 		const farmingLvl = user.skillsAsLevels.farming;
 
-		// Redwood logs, logs, sulliuscep, farming patches, woodcutting guild don't spawn forestry events
-		if (!forestry_events || resolveItems(['Redwood logs', 'Logs']).includes(log.id) || log.lootTable) {
-			forestry_events = false;
+		// Handle blocking or allowing forestry events, egg_hunting can still be done with log types
+		const forestryBlocked = resolveItems(['Redwood logs', 'Logs']).includes(log.id) || log.lootTable;
+		if (forestryBlocked && forestry_events === 'normal') {
+			forestry_events = 'false';
+		}
+		
+		if (forestry_events === 'false' || forestry_events === 'egg_hunting') {
 			// Invisible wc boost for woodcutting guild
 			if (skills.woodcutting >= 60 && log.wcGuild) {
 				boosts.push('+7 invisible WC lvls at the Woodcutting guild');
 				wcLvl += 7;
 			}
+		
 			// 1.5 tick hardwood at 92 wc, 1.5t is only possible at farming patches
 			if (skills.woodcutting >= 92) {
 				if (resolveItems('Teak logs').includes(log.id) && farmingLvl >= 35) {
 					boosts.push('1.5t woodcutting teak trees with 92+ wc & 35+ farming');
 				}
+		
 				if (resolveItems('Mahogany logs').includes(log.id) && farmingLvl >= 55) {
 					boosts.push('1.5t woodcutting mahogany trees with 92+ wc & 55+ farming');
 				}
 			}
-		} else {
+		} 
+
+		if (forestry_events === 'normal') {
 			boosts.push('Participating in Forestry events');
+		} else if (forestry_events === 'egg_hunting') {
+			boosts.push('Participating in Forestry events (egg hunting)');
 		}
 
 		// Default bronze axe, last in the array

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -1,5 +1,12 @@
-import { Emoji, Events, increaseNumByPercent, objectEntries, perTimeUnitChance, reduceNumByPercent, Time } from '@oldschoolgg/toolkit';
-import { roll } from 'node-rng';
+import {
+	Emoji,
+	Events,
+	increaseNumByPercent,
+	objectEntries,
+	perTimeUnitChance,
+	reduceNumByPercent,
+	Time
+} from '@oldschoolgg/toolkit';
 import { Bank, EItem } from 'oldschooljs';
 
 import { MediumSeedPackTable } from '@/lib/data/seedPackTables.js';
@@ -41,7 +48,7 @@ async function handleForestry({
 	let strForestry = '';
 	const userWcLevel = user.skillsAsLevels.woodcutting;
 
-	const handleEvent = (event: typeof ForestryEvents[number]) => {
+	const handleEvent = (event: (typeof ForestryEvents)[number]) => {
 		let eventRounds = 0;
 		let eventInteraction = 0;
 
@@ -74,8 +81,7 @@ async function handleForestry({
 					eventInteraction += rng.randInt(12, 20);
 				}
 
-				loot.add('Strange fruit', rng.randInt(4, 8))
-					.add(MediumSeedPackTable.roll());
+				loot.add('Strange fruit', rng.randInt(4, 8)).add(MediumSeedPackTable.roll());
 
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += user.skillLevel(event.uniqueXP) * 0.25 * eventInteraction * 3;
@@ -162,9 +168,7 @@ async function handleForestry({
 
 	// Normal forestry events
 	if (!forestryBlocked) {
-		const eventChance = forestry === 'ent_scouting'
-			? increaseNumByPercent(8, 40)
-			: 8;
+		const eventChance = forestry === 'ent_scouting' ? increaseNumByPercent(8, 40) : 8;
 
 		perTimeUnitChance(rng, duration, eventChance, Time.Minute, () => {
 			const event = ForestryEvents[rng.randInt(0, ForestryEvents.length - 1)];

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -1,4 +1,4 @@
-import { Emoji, Events, increaseNumByPercent, objectEntries, perTimeUnitChance, Time } from '@oldschoolgg/toolkit';
+import { Emoji, Events, increaseNumByPercent, objectEntries, perTimeUnitChance, reduceNumByPercent, Time } from '@oldschoolgg/toolkit';
 import { roll } from 'node-rng';
 import { Bank, EItem } from 'oldschooljs';
 
@@ -232,7 +232,13 @@ async function handleForestry({
 export const woodcuttingTask: MinionTask = {
 	type: 'Woodcutting',
 	async run(data: WoodcuttingActivityTaskOptions, { user, handleTripFinish, rng }) {
-		const { logID, quantity, channelId, duration, powerchopping, forestryBlocked, forestry, twitchers } = data;
+		let { logID, quantity, channelId, duration, powerchopping, forestryBlocked, forestry, twitchers } = data;
+
+		if (forestry === 'normal') {
+			quantity = Math.floor(reduceNumByPercent(quantity, 15));
+		} else if (forestry === 'ent_scouting') {
+			quantity = Math.floor(reduceNumByPercent(quantity, 30));
+		}
 
 		const userWcLevel = user.skillsAsLevels.woodcutting;
 		const log = Woodcutting.Logs.find(i => i.id === logID)!;

--- a/src/tasks/minions/woodcuttingActivity.ts
+++ b/src/tasks/minions/woodcuttingActivity.ts
@@ -1,4 +1,5 @@
-import { Emoji, Events, objectEntries, perTimeUnitChance, Time } from '@oldschoolgg/toolkit';
+import { Emoji, Events, increaseNumByPercent, objectEntries, perTimeUnitChance, Time } from '@oldschoolgg/toolkit';
+import { roll } from 'node-rng';
 import { Bank, EItem } from 'oldschooljs';
 
 import { MediumSeedPackTable } from '@/lib/data/seedPackTables.js';
@@ -6,7 +7,7 @@ import addSkillingClueToLoot from '@/lib/minions/functions/addSkillingClueToLoot
 import { eggNest } from '@/lib/simulation/birdsNest.js';
 import { soteSkillRequirements } from '@/lib/skilling/functions/questRequirements.js';
 import { ForestryEvents, LeafTable } from '@/lib/skilling/skills/woodcutting/forestry.js';
-import Woodcutting, { type TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
+import Woodcutting, { type ForestryType, type TwitcherGloves } from '@/lib/skilling/skills/woodcutting/woodcutting.js';
 import type { SkillNameType } from '@/lib/skilling/types.js';
 import type { WoodcuttingActivityTaskOptions } from '@/lib/types/minions.js';
 import { rollForMoonKeyHalf } from '@/lib/util/minionUtils.js';
@@ -16,15 +17,22 @@ async function handleForestry({
 	user,
 	duration,
 	loot,
-	rng
+	rng,
+	forestry,
+	forestryBlocked
 }: {
 	user: MUser;
 	duration: number;
 	loot: Bank;
 	rng: RNGProvider;
+	forestry: ForestryType;
+	forestryBlocked: boolean;
 }) {
+	if (forestry === 'false') return;
+
 	const eventCounts: { [key: number]: number } = {};
 	const eventXP = {} as { [key in SkillNameType]: number };
+
 	for (const ev of ForestryEvents) {
 		eventCounts[ev.id] = 0;
 		eventXP[ev.uniqueXP] = 0;
@@ -33,97 +41,143 @@ async function handleForestry({
 	let strForestry = '';
 	const userWcLevel = user.skillsAsLevels.woodcutting;
 
-	perTimeUnitChance(rng, duration, 8, Time.Minute, async () => {
-		const eventIndex = rng.randInt(0, ForestryEvents.length - 1);
-		const event = ForestryEvents[eventIndex];
+	const handleEvent = (event: typeof ForestryEvents[number]) => {
 		let eventRounds = 0;
 		let eventInteraction = 0;
 
 		switch (event.id) {
 			case 1: // Rising Roots
-				eventRounds = rng.randInt(5, 7); // anima-infused roots spawned
+				eventRounds = rng.randInt(5, 7);
+
 				for (let i = 0; i < eventRounds; i++) {
-					eventInteraction += rng.randInt(5, 6); // anima-infused roots chopped
+					eventInteraction += rng.randInt(5, 6);
 				}
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += user.skillLevel(event.uniqueXP) * 1.4 * eventInteraction;
 				break;
+
 			case 2: // Struggling Sapling
-				eventInteraction = rng.randInt(12, 15); // mulch added to sapling
+				eventInteraction = rng.randInt(12, 15);
+
 				loot.add(LeafTable.roll());
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += eventInteraction * (user.skillLevel(event.uniqueXP) * 0.6);
 				eventXP.woodcutting += eventInteraction * (userWcLevel * 1.95) * 2;
 				break;
+
 			case 3: // Flowering Bush
-				eventRounds = rng.randInt(5, 7); // bush pairs spawned
+				eventRounds = rng.randInt(5, 7);
+
 				for (let i = 0; i < eventRounds; i++) {
-					eventInteraction += rng.randInt(12, 20); // bushes pollinated
+					eventInteraction += rng.randInt(12, 20);
 				}
-				loot.add('Strange fruit', rng.randInt(4, 8)).add(MediumSeedPackTable.roll());
+
+				loot.add('Strange fruit', rng.randInt(4, 8))
+					.add(MediumSeedPackTable.roll());
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += user.skillLevel(event.uniqueXP) * 0.25 * eventInteraction * 3;
 				break;
+
 			case 4: // Woodcutting Leprechaun
-				eventInteraction = rng.randInt(6, 8); // rainbows entered
+				eventInteraction = rng.randInt(6, 8);
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += user.skillLevel(event.uniqueXP) * 2 * eventInteraction;
 				break;
+
 			case 5: // Beehive
-				eventRounds = rng.randInt(5, 7); // beehives spawned
+				eventRounds = rng.randInt(5, 7);
+
 				for (let i = 0; i < eventRounds; i++) {
 					if (rng.percentChance(66)) {
 						loot.add('Sturdy beehive parts');
 					}
-					eventInteraction += rng.randInt(5, 10); // repairs per beehive
+
+					eventInteraction += rng.randInt(5, 10);
 				}
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += user.skillLevel(event.uniqueXP) * 0.3 * eventInteraction;
 				eventXP.woodcutting += eventInteraction * (userWcLevel * 0.6) + userWcLevel * 3.8 * eventRounds;
 				break;
+
 			case 6: // Friendly Ent
-				eventInteraction = rng.randInt(40, 60); // ents pruned
+				eventInteraction = rng.randInt(40, 60);
+
 				loot.add(LeafTable.roll());
 				loot.add(eggNest.roll());
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += user.skillLevel(event.uniqueXP) * 0.2 * eventInteraction;
 				eventXP.woodcutting += eventInteraction * (userWcLevel * 0.55);
 				break;
+
 			case 7: // Poachers
-				eventInteraction = rng.randInt(12, 15); // traps disarmed
+				eventInteraction = rng.randInt(12, 15);
+
 				if (rng.roll(30)) {
 					loot.add('Fox whistle');
 				}
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += eventInteraction * (user.skillLevel(event.uniqueXP) / 2);
 				eventXP.woodcutting += eventInteraction * (userWcLevel * 1.35);
 				break;
+
 			case 8: // Enchantment Ritual
-				eventInteraction = rng.randInt(6, 8); // ritual circles
+				eventInteraction = rng.randInt(6, 8);
+
 				if (rng.roll(30)) {
 					loot.add('Petal garland');
 				}
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += user.skillLevel(event.uniqueXP) * eventInteraction * 5.5;
 				break;
+
 			case 9: // Pheasant Control
-				eventInteraction = rng.randInt(15, 45); // eggs delivered
+				eventInteraction = rng.randInt(15, 45);
+
 				for (let i = 0; i < eventInteraction; i++) {
 					if (rng.percentChance(50)) {
 						loot.add('Pheasant tail feathers');
 					}
+
 					if (rng.roll(900)) {
 						loot.add('Golden pheasant egg');
 					}
 				}
+
 				eventCounts[event.id]++;
 				eventXP[event.uniqueXP] += eventInteraction * (user.skillLevel(event.uniqueXP) / 2);
 				eventXP.woodcutting += eventInteraction * (userWcLevel * 1.1);
 				break;
 		}
-		// Give user Anima-infused bark per event
+
 		loot.add('Anima-infused bark', rng.randInt(250, 500));
-	});
+	};
+
+	// Normal forestry events
+	if (!forestryBlocked) {
+		const eventChance = forestry === 'ent_scouting'
+			? increaseNumByPercent(8, 40)
+			: 8;
+
+		perTimeUnitChance(rng, duration, eventChance, Time.Minute, () => {
+			const event = ForestryEvents[rng.randInt(0, ForestryEvents.length - 1)];
+			handleEvent(event);
+		});
+	}
+
+	// Ent scouting can bypass forestry blocks
+	if (forestry === 'ent_scouting') {
+		perTimeUnitChance(rng, duration, 8, Time.Minute, () => {
+			handleEvent(ForestryEvents.find(e => e.id === 6)!);
+		});
+	}
 
 	let totalEvents = 0;
 	for (const [event, count] of objectEntries(eventCounts)) {
@@ -178,7 +232,7 @@ async function handleForestry({
 export const woodcuttingTask: MinionTask = {
 	type: 'Woodcutting',
 	async run(data: WoodcuttingActivityTaskOptions, { user, handleTripFinish, rng }) {
-		const { logID, quantity, channelId, duration, powerchopping, forestry, twitchers } = data;
+		const { logID, quantity, channelId, duration, powerchopping, forestryBlocked, forestry, twitchers } = data;
 
 		const userWcLevel = user.skillsAsLevels.woodcutting;
 		const log = Woodcutting.Logs.find(i => i.id === logID)!;
@@ -261,7 +315,7 @@ export const woodcuttingTask: MinionTask = {
 		}
 
 		// Add crystal shards for chopping teaks/mahogany in priff
-		if (forestry && priffUnlocked && [EItem.TEAK_LOGS, EItem.MAHOGANY_LOGS].includes(log.id)) {
+		if (forestry !== 'false' && priffUnlocked && [EItem.TEAK_LOGS, EItem.MAHOGANY_LOGS].includes(log.id)) {
 			// 1/40 chance of receiving a crystal shard
 			for (let i = 0; i < quantity; i++) {
 				if (rng.roll(40)) loot.add('Crystal shard', 1);
@@ -316,8 +370,15 @@ export const woodcuttingTask: MinionTask = {
 		}
 
 		// Forestry events
-		if (forestry) {
-			str += await handleForestry({ user, duration, loot, rng });
+		if (forestry && forestry !== 'false') {
+			str += await handleForestry({
+				user,
+				duration,
+				loot,
+				rng,
+				forestry,
+				forestryBlocked
+			});
 		}
 
 		// Roll for pet


### PR DESCRIPTION
### Description:
Adds the ability to scout ent events, similar to ingame osrs, which allows users to find more god eggs for the evil chicken outfit. Ent scouting should still work with redwoods and logs since you don't actually need to be at the spawn to get the god egg/credit.

### Changes:
- add `ForestryType` for determining `false` `normal` `ent_scouting`
- add a 15% reduction to logs/loot/xp when participating in forestry (should have been a thing on release)
- add a 30% reduction to logs/loot/xp and 40% reduction in forestry events when ent_scoutting.
- change the logic in `handleForestry` to accommodate specifying which case to target with ent_scouting.

### Other checks:
- [ ] I have tested all my changes thoroughly.
