### PR TITLE
Correct Verdant logs item IDs

### DIFF
--- a/data/bso/skills/woodcutting-logs.json
+++ b/data/bso/skills/woodcutting-logs.json
@@ -16,7 +16,7 @@
 	{
 		"level": 115,
 		"xp": 650,
-		"id": 75027,
+		"id": 75026,
 		"name": "Ancient Verdant Logs",
 		"find_new_tree_time": 8.5,
 		"banking_time": 25,
@@ -211,7 +211,7 @@
 	{
 		"level": 100,
 		"xp": 500,
-		"id": 75026,
+		"id": 75025,
 		"name": "Verdant Logs",
 		"find_new_tree_time": 8.5,
 		"banking_time": 25,

--- a/src/lib/bso/skills/woodcutting/logs.ts
+++ b/src/lib/bso/skills/woodcutting/logs.ts
@@ -39,7 +39,7 @@ export const bsoLogs: Log[] = [
 	{
 		level: 115,
 		xp: 650,
-		id: 75_027,
+		id: 75_026,
 		name: 'Ancient Verdant Logs',
 		findNewTreeTime: 8.5,
 		bankingTime: 25,
@@ -54,7 +54,7 @@ export const bsoLogs: Log[] = [
 	{
 		level: 100,
 		xp: 500,
-		id: 75_026,
+		id: 75_025,
 		name: 'Verdant Logs',
 		findNewTreeTime: 8.5,
 		bankingTime: 25,


### PR DESCRIPTION
Fix incorrect item IDs for Verdant logs. Updated Ancient Verdant Logs id 75027 (living bark) → 75026 (ancient verdant logs) and Verdant Logs id 75026 (ancient verdant logs) → 75025 (verdant logs) in data/bso/skills/woodcutting-logs.json and mirrored the same numeric changes in src/lib/bso/skills/woodcutting/logs.ts so data and code remain consistent.

Also fixes the repeat trip errors

- [x] I have tested all my changes thoroughly.
