### PR TITLE
Fix command sync on BSO

### DIFF
--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -962,6 +962,12 @@ export const adminCommand = defineCommand({
 			description: 'Spawn items for a user',
 			options: [
 				{
+					type: 'String',
+					name: 'items',
+					description: 'The items to give',
+					required: true
+				},
+				{
 					type: 'User',
 					name: 'user',
 					description: 'The user',
@@ -973,12 +979,6 @@ export const adminCommand = defineCommand({
 					description: 'Where to send the items',
 					required: false,
 					choices: choicesOf(adminGiveItemDestinations)
-				},
-				{
-					type: 'String',
-					name: 'items',
-					description: 'The items to give',
-					required: true
 				},
 				{
 					type: 'String',


### PR DESCRIPTION
Discord requires required options to come before optional ones, but items was after optional user and destination.

I moved items to the top of that subcommand’s options.

- [x] I have tested all my changes thoroughly.
