### PR TITLE
Add a compost warning message (toggleable)

### DIFF
--- a/data/osb/buyables.json
+++ b/data/osb/buyables.json
@@ -2951,14 +2951,14 @@
 	},
 	{
 		"name": "Olive oil pack",
-		"gp_cost": 2670,
+		"gp_cost": 27000,
 		"output_items": {
 			"12857": 1
 		}
 	},
 	{
 		"name": "Olive oil(4)",
-		"gp_cost": 220,
+		"gp_cost": 270,
 		"output_items": {
 			"3422": 1
 		}

--- a/docs/src/content/docs/osb/Skills/farming/README.md
+++ b/docs/src/content/docs/osb/Skills/farming/README.md
@@ -46,6 +46,7 @@ XP, speed, and harvest quantity can be boosted by the following:
 - [[/farming auto_farm_filter]] - Choose your auto farm filter
 - [[/farming set_preferred]] - View or set per-patch seed preferences, contract priority, and `reset_all`
 - [[/farming default_compost]] - Set the compost tier to auto apply
+- [[/config user toggle name\:Compost Warning]] - Block farming trips when you are missing your default compost
 - [[/farming always_pay]] - Toggle automatic farmer payments
 - [[/farming compost_bin]] - Convert crops into supercompost
 - [[/farming contract]] - View, request, or downgrade farming contracts

--- a/docs/src/content/docs/osb/Skills/farming/auto-farming.md
+++ b/docs/src/content/docs/osb/Skills/farming/auto-farming.md
@@ -44,6 +44,7 @@ Auto farming collects ready patches into a single Farming activity so you can ha
 
 - Seeds, compost, farmer payments, and tree removal fees are checked up-front.
 - Your [[/farming default_compost]] choice and [[/farming always_pay]] toggle are applied automatically.
+- Enable [[/config user toggle name\:Compost Warning]] to block manual planting and auto farming when you do not have enough of your default compost for the planned patches.
 - Coins for chopping trees without the required Woodcutting level are reserved (200 gp for most trees, 2,000 gp for redwoods).
 - Seed/compost/protection costs are removed immediately before the trip starts.
 - Tree-removal coin costs are deducted up-front as part of trip start, then partially refunded during execution if the estimate was higher than needed.

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -166,6 +166,7 @@ export enum BitField {
 	ServerSupport = 52,
 	DisabledPassiveImplings = 53,
 	DisableAutoFarmButton = 54,
+	CompostWarning = 55,
 
 	OriginalCyrSupporter = 199
 }
@@ -259,6 +260,11 @@ export const BitFieldData: Record<BitField, IBitFieldData> = {
 	},
 	[BitField.DisableAutoFarmButton]: {
 		name: 'Disable Auto Farm Button',
+		protected: false,
+		userConfigurable: true
+	},
+	[BitField.CompostWarning]: {
+		name: 'Compost Warning',
 		protected: false,
 		userConfigurable: true
 	},

--- a/src/lib/minions/functions/autoFarm.ts
+++ b/src/lib/minions/functions/autoFarm.ts
@@ -229,6 +229,9 @@ export async function autoFarm(
 				compostTier
 			});
 			if (!prepared.success) {
+				if (prepared.reason === 'missing_compost') {
+					return { content: prepared.error, allowedMentions: { users: [user.id] } };
+				}
 				errorsForPatch.push(prepared.error);
 				continue;
 			}

--- a/src/lib/minions/functions/farmingTripHelpers.ts
+++ b/src/lib/minions/functions/farmingTripHelpers.ts
@@ -2,11 +2,13 @@ import { formatDuration, Time } from '@oldschoolgg/toolkit';
 import { Bank } from 'oldschooljs';
 
 import type { CropUpgradeType } from '@/prisma/main/enums.js';
+import { BitField } from '@/lib/constants.js';
 import { calcNumOfPatches } from '@/lib/skilling/skills/farming/utils/calcsFarming.js';
 import {
 	farmingBoostMessages,
 	formatCropProtectionPayment,
 	formatMissingCropProtectionPayment,
+	formatMissingFavouritedCompost,
 	formatPatchTreatment,
 	formatTreeRemovalPreparation
 } from '@/lib/skilling/skills/farming/utils/farmingFormatters.js';
@@ -23,6 +25,7 @@ export interface PrepareFarmingStepOptions {
 	maxTripLength: number;
 	availableBank: Bank;
 	compostTier: CropUpgradeType;
+	compostWarning?: boolean;
 }
 
 export interface PreparedFarmingStep {
@@ -65,9 +68,10 @@ export async function prepareFarmingStep({
 	patchDetailed,
 	maxTripLength,
 	availableBank,
-	compostTier
+	compostTier,
+	compostWarning = user.bitfield.includes(BitField.CompostWarning)
 }: PrepareFarmingStepOptions): Promise<
-	{ success: true; data: PreparedFarmingStep } | { success: false; error: string }
+	{ success: true; data: PreparedFarmingStep } | { success: false; error: string; reason?: 'missing_compost' }
 > {
 	const infoStr: string[] = [];
 	const boostStr: string[] = [];
@@ -163,6 +167,17 @@ export async function prepareFarmingStep({
 			infoStr.push(formatPatchTreatment(compostCost));
 			cost.add(compostCost);
 			upgradeType = compostTier;
+		} else if (compostWarning) {
+			return {
+				success: false,
+				error: formatMissingFavouritedCompost(
+					compostTier,
+					compostCost,
+					availableBank.amount(compostTier),
+					user.mention
+				),
+				reason: 'missing_compost'
+			};
 		}
 	}
 

--- a/src/lib/skilling/skills/farming/utils/farmingFormatters.ts
+++ b/src/lib/skilling/skills/farming/utils/farmingFormatters.ts
@@ -1,5 +1,7 @@
 import type { Bank } from 'oldschooljs';
 
+import type { CropUpgradeType } from '@/prisma/main/enums.js';
+import { mentionCommand } from '@/discord/utils.js';
 import type { AutoFarmSummary } from '@/lib/types/minions.js';
 
 export const farmingBoostMessages = {
@@ -25,6 +27,17 @@ export function formatMissingCropProtectionPayment(): string {
 
 export function formatPatchTreatment(compostCost: Bank): string {
 	return `You are treating your patches with ${compostCost}.`;
+}
+
+export function formatMissingFavouritedCompost(
+	compostTier: CropUpgradeType,
+	compostCost: Bank,
+	ownedQuantity: number,
+	userMention: string
+): string {
+	const compostName = compostCost.items()[0]?.[0].name ?? compostTier;
+	const configToggleCommand = mentionCommand('config', 'user', 'toggle') || '/config user toggle';
+	return `${userMention}, your minion could not farm because your default compost is ${compostName}, but you do not have enough of it. You need ${compostCost} and currently have ${ownedQuantity.toLocaleString()}. Obtain more ${compostName}, or disable the Compost Warning toggle with ${configToggleCommand} if you want to continue without it.`;
 }
 
 const compostItemNames = new Set(['Compost', 'Supercompost', 'Ultracompost']);

--- a/tests/unit/autoFarm.test.ts
+++ b/tests/unit/autoFarm.test.ts
@@ -20,6 +20,7 @@ import { mockMUser } from './userutil.js';
 import '../../src/lib/util/clientSettings.js';
 
 import { fetchRepeatTrips, repeatTrip } from '@/lib/util/repeatStoredTrip.js';
+import { BitField } from '../../src/lib/constants.js';
 import { AutoFarmFilterEnum, activity_type_enum, CropUpgradeType } from '../../src/prisma/main/enums.js';
 import type { User } from '../../src/prisma/main.js';
 
@@ -292,6 +293,39 @@ describe('auto farm helpers', () => {
 		expect(cost.amount('Tomatoes(5)')).toBe(0);
 	});
 
+	it('prepareFarmingStep blocks missing favourited compost when compost warning is enabled', async () => {
+		const bank = new Bank().add('Guam seed', 4);
+		const user = mockMUser({
+			bank,
+			bitfield: [BitField.CompostWarning],
+			id: '123456789',
+			skills_farming: convertLVLtoXP(50)
+		});
+		const mutableUser = user.user as MutableUser;
+		mutableUser.minion_defaultCompostToUse = CropUpgradeType.ultracompost;
+
+		const result = await prepareFarmingStep({
+			user,
+			plant: herbPlant,
+			quantity: null,
+			pay: false,
+			patchDetailed: herbPatchDetailed,
+			maxTripLength: 300 * 1000,
+			availableBank: user.bank.clone().add('Coins', user.GP),
+			compostTier: CropUpgradeType.ultracompost
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) {
+			return;
+		}
+		expect(result.reason).toBe('missing_compost');
+		expect(result.error).toContain('<@123456789>');
+		expect(result.error).toContain('your minion could not farm because your default compost is Ultracompost');
+		expect(result.error).toContain('You need 4x Ultracompost and currently have 0.');
+		expect(result.error).toContain('disable the Compost Warning toggle with /config user toggle');
+	});
+
 	it('autoFarm generates plan for AllFarm filter', async () => {
 		const bank = new Bank().add('Guam seed', 4).add('Compost', 4);
 		const user = mockMUser({
@@ -348,6 +382,43 @@ describe('auto farm helpers', () => {
 		// We don't assert internal shape of autoFarmPlan here –
 		// just that a task was queued.
 		expect(addSubTaskToActivityTask).toHaveBeenCalledTimes(1);
+	});
+
+	it('autoFarm blocks missing favourited compost when compost warning is enabled', async () => {
+		const bank = new Bank().add('Guam seed', 4);
+		const user = mockMUser({
+			bank,
+			bitfield: [BitField.CompostWarning],
+			id: '123456789',
+			skills_farming: convertLVLtoXP(50)
+		});
+		const mutableUser = user.user as MutableUser;
+		mutableUser.auto_farm_filter = AutoFarmFilterEnum.AllFarm;
+		mutableUser.minion_defaultCompostToUse = CropUpgradeType.ultracompost;
+
+		const transactSpy = vi.spyOn(user, 'transactItems');
+		calcMaxTripLengthSpy.mockReturnValue(300 * 1000);
+
+		const response = await autoFarm(
+			user,
+			[herbPatchDetailed],
+			herbPatches as Record<FarmingPatchName, IPatchData>,
+			baseInteraction as MInteraction
+		);
+		expect(response).toEqual(
+			expect.objectContaining({
+				content: expect.any(String),
+				allowedMentions: { users: ['123456789'] }
+			})
+		);
+		const content = typeof response === 'object' && 'content' in response ? response.content! : '';
+
+		expect(content).toContain('<@123456789>');
+		expect(content).toContain('your minion could not farm because your default compost is Ultracompost');
+		expect(content).toContain('You need 4x Ultracompost and currently have 0.');
+		expect(content).toContain('disable the Compost Warning toggle with /config user toggle');
+		expect(transactSpy).not.toHaveBeenCalled();
+		expect(addSubTaskToActivityTask).not.toHaveBeenCalled();
 	});
 
 	it('autoFarm names patch groups skipped due to trip length', async () => {


### PR DESCRIPTION
Adds a user config toggle that turns on a compost warning.

When utilised if you run out of your fav selected compost, the bot now pings you and tells you to disable the toggle or obtain more compost.

This especially helps irons wasting valuable seeds by planting without compost.

- [x] I have tested all my changes thoroughly.
