### PR TITLE
Fix Ironman Command Error

### DIFF
--- a/src/mahoji/lib/abstracted_commands/ironmanCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/ironmanCommand.ts
@@ -189,6 +189,7 @@ After becoming an ironman:
 	await prisma.user.create({
 		data: createOptions
 	});
+	await user.sync();
 
 	// Refund the leagues points they spent
 	const roboChimpUser = await Cache.getRoboChimpUser(user.id);


### PR DESCRIPTION
After deleting and recreating the user row, the final sanity check was still reading the stale pre-reset MUser object.

This pr has added an await user.sync() immediately after prisma.user.create(...), so the assertion now checks the freshly reset ironman account state.

- [x] I have tested all my changes thoroughly.
