### PR TITLE
Add BeachCombing to deprecated activities

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -676,7 +676,8 @@ export const DEPRECATED_ACTIVITY_TYPES: activity_type_enum[] = [
 	activity_type_enum.HalloweenMiniMinigame,
 	activity_type_enum.Mortimer,
 	activity_type_enum.BirthdayCollectIngredients,
-	activity_type_enum.SnoozeSpellActive
+	activity_type_enum.SnoozeSpellActive,
+	activity_type_enum.BeachCombing
 ];
 
 export const CONSTANTS = {


### PR DESCRIPTION
Include activity_type_enum.BeachCombing in DEPRECATED_ACTIVITY_TYPES in src/lib/constants.ts so the BeachCombing activity is treated as deprecated by the application.

This removes it from the music cape requirement.

- [ ] I have tested all my changes thoroughly.
