### PR TITLE
Sepulrche - Summer Sweep Up Changes

### DIFF
--- a/data/osb/buyables.json
+++ b/data/osb/buyables.json
@@ -2951,14 +2951,14 @@
 	},
 	{
 		"name": "Olive oil pack",
-		"gp_cost": 2670,
+		"gp_cost": 27000,
 		"output_items": {
 			"12857": 1
 		}
 	},
 	{
 		"name": "Olive oil(4)",
-		"gp_cost": 220,
+		"gp_cost": 270,
 		"output_items": {
 			"3422": 1
 		}

--- a/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
+++ b/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
@@ -14,8 +14,9 @@ To start the Sepulchre, use [[/minigames sepulchre start]].
   - Floor 1 – [[agility:52]]
   - Floor 2 – [[agility:62]]
   - Floor 3 – [[agility:72]]
-  - Floor 4 – [[agility:82]]
-  - Floor 5 – [[agility:92]]
+  - Floor 4 – [[agility:77]]
+  - Floor 5 – [[agility:87]]
+- Floor 5's Grand Coffin requires [[thieving:84]] or [[agility:92]] to open.
 
 ## Boosts
 

--- a/src/lib/minions/data/sepulchre.ts
+++ b/src/lib/minions/data/sepulchre.ts
@@ -86,7 +86,7 @@ export const sepulchreFloors = [
 	{
 		number: 4,
 		petChance: 4000,
-		agilityLevel: 82,
+		agilityLevel: 77,
 		xp: 2625,
 		time: Time.Minute * 2.2,
 		lockpickCoffinChance: 800,
@@ -100,7 +100,7 @@ export const sepulchreFloors = [
 	{
 		number: 5,
 		petChance: 2000,
-		agilityLevel: 92,
+		agilityLevel: 87,
 		xp: 5850,
 		time: Time.Minute * 3.75,
 		lockpickCoffinChance: 600,

--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -18,17 +18,19 @@ export const sepulchreTask: MinionTask = {
 		let agilityXP = 0;
 		let thievingXP = 0;
 		let numCoffinsOpened = 0;
+		const canOpenGrandCoffin = user.skillLevel('agility') >= 92 || user.skillLevel('thieving') >= 84;
+		const completedFloor5 = completedFloors.some(floor => floor.number === 5);
 
 		const highestCompletedFloor = completedFloors.reduce((prev, next) => (prev.number > next.number ? prev : next));
 		for (let i = 0; i < quantity; i++) {
 			for (const floor of completedFloors) {
-				if (floor.number === 5) {
+				if (floor.number === 5 && canOpenGrandCoffin) {
 					loot.add(GrandHallowedCoffin.roll());
 				}
 
 				const numCoffinsToOpen = 1;
 				numCoffinsOpened += numCoffinsToOpen;
-				for (let i = 0; i < numCoffinsToOpen; i++) {
+				for (let coffinIndex = 0; coffinIndex < numCoffinsToOpen; coffinIndex++) {
 					loot.add(openCoffin(rng, floor.number, user));
 				}
 				agilityXP += floor.xp;
@@ -104,6 +106,9 @@ export const sepulchreTask: MinionTask = {
 		let str = `${user}, ${user.minionName} finished doing the Hallowed Sepulchre ${quantity}x times (floor ${
 			floors[0]
 		}-${floors[floors.length - 1]}), and opened ${numCoffinsOpened}x coffins.\n\n${xpRes}\n${thievingXpRes}`;
+		if (completedFloor5 && !canOpenGrandCoffin) {
+			str += `\n${user.minionName} did not open Floor 5's Grand Coffin because it requires 84 Thieving or 92 Agility.`;
+		}
 
 		const image = await makeBankImage({
 			bank: itemsAdded,


### PR DESCRIPTION
Lowered the Floor 4 entry requirement to Level 77, down from 82. 
Lowered the Floor 5 entry requirement to Level 87, down from 92. 
Floor 5's Grand Coffin now requires 84 Thieving or 92 Agility to open. 

Source - https://secure.runescape.com/m=news/summer-sweep-up---agility--chambers-of-xeric-changes?oldschool=1

Update docs to reflect the changes

- [x] I have tested all my changes thoroughly.
