### PR TITLE
Fix hunter test flake

### DIFF
--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -3,7 +3,7 @@ import '../../src/lib/cache/redis.js';
 
 import { noOp } from '@oldschoolgg/toolkit';
 import type { Bank } from 'oldschooljs';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
 import type { OldSchoolBotClient } from '@/discord/OldSchoolBotClient.js';
 import { globalConfig } from '@/lib/constants.js';
@@ -23,6 +23,10 @@ await prisma.clientStorage
 	.catch(noOp);
 
 global.globalClient = new TestClient({} as any) as any as OldSchoolBotClient;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 vi.mock('../../src/lib/util/handleTripFinish.js', async importOriginal => {
 	const originalModule: any = await importOriginal();


### PR DESCRIPTION
This PR stops test mocks from leaking between integration tests.

The Hunter test could sometimes receive doubled salamander counts because another test had changed random number behaviour and did not reset it afterwards. 

The shared integration test setup now resets mocks after each test, keeping each test isolated and making the Hunter result consistent.

- [x] I have tested all my changes thoroughly.
