### PR TITLE
Fix Unknown Test bot username issue

### DIFF
--- a/src/discord/interactionHandler.ts
+++ b/src/discord/interactionHandler.ts
@@ -6,7 +6,6 @@ import {
 	InteractionType
 } from '@oldschoolgg/discord';
 import type { IAutoCompleteInteraction, IButtonInteraction, IChatInputCommandInteraction } from '@oldschoolgg/schemas';
-import { cleanUsername } from '@oldschoolgg/toolkit';
 import { DiscordSnowflake } from '@sapphire/snowflake';
 
 import { autoCompleteHandler } from '@/discord/autoCompleteHandler.js';
@@ -22,12 +21,11 @@ export async function interactionHandler(client: OldSchoolBotClient, itx: APIInt
 	const userId = user.id;
 
 	if (!DISCORD_USER_IDS_INSERTED_CACHE.has(userId) && user) {
-		client.upsertDiscordUser(user);
+		void client.upsertDiscordUser(user);
 	}
 
-	const fullUser = await mUserFetch(userId, {
-		username: cleanUsername(user.username)
-	});
+	if (user?.username) await Cache.updateUsername(user.id, user.username);
+	const fullUser = await mUserFetch(userId);
 
 	if (itx.type === InteractionType.ApplicationCommandAutocomplete) {
 		const d: IAutoCompleteInteraction = {

--- a/src/discord/interactionHandler.ts
+++ b/src/discord/interactionHandler.ts
@@ -6,6 +6,7 @@ import {
 	InteractionType
 } from '@oldschoolgg/discord';
 import type { IAutoCompleteInteraction, IButtonInteraction, IChatInputCommandInteraction } from '@oldschoolgg/schemas';
+import { cleanUsername } from '@oldschoolgg/toolkit';
 import { DiscordSnowflake } from '@sapphire/snowflake';
 
 import { autoCompleteHandler } from '@/discord/autoCompleteHandler.js';
@@ -24,7 +25,9 @@ export async function interactionHandler(client: OldSchoolBotClient, itx: APIInt
 		client.upsertDiscordUser(user);
 	}
 
-	const fullUser = await mUserFetch(userId);
+	const fullUser = await mUserFetch(userId, {
+		username: cleanUsername(user.username)
+	});
 
 	if (itx.type === InteractionType.ApplicationCommandAutocomplete) {
 		const d: IAutoCompleteInteraction = {

--- a/src/lib/cache/redis.ts
+++ b/src/lib/cache/redis.ts
@@ -353,20 +353,20 @@ class CacheManager {
 		return baseSeconds + Math.floor(Math.random() * (jitterSeconds * 2 + 1)) - jitterSeconds;
 	}
 
-	async getUsername(userId: string): Promise<string> {
-		if (!isValidDiscordSnowflake(userId)) {
-			throw new Error(`Invalid userID: ${userId}`);
-		}
-
+	async updateUsername(userId: string, username: string): Promise<boolean> {
 		const cached = await this.getExpiringString(RedisKeys.Discord.Username(userId));
-		if (cached) return cached;
+		if (cached) return false;
 
-		let username: string | null = null;
-		const djsUser = await globalClient.fetchUser(userId).catch(() => null);
-		if (djsUser?.username) {
-			username = cleanUsername(djsUser.username);
-		}
+		username = cleanUsername(username);
+		if (!username) return false;
 
+		const successfulUpdate = await this.prismaUpdateUsername(userId, username);
+
+		await this.setUsername(userId, username);
+		return successfulUpdate;
+	}
+
+	private async prismaUpdateUsername(userId: string, username: string) {
 		const user = await prisma.user.upsert({
 			where: {
 				id: userId
@@ -384,11 +384,30 @@ class CacheManager {
 				username: true
 			}
 		});
+		return user?.username === username;
+	}
 
-		if (!user.username) return 'Unknown';
+	async getUsername(userId: string): Promise<string> {
+		if (!isValidDiscordSnowflake(userId)) {
+			throw new Error(`Invalid userID: ${userId}`);
+		}
 
-		await this.setUsername(userId, user.username);
-		return user.username;
+		const cached = await this.getExpiringString(RedisKeys.Discord.Username(userId));
+		if (cached) return cached;
+
+		let username: string | null = null;
+		const djsUser = await globalClient.fetchUser(userId).catch(() => null);
+		if (djsUser?.username) {
+			username = cleanUsername(djsUser.username);
+		}
+
+		if (username) {
+			await this.prismaUpdateUsername(userId, username);
+
+			await this.setUsername(userId, username);
+			return username;
+		}
+		return 'Unknown';
 	}
 
 	async setUsername(userId: string, username: string): Promise<void> {

--- a/src/lib/openables.ts
+++ b/src/lib/openables.ts
@@ -132,7 +132,7 @@ for (const clueTier of ClueTiers) {
 				let qtyRemaining = qty;
 				while (qtyRemaining > 0) {
 					const toOpen = Math.min(qtyRemaining, batchSize);
-					await yielder.checkpoint()
+					await yielder.checkpoint();
 					miniLoot.add(table.roll(toOpen));
 					qtyRemaining -= batchSize;
 				}

--- a/src/lib/user/MUser.ts
+++ b/src/lib/user/MUser.ts
@@ -7,7 +7,7 @@ import {
 	ZBlowpipeData,
 	ZFarmingContract
 } from '@oldschoolgg/schemas';
-import { calcWhatPercent, isObject, type PerkTier, UserError, uniqueArr } from '@oldschoolgg/toolkit';
+import { calcWhatPercent, cleanUsername, isObject, type PerkTier, UserError, uniqueArr } from '@oldschoolgg/toolkit';
 import { isValidDiscordSnowflake } from '@oldschoolgg/util';
 import { Mutex } from 'async-mutex';
 import { cryptoRng } from 'node-rng/crypto';
@@ -1026,12 +1026,14 @@ export async function srcMUserFetch(userID: string, updates?: Prisma.UserUpdateI
 	if (!isValidDiscordSnowflake(userID)) {
 		throw new Error(`Invalid userID: ${userID}`);
 	}
-	const user =
+	const createData: Prisma.UserCreateInput = { id: userID };
+	if (updates && typeof updates.username === 'string') {
+		createData.username = updates.username;
+	}
+	let user =
 		updates !== undefined
 			? await prisma.user.upsert({
-					create: {
-						id: userID
-					},
+					create: createData,
 					update: updates,
 					where: {
 						id: userID
@@ -1041,6 +1043,24 @@ export async function srcMUserFetch(userID: string, updates?: Prisma.UserUpdateI
 
 	if (!user) {
 		return srcMUserFetch(userID, {});
+	}
+	if (
+		!user.username &&
+		!process.env.TEST &&
+		typeof globalClient !== 'undefined' &&
+		typeof globalClient.fetchUser === 'function'
+	) {
+		const discordUser = await globalClient.fetchUser(userID).catch(() => null);
+		if (discordUser?.username) {
+			user = await prisma.user.update({
+				where: {
+					id: userID
+				},
+				data: {
+					username: cleanUsername(discordUser.username)
+				}
+			});
+		}
 	}
 	return new MUserClass(user);
 }

--- a/src/lib/user/MUser.ts
+++ b/src/lib/user/MUser.ts
@@ -1022,14 +1022,15 @@ Charge your items using ${globalClient.mentionCommand('minion', 'charge')}.`
 	}
 }
 
-export async function srcMUserFetch(userID: string, updates?: Prisma.UserUpdateInput) {
+type MUserFetchCreateInput = Omit<Prisma.UserCreateInput, 'id'>;
+type MUserFetchUpdateInput = MUserFetchCreateInput & Omit<Prisma.UserUpdateInput, 'id'>;
+
+export async function srcMUserFetch(userID: string, updates?: MUserFetchUpdateInput) {
 	if (!isValidDiscordSnowflake(userID)) {
 		throw new Error(`Invalid userID: ${userID}`);
 	}
-	const createData: Prisma.UserCreateInput = { id: userID };
-	if (updates && typeof updates.username === 'string') {
-		createData.username = updates.username;
-	}
+	const createData = { ...updates, id: userID } satisfies Prisma.UserCreateInput;
+
 	let user =
 		updates !== undefined
 			? await prisma.user.upsert({

--- a/tests/integration/MUser.test.ts
+++ b/tests/integration/MUser.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from 'vitest';
 import { activity_type_enum } from '@/prisma/main.js';
 import { ClueTiers } from '../../src/lib/clues/clueTiers.js';
 import { assert } from '../../src/lib/util/logError.js';
-import { createTestUser } from './util.js';
+import { createTestUser, mockedId } from './util.js';
 
 async function stressTest(userID: string) {
 	const user = await mUserFetch(userID);
@@ -76,6 +76,14 @@ async function stressTest(userID: string) {
 }
 
 describe('MUser', () => {
+	test('mUserFetch applies updates when creating a user', async () => {
+		const user = await mUserFetch(mockedId(), { username: 'FreshUser' });
+		expect(user.username).toBe('FreshUser');
+
+		const refetchedUser = await mUserFetch(user.id);
+		expect(refetchedUser.username).toBe('FreshUser');
+	});
+
 	test('Should pass stress test', async () => {
 		const firstUser = await createTestUser();
 		const secondUser = await createTestUser();


### PR DESCRIPTION
Interaction handler now passes the cleaned Discord username into mUserFetch.

MUser now preserves username when creating a user via mUserFetch(..., updates).

MUser also falls back to globalClient.fetchUser() if an existing user row has no username.

Adds a test

Issue:
<img width="697" height="352" alt="image" src="https://github.com/user-attachments/assets/1ca50728-7d24-4c45-b856-96aae61ecd88" />

Resolved:
<img width="734" height="356" alt="image" src="https://github.com/user-attachments/assets/c5cac64d-696b-40f8-9c0f-7698f94f5e3e" />

- [x] I have tested all my changes thoroughly.
