### PR TITLE
Allow admins to view /data commands for users

### DIFF
--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -34,6 +34,7 @@ import { countUsersWithItemInCl } from '@/lib/rawSql.js';
 import { sorts } from '@/lib/sorts.js';
 import { makeBankImage } from '@/lib/util/makeBankImage.js';
 import { parseBank } from '@/lib/util/parseStringBank.js';
+import { dataPointNameAutocomplete, statsCommand } from '@/mahoji/lib/abstracted_commands/statCommand.js';
 
 export const gifs = [
 	'https://tenor.com/view/angry-stab-monkey-knife-roof-gif-13841993',
@@ -688,6 +689,28 @@ export const adminCommand = defineCommand({
 		},
 		{
 			type: 'Subcommand',
+			name: 'data',
+			description: 'View data for a user',
+			options: [
+				{
+					type: 'User',
+					name: 'user',
+					description: 'The user',
+					required: true
+				},
+				{
+					type: 'String',
+					name: 'name',
+					description: 'The data you want to see.',
+					autocomplete: async ({ value }: StringAutoComplete) => {
+						return dataPointNameAutocomplete(value);
+					},
+					required: true
+				}
+			]
+		},
+		{
+			type: 'Subcommand',
 			name: 'ltc',
 			description: 'Ltc?',
 			options: [
@@ -944,6 +967,11 @@ ${META_CONSTANTS.RENDERED_STR}`
 				title: thing.name,
 				flags: thing.name === 'All Equipped Items' ? { sort: 'name' } : undefined
 			});
+		}
+
+		if (options.data) {
+			const user = await mUserFetch(options.data.user.user.id);
+			return statsCommand(user, options.data.name, { bypassPerkTier: true });
 		}
 
 		if (options.give_items) {

--- a/src/mahoji/commands/data.ts
+++ b/src/mahoji/commands/data.ts
@@ -1,4 +1,4 @@
-import { dataPoints, statsCommand } from '@/mahoji/lib/abstracted_commands/statCommand.js';
+import { dataPointNameAutocomplete, statsCommand } from '@/mahoji/lib/abstracted_commands/statCommand.js';
 
 export const dataCommand = defineCommand({
 	name: 'data',
@@ -12,13 +12,7 @@ export const dataCommand = defineCommand({
 			name: 'name',
 			description: 'The data you want to see.',
 			autocomplete: async ({ value }: StringAutoComplete) => {
-				return dataPoints
-					.map(i => i.name)
-					.filter(i => (!value ? true : i.toLowerCase().includes(value.toLowerCase())))
-					.map(i => ({
-						name: i,
-						value: i
-					}));
+				return dataPointNameAutocomplete(value);
 			},
 			required: true
 		}

--- a/src/mahoji/lib/abstracted_commands/statCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/statCommand.ts
@@ -1269,7 +1269,21 @@ ${(
 	}
 ] as const;
 
-export async function statsCommand(user: MUser, type: string): Promise<SendableMessage> {
+export function dataPointNameAutocomplete(value: string) {
+	return dataPoints
+		.map(i => i.name)
+		.filter(i => (!value ? true : i.toLowerCase().includes(value.toLowerCase())))
+		.map(i => ({
+			name: i,
+			value: i
+		}));
+}
+
+export async function statsCommand(
+	user: MUser,
+	type: string,
+	options: { bypassPerkTier?: boolean } = {}
+): Promise<SendableMessage> {
 	const ratelimit = await Cache.tryRatelimit(user.id, 'stats_command');
 	if (!ratelimit.success) {
 		return `This command is on cooldown, you can use it again in ${formatDuration(ratelimit.timeRemainingMs)}.`;
@@ -1277,7 +1291,7 @@ export async function statsCommand(user: MUser, type: string): Promise<SendableM
 	const dataPoint = dataPoints.find(dp => stringMatches(dp.name, type));
 	if (!dataPoint) return 'Invalid stat name.';
 	const { perkTierNeeded } = dataPoint;
-	if (perkTierNeeded !== null && (await user.fetchPerkTier()) < perkTierNeeded) {
+	if (!options.bypassPerkTier && perkTierNeeded !== null && (await user.fetchPerkTier()) < perkTierNeeded) {
 		return `Sorry, you need to be a Tier ${perkTierNeeded - 1} Patron to see this stat.`;
 	}
 	const userStats = await fetchUserStats(user.id);


### PR DESCRIPTION
Added /admin data user:<user> name:<data point>

Reused the normal /data autocomplete list via dataPointNameAutocomplete

Kept normal /data behaviour unchanged, but admin usage bypasses the target user’s /data Patron-tier gate.

- [x] I have tested all my changes thoroughly.
