### PR TITLE
Fix Superior Dwarf Multicannon combat boost

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill/determineIfUsingCannon.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/determineIfUsingCannon.ts
@@ -1,4 +1,4 @@
-import { canAffordInventionBoostRaw, InventionID } from '@/lib/bso/skills/invention/inventions.js';
+import { InventionID, inventionItemBoostRaw } from '@/lib/bso/skills/invention/inventions.js';
 
 import { Time } from '@oldschoolgg/toolkit';
 import { Monsters } from 'oldschooljs';
@@ -69,16 +69,14 @@ export function determineIfUsingCannon({
 		}
 	}
 
-	const { canAfford } = canAffordInventionBoostRaw(
-		gearBank.materials,
-		InventionID.SuperiorDwarfMultiCannon,
-		Time.Hour
-	);
-	const canUseSuperiorCannon = !(
-		disabledInventions.includes(InventionID.SuperiorDwarfMultiCannon) && hasSuperiorCannon
-	)
-		? canAfford
-		: false;
+	const canUseSuperiorCannon =
+		hasSuperiorCannon &&
+		inventionItemBoostRaw({
+			gearBank,
+			inventionID: InventionID.SuperiorDwarfMultiCannon,
+			duration: Time.Hour,
+			disabledInventions
+		}).success;
 
 	return {
 		usingCannon,

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -275,6 +275,8 @@ export function newMinionKillCommand(args: MinionKillOptions): string | MinionKi
 			}
 			if (boostResult.charges) speedDurationResult.updateBank.chargeBank.add(boostResult.charges);
 			if (boostResult.itemCost) speedDurationResult.updateBank.itemCostBank.add(boostResult.itemCost);
+			if (boostResult.materialCost)
+				speedDurationResult.updateBank.materialsCostBank.add(boostResult.materialCost);
 			if (boostResult.message) speedDurationResult.messages.push(boostResult.message);
 		}
 	}

--- a/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
@@ -19,7 +19,7 @@ const noFoodBoost = Math.floor(Math.max(...Eatables.map(eatable => eatable.pvmBo
 // Runs after we know the quantity/duration/etc
 type PostBoostEffectReturn = Pick<
 	BoostResult,
-	'percentageReduction' | 'percentageIncrease' | 'message' | 'charges' | 'changes' | 'itemCost'
+	'percentageReduction' | 'percentageIncrease' | 'message' | 'charges' | 'changes' | 'itemCost' | 'materialCost'
 >;
 export type PostBoostEffect = {
 	description: string;

--- a/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
@@ -1,6 +1,7 @@
 import { dwarvenBlessing } from '@/lib/bso/dwarvenBlessing.js';
 import { gearstatToSetup, gorajanBoosts } from '@/lib/bso/gorajanGearBoost.js';
-import { InventionID } from '@/lib/bso/skills/invention/inventions.js';
+import { InventionID, inventionItemBoostRaw } from '@/lib/bso/skills/invention/inventions.js';
+import type { MaterialBank } from '@/lib/bso/skills/invention/MaterialBank.js';
 
 import type { OffenceGearStat, PrimaryGearSetupType } from '@oldschoolgg/gear';
 import { calcWhatPercent, sumArr, Time } from '@oldschoolgg/toolkit';
@@ -14,6 +15,8 @@ import {
 	boostCannonMulti,
 	boostIceBarrage,
 	boostIceBurst,
+	boostSuperiorCannon,
+	boostSuperiorCannonMulti,
 	cannonMultiConsumables,
 	cannonSingleConsumables,
 	iceBarrageConsumables,
@@ -67,6 +70,7 @@ export type BoostResult = {
 	message?: string;
 	consumables?: Consumable[];
 	itemCost?: Bank;
+	materialCost?: MaterialBank;
 	charges?: ChargeBank;
 	changes?: { attackStyles?: AttackStyles[] } & CombatMethodOptions;
 	confirmation?: string;
@@ -94,9 +98,18 @@ export type Boost = {
 
 const oneSixthBoost = 16.67;
 
-const cannonBoost: Boost = {
+export const cannonBoost: Boost = {
 	description: 'Cannon',
-	run: ({ gearBank, monster, combatMethods, isOnTask, isInWilderness, disabledInventions, addInvention }) => {
+	run: ({
+		gearBank,
+		monster,
+		combatMethods,
+		isOnTask,
+		isInWilderness,
+		disabledInventions,
+		addInvention,
+		addPostBoostEffect
+	}) => {
 		const cannonResult = determineIfUsingCannon({
 			gearBank,
 			monster,
@@ -107,26 +120,46 @@ const cannonBoost: Boost = {
 		});
 		if (typeof cannonResult === 'string') return cannonResult;
 		if (!cannonResult.usingCannon) return null;
+		const usingSuperiorCannon = Boolean(cannonResult.canUseSuperiorCannon);
+		if (usingSuperiorCannon) {
+			addInvention(InventionID.SuperiorDwarfMultiCannon);
+			addPostBoostEffect({
+				description: 'Superior dwarf multicannon material cost',
+				run: ({ gearBank: postBoostGearBank, duration, disabledInventions: postBoostDisabledInventions }) => {
+					const inventionResult = inventionItemBoostRaw({
+						gearBank: postBoostGearBank,
+						inventionID: InventionID.SuperiorDwarfMultiCannon,
+						duration,
+						disabledInventions: postBoostDisabledInventions
+					});
+					if (!inventionResult.success || !inventionResult.materialCost) {
+						return "You don't have enough materials to use the Superior dwarf multicannon for this trip.";
+					}
+					return {
+						materialCost: inventionResult.materialCost,
+						message: `Using Superior dwarf multicannon (${inventionResult.messages.join(', ')})`
+					};
+				}
+			});
+		}
 		if (monster?.cannonMulti && cannonResult.cannonMulti) {
-			if (cannonResult.canUseSuperiorCannon) addInvention(InventionID.SuperiorDwarfMultiCannon);
 			return {
-				percentageReduction: boostCannonMulti,
-				consumables: [
-					cannonResult.canUseSuperiorCannon ? superiorCannonMultiConsumables : cannonMultiConsumables
-				],
-				message: `${boostCannonMulti}% for Cannon in multi`,
+				percentageReduction: usingSuperiorCannon ? boostSuperiorCannonMulti : boostCannonMulti,
+				consumables: [usingSuperiorCannon ? superiorCannonMultiConsumables : cannonMultiConsumables],
+				message: `${
+					usingSuperiorCannon ? boostSuperiorCannonMulti : boostCannonMulti
+				}% for ${usingSuperiorCannon ? 'Superior dwarf multicannon' : 'Cannon'} in multi`,
 				changes: {
 					cannonMulti: true
 				}
 			};
 		} else if (monster?.canCannon) {
-			if (cannonResult.canUseSuperiorCannon) addInvention(InventionID.SuperiorDwarfMultiCannon);
 			return {
-				percentageReduction: boostCannon,
-				consumables: [
-					cannonResult.canUseSuperiorCannon ? superiorCannonSingleConsumables : cannonSingleConsumables
-				],
-				message: `${boostCannon}% for Cannon in singles`
+				percentageReduction: usingSuperiorCannon ? boostSuperiorCannon : boostCannon,
+				consumables: [usingSuperiorCannon ? superiorCannonSingleConsumables : cannonSingleConsumables],
+				message: `${
+					usingSuperiorCannon ? boostSuperiorCannon : boostCannon
+				}% for ${usingSuperiorCannon ? 'Superior dwarf multicannon' : 'Cannon'} in singles`
 			};
 		}
 

--- a/src/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/timeAndSpeed.ts
@@ -1,3 +1,5 @@
+import { MaterialBank } from '@/lib/bso/skills/invention/MaterialBank.js';
+
 import {
 	calcWhatPercent,
 	increaseNumByPercent,
@@ -87,6 +89,7 @@ export function speedCalculations(args: Omit<BoostArgs, 'currentTaskOptions'>) {
 
 	let currentTaskOptions: CombatMethodOptions = {};
 	const itemCost = new Bank();
+	const materialCost = new MaterialBank();
 	const charges = new ChargeBank();
 	const consumables: Consumable[] = [];
 	const confirmations: string[] = [];
@@ -126,6 +129,7 @@ export function speedCalculations(args: Omit<BoostArgs, 'currentTaskOptions'>) {
 				timeToFinish = increaseNumByPercent(timeToFinish, boostResult.percentageIncrease);
 			}
 			if (boostResult.itemCost) itemCost.add(boostResult.itemCost);
+			if (boostResult.materialCost) materialCost.add(boostResult.materialCost);
 			if (boostResult.consumables) consumables.push(...boostResult.consumables);
 			if (boostResult.charges) charges.add(boostResult.charges);
 			if (boostResult.confirmation) confirmations.push(boostResult.confirmation);
@@ -151,6 +155,7 @@ export function speedCalculations(args: Omit<BoostArgs, 'currentTaskOptions'>) {
 
 	const updateBank = new UpdateBank();
 	updateBank.itemCostBank.add(itemCost);
+	updateBank.materialsCostBank.add(materialCost);
 	updateBank.chargeBank.add(charges);
 
 	if (consumablesCost.itemCost) {

--- a/tests/unit/superiorCannon.test.ts
+++ b/tests/unit/superiorCannon.test.ts
@@ -1,0 +1,107 @@
+import { MaterialBank } from '@/lib/bso/skills/invention/MaterialBank.js';
+
+import { Time } from '@oldschoolgg/toolkit';
+import { Bank } from 'oldschooljs';
+import { describe, expect, test } from 'vitest';
+
+import type { KillableMonster } from '@/lib/minions/types.js';
+import { Gear } from '@/lib/structures/Gear.js';
+import { GearBank } from '@/lib/structures/GearBank.js';
+import type { PostBoostEffect } from '@/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.js';
+import { type BoostResult, cannonBoost } from '@/mahoji/lib/abstracted_commands/minionKill/speedBoosts.js';
+
+const cannonParts = new Bank({
+	'Cannon barrels': 1,
+	'Cannon base': 1,
+	'Cannon furnace': 1,
+	'Cannon stand': 1
+});
+
+const cannonableMultiMonster = {
+	canCannon: true,
+	cannonMulti: true,
+	id: 1,
+	name: 'Test cannon monster'
+} as KillableMonster;
+
+const materials = new MaterialBank({
+	heavy: 10_000,
+	metallic: 10_000,
+	strong: 10_000
+});
+
+function gearBankWith(bank: Bank) {
+	return new GearBank({
+		bank,
+		chargeBank: {} as never,
+		gear: {
+			fashion: new Gear(),
+			mage: new Gear(),
+			melee: new Gear(),
+			misc: new Gear(),
+			other: new Gear(),
+			range: new Gear(),
+			skilling: new Gear(),
+			wildy: new Gear()
+		},
+		materials,
+		minionName: 'Test minion',
+		pet: null,
+		skillsAsXP: {
+			attack: 13_034_431,
+			defence: 13_034_431,
+			hitpoints: 13_034_431,
+			strength: 13_034_431
+		} as never
+	});
+}
+
+function runCannonBoost(bank: Bank) {
+	const postBoostEffects: PostBoostEffect[] = [];
+	const result = cannonBoost.run({
+		addInvention: () => undefined,
+		addPostBoostEffect: (effect: PostBoostEffect) => postBoostEffects.push(effect),
+		combatMethods: ['cannon'],
+		disabledInventions: [],
+		gearBank: gearBankWith(bank.add('Cannonball', 10_000)),
+		isInWilderness: false,
+		isOnTask: false,
+		monster: cannonableMultiMonster
+	} as never);
+
+	if (!result || typeof result === 'string' || Array.isArray(result)) {
+		throw new Error(`Unexpected cannon boost result: ${String(result)}`);
+	}
+
+	return { postBoostEffects, result: result as BoostResult };
+}
+
+describe('Superior dwarf multicannon', () => {
+	test('uses superior cannon speed, message and materials when owned', () => {
+		const { postBoostEffects, result } = runCannonBoost(new Bank().add('Superior dwarf multicannon'));
+
+		expect(result.percentageReduction).toBe(65);
+		expect(result.message).toBe('65% for Superior dwarf multicannon in multi');
+		expect(postBoostEffects).toHaveLength(1);
+
+		const postBoostResult = postBoostEffects[0].run({
+			disabledInventions: [],
+			duration: Time.Minute * 24,
+			gearBank: gearBankWith(new Bank().add('Superior dwarf multicannon'))
+		} as never);
+		if (!postBoostResult || typeof postBoostResult === 'string' || Array.isArray(postBoostResult)) {
+			throw new Error(`Unexpected post boost result: ${String(postBoostResult)}`);
+		}
+
+		expect(postBoostResult.message?.startsWith('Using Superior dwarf multicannon (Removed ')).toBe(true);
+		expect(postBoostResult.materialCost?.amount('strong')).toBeGreaterThan(0);
+	});
+
+	test('does not use superior cannon from materials alone', () => {
+		const { postBoostEffects, result } = runCannonBoost(cannonParts.clone());
+
+		expect(result.percentageReduction).toBe(55);
+		expect(result.message).toBe('55% for Cannon in multi');
+		expect(postBoostEffects).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Restores the Superior Dwarf Multicannon so it gives its intended improved cannon boost during monster-killing trips.

The boost message now clearly shows when the Superior Dwarf Multicannon is being used, instead of showing the regular cannon boost.

It also checks and removes the required invention materials properly.

- [ ] I have tested all my changes thoroughly.
