### PR TITLE
Fix kill messages

### DIFF
--- a/src/lib/util/hasMonsterRequirements.ts
+++ b/src/lib/util/hasMonsterRequirements.ts
@@ -164,6 +164,7 @@ export async function hasMonsterRequirements(user: MUser, monster: KillableMonst
 			slayerKillsRemaining: null
 		});
 		if (consumablesCost.itemCost && !user.bank.has(consumablesCost.itemCost)) {
+			const missingItems = consumablesCost.itemCost.clone().remove(user.bank);
 			const items = Array.isArray(monster.itemCost) ? monster.itemCost : [monster.itemCost];
 			const messages: string[] = [];
 			for (const group of items) {
@@ -175,7 +176,7 @@ export async function hasMonsterRequirements(user: MUser, monster: KillableMonst
 			}
 			return [
 				false,
-				`You don't have the items needed to kill ${monster.name}. This monster requires (per kill) ${formatList(messages)}.`
+				`You don't have the items needed to kill ${monster.name}. You're missing: ${missingItems}. This monster requires (per kill) ${formatList(messages)}.`
 			];
 		}
 	}

--- a/src/lib/util/smallUtils.ts
+++ b/src/lib/util/smallUtils.ts
@@ -71,8 +71,10 @@ export function calculateSimpleMonsterDeathChance({
 }): number {
 	if (!currentKC) currentKC = 1;
 	currentKC = Math.max(1, currentKC);
-	const baseDeathChance = Math.min(highestDeathChance, (100 * hardness) / steepness);
-	const maxScalingKC = 5 + (75 * hardness) / steepness;
+	if (hardness <= 0) return lowestDeathChance;
+	const scalingSteepness = steepness <= 0 ? 0.5 : steepness;
+	const baseDeathChance = Math.min(highestDeathChance, (100 * hardness) / scalingSteepness);
+	const maxScalingKC = 5 + (75 * hardness) / scalingSteepness;
 	const reductionFactor = Math.min(1, currentKC / maxScalingKC);
 	const deathChance = baseDeathChance - reductionFactor * (baseDeathChance - lowestDeathChance);
 	return clamp(deathChance, { min: lowestDeathChance, max: highestDeathChance });

--- a/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/newMinionKill.ts
@@ -313,13 +313,11 @@ export function newMinionKillCommand(args: MinionKillOptions): string | MinionKi
 	speedDurationResult.updateBank.itemCostBank.freeze();
 	speedDurationResult.updateBank.itemLootBank.freeze();
 
-	if (speedDurationResult.updateBank.itemCostBank.length > 0) {
-		speedDurationResult.messages.push(`Removing items: ${speedDurationResult.updateBank.itemCostBank}`);
-	}
-
 	if (monster.deathProps) {
 		const deathChance = calculateSimpleMonsterDeathChance({ ...monster.deathProps, currentKC: args.monsterKC });
-		speedDurationResult.messages.push(`${deathChance.toFixed(1)}% chance of death`);
+		if (deathChance > 0) {
+			speedDurationResult.messages.push(`${deathChance.toFixed(1)}% chance of death`);
+		}
 	}
 
 	const result = newMinionKillReturnSchema.parse({

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -1,13 +1,17 @@
-import { calcPercentOfNum, reduceNumByPercent, stripEmojis, truncateString } from '@oldschoolgg/toolkit';
-import { Bank, convertLVLtoXP, Items } from 'oldschooljs';
+import { calcPercentOfNum, reduceNumByPercent, stripEmojis, Time, truncateString } from '@oldschoolgg/toolkit';
+import { Bank, convertLVLtoXP, Items, Monsters } from 'oldschooljs';
 import { describe, expect, test } from 'vitest';
 
 import { Eatables } from '@/lib/data/eatables.js';
 import getUserFoodFromBank from '@/lib/minions/functions/getUserFoodFromBank.js';
-import { pluraliseItemName } from '@/lib/util/smallUtils.js';
+import type { KillableMonster } from '@/lib/minions/types.js';
+import { PeakTier } from '@/lib/util/peaks.js';
+import { calculateSimpleMonsterDeathChance, pluraliseItemName } from '@/lib/util/smallUtils.js';
 import { skillingPetDropRate } from '@/lib/util.js';
 import { sellPriceOfItem, sellStorePriceOfItem } from '@/mahoji/commands/sell.js';
+import { newMinionKillCommand } from '@/mahoji/lib/abstracted_commands/minionKill/newMinionKill.js';
 import { mockMUser } from './userutil.js';
+import { makeGearBank } from './utils.js';
 
 describe('util', () => {
 	test('stripEmojis', () => {
@@ -139,5 +143,78 @@ describe('util', () => {
 		expect(pluraliseItemName('Steel Axe')).toEqual('Steel Axes');
 		expect(pluraliseItemName('Steel Arrowtips')).toEqual('Steel Arrowtips');
 		expect(pluraliseItemName('Adamantite nails')).toEqual('Adamantite nails');
+	});
+
+	test('calculateSimpleMonsterDeathChance handles zero-hardness monsters', () => {
+		expect(
+			calculateSimpleMonsterDeathChance({
+				hardness: 0,
+				currentKC: 0,
+				lowestDeathChance: 0,
+				highestDeathChance: 0,
+				steepness: 0
+			})
+		).toEqual(0);
+	});
+
+	test('newMinionKillCommand leaves item removal messaging to the transaction layer', () => {
+		const gearBank = makeGearBank({ bank: new Bank().add('Coins', 10) });
+		const monster: KillableMonster = {
+			id: Monsters.Man.id,
+			name: 'Test Man',
+			aliases: ['test man'],
+			timeToFinish: Time.Minute,
+			table: { kill: () => new Bank() },
+			itemCost: {
+				itemCost: new Bank().add('Coins'),
+				qtyPerKill: 1
+			},
+			deathProps: {
+				hardness: 0,
+				lowestDeathChance: 0,
+				highestDeathChance: 0,
+				steepness: 0
+			}
+		};
+
+		const result = newMinionKillCommand({
+			attackStyles: ['attack'],
+			gearBank,
+			currentSlayerTask: {
+				currentTask: null,
+				assignedTask: null,
+				slayerMaster: null,
+				slayerPoints: 0,
+				statsWithStreaks: {
+					slayer_task_streak: 0,
+					slayer_wildy_task_streak: 0
+				}
+			},
+			monster,
+			isTryingToUseWildy: false,
+			combatOptions: [],
+			inputPVMMethod: undefined,
+			monsterKC: 0,
+			poh: null as never,
+			maxTripLength: Time.Hour,
+			inputQuantity: 1,
+			slayerUnlocks: [],
+			favoriteFood: [],
+			bitfield: [],
+			pkEvasionExperience: 0,
+			currentPeak: {
+				startTime: 0,
+				finishTime: Time.Hour,
+				peakTier: PeakTier.Low
+			},
+			disabledInventions: [],
+			rng: MathRNG
+		});
+
+		expect(result).not.toBeTypeOf('string');
+		if (typeof result === 'string') return;
+		expect(result.messages).not.toContain('0.0% chance of death');
+		expect(result.messages).not.toContain('Removing items: 1x Coins');
+		expect(result.updateBank.itemCostBank.toString()).toEqual('1x Coins');
 	});
 });


### PR DESCRIPTION
The bot will no longer show NaN% chance of death for monsters that cannot kill your minion, and item costs will no longer be listed twice when a trip starts.

It also improves the missing-item error so it tells players exactly what item they are missing, instead of only repeating the full list of required items.

- [x] I have tested all my changes thoroughly.
