### PR TITLE
Add Sailing skill foundation

### DIFF
--- a/data/osb/quests.json
+++ b/data/osb/quests.json
@@ -103,6 +103,19 @@
 		"prerequisites_quests": [3]
 	},
 	{
+		"id": 19,
+		"qp": 1,
+		"name": "Pandemonium",
+		"skills_rewards": {
+			"sailing": 400
+		},
+		"rewards": {
+			"31803": 1,
+			"31964": 2,
+			"32083": 25
+		}
+	},
+	{
 		"id": 6,
 		"qp": 2,
 		"name": "Perilous Moons",

--- a/docs/src/content/docs/osb/quests.mdx
+++ b/docs/src/content/docs/osb/quests.mdx
@@ -157,6 +157,18 @@ You can send your minion to do this quest using [[/activities quest name\:Meat A
 
 [[cooking\:8,000]]
 
+## Pandemonium
+
+You can send your minion to do this quest using [[/activities quest name\:Pandemonium]]
+
+### Item Rewards
+
+[[32083]] [[31964]] [[31803]]
+
+### XP Rewards
+
+[[sailing\:400]]
+
 ## Perilous Moons
 
 You can send your minion to do this quest using [[/activities quest name\:Perilous Moons]]

--- a/packages/oldschooljs/src/assets/item_data.json
+++ b/packages/oldschooljs/src/assets/item_data.json
@@ -197717,7 +197717,7 @@
 		}
 	},
 	"31290": {
-		"name": "Sailing cape (t)",
+		"name": "Sailing cape(t)",
 		"tradeable": false,
 		"tradeable_on_ge": false,
 		"equipable": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -332,6 +332,7 @@ model User {
   skills_agility      BigInt @default(0) @map("skills.agility")
   skills_cooking      BigInt @default(0) @map("skills.cooking")
   skills_fishing      BigInt @default(0) @map("skills.fishing")
+  skills_sailing      BigInt @default(0) @map("skills.sailing")
   skills_mining       BigInt @default(0) @map("skills.mining")
   skills_smithing     BigInt @default(0) @map("skills.smithing")
   skills_woodcutting  BigInt @default(0) @map("skills.woodcutting")
@@ -957,6 +958,7 @@ enum xp_gains_skill_enum {
   agility
   cooking
   fishing
+  sailing
   mining
   smithing
   woodcutting

--- a/src/lib/InteractionID.ts
+++ b/src/lib/InteractionID.ts
@@ -42,6 +42,7 @@ export const InteractionID = {
 		CheckPatches: 'CHECK_PATCHES',
 		ClaimDaily: 'CLAIM_DAILY',
 		DoShootingStar: 'DO_SHOOTING_STAR',
+		StartQuest: 'START_QUEST',
 		StartTearsOfGuthix: 'START_TOG',
 		NewSlayerTask: 'NEW_SLAYER_TASK',
 		DoBirdHouseRun: 'DO_BIRDHOUSE_RUN',

--- a/src/lib/data/emojis.ts
+++ b/src/lib/data/emojis.ts
@@ -13,6 +13,7 @@ export const skillEmoji = {
 	strength: '<:strength:630911040481263617>',
 	defence: '<:defence:630911040393052180>',
 	fishing: '<:fishing:630911040091193356>',
+	sailing: '<:Sailing:1537491722920267889>',
 	hitpoints: '<:hitpoints:630911040460292108>',
 	total: '<:xp:630911040510623745>',
 	overall: '<:xp:630911040510623745>',

--- a/src/lib/minions/data/quests.ts
+++ b/src/lib/minions/data/quests.ts
@@ -35,7 +35,8 @@ export enum QuestID {
 	TheFinalDawn = 15,
 	'Scrambled!' = 16,
 	ShadowsOfCustodia = 17,
-	TutorialIsland = 18
+	TutorialIsland = 18,
+	Pandemonium = 19
 }
 
 export const quests: Quest[] = [
@@ -453,6 +454,21 @@ export const quests: Quest[] = [
 			.add(995, 25),
 		calcTime: () => {
 			return Time.Minute * 7;
+		}
+	},
+	{
+		id: QuestID.Pandemonium,
+		qp: 1,
+		name: 'Pandemonium',
+		skillsRewards: {
+			sailing: 400
+		},
+		rewards: new Bank()
+			.add(32083, 25) // Sawmill coupon (wood plank)
+			.add('Repair kit', 2)
+			.add('Spyglass'),
+		calcTime: () => {
+			return Time.Minute * 5;
 		}
 	}
 ];

--- a/src/lib/skilling/skillcapes.ts
+++ b/src/lib/skilling/skillcapes.ts
@@ -147,6 +147,12 @@ const Skillcapes: Skillcape[] = [
 		hood: itemID('Slayer hood'),
 		untrimmed: itemID('Slayer cape'),
 		trimmed: itemID('Slayer cape(t)')
+	},
+	{
+		skill: 'sailing',
+		hood: itemID('Sailing hood'),
+		untrimmed: itemID('Sailing cape'),
+		trimmed: itemID('Sailing cape(t)')
 	}
 ];
 

--- a/src/lib/skilling/skills/index.ts
+++ b/src/lib/skilling/skills/index.ts
@@ -15,6 +15,7 @@ import Magic from './magic/index.js';
 import Mining from './mining.js';
 import Prayer from './prayer.js';
 import Runecraft from './runecraft.js';
+import Sailing from './sailing/index.js';
 import Smithing from './smithing/index.js';
 import { Thieving } from './thieving/index.js';
 import Woodcutting from './woodcutting/woodcutting.js';
@@ -24,6 +25,7 @@ export const Skills: Record<string, Skill> = {
 	Agility,
 	Cooking,
 	Fishing,
+	Sailing,
 	Mining,
 	Smithing,
 	Woodcutting,

--- a/src/lib/skilling/skills/sailing/index.ts
+++ b/src/lib/skilling/skills/sailing/index.ts
@@ -1,0 +1,12 @@
+import type { Emoji as EmojiType } from '@oldschoolgg/toolkit';
+
+import { defineSkill } from '@/lib/skilling/types.js';
+
+const Sailing = defineSkill({
+	aliases: ['sailing', 'sail'],
+	id: 'sailing',
+	emoji: '<:Sailing:1537491722920267889>' as EmojiType,
+	name: 'Sailing'
+});
+
+export default Sailing;

--- a/src/lib/skilling/skills/sailing/sailingXPUnlock.ts
+++ b/src/lib/skilling/skills/sailing/sailingXPUnlock.ts
@@ -1,0 +1,16 @@
+import { QuestID } from '@/lib/minions/data/quests.js';
+
+interface SailingXPUser {
+	minionName?: string;
+	user: {
+		finished_quest_ids?: QuestID[] | null;
+	};
+}
+
+export function canGainSailingXP(user: SailingXPUser): boolean {
+	return user.user.finished_quest_ids?.includes(QuestID.Pandemonium) ?? false;
+}
+
+export function sailingXPUnlockMessage(user: SailingXPUser): string {
+	return `${user.minionName ?? 'Your minion'} needs to have completed the Pandemonium quest to gain Sailing XP.`;
+}

--- a/src/lib/skilling/types.ts
+++ b/src/lib/skilling/types.ts
@@ -9,6 +9,7 @@ export const SkillsArray = [
 	'agility',
 	'cooking',
 	'fishing',
+	'sailing',
 	'mining',
 	'smithing',
 	'woodcutting',

--- a/src/lib/user/BaseUser.ts
+++ b/src/lib/user/BaseUser.ts
@@ -274,6 +274,7 @@ export class BaseUser {
 			agility: Number(this.user.skills_agility),
 			cooking: Number(this.user.skills_cooking),
 			fishing: Number(this.user.skills_fishing),
+			sailing: Number(this.user.skills_sailing),
 			mining: Number(this.user.skills_mining),
 			smithing: Number(this.user.skills_smithing),
 			woodcutting: Number(this.user.skills_woodcutting),

--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -337,6 +337,15 @@ async function globalButtonInteractionHandler({
 		});
 	}
 
+	if (id.startsWith(`${InteractionID.Commands.StartQuest}_`)) {
+		const questName = id.slice(`${InteractionID.Commands.StartQuest}_`.length);
+		return runCommand({
+			commandName: 'activities',
+			args: { quest: { name: questName } },
+			...options
+		});
+	}
+
 	if (id === InteractionID.Open.BeginnerCasket) return openCasket('Beginner');
 	if (id === InteractionID.Open.EasyCasket) return openCasket('Easy');
 	if (id === InteractionID.Open.MediumCasket) return openCasket('Medium');

--- a/src/lib/util/interactions.ts
+++ b/src/lib/util/interactions.ts
@@ -62,6 +62,13 @@ export function makeTearsOfGuthixButton() {
 		.setEmoji({ name: '🐍' });
 }
 
+export function makeStartQuestButton(questName: string) {
+	return new ButtonBuilder()
+		.setCustomId(`${InteractionID.Commands.StartQuest}_${questName}`)
+		.setLabel('Start Quest')
+		.setStyle(ButtonStyle.Secondary);
+}
+
 export function makeBirdHouseTripButton() {
 	return new ButtonBuilder()
 		.setCustomId(InteractionID.Commands.DoBirdHouseRun)

--- a/src/lib/util/minionStatsEmbed.ts
+++ b/src/lib/util/minionStatsEmbed.ts
@@ -26,12 +26,6 @@ export async function minionStatsEmbed({
 	const xp = sumArr(Object.values(user.skillsAsXP) as number[]);
 	const { totalLevel } = user;
 	const skillCell = (skill: string) => {
-		if (skill === 'overall') {
-			return `${skillEmoji[skill as keyof typeof skillEmoji] as keyof SkillsScore} ${totalLevel}\n${
-				skillEmoji.combat
-			} ${user.combatLevel}`;
-		}
-
 		const skillXP = user.skillsAsXP[skill as keyof Skills] ?? 1;
 		return `${skillEmoji[skill as keyof typeof skillEmoji] as keyof SkillsScore} ${convertXPtoLVL(
 			skillXP,
@@ -65,7 +59,7 @@ export async function minionStatsEmbed({
 		},
 		{
 			name: '\u200b',
-			value: ['mining', 'smithing', 'fishing', 'cooking', 'firemaking', 'woodcutting', 'farming', 'overall']
+			value: ['mining', 'smithing', 'fishing', 'sailing', 'cooking', 'firemaking', 'woodcutting', 'farming']
 				.map(skillCell)
 				.join('\n'),
 			inline: true
@@ -81,6 +75,7 @@ export async function minionStatsEmbed({
 		name: `${skillEmoji.total} Overall`,
 		value: `**Level:** ${totalLevel}
 **XP:** ${xp.toLocaleString()}
+**Combat:** ${user.combatLevel}
 **QP** ${QP}
 **CL Completion:** ${percent.toFixed(1)}%`,
 		inline: true

--- a/src/mahoji/commands/lvl.ts
+++ b/src/mahoji/commands/lvl.ts
@@ -34,7 +34,11 @@ export const lvlCommand = defineCommand({
 			return error;
 		}
 
-		const res = player.skills[options.skill];
+		if (options.skill === 'sailing') {
+			return 'Sailing is not available on OSRS hiscores yet.';
+		}
+
+		const res = player.skills[options.skill as keyof typeof player.skills];
 		let str = `**${options.rsn}**'s ${options.skill} level is **${res.level}** and is`;
 
 		if (res.level < 99) {

--- a/src/mahoji/lib/abstracted_commands/lampCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lampCommand.ts
@@ -1,8 +1,10 @@
 import { Bank, type Item, Items, itemID, resolveItems } from 'oldschooljs';
 import { clamp } from 'remeda';
 
+import { canGainSailingXP, sailingXPUnlockMessage } from '@/lib/skilling/skills/sailing/sailingXPUnlock.js';
 import { type SkillNameType, SkillsArray } from '@/lib/skilling/types.js';
 import type { Skills } from '@/lib/types/index.js';
+import { makeStartQuestButton } from '@/lib/util/interactions.js';
 import { assert } from '@/lib/util/logError.js';
 import { isValidSkill } from '@/lib/util/smallUtils.js';
 
@@ -281,6 +283,13 @@ export async function lampCommand(user: MUser, itemToUse: string, skill: string,
 
 	if (!skillsToReceive[skill]) {
 		return 'This is not a valid skill for this item.';
+	}
+
+	if (skill === 'sailing' && !canGainSailingXP(user)) {
+		return {
+			content: sailingXPUnlockMessage(user),
+			components: [makeStartQuestButton('Pandemonium')]
+		};
 	}
 
 	if (skillsRequirements && user.skillLevel(skill) < skillsRequirements[skill]!) {

--- a/tests/unit/MUser.test.ts
+++ b/tests/unit/MUser.test.ts
@@ -39,6 +39,7 @@ describe('MUser.test', () => {
 			prayer: 1,
 			ranged: 1,
 			runecraft: 1,
+			sailing: 1,
 			slayer: 1,
 			smithing: 1,
 			strength: 1,

--- a/tests/unit/userutil.ts
+++ b/tests/unit/userutil.ts
@@ -55,6 +55,7 @@ const mockUser = (overrides?: MockUserArgs): User => {
 		skills_agility: overrides?.skills_agility ?? 0,
 		skills_cooking: 0,
 		skills_fishing: overrides?.skills_fishing ?? 0,
+		skills_sailing: 0,
 		skills_mining: 0,
 		skills_smithing: 0,
 		skills_woodcutting: overrides?.skills_woodcutting ?? 0,


### PR DESCRIPTION
### Description:

- Add Sailing as a recognised bot skill in the core skill registry, user XP plumbing, stats display, and skillcape data
- Add Pandemonium as the initial Sailing unlock quest, awarding 400 Sailing XP to include the cargo delivery XP
- Gate lamp XP into Sailing behind Pandemonium
- Add the Sailing emoji and basic quest-start button support

This is the first split from the larger Sailing branch. It intentionally does not add Sailing activities, ship commands, shipbuilding, facilities, or ship state.

### Other checks:

- [x] I have tested all my changes thoroughly.
