### PR TITLE
Add Wildy Elite green dragon buff

### DIFF
--- a/data/osb/buyables.json
+++ b/data/osb/buyables.json
@@ -2951,14 +2951,14 @@
 	},
 	{
 		"name": "Olive oil pack",
-		"gp_cost": 2670,
+		"gp_cost": 27000,
 		"output_items": {
 			"12857": 1
 		}
 	},
 	{
 		"name": "Olive oil(4)",
-		"gp_cost": 220,
+		"gp_cost": 270,
 		"output_items": {
 			"3422": 1
 		}

--- a/scripts/monster_table.ts
+++ b/scripts/monster_table.ts
@@ -146,6 +146,7 @@ async function main() {
 					slayerUnlocks: [],
 					favoriteFood: [EItem.SHARK],
 					bitfield: [],
+					hasWildyEliteDiary: false,
 					rng: MathRNG,
 					currentPeak: { peakTier: PeakTier.Medium, startTime: Date.now(), finishTime: Date.now() + 1000 }
 				});

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -17,6 +17,7 @@ import { COXMaxMageGear, COXMaxMeleeGear, COXMaxRangeGear } from '@/lib/data/cox
 import { leaguesCreatables } from '@/lib/data/creatables/leagueCreatables.js';
 import { Eatables } from '@/lib/data/eatables.js';
 import { TOBMaxMageGear, TOBMaxMeleeGear, TOBMaxRangeGear } from '@/lib/data/tob.js';
+import { diaries } from '@/lib/diaries.js';
 import { effectiveMonsters } from '@/lib/minions/data/killableMonsters/index.js';
 import potions from '@/lib/minions/data/potions.js';
 import { MAX_QP, quests } from '@/lib/minions/data/quests.js';
@@ -36,6 +37,7 @@ import { SlayerRewardsShop } from '@/lib/slayer/slayerUnlocks.js';
 import { allSlayerMonsters } from '@/lib/slayer/tasks/index.js';
 import { Gear } from '@/lib/structures/Gear.js';
 import type { SafeUserUpdateInput } from '@/lib/user/update.js';
+import type { HasDiaryDiaryKey } from '@/lib/user/userTypes.js';
 import { parseStringBank } from '@/lib/util/parseStringBank.js';
 import { fetchBingosThatUserIsInvolvedIn } from '@/mahoji/commands/bingo.js';
 import { gearViewCommand } from '@/mahoji/lib/abstracted_commands/gearCommands.js';
@@ -338,6 +340,14 @@ const thingsToWipe = [
 	'giveaways'
 ] as const;
 
+const diaryTierChoices = ['easy', 'medium', 'hard', 'elite', 'all'] as const;
+type TestPotatoDiaryTier = (typeof diaryTierChoices)[number];
+const diaryTierNames = ['easy', 'medium', 'hard', 'elite'] as const;
+
+function formatDiaryKey(diaryName: string, tier: (typeof diaryTierNames)[number]): HasDiaryDiaryKey {
+	return `${diaryName}.${tier}`.replace(/\s/g, '').toLowerCase() as HasDiaryDiaryKey;
+}
+
 export const testPotatoCommand = globalConfig.isProduction
 	? null
 	: defineCommand({
@@ -611,6 +621,27 @@ export const testPotatoCommand = globalConfig.isProduction
 							required: true,
 							min_value: 0,
 							max_value: 10_000
+						}
+					]
+				},
+				{
+					type: 'Subcommand',
+					name: 'setdiarytier',
+					description: 'Set an achievement diary tier as complete.',
+					options: [
+						{
+							type: 'String',
+							name: 'diary',
+							description: 'The achievement diary.',
+							required: true,
+							choices: diaries.map(diary => ({ name: diary.name, value: diary.name }))
+						},
+						{
+							type: 'String',
+							name: 'tier',
+							description: 'The diary tier to complete.',
+							required: true,
+							choices: diaryTierChoices.map(tier => ({ name: tier, value: tier }))
 						}
 					]
 				},
@@ -1066,6 +1097,25 @@ export const testPotatoCommand = globalConfig.isProduction
 				}
 				if (options.setxp) {
 					return setXP(user, options.setxp.skill, options.setxp.xp);
+				}
+				if (options.setdiarytier) {
+					const diary = diaries.find(d => stringMatches(d.name, options.setdiarytier?.diary ?? ''));
+					if (!diary) return 'Invalid diary.';
+
+					const tier = options.setdiarytier.tier as TestPotatoDiaryTier;
+					const tiersToSet = tier === 'all' ? diaryTierNames : [tier];
+					const completedDiaries = new Set(user.user.completed_achievement_diaries);
+
+					for (const tierToSet of tiersToSet) {
+						completedDiaries.add(formatDiaryKey(diary.name, tierToSet));
+					}
+
+					await user.update({
+						completed_achievement_diaries: [...completedDiaries]
+					});
+
+					const tierName = tier === 'all' ? 'all tiers' : diary[tier].name;
+					return `Set your ${diary.name} ${tierName} diary as complete.`;
 				}
 				if (options.spawn) {
 					const { preset, collectionlog, item, items } = options.spawn;

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -90,6 +90,7 @@ export async function minionKillCommand(
 		slayerUnlocks: user.user.slayer_unlocks,
 		favoriteFood: user.user.favorite_food,
 		bitfield: user.bitfield,
+		hasWildyEliteDiary: user.hasDiary('wilderness.elite'),
 		currentPeak: generateDailyPeakIntervals().currentPeak,
 		rng
 	});

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -54,6 +54,7 @@ export interface MinionKillOptions {
 	slayerUnlocks: SlayerTaskUnlocksEnum[];
 	favoriteFood: number[];
 	bitfield: readonly BitField[];
+	hasWildyEliteDiary: boolean;
 	pkEvasionExperience: number;
 	currentPeak: Peak;
 	rng: RNGProvider;

--- a/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/postBoostEffects.ts
@@ -1,6 +1,6 @@
 import { convertAttackStyleToGearSetup } from '@oldschoolgg/gear';
 import { calcPercentOfNum, Time, uniqueArr } from '@oldschoolgg/toolkit';
-import { Bank } from 'oldschooljs';
+import { Bank, Monsters } from 'oldschooljs';
 
 import type { GearSetupType } from '@/prisma/main/enums.js';
 import { BitField } from '@/lib/constants.js';
@@ -13,6 +13,7 @@ import { type Peak, PeakTier } from '@/lib/util/peaks.js';
 import type { BoostArgs, BoostResult } from '@/mahoji/lib/abstracted_commands/minionKill/speedBoosts.js';
 
 const noFoodBoost = Math.floor(Math.max(...Eatables.map(eatable => eatable.pvmBoost ?? 0)) + 1);
+const wildyEliteGreenDragonBoost = 30;
 
 // Runs after we know the quantity/duration/etc
 type PostBoostEffectReturn = Pick<
@@ -104,6 +105,17 @@ export const postBoostEffects: PostBoostEffect[] = [
 				itemCost: foodRemoveResult.foodToRemove
 			});
 			return results;
+		}
+	},
+	{
+		description: 'Wilderness elite green dragon boost',
+		run: ({ monster, isInWilderness, hasWildyEliteDiary }) => {
+			if (monster.id !== Monsters.GreenDragon.id || !isInWilderness || !hasWildyEliteDiary) return;
+
+			return {
+				percentageReduction: wildyEliteGreenDragonBoost,
+				message: `${wildyEliteGreenDragonBoost}% for Wilderness Elite Diary`
+			};
 		}
 	},
 	{

--- a/tests/integration/pvm/pvm.test.ts
+++ b/tests/integration/pvm/pvm.test.ts
@@ -438,6 +438,61 @@ describe('PVM', async () => {
 		expect(user.bank.amount('Cannonball')).toBeGreaterThan(100_000 - 500);
 	});
 
+	async function makeGreenDragonUser(hasWildyEliteDiary = false) {
+		const meleeGear = resolveItems([
+			'Dragon hunter lance',
+			'Anti-dragon shield',
+			'Torva full helm',
+			'Torva platebody',
+			'Torva platelegs',
+			'Infernal cape',
+			'Amulet of torture',
+			'Ferocious gloves',
+			'Primordial boots',
+			'Berserker ring (i)'
+		]);
+		const user = await client.mockUser({
+			maxed: true,
+			meleeGear,
+			wildyGear: meleeGear,
+			bank: new Bank()
+				.add('Saradomin brew(4)', 100)
+				.add('Blighted super restore(4)', 100)
+				.add('Blighted karambwan', 120)
+		});
+		await user.setAttackStyle(['attack', 'strength', 'defence']);
+		await user.statsUpdate({
+			monster_scores: {
+				[Monsters.GreenDragon.id]: 1_000_000
+			}
+		});
+		if (hasWildyEliteDiary) {
+			await user.update({
+				completed_achievement_diaries: ['wilderness.elite']
+			});
+		}
+		return user;
+	}
+
+	test('Wilderness elite diary buffs only wildy green dragons', async () => {
+		const nonWildyBase = await makeGreenDragonUser();
+		const nonWildyElite = await makeGreenDragonUser(true);
+		const wildyElite = await makeGreenDragonUser(true);
+
+		const nonWildyBaseResult = await nonWildyBase.kill(EMonster.GREEN_DRAGON, { quantity: 159 });
+		const nonWildyEliteResult = await nonWildyElite.kill(EMonster.GREEN_DRAGON, { quantity: 159 });
+		const wildyEliteResult = await wildyElite.kill(EMonster.GREEN_DRAGON, { quantity: 159, wilderness: true });
+
+		expect(nonWildyEliteResult.commandResult).not.toContain('Wilderness Elite Diary');
+		expect(nonWildyEliteResult.activityResult!.duration).toEqual(nonWildyBaseResult.activityResult!.duration);
+		expect(wildyEliteResult.commandResult).toContain('30% for Wilderness Elite Diary');
+		const expectedRate = String(wildyEliteResult.commandResult).includes('10% for Weekend') ? 330 / 0.9 : 330;
+		expect(calcPerHour(wildyEliteResult.activityResult!.q, wildyEliteResult.activityResult!.duration)).toBeCloseTo(
+			expectedRate,
+			1
+		);
+	});
+
 	it('should give a scythe boost and deduct charges', async () => {
 		const user = await makeAraxxorUser();
 		await user.equip('melee', [

--- a/tests/test-utils/mockUser.ts
+++ b/tests/test-utils/mockUser.ts
@@ -343,6 +343,7 @@ export async function mockUser(
 		gear_mage: options.mageGear ? (mageGear.raw() as Prisma.InputJsonValue) : undefined,
 		gear_melee: options.meleeGear ? (meleeGear.raw() as Prisma.InputJsonValue) : undefined,
 		gear_range: options.rangeGear ? (rangeGear.raw() as Prisma.InputJsonValue) : undefined,
+		gear_wildy: options.wildyGear ? (wildyGear.raw() as Prisma.InputJsonValue) : undefined,
 		venator_bow_charges: options.venatorBowCharges,
 		QP: options.QP,
 		minion_hasBought: true


### PR DESCRIPTION
Propagate hasWildyEliteDiary through minion kill flow (minionKill/newMinionKill) and add a postBoostEffects entry that grants a 30% boost for Green Dragons in the Wilderness when the Wilderness Elite diary is completed. 

Add Monsters import and minor formatting fixes. 

Add integration test for the wilderness elite buff and update mockUser to support wildyGear; update monster_table test data.

Add a testpotato subcommand to mark achievement diary tiers complete.

Also correct gp_cost values for Olive oil pack and Olive oil(4) in buyables.json.

- [x] I have tested all my changes thoroughly.
