### PR TITLE
Add Trade with files - Fix some /trade issues

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1385,6 +1385,7 @@ model GETransaction {
   sell_listing    GEListing @relation("sell_transactions", fields: [sell_listing_id], references: [id], onDelete: Cascade)
   sell_listing_id Int
 
+  @@index([buy_listing_id])
   @@index([sell_listing_id])
   @@index([created_at])
   @@map("ge_transaction")

--- a/src/discord/commands/commandOptionConversions.ts
+++ b/src/discord/commands/commandOptionConversions.ts
@@ -207,6 +207,8 @@ export function convertAPIOptionsToCommandOptions({
 				user,
 				member
 			};
+		} else if (opt.type === ApplicationCommandOptionType.Attachment) {
+			parsedOptions[opt.name] = resolvedObjects.attachments![opt.value]!;
 		} else {
 			parsedOptions[opt.name as string] = opt.value;
 		}

--- a/src/discord/commands/commandOptions.ts
+++ b/src/discord/commands/commandOptions.ts
@@ -1,4 +1,4 @@
-import type { APIApplicationCommandOptionChoice } from '@oldschoolgg/discord';
+import type { APIApplicationCommandOptionChoice, APIAttachment } from '@oldschoolgg/discord';
 import type { IChannel, IMember, IRole, IUser } from '@oldschoolgg/schemas';
 
 import type { AnyArr, Lit, Simplify, ToObj, UnionToIntersection } from './typeUtils.js';
@@ -8,7 +8,7 @@ export interface MahojiUserOption {
 	member?: IMember;
 }
 
-export type MahojiCommandOption = number | string | MahojiUserOption | IChannel | IRole | boolean;
+export type MahojiCommandOption = number | string | MahojiUserOption | IChannel | IRole | APIAttachment | boolean;
 
 export interface CommandOptions {
 	[key: string]: MahojiCommandOption | CommandOptions;
@@ -58,9 +58,11 @@ type OptionValue<O> = O extends { type: 'String'; choices?: infer C }
 			? boolean
 			: O extends { type: 'User' }
 				? MahojiUserOption
-				: O extends { type: 'Channel' | 'Role' | 'Mentionable' }
-					? string
-					: never;
+				: O extends { type: 'Attachment' }
+					? APIAttachment
+					: O extends { type: 'Channel' | 'Role' | 'Mentionable' }
+						? string
+						: never;
 
 type ExtractArgs<T extends AnyArr<unknown> | undefined> =
 	T extends AnyArr<unknown>

--- a/src/lib/canvas/geImage.ts
+++ b/src/lib/canvas/geImage.ts
@@ -104,15 +104,12 @@ class GeImageGeneratorSingleton {
 
 		const maxWidth = progressShadowImage.width;
 		ctx.fillStyle = OSRSCanvas.COLORS.ORANGE;
-		let percentFullfilled = calcWhatPercent(
+		const percentFullfilled = calcWhatPercent(
 			listing.total_quantity - listing.quantity_remaining,
 			listing.total_quantity
 		);
-		if (listing.type === 'Sell') {
-			percentFullfilled = 100 - percentFullfilled;
-		}
 		const progressWidth = calcPercentOfNum(percentFullfilled, maxWidth);
-		if (percentFullfilled === 100) {
+		if (percentFullfilled === 100 && listing.type !== 'Sell') {
 			ctx.fillStyle = OSRSCanvas.COLORS.DARK_GREEN;
 		} else {
 			ctx.fillStyle = OSRSCanvas.COLORS.ORANGE;
@@ -142,9 +139,11 @@ class GeImageGeneratorSingleton {
 		canvas.ctx.drawImage(this.geInterface!, 0, 0, canvas.width, canvas.height);
 
 		// Pages
-		const chunkSize = 8;
-		const totalChunks = Math.ceil(maxSlots / chunkSize);
-		if (page > totalChunks) page = totalChunks;
+		const slotsPerRow = 4;
+		const rowsPerPage = 2;
+		const chunkSize = slotsPerRow * rowsPerPage;
+		const totalChunks = Math.max(1, Math.ceil(maxSlots / chunkSize));
+		page = Math.min(Math.max(page, 1), totalChunks);
 		if (page >= 0) {
 			canvas.drawTitleText({
 				text: `Page ${page} of ${totalChunks}`,
@@ -157,22 +156,18 @@ class GeImageGeneratorSingleton {
 		const startX = 9;
 		const startY = 64;
 
-		let y = 0;
-		let x = 0;
-		for (let i = (page - 1) * chunkSize; i < maxSlots; i++) {
+		const pageStart = (page - 1) * chunkSize;
+		const pageEnd = Math.min(pageStart + chunkSize, maxSlots);
+		for (let i = pageStart; i < pageEnd; i++) {
 			const listing: GEListingWithTransactions = activeListings[i];
-			if (i > (page - 1) * chunkSize && i % 4 === 0) {
-				y += this.geSlotOpen!.height + 10;
-				x = 0;
-			}
+			const indexOnPage = i - pageStart;
+			const x = indexOnPage % slotsPerRow;
+			const y = Math.floor(indexOnPage / slotsPerRow) * (this.geSlotOpen!.height + 10);
 
 			canvas.ctx.save();
 			canvas.ctx.translate(startX + x * (this.geSlotOpen!.width + 2), startY + y);
 			await this.getSlotImage(opts.user ?? null, canvas, i + 1, i >= slotsUsed, listing);
 			canvas.ctx.restore();
-
-			x++;
-			if (i > (page - 1) * chunkSize + 8) break;
 		}
 
 		return canvas.toScaledOutput(2);

--- a/src/lib/customItems/customItems.ts
+++ b/src/lib/customItems/customItems.ts
@@ -15447,6 +15447,7 @@ setCustomItem(
 		tradeable: false,
 		tradeable_on_ge: false,
 		customItemData: {
+			isSuperUntradeable: true,
 			cantDropFromMysteryBoxes: true
 		}
 	},
@@ -15483,6 +15484,7 @@ setCustomItem(
 		tradeable: false,
 		tradeable_on_ge: false,
 		customItemData: {
+			isSuperUntradeable: true,
 			cantDropFromMysteryBoxes: true
 		}
 	},
@@ -15519,6 +15521,7 @@ setCustomItem(
 		tradeable: false,
 		tradeable_on_ge: false,
 		customItemData: {
+			isSuperUntradeable: true,
 			cantDropFromMysteryBoxes: true
 		}
 	},
@@ -15555,6 +15558,7 @@ setCustomItem(
 		tradeable: false,
 		tradeable_on_ge: false,
 		customItemData: {
+			isSuperUntradeable: true,
 			cantDropFromMysteryBoxes: true
 		}
 	},
@@ -15591,6 +15595,7 @@ setCustomItem(
 		tradeable: false,
 		tradeable_on_ge: false,
 		customItemData: {
+			isSuperUntradeable: true,
 			cantDropFromMysteryBoxes: true
 		}
 	},

--- a/src/lib/grandExchange.ts
+++ b/src/lib/grandExchange.ts
@@ -1002,9 +1002,7 @@ Difference: ${shouldHave.difference(currentBank)}`);
 			grand_exchange_tax_bank: 0,
 			grand_exchange_total_tax: 0
 		});
-		await prisma.gEBank.deleteMany();
-		await prisma.gETransaction.deleteMany();
-		await prisma.gEListing.deleteMany();
+		await prisma.$executeRaw`TRUNCATE TABLE "ge_bank", "ge_transaction", "ge_listing" RESTART IDENTITY;`;
 	}
 }
 

--- a/src/lib/grandExchange.ts
+++ b/src/lib/grandExchange.ts
@@ -24,6 +24,13 @@ interface CreateListingArgs {
 	type: GEListingType;
 }
 
+const gePerkTierSlotBoosts = [
+	[PerkTier.Two, 3],
+	[PerkTier.Three, 3],
+	[PerkTier.Four, 6],
+	...[PerkTier.Five, PerkTier.Six, PerkTier.Seven].map(tier => [tier, 2])
+] as const;
+
 function validateNumber(num: number) {
 	if (num < 0 || Number.isNaN(num) || !Number.isInteger(num) || num >= Number.MAX_SAFE_INTEGER) {
 		throw new Error(`Invalid number: ${num}.`);
@@ -155,21 +162,11 @@ class GrandExchangeSingleton {
 					name: `${num.toLocaleString()} Leagues Points`,
 					amount: 1
 				})),
-				{
-					has: async (user: MUser) => (await user.fetchPerkTier()) >= PerkTier.Four,
-					name: 'Tier 3 Patron',
-					amount: 8
-				},
-				{
-					has: async (user: MUser) => (await user.fetchPerkTier()) >= PerkTier.Three,
-					name: 'Tier 2 Patron',
-					amount: 4
-				},
-				{
-					has: async (user: MUser) => (await user.fetchPerkTier()) >= PerkTier.Two,
-					name: 'Tier 1 Patron',
-					amount: 2
-				}
+				...gePerkTierSlotBoosts.map(([tier, amount]) => ({
+					has: async (user: MUser) => (await user.fetchPerkTier()) >= tier,
+					name: `Perk Tier ${tier}`,
+					amount
+				}))
 			]
 		}
 	};

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -382,6 +382,25 @@ const adminRunnableCommands: AdminRunnableCommand[] = [
 		}
 	},
 	{
+		name: 'reset_grand_exchange',
+		description: 'Reset the grand exchange.',
+		args: [
+			{
+				name: 'actually_reset_ge',
+				description: `Must be \`actually_reset_ge\` but it won't work on production anyway.`,
+				required: true
+			}],
+		run: async ({ arg1, adminUser}) => {
+			if (!adminUser.isAdmin) return 'You must be the owner to reset the grand exchange.';
+			if (globalConfig.isProduction) {
+				return 'You cannot reset the grand exchange on production no matter who you are.';
+			}
+			if (arg1 !== 'actually_reset_ge') return 'Missing confirmation.';
+			await GrandExchange.totalReset();
+			return 'Reset the grand exchange.';
+		}
+	},
+	{
 		name: 'activate_lottery',
 		description: 'Set lottery_is_active to true.',
 		args: [],

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -1218,7 +1218,7 @@ export const adminCommand = defineCommand({
 				{
 					type: 'Subcommand',
 					name: 'allow_irons',
-					description: 'Allow ironmen to join a giveaway.',
+					description: 'Toggle whether ironmen can join a giveaway.',
 					options: [
 						{
 							type: 'String',
@@ -1704,10 +1704,11 @@ ${META_CONSTANTS.RENDERED_STR}`
 					id: giveaway.id
 				},
 				data: {
-					allow_ironmen: true
+					allow_ironmen: !giveaway.allow_ironmen
 				}
 			});
 			giveawayCache.set(updatedGiveaway.id, updatedGiveaway);
+			const ironmanStatus = updatedGiveaway.allow_ironmen ? 'enabled' : 'disabled';
 
 			try {
 				await globalClient.editMessage(updatedGiveaway.channel_id, updatedGiveaway.message_id, {
@@ -1725,10 +1726,10 @@ ${META_CONSTANTS.RENDERED_STR}`
 					channel_id: updatedGiveaway.channel_id,
 					message_id: updatedGiveaway.message_id
 				});
-				return 'Ironmen are enabled for this giveaway, but I failed to edit the giveaway message.';
+				return `Ironmen are now ${ironmanStatus} for this giveaway, but I failed to edit the giveaway message.`;
 			}
 
-			return `Ironmen are now enabled for giveaway message ${updatedGiveaway.message_id}.`;
+			return `Ironmen are now ${ironmanStatus} for giveaway message ${updatedGiveaway.message_id}.`;
 		}
 
 		if (options.item_stats) {

--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -111,7 +111,7 @@ export async function getUserInfo(user: MUser) {
 		if (user.isMod || user.isWikiContrib || user.isContributor || user.isTrusted) {
 			perkTierDisplay = `**Courtesy** __Tier ${result.perkTier - 1}__`;
 		} else {
-			perkTierDisplay = `🔴 **Expiring** __Tier ${result.perkTier - 1}__`;
+			perkTierDisplay = `🔴 **Temporary** __Tier ${result.perkTier - 1}__`;
 		}
 	}
 	return {

--- a/src/mahoji/commands/trade.ts
+++ b/src/mahoji/commands/trade.ts
@@ -22,8 +22,6 @@ import { mahojiParseNumber } from '@/mahoji/mahojiSettings.js';
 const MAX_CHARACTER_LENGTH = 950;
 const MAX_TRADE_CONFIRMATION_LENGTH = 1950;
 const DEFAULT_TRADE_MAX_PULL = 70;
-const TRADE_MAX_PULL_REDUCTION_STEP = 10;
-const MIN_TRADE_MAX_PULL = 10;
 const MAX_TRADE_SYNOPSIS_LENGTH = 1950;
 const EMBED_SIDE_LENGTH = 1800;
 const MAX_TRADE_FILE_BYTES = 2 * 1024 * 1024;
@@ -304,15 +302,13 @@ function buildTradeCompletionResponse(
 	senderUser: MUser,
 	recipientUser: MUser,
 	itemsSent: Bank,
-	itemsReceived: Bank,
-	newTradeStyle: boolean
+	itemsReceived: Bank
 ) {
 	let synopsis = `Trade completed! ${senderUser.mention} sold ${itemsSent.toStringFull()} to ${
 		recipientUser.mention
 	} in return for ${itemsReceived.toStringFull()}.`;
-	if (newTradeStyle) {
-		synopsis += `\n\n${formatTradeHashSummary(senderUser, recipientUser, itemsSent, itemsReceived)}`;
-	}
+
+	synopsis += `\n\n${formatTradeHashSummary(senderUser, recipientUser, itemsSent, itemsReceived)}`;
 
 	synopsis += `You can now buy/sell items in the Grand Exchange: ${globalClient.mentionCommand('ge')}`;
 	const response: BaseSendableMessage = {
@@ -650,7 +646,7 @@ export const tradeCommand = defineCommand({
 			return SpecialResponse.RespondedManually;
 		}
 		if (!senderUser.owns(itemsSent)) {
-			await interaction.editFollowUp(tradeMessage.id, {
+			await interaction.editFollowUp(confirmationMessage.id, {
 				content: "You don't own those items.",
 				components: [],
 				clearAttachments: true
@@ -660,7 +656,7 @@ export const tradeCommand = defineCommand({
 
 		const { success, message } = await tradePlayerItems(senderUser, recipientUser, itemsSent, itemsReceived);
 		if (!success) {
-			await interaction.editFollowUp(tradeMessage.id, {
+			await interaction.editFollowUp(confirmationMessage.id, {
 				content: `Trade failed because: ${message}`,
 				components: [],
 				clearAttachments: true
@@ -692,10 +688,9 @@ export const tradeCommand = defineCommand({
 			senderUser,
 			recipientUser,
 			itemsSent,
-			itemsReceived,
-			newTradeStyle
+			itemsReceived
 		);
-		await interaction.editFollowUp(tradeMessage.id, { ...completionResponse, clearAttachments: true });
+		await interaction.editFollowUp(confirmationMessage.id, { ...completionResponse, clearAttachments: true });
 		return SpecialResponse.RespondedManually;
 	}
 });

--- a/src/mahoji/commands/trade.ts
+++ b/src/mahoji/commands/trade.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto';
+import { TextDecoder } from 'node:util';
 import {
 	type APIMessage,
+	type APIAttachment,
 	ButtonBuilder,
 	ButtonStyle,
 	EmbedBuilder,
@@ -8,9 +10,10 @@ import {
 	userMention
 } from '@oldschoolgg/discord';
 import { Events, ellipsize } from '@oldschoolgg/toolkit';
-import { Bank } from 'oldschooljs';
+import { Bank, type ItemBank } from 'oldschooljs';
 
 import { filterOption } from '@/discord/index.js';
+import { ZItemBank } from '@/lib/structures/Bank.js';
 import itemIsTradeable from '@/lib/util/itemIsTradeable.js';
 import { parseBank } from '@/lib/util/parseStringBank.js';
 import { tradePlayerItems } from '@/lib/util/tradePlayerItems.js';
@@ -23,6 +26,7 @@ const TRADE_MAX_PULL_REDUCTION_STEP = 10;
 const MIN_TRADE_MAX_PULL = 10;
 const MAX_TRADE_SYNOPSIS_LENGTH = 1950;
 const EMBED_SIDE_LENGTH = 1800;
+const MAX_TRADE_FILE_BYTES = 2 * 1024 * 1024;
 const TradeConfirmationButtonID = {
 	Confirm: 'TRADE_CONFIRM',
 	Cancel: 'TRADE_CANCEL'
@@ -32,6 +36,159 @@ const TradeConfirmationStopReason = {
 	UserCancelled: 'user_cancelled',
 	Timeout: 'timeout'
 };
+type TradeFileOptionName = 'send_file' | 'receive_file';
+type TradeFileTextResult = { text: string } | { error: string };
+
+function formatTradeFileError(optionName: TradeFileOptionName, message: string, underlyingError?: string) {
+	const prefix = `I couldn't use your ${optionName} attachment. ${message}`;
+	if (!underlyingError) return prefix;
+	return `${prefix}\n\n\`\`\`text\n${underlyingError}\n\`\`\``;
+}
+
+function formatTradeFileParseError(optionName: TradeFileOptionName, underlyingError?: string) {
+	const prefix = `I couldn't parse your ${optionName} attachment as an item bank.`;
+	if (!underlyingError) return prefix;
+	return `${prefix}\n\n\`\`\`text\n${underlyingError}\n\`\`\``;
+}
+
+function hasAllowedTradeFileExtension(attachment: APIAttachment) {
+	return /\.(?:txt|json)$/i.test(attachment.filename);
+}
+
+function hasBinaryTextCharacters(text: string) {
+	return /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/u.test(text);
+}
+
+function assertJSONObject(value: unknown): asserts value is Record<string, unknown> {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		throw new Error('JSON item banks must be an object of item ID keys to quantities.');
+	}
+}
+
+function assertJSONItemBankUsesIDKeys(bank: Record<string, unknown>) {
+	const nonIDKey = Object.keys(bank).find(key => !/^\d+$/.test(key));
+	if (nonIDKey) {
+		throw new Error('JSON item bank keys must be item IDs only.');
+	}
+}
+
+function validateJSONItemBank(json: unknown): ItemBank {
+	assertJSONObject(json);
+	assertJSONItemBankUsesIDKeys(json);
+	const parsed = ZItemBank.safeParse(json);
+	if (!parsed.success) {
+		throw new Error(
+			parsed.error.issues.map(issue => `${issue.path.join('.') || 'bank'}: ${issue.message}`).join('\n')
+		);
+	}
+	const parsedKeyCount = Object.keys(parsed.data).length;
+	if (parsedKeyCount !== Object.keys(json).length) {
+		throw new Error('JSON item bank contains unknown item IDs.');
+	}
+	return parsed.data;
+}
+
+function parseTradeFileBankContent({
+	optionName,
+	content,
+	inputBank
+}: {
+	optionName: TradeFileOptionName;
+	content: string;
+	inputBank?: Bank;
+}): Bank | string {
+	const trimmedContent = content.trim();
+	if (!trimmedContent) {
+		return formatTradeFileError(optionName, 'Attachment content is empty.');
+	}
+
+	try {
+		if (trimmedContent[0] === '{') {
+			const parsedJSON = JSON.parse(trimmedContent);
+			return new Bank(validateJSONItemBank(parsedJSON)).filter(i => itemIsTradeable(i.id, true));
+		}
+
+		return parseBank({
+			inputBank,
+			inputStr: trimmedContent,
+			flags: {},
+			noDuplicateItems: true
+		}).filter(i => itemIsTradeable(i.id, true));
+	} catch (err) {
+		return formatTradeFileParseError(
+			optionName,
+			err instanceof Error ? err.message : 'Unknown parsing error.'
+		);
+	}
+}
+
+async function downloadTradeAttachmentText(
+	optionName: TradeFileOptionName,
+	attachment: APIAttachment
+): Promise<TradeFileTextResult> {
+	if (!hasAllowedTradeFileExtension(attachment)) {
+		return { error: formatTradeFileError(optionName, 'The file must be a .txt or .json file.') };
+	}
+
+	if (attachment.size > MAX_TRADE_FILE_BYTES) {
+		return {
+			error: formatTradeFileError(
+				optionName,
+				'The file is over 2MB. Use item IDs instead of item names to make it smaller.'
+			)
+		};
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(attachment.url);
+	} catch (err) {
+		return {
+			error: formatTradeFileError(
+				optionName,
+				"I couldn't download the file.",
+				err instanceof Error ? err.message : 'Unknown download error.'
+			)
+		};
+	}
+	if (!response.ok) {
+		return {
+			error: formatTradeFileError(
+				optionName,
+				"I couldn't download the file.",
+				`${response.status} ${response.statusText}`
+			)
+		};
+	}
+
+	const buffer = Buffer.from(await response.arrayBuffer());
+	if (buffer.length > MAX_TRADE_FILE_BYTES) {
+		return {
+			error: formatTradeFileError(
+				optionName,
+				'The downloaded file is over 2MB. Use item IDs instead of item names to make it smaller.'
+			)
+		};
+	}
+
+	try {
+		const text = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+		if (hasBinaryTextCharacters(text)) {
+			return {
+				error: formatTradeFileError(optionName, 'The file must be plaintext UTF-8.', 'Binary data was detected.')
+			};
+		}
+		return { text };
+	} catch (err) {
+		return {
+			error: formatTradeFileError(
+				optionName,
+				'The file must be plaintext UTF-8.',
+				err instanceof Error ? err.message : 'Invalid UTF-8 content.'
+			)
+		};
+	}
+}
 
 function formatBankForDisplay(bank: Bank): string {
 	const fullStr = bank.toStringFull();
@@ -281,9 +438,21 @@ export const tradeCommand = defineCommand({
 			required: false
 		},
 		{
+			type: 'Attachment',
+			name: 'send_file',
+			description: 'A plaintext item bank file of items you want to send.',
+			required: false
+		},
+		{
 			type: 'String',
 			name: 'receive',
 			description: 'The items you want to receive from the other player.',
+			required: false
+		},
+		{
+			type: 'Attachment',
+			name: 'receive_file',
+			description: 'A plaintext item bank file of items you want to receive.',
 			required: false
 		},
 		{
@@ -319,12 +488,43 @@ export const tradeCommand = defineCommand({
 		if (recipientUser.id === senderUser.id) return "You can't trade yourself.";
 		if (options.user.user.bot) return "You can't trade a bot.";
 		if (await recipientUser.getIsLocked()) return 'That user is busy right now.';
+		if (options.send && options.send_file) return 'Use either send or send_file, not both.';
+		if (options.receive && options.receive_file) return 'Use either receive or receive_file, not both.';
+		if (options.send_file && (options.filter || options.search || options.all)) {
+			return 'You cannot use send_file with filter, search, or all.';
+		}
 
 		const extraSettings = await ClientSettings.getExtraSettings();
+		let fileItemsSent: Bank | undefined;
+		let fileItemsReceived: Bank | undefined;
+
+		if (options.send_file) {
+			const sendFileText = await downloadTradeAttachmentText('send_file', options.send_file);
+			if ('error' in sendFileText) return sendFileText.error;
+			const parsed = parseTradeFileBankContent({
+				optionName: 'send_file',
+				content: sendFileText.text,
+				inputBank: senderUser.bankWithGP
+			});
+			if (typeof parsed === 'string') return parsed;
+			fileItemsSent = parsed;
+		}
+
+		if (options.receive_file) {
+			const receiveFileText = await downloadTradeAttachmentText('receive_file', options.receive_file);
+			if ('error' in receiveFileText) return receiveFileText.error;
+			const parsed = parseTradeFileBankContent({
+				optionName: 'receive_file',
+				content: receiveFileText.text
+			});
+			if (typeof parsed === 'string') return parsed;
+			fileItemsReceived = parsed;
+		}
 
 		function parseTradeBanks(maxSize: number) {
 			const parsedItemsSent =
-				!options.search && !options.filter && !options.send && !options.all
+				(fileItemsSent ? new Bank(fileItemsSent) : undefined) ??
+				(!options.search && !options.filter && !options.send && !options.all
 					? new Bank()
 					: parseBank({
 							inputBank: senderUser.bankWithGP,
@@ -334,13 +534,15 @@ export const tradeCommand = defineCommand({
 							filters: [options.filter],
 							search: options.search,
 							noDuplicateItems: true
-						}).filter(i => itemIsTradeable(i.id, true));
-			const parsedItemsReceived = parseBank({
-				inputStr: options.receive,
-				maxSize,
-				flags: {},
-				noDuplicateItems: true
-			}).filter(i => itemIsTradeable(i.id, true));
+						}).filter(i => itemIsTradeable(i.id, true)));
+			const parsedItemsReceived =
+				(fileItemsReceived ? new Bank(fileItemsReceived) : undefined) ??
+				parseBank({
+					inputStr: options.receive,
+					maxSize,
+					flags: {},
+					noDuplicateItems: true
+				}).filter(i => itemIsTradeable(i.id, true));
 
 			if (options.price) {
 				const gp = mahojiParseNumber({ input: options.price, min: 1 });
@@ -446,8 +648,7 @@ export const tradeCommand = defineCommand({
 			});
 		}
 
-		await senderUser.sync();
-		await recipientUser.sync();
+		// Don't sync now because the tradePlayerItems syncs already
 		if (!recipientUser.owns(itemsReceived)) {
 			await interaction.editFollowUp(tradeMessage.id, {
 				content: "They don't own those items.",

--- a/src/mahoji/commands/trade.ts
+++ b/src/mahoji/commands/trade.ts
@@ -227,7 +227,7 @@ function formatTradeHashSummary(senderUser: MUser, recipientUser: MUser, itemsSe
 ${formatTradeItemSummary(senderUser, recipientUser, itemsSent, itemsReceived)}`;
 }
 
-function buildTradeConfirmationContent(senderUser: MUser, recipientUser: MUser, itemsSent: Bank, itemsReceived: Bank) {
+function tradeComposeMainContent(senderUser: MUser, recipientUser: MUser, itemsSent: Bank, itemsReceived: Bank) {
 	return `${recipientUser.mention}, ${userMention(senderUser.id)} wants to trade with you.
 
 **${userMention(senderUser.id)}** is giving: ${formatBankForDisplay(itemsSent)}
@@ -266,7 +266,7 @@ function buildTradeOfferDisplay(
 	};
 }
 
-function buildTradeConfirmationEmbedMessage(
+function tradeComposeEmbed(
 	senderUser: MUser,
 	recipientUser: MUser,
 	itemsSent: Bank,
@@ -372,14 +372,14 @@ async function confirmTradeFollowUp({
 			}
 
 			if (confirms.has(buttonInteraction.userId)) {
-				buttonInteraction.reply({ ephemeral: true, content: `You have already confirmed.` });
+				void buttonInteraction.reply({ ephemeral: true, content: `You have already confirmed.` });
 				return;
 			}
 
 			confirms.add(buttonInteraction.userId);
 
 			if (buttonInteraction.customId === TradeConfirmationButtonID.Confirm) {
-				buttonInteraction.silentButtonAck();
+				void buttonInteraction.silentButtonAck();
 				if (confirms.size === users.length) {
 					collector.stop(TradeConfirmationStopReason.AllConfirmed);
 					resolve();
@@ -521,6 +521,11 @@ export const tradeCommand = defineCommand({
 			fileItemsReceived = parsed;
 		}
 
+		// Need to use a new followUp() message to ping because we use defer()
+		function tradeConfirmationMsg(tradeTimeout: number) {
+			return `${recipientUser.mention}, ${senderUser.mention} wants to trade with you. Review the trade details above, then confirm if you accept.\n\nYou have ${Math.floor(tradeTimeout / 1000)} seconds to confirm.`;
+		}
+
 		function parseTradeBanks(maxSize: number) {
 			const parsedItemsSent =
 				(fileItemsSent ? new Bank(fileItemsSent) : undefined) ??
@@ -556,20 +561,9 @@ export const tradeCommand = defineCommand({
 
 		let tradeMaxPull = extraSettings.tradeMaxPull ?? DEFAULT_TRADE_MAX_PULL;
 		let { itemsSent, itemsReceived } = parseTradeBanks(tradeMaxPull);
-		let confirmationContent = buildTradeConfirmationContent(senderUser, recipientUser, itemsSent, itemsReceived);
+		let mainContent = tradeComposeMainContent(senderUser, recipientUser, itemsSent, itemsReceived);
 		const tradeTimeout = extraSettings.tradeTimeout * 1000;
 		const tradeEmbedTimeout = extraSettings.tradeEmbedTimeout * 1000;
-
-		while (
-			!extraSettings.tradeEnableEmbed &&
-			confirmationMessageLength(confirmationContent, extraSettings.tradeTimeout) >
-				MAX_TRADE_CONFIRMATION_LENGTH &&
-			tradeMaxPull > MIN_TRADE_MAX_PULL
-		) {
-			tradeMaxPull = Math.max(MIN_TRADE_MAX_PULL, tradeMaxPull - TRADE_MAX_PULL_REDUCTION_STEP);
-			({ itemsSent, itemsReceived } = parseTradeBanks(tradeMaxPull));
-			confirmationContent = buildTradeConfirmationContent(senderUser, recipientUser, itemsSent, itemsReceived);
-		}
 
 		const allItems = new Bank().add(itemsSent).add(itemsReceived);
 		if (allItems.items().some(i => !itemIsTradeable(i[0].id, true))) {
@@ -581,41 +575,41 @@ export const tradeCommand = defineCommand({
 		await senderUser.sync();
 		if (!senderUser.owns(itemsSent)) return "You don't own those items.";
 
-		const confirmationIsTooLong =
-			confirmationMessageLength(confirmationContent, extraSettings.tradeTimeout) > MAX_TRADE_CONFIRMATION_LENGTH;
+		const needsEmbed =
+			confirmationMessageLength(mainContent, extraSettings.tradeTimeout) > MAX_TRADE_CONFIRMATION_LENGTH;
 
 		const usersToConfirm = [recipientUser.id, senderUser.id];
 
 		let tradeMessage: APIMessage;
 		let confirmationMessage: APIMessage;
-		let newTradeStyle = false;
-		if (confirmationIsTooLong && extraSettings.tradeEnableEmbed) {
-			newTradeStyle = true;
-			const embedMessage = buildTradeConfirmationEmbedMessage(
+		if (needsEmbed) {
+			const embedMessage = tradeComposeEmbed(
 				senderUser,
 				recipientUser,
 				itemsSent,
 				itemsReceived
 			);
-			const hasOfferFiles = Boolean(embedMessage.files?.length);
-			if (hasOfferFiles) {
+			// Is the response too big for an embed?
+			if (Boolean(embedMessage.files?.length)) {
 				tradeMessage = await interaction.followUp(embedMessage);
-				const confirmationContent = `${recipientUser.mention}, ${senderUser.mention} wants to trade with you. Review the trade details above, then confirm if you accept.`;
+				const content = tradeConfirmationMsg(tradeEmbedTimeout);
+
 				confirmationMessage = await interaction.followUp({
-					content: `${confirmationContent}\n\nYou have ${Math.floor(tradeEmbedTimeout / 1000)} seconds to confirm.`,
+					content,
 					components: tradeConfirmationButtons(),
 					allowedMentions: tradeAllowedMentions(senderUser, recipientUser)
 				});
 				await confirmTradeFollowUp({
 					interaction,
 					message: confirmationMessage,
-					content: confirmationContent,
+					content,
 					users: usersToConfirm,
 					timeout: tradeEmbedTimeout
 				});
 				await interaction.editFollowUp(confirmationMessage.id, { content: 'Trade confirmed.', components: [] });
 			} else {
 				const content = `${embedMessage.content}\n\nYou have ${Math.floor(tradeEmbedTimeout / 1000)} seconds to confirm.`;
+				confirmationMessage =
 				tradeMessage = await interaction.followUp({
 					...embedMessage,
 					content,
@@ -630,19 +624,17 @@ export const tradeCommand = defineCommand({
 					timeout: tradeEmbedTimeout
 				});
 			}
-		} else if (confirmationIsTooLong) {
-			return "All those items won't fit in a trade confirmation. Maybe you should've helped with Cyr's embed test.";
 		} else {
-			const content = `${confirmationContent}\n\nYou have ${Math.floor(tradeTimeout / 1000)} seconds to confirm.`;
-			tradeMessage = await interaction.followUp({
+			const content = `${mainContent}\n\nYou have ${Math.floor(tradeTimeout / 1000)} seconds to confirm.`;
+			confirmationMessage = await interaction.followUp({
 				content,
 				components: tradeConfirmationButtons(),
 				allowedMentions: tradeAllowedMentions(senderUser, recipientUser)
 			});
 			await confirmTradeFollowUp({
 				interaction,
-				message: tradeMessage,
-				content: confirmationContent,
+				message: confirmationMessage,
+				content: mainContent,
 				users: usersToConfirm,
 				timeout: tradeTimeout
 			});
@@ -650,7 +642,7 @@ export const tradeCommand = defineCommand({
 
 		// Don't sync now because the tradePlayerItems syncs already
 		if (!recipientUser.owns(itemsReceived)) {
-			await interaction.editFollowUp(tradeMessage.id, {
+			await interaction.editFollowUp(confirmationMessage.id, {
 				content: "They don't own those items.",
 				components: [],
 				clearAttachments: true

--- a/src/mahoji/lib/abstracted_commands/gearCommands.ts
+++ b/src/mahoji/lib/abstracted_commands/gearCommands.ts
@@ -192,7 +192,7 @@ export async function gearEquipCommand(args: {
 	if (items) {
 		return gearEquipMultiCommand(user, setup, items);
 	}
-	if (setup === 'other' && (await user.fetchPerkTier()) < PerkTier.Four) {
+	if (setup === 'other' && user.perkTier < PerkTier.Four) {
 		return PATRON_ONLY_GEAR_SETUP;
 	}
 	if (preset) {


### PR DESCRIPTION
### Description:

- Adds the ability to trade any sized bank string!

Simple use the send_file or receive_file option and upload a file containing the bank string you want to trade. This can be a .json file, like when you export your bank to JSON, or it can be a normal bank string, like, `30 cannonball,10 smokey, 3 cob, 1 side order of fries, diet coke`

This should make your lives easier :D

Also: 
- `all` sends your entire bank
- searches - no longer limited to just 20 or so items
- if the file list is too long, you can decline the trade, and take your time to examine the trade. You will see the, 'trade hash,'  for each side of the trade. This value ensures that it is the same batch of items on each side of the trade :) 

### Note:
- This will be backported to OSB