### PR TITLE
Verdant Balance

### DIFF
--- a/src/lib/bso/commands/islandUpgrades.ts
+++ b/src/lib/bso/commands/islandUpgrades.ts
@@ -109,7 +109,6 @@ export const PASSIVE_YIELD_TABLES: Record<SkillCategory, PassiveYieldEntry[]> = 
 		{ item: 'Coal', minLevel: 30, tierCeiling: 1, ratePerHour: 300 },
 		{ item: 'Gold ore', minLevel: 40, tierCeiling: 1, ratePerHour: 80 },
 		{ item: 'Mithril ore', minLevel: 55, tierCeiling: 2, ratePerHour: 70 },
-		{ item: 'Lovakite ore', minLevel: 65, tierCeiling: 3, ratePerHour: 60 },
 		{ item: 'Adamantite ore', minLevel: 70, tierCeiling: 2, ratePerHour: 55 },
 		{ item: 'Obsidian shards', minLevel: 80, tierCeiling: 3, ratePerHour: 30 },
 		{ item: 'Runite ore', minLevel: 85, tierCeiling: 3, ratePerHour: 30 },
@@ -278,7 +277,7 @@ export function calculateAccumulatedYields(
 		for (let roll = 0; roll < rollsPerTick; roll++) {
 			const item = weightedPick(entries, rand);
 			const baseQty = 1 + Math.floor(rand() * 3);
-			const qty = Math.max(1, Math.floor(baseQty * rateMultiplier));
+			const qty = Math.max(1, Math.floor(baseQty * 2.25 * rateMultiplier));
 			totals.set(item, (totals.get(item) ?? 0) + qty);
 		}
 	}
@@ -353,7 +352,6 @@ const MAINTENANCE_BASE_QTY: Record<string, number> = {
 	'Mithril ore': 3_000,
 	'Gold ore': 2_000,
 	'Granite (500g)': 2_500,
-	'Lovakite ore': 2_000,
 	'Soft clay': 4_000,
 	'Bronze pickaxe': 10,
 	'Dragon pickaxe': 1,
@@ -392,8 +390,8 @@ const MAINTENANCE_BASE_QTY: Record<string, number> = {
 };
 
 const MAINTENANCE_ITEM_CAPS: Partial<Record<string, number>> = {
-	'Sentinel core': 50,
-	'Verdant heart': 50,
+	'Sentinel core': 1,
+	'Verdant heart': 1,
 	'Empyrean shards': 25
 };
 
@@ -446,7 +444,7 @@ export function getWeeklyMaintenanceDemand(
 	const bank = new Bank();
 	for (const itemName of chosen) {
 		const baseQty = MAINTENANCE_BASE_QTY[itemName] ?? 500;
-		const rawQty = Math.max(1, Math.round((baseQty * mult * catMult) / 50) * 50);
+		const rawQty = Math.max(1, Math.round((baseQty * mult * catMult * 0.5) / 50) * 50);
 		const cap = MAINTENANCE_ITEM_CAPS[itemName];
 		const qty = cap !== undefined ? Math.min(rawQty, cap) : rawQty;
 		bank.add(itemName, qty);
@@ -1475,11 +1473,26 @@ export function getNextUpgradeForCategory(
 	return upgradeDefinitions[category].find(t => t.tier === current + 1) ?? null;
 }
 
+export function getUpgradeCost(upgrade: UpgradeTier, isIronman: boolean = false): Bank {
+	if (!isIronman) return upgrade.cost;
+	const cost = new Bank();
+	for (const [item, qty] of upgrade.cost.items()) {
+		if (item.name === 'Coins') {
+			cost.add(item.id, Math.floor(qty / 10));
+		} else {
+			cost.add(item.id, qty);
+		}
+	}
+	return cost;
+}
+
 export function getContributionProgress(
 	nextUpgrade: UpgradeTier,
-	contributions: Partial<Record<string, number>>
+	contributions: Partial<Record<string, number>>,
+	isIronman: boolean = false
 ): number {
-	const costItems = nextUpgrade.cost.items();
+	const cost = getUpgradeCost(nextUpgrade, isIronman);
+	const costItems = cost.items();
 	const totalCostItems = costItems.reduce((s: number, [, q]: [unknown, number]) => s + q, 0);
 	if (totalCostItems === 0) return 0;
 	let contributed = 0;
@@ -1491,17 +1504,24 @@ export function getContributionProgress(
 
 export function isContributionComplete(
 	nextUpgrade: UpgradeTier,
-	contributions: Partial<Record<string, number>>
+	contributions: Partial<Record<string, number>>,
+	isIronman: boolean = false
 ): boolean {
-	for (const [item, qty] of nextUpgrade.cost.items()) {
+	const cost = getUpgradeCost(nextUpgrade, isIronman);
+	for (const [item, qty] of cost.items()) {
 		if ((contributions[item.id.toString()] ?? 0) < qty) return false;
 	}
 	return true;
 }
 
-export function getRemainingCost(nextUpgrade: UpgradeTier, contributions: Partial<Record<string, number>>): Bank {
+export function getRemainingCost(
+	nextUpgrade: UpgradeTier,
+	contributions: Partial<Record<string, number>>,
+	isIronman: boolean = false
+): Bank {
+	const cost = getUpgradeCost(nextUpgrade, isIronman);
 	const remaining = new Bank();
-	for (const [item, qty] of nextUpgrade.cost.items()) {
+	for (const [item, qty] of cost.items()) {
 		const still = qty - (contributions[item.id.toString()] ?? 0);
 		if (still > 0) remaining.add(item.id, still);
 	}

--- a/src/lib/bso/elderOpenables.ts
+++ b/src/lib/bso/elderOpenables.ts
@@ -3,6 +3,7 @@ import { LampTable } from '@/lib/bso/xpLamps.js';
 import { randArrItem, randInt, roll } from 'node-rng';
 import { Bank, LootTable, resolveItems } from 'oldschooljs';
 
+import { IslandTable } from './monsters/VerdantIsland.js';
 import { AllBarrows, BattlestaffTable, runeAlchablesTable, StaffOrbTable } from './tables/sharedTables.js';
 
 const boxTable = new LootTable()
@@ -135,6 +136,7 @@ type LootTableRollOptions = { targetBank?: Bank; cl: Bank };
 export class ElderMimicCasket {
 	public allItems = resolveItems([
 		...elderMimicTable.allItems,
+		...IslandTable.allItems,
 		'Clue bag',
 		'Inventors tools',
 		'Elder knowledge',
@@ -147,9 +149,10 @@ export class ElderMimicCasket {
 		const loot = options.targetBank ?? new Bank();
 
 		for (let i = 0; i < quantity; i++) {
-			const numberOfRolls = randInt(7, 12);
+			const numberOfRolls = randInt(10, 15);
 
 			elderMimicTable.roll(numberOfRolls, { targetBank: loot });
+			IslandTable.roll(1, { targetBank: loot });
 
 			const untradeableUniques = resolveItems(['Clue bag', 'Inventors tools', 'Elder knowledge']);
 			if (roll(30)) {

--- a/src/lib/bso/monsters/VerdantIsland.ts
+++ b/src/lib/bso/monsters/VerdantIsland.ts
@@ -9,11 +9,11 @@ import { addStatsOfItemsTogether, Gear } from '@/lib/structures/Gear.js';
 import type { MUserClass } from '@/lib/user/MUser.js';
 
 export const IslandTable = new LootTable()
-	.add('Ancient cap', [5, 15])
-	.add('Colossal stem', [5, 15])
-	.add('Brimstone spore', [5, 15])
-	.add('Ignilace seed', [2, 8])
-	.add('Ignilace', [3, 12])
+	.add('Ancient cap', [15, 250])
+	.add('Colossal stem', [15, 250])
+	.add('Brimstone spore', [15, 250])
+	.add('Ignilace seed', [5, 25])
+	.add('Ignilace', [25, 75])
 	.add('Verdant logs', [20, 500])
 	.add('Ancient verdant logs', [10, 300])
 	.add('Living bark', [15, 400])
@@ -195,10 +195,10 @@ export const FungalBehemothLootTable = new LootTable()
 	.add('Super combat potion(4)', [3, 10])
 	.add('Super restore(4)', [4, 12])
 
-	.add('Ancient cap', [8, 20])
-	.add('Colossal stem', [8, 20])
-	.add('Brimstone spore', [8, 20])
-	.add('Verdant logs', [25, 60])
+	.add('Ancient cap', [25, 75])
+	.add('Colossal stem', [25, 75])
+	.add('Brimstone spore', [25, 75])
+	.add('Verdant logs', [25, 75])
 	.add('Ancient verdant logs', [15, 40])
 	.add('Living bark', [20, 50])
 
@@ -258,6 +258,7 @@ export const OrymLootTable = new LootTable()
 	.add('Grimy lantadyme', [35, 90])
 	.add('Ignilace', [5, 30])
 	.add('Ignilace seed', [1, 10])
+	.add('Brimstone spore', [25, 75])
 	.add('Elderflame arrowtips', [3, 10]);
 
 export const OrrodilLootTable = new LootTable()
@@ -315,6 +316,7 @@ export const OrrodilLootTable = new LootTable()
 	.add('Grimy torstol', [40, 100])
 	.add('Grimy dwarf weed', [50, 125])
 	.add('Grimy lantadyme', [60, 150])
+	.add('Brimstone spore', [25, 75])
 
 	.add('Uncut zenyte', 1)
 	.add('Uncut onyx', [3, 5])
@@ -387,6 +389,7 @@ export const BurningDominionLootTable = new LootTable()
 	.add('Grimy dwarf weed', [80, 200])
 	.add('Grimy lantadyme', [95, 240])
 
+	.add('Brimstone spore', [25, 75])
 	.add('Ignilace', [5, 30])
 	.add('Ignilace seed', [1, 10])
 	.add('Uncut zenyte', 1)
@@ -439,10 +442,26 @@ export const CrystallineSentinel: CustomMonster = {
 	minimumWeaponShieldStats: {
 		melee: addStatsOfItemsTogether(resolveItems(['Dragon scimitar', 'Dragon defender']), [GearStat.AttackSlash])
 	},
-	itemCost: {
-		itemCost: new Bank().add('Super combat potion(4)').add('Prayer potion(4)', 2),
-		qtyPerKill: 1
-	},
+	itemCost: [
+		{
+			itemCost: new Bank().add('Super combat potion(4)'),
+			qtyPerMinute: 5.5 / 60
+		},
+		{
+			itemCost: new Bank().add('Prayer potion(4)'),
+			qtyPerMinute: 5.5 / 60,
+			alternativeConsumables: [
+				{
+					itemCost: new Bank().add('Super restore(4)'),
+					qtyPerMinute: 5.5 / 60
+				}
+			]
+		},
+		{
+			itemCost: new Bank().add('Saradomin brew(4)'),
+			qtyPerMinute: 16.5 / 60
+		}
+	],
 	setupsUsed: ['melee', 'range'],
 	equippedItemBoosts: [
 		{
@@ -515,10 +534,26 @@ export const FungalBehemoth: CustomMonster = {
 	minimumWeaponShieldStats: {
 		melee: addStatsOfItemsTogether(resolveItems(['Dragon scimitar', 'Dragon defender']), [GearStat.AttackSlash])
 	},
-	itemCost: {
-		itemCost: new Bank().add('Super combat potion(4)').add('Prayer potion(4)', 3).add('Saradomin brew(4)', 2),
-		qtyPerKill: 1
-	},
+	itemCost: [
+		{
+			itemCost: new Bank().add('Super combat potion(4)'),
+			qtyPerMinute: 5.5 / 60
+		},
+		{
+			itemCost: new Bank().add('Prayer potion(4)'),
+			qtyPerMinute: 5.5 / 60,
+			alternativeConsumables: [
+				{
+					itemCost: new Bank().add('Super restore(4)'),
+					qtyPerMinute: 5.5 / 60
+				}
+			]
+		},
+		{
+			itemCost: new Bank().add('Saradomin brew(4)'),
+			qtyPerMinute: 16.5 / 60
+		}
+	],
 	setupsUsed: ['melee', 'range'],
 	equippedItemBoosts: [
 		{
@@ -577,10 +612,10 @@ export const ElderMimic: CustomMonster = {
 	baseMonster: Monsters.AbyssalSire,
 	name: 'Elder Mimic',
 	aliases: ['elder mimic', 'elder'],
-	timeToFinish: Time.Minute * 400,
-	hp: 2000,
+	timeToFinish: Time.Minute * 250,
+	hp: 1750,
 	table: new LootTable().every('Elder mimic casket'),
-	difficultyRating: 6,
+	difficultyRating: 5,
 	qpRequired: 1500,
 	healAmountNeeded: 200 * 100,
 	attackStyleToUse: GearStat.AttackSlash,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -572,7 +572,7 @@ export const COMBAT_TIER_XP = {
 	TIER_3: 5_000_000_000
 } as const;
 
-export const ARCHON_SPAWN_CHANCE = 50;
+export const ARCHON_SPAWN_CHANCE = 20;
 
 export const PATRON_ONLY_GEAR_SETUP =
 	'Sorry - but the `other` gear setup is only available for Tier 3 Patrons (and higher) to use.';

--- a/src/mahoji/commands/islandupgrade.ts
+++ b/src/mahoji/commands/islandupgrade.ts
@@ -15,6 +15,7 @@ import {
 	getNextUpgradeForCategory,
 	getRemainingCost,
 	getTier,
+	getUpgradeCost,
 	getWeeklyMaintenanceDemand,
 	type IslandLastCollected,
 	type IslandMaintenanceTimestamps,
@@ -659,10 +660,10 @@ export const islandUpgradeCommand = defineCommand({
 
 			if (nextUpgrade) {
 				str += `**Next:** ${nextUpgrade.name} *(${nextUpgrade.bonus})*\n`;
-				if (isContributionComplete(nextUpgrade, contribs)) {
+				if (isContributionComplete(nextUpgrade, contribs, user.isIronman)) {
 					str += `Ready! \`/islandupgrade complete type:${CATEGORY_TO_CHOICE[category]}\`\n`;
 				} else {
-					const remaining = getRemainingCost(nextUpgrade, contribs);
+					const remaining = getRemainingCost(nextUpgrade, contribs, user.isIronman);
 					str += `**Still needed:** ${truncateString(remaining.toString(), 300)}\n`;
 				}
 			} else {
@@ -884,11 +885,11 @@ export const islandUpgradeCommand = defineCommand({
 
 			const contribs = currentContributions[category] ?? {};
 
-			if (isContributionComplete(nextUpgrade, contribs)) {
+			if (isContributionComplete(nextUpgrade, contribs, user.isIronman)) {
 				return `All resources are in. \`/islandupgrade complete type:${CATEGORY_TO_CHOICE[category]}\``;
 			}
 
-			const remaining = getRemainingCost(nextUpgrade, contribs);
+			const remaining = getRemainingCost(nextUpgrade, contribs, user.isIronman);
 			const toContribute = new Bank();
 			for (const [item, qty] of remaining.items()) {
 				const has = item.name === 'Coins' ? Number(user.user.GP) : user.bank.amount(item.id);
@@ -907,7 +908,7 @@ export const islandUpgradeCommand = defineCommand({
 				const key = item.id.toString();
 				afterContribs[key] = (afterContribs[key] ?? 0) + qty;
 			}
-			const afterRemaining = getRemainingCost(nextUpgrade, afterContribs);
+			const afterRemaining = getRemainingCost(nextUpgrade, afterContribs, user.isIronman);
 			const willComplete = afterRemaining.length === 0;
 
 			const image = await makeBankImage({
@@ -916,6 +917,8 @@ export const islandUpgradeCommand = defineCommand({
 				user
 			});
 
+			const fullCost = getUpgradeCost(nextUpgrade, user.isIronman);
+
 			await interaction.confirmation(
 				`**Contribute to ${nextUpgrade.name}?**\n\n` +
 					`> ${nextUpgrade.flavorText}\n\n` +
@@ -923,7 +926,7 @@ export const islandUpgradeCommand = defineCommand({
 					(willComplete
 						? `**This will complete the upgrade!**`
 						: `**Still needed after this:** ${truncateString(afterRemaining.toString(), 300)}`) +
-					`\n\n**Full cost:** ${truncateString(nextUpgrade.cost.toString(), 300)}\n\n` +
+					`\n\n**Full cost:** ${truncateString(fullCost.toString(), 300)}\n\n` +
 					`Contributed items cannot be refunded.`
 			);
 
@@ -946,7 +949,7 @@ export const islandUpgradeCommand = defineCommand({
 
 			await saveState(currentUpgrades, updatedContributions, currentMaintenance, activeAssignment);
 
-			const nowComplete = isContributionComplete(nextUpgrade, updatedContribs);
+			const nowComplete = isContributionComplete(nextUpgrade, updatedContribs, user.isIronman);
 
 			if (nowComplete) {
 				return {
@@ -957,7 +960,7 @@ export const islandUpgradeCommand = defineCommand({
 				};
 			}
 
-			const newRemaining = getRemainingCost(nextUpgrade, updatedContribs);
+			const newRemaining = getRemainingCost(nextUpgrade, updatedContribs, user.isIronman);
 			return {
 				content:
 					`**Contributed to ${nextUpgrade.name}!**\n\n> ${nextUpgrade.flavorText}\n\n` +
@@ -975,8 +978,8 @@ export const islandUpgradeCommand = defineCommand({
 
 			const contribs = currentContributions[category] ?? {};
 
-			if (!isContributionComplete(nextUpgrade, contribs)) {
-				const remaining = getRemainingCost(nextUpgrade, contribs);
+			if (!isContributionComplete(nextUpgrade, contribs, user.isIronman)) {
+				const remaining = getRemainingCost(nextUpgrade, contribs, user.isIronman);
 				return (
 					`**${nextUpgrade.name}** is not yet fully funded.\n\n` +
 					`**Still needed:** ${truncateString(remaining.toString(), 500)}\n\n` +


### PR DESCRIPTION
### Description:
Various adjustments to rates across the update

### Changes:
- Increased Archon spawn rate
- Removed lovakite from island maintenance and supply generation
- Added lowered gp costs to island upgrades for irons
- Adjusted the quantity cap of 'rares' to 1 within island maintenance
- Increased island resource generation, decreased island maintenance cost
- Slightly buffed elder mimic
- Increased drop rates and sources of certain island materials
- Significantly reduced supply costs for fungal behemoth / crystalline sentinel
### Other checks:

- [x] I have tested all my changes thoroughly.
