### PR TITLE
Add hunting mode for Shooting Stars

### DIFF
--- a/data/osb/buyables.json
+++ b/data/osb/buyables.json
@@ -2951,14 +2951,14 @@
 	},
 	{
 		"name": "Olive oil pack",
-		"gp_cost": 2670,
+		"gp_cost": 27000,
 		"output_items": {
 			"12857": 1
 		}
 	},
 	{
 		"name": "Olive oil(4)",
-		"gp_cost": 220,
+		"gp_cost": 270,
 		"output_items": {
 			"3422": 1
 		}

--- a/docs/src/content/docs/osb/Activities/shooting-stars.md
+++ b/docs/src/content/docs/osb/Activities/shooting-stars.md
@@ -6,6 +6,8 @@ Shooting Stars is a [[mining]] activity. A star can spawn after any trip, and yo
 
 Start this trip by clicking the `Mine Crashed Star` button when you see it on a return trip message.
 
+You can also actively hunt for Crashed Stars using [[/activities other activity\:Hunt Crashed Stars]]. As your minion is spending time searching for a star, hunted Crashed Stars are mined at 75% efficiency compared with stars found from trip return buttons.
+
 ## Requirements
 
 | Star Size | Mining Level Required |

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -75,6 +75,7 @@ export interface ShootingStarsOptions extends ActivityTaskOptions {
 	usersWith: number;
 	totalXp: number;
 	lootItems: ItemBank;
+	hunted?: boolean;
 }
 interface ActivityTaskOptionsWithUsers extends ActivityTaskOptions {
 	users: string[];

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -72,6 +72,7 @@ import type {
 	SepulchreActivityTaskOptions,
 	ShadesOfMortonOptions,
 	ShadesOfMortonPyreLogsOptions,
+	ShootingStarsOptions,
 	SmeltingActivityTaskOptions,
 	SmithingActivityTaskOptions,
 	TempleTrekkingActivityTaskOptions,
@@ -99,10 +100,13 @@ const taskCanBeRepeated = (activity: Activity, user: MUser, taskIndex: number) =
 			user.owns(ClueTiers.find(clue => clue.id === realActivity.ci)!.scrollID)
 		);
 	}
+	if (activity.type === activity_type_enum.ShootingStars) {
+		const realActivity = data as ShootingStarsOptions;
+		return realActivity.hunted === true;
+	}
 	return !(
 		[
 			activity_type_enum.TearsOfGuthix,
-			activity_type_enum.ShootingStars,
 			activity_type_enum.BirthdayEvent,
 			activity_type_enum.BlastFurnace,
 			activity_type_enum.Easter,
@@ -184,8 +188,8 @@ const tripHandlers: {
 		}
 	},
 	[activity_type_enum.ShootingStars]: {
-		commandName: 'm',
-		args: () => ({})
+		commandName: 'activities',
+		args: () => ({ other: { activity: activity_type_enum.ShootingStars } })
 	},
 	[activity_type_enum.BirthdayEvent]: {
 		commandName: 'm',

--- a/src/mahoji/lib/abstracted_commands/otherActivitiesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/otherActivitiesCommand.ts
@@ -3,6 +3,7 @@ import { championsChallengeCommand } from '@/mahoji/lib/abstracted_commands/cham
 import { combatRingCommand } from '@/mahoji/lib/abstracted_commands/combatRingCommand.js';
 import { mageArena2Command } from '@/mahoji/lib/abstracted_commands/mageArena2Command.js';
 import { mageArenaCommand } from '@/mahoji/lib/abstracted_commands/mageArenaCommand.js';
+import { huntCrashedStarsCommand } from '@/mahoji/lib/abstracted_commands/shootingStarsCommand.js';
 import { strongHoldOfSecurityCommand } from '@/mahoji/lib/abstracted_commands/strongHoldOfSecurityCommand.js';
 
 export const otherActivities = [
@@ -25,6 +26,10 @@ export const otherActivities = [
 	{
 		name: 'Combat Ring (Shayzien)',
 		type: activity_type_enum.CombatRing
+	},
+	{
+		name: 'Hunt Crashed Stars',
+		type: activity_type_enum.ShootingStars
 	}
 ];
 
@@ -55,6 +60,9 @@ export function otherActivitiesCommand({
 	}
 	if (type === 'CombatRing') {
 		return combatRingCommand(interaction);
+	}
+	if (type === 'ShootingStars') {
+		return huntCrashedStarsCommand({ rng, channelId, user });
 	}
 	return 'Invalid activity type.';
 }

--- a/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
@@ -163,16 +163,19 @@ export async function shootingStarsCommand({
 	rng,
 	channelId,
 	user,
-	star: _star
+	star: _star,
+	hunted = false
 }: {
 	rng: RNGProvider;
 	channelId: string;
 	user: MUser;
 	star: ShootingStars | Star;
+	hunted?: boolean;
 }): Promise<string> {
 	const skills = user.skillsAsLevels;
 	const boosts = [];
 	const star: Star = ('dustAvailable' in _star ? _star : starSizes.find(s => s.size === _star.size))!;
+	const miningEfficiency = hunted ? 0.75 : 1;
 
 	let miningLevel = skills.mining;
 
@@ -210,7 +213,7 @@ export async function shootingStarsCommand({
 			quantity: Math.round(s.dustAvailable / usersWith),
 			gearBank: user.gearBank,
 			ore: star,
-			ticksBetweenRolls: currentPickaxe.ticksBetweenRolls,
+			ticksBetweenRolls: currentPickaxe.ticksBetweenRolls / miningEfficiency,
 			glovesEffect: 0,
 			armourEffect: 0,
 			miningCapeEffect: 0,
@@ -254,18 +257,49 @@ export async function shootingStarsCommand({
 		usersWith,
 		totalXp,
 		type: 'ShootingStars',
-		size: star.size
+		size: star.size,
+		hunted
 	});
 
-	let str = `${user.minionName} is now mining a size ${star.size} Crashed Star with ${
+	let str = `${user.minionName} is now ${
+		hunted ? 'hunting and mining' : 'mining'
+	} a size ${star.size} Crashed Star with ${
 		usersWith - 1 || 'no'
 	} other players! The trip will return in about ${formatTripDuration(user, duration)}.`;
+
+	if (hunted) {
+		boosts.push('as your minion is actively hunting Crashed Stars, they mine at 75% efficiency');
+	}
 
 	if (boosts.length > 0) {
 		str += `\n\n**Boosts:** ${boosts.join(', ')}.`;
 	}
 
 	return str;
+}
+
+export function rollShootingStar(miningLevel: number) {
+	const eligibleStars = starSizes.filter(i => i.chance > 0 && i.level <= miningLevel);
+	if (eligibleStars.length === 0) return null;
+	const shootingStarTable = new SimpleTable<Star>();
+	for (const star of eligibleStars) shootingStarTable.add(star, star.chance);
+	return shootingStarTable.roll();
+}
+
+export async function huntCrashedStarsCommand({
+	rng,
+	channelId,
+	user
+}: {
+	rng: RNGProvider;
+	channelId: string;
+	user: MUser;
+}) {
+	const star = rollShootingStar(user.skillsAsLevels.mining);
+	if (!star) {
+		return `${user.minionName} needs at least 20 Mining to hunt Crashed Stars.`;
+	}
+	return shootingStarsCommand({ rng, channelId, user, star, hunted: true });
 }
 
 const activitiesCantGetStars: activity_type_enum[] = [
@@ -301,14 +335,11 @@ export async function handleTriggerShootingStar({
 }) {
 	if (activitiesCantGetStars.includes(data.type)) return;
 	const miningLevel = user.skillsAsLevels.mining;
-	const eligibleStars = starSizes.filter(i => i.chance > 0 && i.level <= miningLevel);
 	const minutes = Math.floor(data.duration / Time.Minute);
 	if (minutes < 1) return;
 	const baseChance = Math.floor(540 / minutes);
 	if (!rng.roll(baseChance)) return;
-	const shootingStarTable = new SimpleTable<Star>();
-	for (const star of eligibleStars) shootingStarTable.add(star, star.chance);
-	const star = shootingStarTable.roll();
+	const star = rollShootingStar(miningLevel);
 	if (!star) return;
 
 	// Got a star

--- a/src/tasks/minions/shootingStarsActivity.ts
+++ b/src/tasks/minions/shootingStarsActivity.ts
@@ -19,7 +19,9 @@ export const shootingStarTask: MinionTask = {
 			duration: data.duration
 		});
 
-		const str = `${user}, ${user.minionName} finished mining a size ${star.size} Crashed Star, there was ${
+		const str = `${user}, ${user.minionName} finished ${
+			data.hunted ? 'hunting and mining' : 'mining'
+		} a size ${star.size} Crashed Star, there was ${
 			usersWith - 1 || 'no'
 		} other players mining with you.\nYou received ${itemsToAdd}.\n${xpStr}`;
 		if (itemsToAdd.has('Rock golem')) {


### PR DESCRIPTION
Introduce a hunted mode for Shooting Stars: add hunted? to ShootingStarsOptions, a huntCrashedStarsCommand and rollShootingStar helper, adjust mining efficiency (75% when hunted), and update messages to reflect "hunting and mining". 

Update otherActivities to expose "Hunt Crashed Stars" and wire the activities command. 

Change trip handler to call the activities command for ShootingStars and make repeatStoredTrip only allow repeating shooting star trips when hunted is true. 

Also refactor star roll logic into rollShootingStar. 

Update buyables: Olive oil pack gp_cost -> 27000, Olive oil(4) gp_cost -> 270. (pnpm dev)

- [x] I have tested all my changes thoroughly.
