### PR TITLE
Update master farmer outfit check for extra patches

### DIFF
--- a/src/lib/skilling/skills/farming/utils/calcsFarming.ts
+++ b/src/lib/skilling/skills/farming/utils/calcsFarming.ts
@@ -32,7 +32,7 @@ export function calcNumOfPatches(plant: Plant, user: MUser, qp: number): [number
 		}
 	}
 	if (user.bitfield.includes(BitField.HasScrollOfFarming)) numOfPatches += 2;
-	if (user.hasEquippedOrInBank(masterFarmerOutfit)) numOfPatches += 3;
+	if (user.hasEquippedOrInBank(masterFarmerOutfit, 'every')) numOfPatches += 3;
 
 	// Unlock extra patches in Atlantis
 	const atlantisPatches: Partial<Record<FarmingPatchName, number>> = {


### PR DESCRIPTION
Fixed the Master farmer outfit check so the +3 patch boost requires all five outfit pieces, rather than activating as soon as any one piece was owned.

- [ ] I have tested all my changes thoroughly.
