### PR TITLE
Add Herbiboar drystreak

### DIFF
--- a/src/mahoji/commands/tools.ts
+++ b/src/mahoji/commands/tools.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder } from '@oldschoolgg/discord';
 import { formatDuration, stringMatches, stringSearch } from '@oldschoolgg/toolkit';
-import { Bank, type Item, type ItemBank, ItemGroups, Items, resolveItems, ToBUniqueTable } from 'oldschooljs';
+import { Bank, ECreature, type Item, type ItemBank, ItemGroups, Items, resolveItems, ToBUniqueTable } from 'oldschooljs';
 
 import type { Activity } from '@/prisma/main.js';
 import { choicesOf, itemOption, monsterOption, skillOption } from '@/discord/index.js';
@@ -10,6 +10,7 @@ import { PerkTier } from '@/lib/constants.js';
 import { allCLItemsFiltered, allDroppedItems } from '@/lib/data/Collections.js';
 import { gnomeRestaurantCL, guardiansOfTheRiftCL, shadesOfMorttonCL } from '@/lib/data/CollectionsExport.js';
 import pets from '@/lib/data/pets.js';
+import { Prisma } from '@/prisma/main.js';
 import killableMonsters, { effectiveMonsters, NightmareMonster } from '@/lib/minions/data/killableMonsters/index.js';
 import { allOpenables, type UnifiedOpenable } from '@/lib/openables.js';
 import type { MinigameName } from '@/lib/settings/minigames.js';
@@ -341,6 +342,25 @@ LIMIT 10;`);
 }
 
 export const dryStreakEntities: DrystreakEntity[] = [
+		{
+		name: 'Herbiboar',
+		items: resolveItems(['Herbi']),
+		run: async ({ item, ironmanOnly }) => {
+			const creatureId = ECreature.HERBIBOAR.toString();
+			const itemId = item.id.toString();
+			const result = await prisma.$queryRaw<{ id: string; val: number }[]>(Prisma.sql`
+SELECT "users"."id", ("creature_scores"->>${creatureId})::int AS val
+FROM users
+INNER JOIN "user_stats" ON "user_stats"."user_id"::text = "users"."id"
+WHERE "collectionLogBank"->>${itemId} IS NULL
+AND "creature_scores"->>${creatureId} IS NOT NULL
+${ironmanOnly ? Prisma.sql`AND "minion.ironman" = true` : Prisma.empty}
+ORDER BY ("creature_scores"->>${creatureId})::int DESC
+LIMIT 10;`);
+			return result;
+		},
+		format: num => `${num.toLocaleString()} Catches`
+	},
 	{
 		name: 'Chambers of Xeric (CoX)',
 		items: resolveItems([


### PR DESCRIPTION
Added ECreature import and Prisma usage in dryStreakEntities.

### Description:

Add the ability to Drystreak Herbi from Herbiboar

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

- [ ] I have tested all my changes thoroughly.
